### PR TITLE
Allow mapping properties and/or fields with different names

### DIFF
--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Common
@@ -39,6 +40,22 @@ namespace FluentAssertions.Common
             string formattedString = Formatter.ToString(value.Substring(index, length));
 
             return $"{formattedString} (index {index})".EscapePlaceholders();
+        }
+
+        /// <summary>
+        /// Replaces all numeric indices from a path like "property[0].nested" and returns "property[].nested"
+        /// </summary>
+        public static string WithoutSpecificCollectionIndices(this string indexedPath)
+        {
+            return Regex.Replace(indexedPath, @"\[\d+\]", "[]");
+        }
+
+        /// <summary>
+        /// Determines whether a string contains a specific index like `[0]` instead of just `[]`.
+        /// </summary>
+        public static bool ContainsSpecificCollectionIndex(this string indexedPath)
+        {
+            return Regex.IsMatch(indexedPath, @"\[\d+\]");
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
@@ -2,9 +2,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency.Execution;
+using FluentAssertions.Equivalency.Matching;
 using FluentAssertions.Equivalency.Ordering;
 using FluentAssertions.Equivalency.Selection;
 
@@ -69,6 +71,95 @@ namespace FluentAssertions.Equivalency
         {
             return new EquivalencyAssertionOptions<IEnumerable<TExpectation>>(
                 new CollectionMemberAssertionOptionsDecorator(this));
+        }
+
+        /// <summary>
+        /// Maps a (nested) property or field of type <typeparamref name="TExpectation"/> to
+        /// a (nested) property or field of <typeparamref name="TSubject"/> using lambda expressions.
+        /// </summary>
+        /// <param name="expectationMemberPath">A field or property expression indicating the (nested) member to map from.</param>
+        /// <param name="subjectMemberPath">A field or property expression indicating the (nested) member to map to.</param>
+        /// <remarks>
+        /// The members of the subject and the expectation must have the same parent. Also, indexes in collections are ignored.
+        /// If the types of the members are different, the usual logic applies depending or not if conversion options were specified.
+        /// Fields can be mapped to properties and vice-versa.
+        /// </remarks>
+        public EquivalencyAssertionOptions<TExpectation> WithMapping<TSubject>(
+            Expression<Func<TExpectation, object>> expectationMemberPath,
+            Expression<Func<TSubject, object>> subjectMemberPath)
+        {
+            return WithMapping(
+                expectationMemberPath.GetMemberPath().ToString().WithoutSpecificCollectionIndices(),
+                subjectMemberPath.GetMemberPath().ToString().WithoutSpecificCollectionIndices());
+        }
+
+        /// <summary>
+        /// Maps a (nested) property or field of the expectation to a (nested) property or field of the subject using a path string.
+        /// </summary>
+        /// <param name="expectationMemberPath">
+        /// A field or property path indicating the (nested) member to map from in the format <c>Parent.Child.Collection[].Member</c>.
+        /// </param>
+        /// <param name="subjectMemberPath">
+        /// A field or property path indicating the (nested) member to map to in the format <c>Parent.Child.Collection[].Member</c>.
+        /// </param>
+        /// <remarks>
+        /// The members of the subject and the expectation must have the same parent. Also, indexes in collections are not allowed
+        /// and must be written as "[]".  If the types of the members are different, the usual logic applies depending or not
+        /// if conversion options were specified.
+        /// Fields can be mapped to properties and vice-versa.
+        /// </remarks>
+        public EquivalencyAssertionOptions<TExpectation> WithMapping(
+            string expectationMemberPath,
+            string subjectMemberPath)
+        {
+            AddMatchingRule(new MappedPathMatchingRule(expectationMemberPath, subjectMemberPath));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Maps a direct property or field of type <typeparamref name="TNestedExpectation"/> to
+        /// a direct property or field of <typeparamref name="TNestedSubject"/> using lambda expressions.
+        /// </summary>
+        /// <param name="expectationMember">A field or property expression indicating the member to map from.</param>
+        /// <param name="subjectMember">A field or property expression indicating the member to map to.</param>
+        /// <remarks>
+        /// Only direct members of <typeparamref name="TNestedExpectation"/> and <typeparamref name="TNestedSubject"/> can be
+        /// mapped to each other. Those types can appear anywhere in the object graphs that are being compared.
+        /// If the types of the members are different, the usual logic applies depending or not if conversion options were specified.
+        /// Fields can be mapped to properties and vice-versa.
+        /// </remarks>
+        public EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(
+            Expression<Func<TNestedExpectation, object>> expectationMember,
+            Expression<Func<TNestedSubject, object>> subjectMember)
+        {
+            return WithMapping<TNestedExpectation, TNestedSubject>(
+                expectationMember.GetMemberPath().ToString(),
+                subjectMember.GetMemberPath().ToString());
+        }
+
+        /// <summary>
+        /// Maps a direct property or field of type <typeparamref name="TNestedExpectation"/> to
+        /// a direct property or field of <typeparamref name="TNestedSubject"/> using member names.
+        /// </summary>
+        /// <param name="expectationMemberName">A field or property name indicating the member to map from.</param>
+        /// <param name="subjectMemberName">A field or property name indicating the member to map to.</param>
+        /// <remarks>
+        /// Only direct members of <typeparamref name="TNestedExpectation"/> and <typeparamref name="TNestedSubject"/> can be
+        /// mapped to each other, so no <c>.</c> or <c>[]</c> are allowed.
+        /// Those types can appear anywhere in the object graphs that are being compared.
+        /// If the types of the members are different, the usual logic applies depending or not if conversion options were specified.
+        /// Fields can be mapped to properties and vice-versa.
+        /// </remarks>
+        public EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(
+            string expectationMemberName,
+            string subjectMemberName)
+        {
+            AddMatchingRule(new MappedMemberMatchingRule<TNestedExpectation, TNestedSubject>(
+                expectationMemberName,
+                subjectMemberName));
+
+            return this;
         }
     }
 

--- a/Src/FluentAssertions/Equivalency/INode.cs
+++ b/Src/FluentAssertions/Equivalency/INode.cs
@@ -16,7 +16,10 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Gets the name of this node.
         /// </summary>
-        string Name { get; }
+        /// <example>
+        /// "Property2"
+        /// </example>
+        string Name { get; set; }
 
         /// <summary>
         /// Gets the type of this node.
@@ -26,11 +29,17 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Gets the path from the root object UNTIL the current node, separated by dots or index/key brackets.
         /// </summary>
+        /// <example>
+        /// "Parent[0].Property2"
+        /// </example>
         string Path { get; }
 
         /// <summary>
         /// Gets the full path from the root object up to and including the name of the node.
         /// </summary>
+        /// <example>
+        /// "Parent[0]"
+        /// </example>
         string PathAndName { get; }
 
         /// <summary>
@@ -41,6 +50,9 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Gets the path including the description of the subject.
         /// </summary>
+        /// <example>
+        /// "property subject.Parent[0].Property2"
+        /// </example>
         string Description { get; }
 
         /// <summary>

--- a/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Text.RegularExpressions;
+using FluentAssertions.Common;
+
+namespace FluentAssertions.Equivalency.Matching
+{
+    /// <summary>
+    /// Allows mapping a member (property or field) of the expectation to a differently named member
+    /// of the subject-under-test using a member name and the target type.
+    /// </summary>
+    internal class MappedMemberMatchingRule<TExpectation, TSubject> : IMemberMatchingRule
+    {
+        private readonly string expectationMemberName;
+        private readonly string subjectMemberName;
+
+        public MappedMemberMatchingRule(string expectationMemberName, string subjectMemberName)
+        {
+            if (Regex.IsMatch(expectationMemberName, @"[\.\[\]]"))
+            {
+                throw new ArgumentException("The expectation's member name cannot be a nested path");
+            }
+
+            if (Regex.IsMatch(subjectMemberName, $@"[\.\[\]]"))
+            {
+                throw new ArgumentException("The subject's member name cannot be a nested path");
+            }
+
+            this.expectationMemberName = expectationMemberName;
+            this.subjectMemberName = subjectMemberName;
+        }
+
+        public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions options)
+        {
+            if (parent.Type.IsSameOrInherits(typeof(TExpectation)) && subject is TSubject)
+            {
+                if (expectedMember.Name == expectationMemberName)
+                {
+                    var member = MemberFactory.Find(subject, subjectMemberName, expectedMember.Type, parent);
+                    if (member is null)
+                    {
+                        throw new ArgumentException(
+                            $"Subject of type {typeof(TSubject)} does not have member {subjectMemberName}");
+                    }
+
+                    return member;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/Matching/MappedPathMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedPathMatchingRule.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using FluentAssertions.Common;
+
+namespace FluentAssertions.Equivalency.Matching
+{
+    /// <summary>
+    /// Allows mapping a member (property or field) of the expectation to a differently named member
+    /// of the subject-under-test using a nested member path in the form of "Parent.NestedCollection[].Member"
+    /// </summary>
+    internal class MappedPathMatchingRule : IMemberMatchingRule
+    {
+        private readonly MemberPath expectationPath;
+        private readonly MemberPath subjectPath;
+
+        public MappedPathMatchingRule(string expectationMemberPath, string subjectMemberPath)
+        {
+            expectationPath = new MemberPath(expectationMemberPath);
+            subjectPath = new MemberPath(subjectMemberPath);
+
+            if (expectationPath.GetContainsSpecificCollectionIndex() || subjectPath.GetContainsSpecificCollectionIndex())
+            {
+                throw new ArgumentException("Mapping properties containing a collection index must use the [] format without specific index.");
+            }
+
+            if (!expectationPath.HasSameParentAs(subjectPath))
+            {
+                throw new ArgumentException("The member paths must have the same parent.");
+            }
+        }
+
+        public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions options)
+        {
+            if (expectationPath.IsEquivalentTo(expectedMember.PathAndName))
+            {
+                var member = MemberFactory.Find(subject, subjectPath.MemberName, expectedMember.Type, parent);
+                if (member is null)
+                {
+                    throw new ArgumentException(
+                        $"Subject of type {subject?.GetType().Name} does not have member {subjectPath.MemberName}");
+                }
+
+                return member;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/MemberFactory.cs
+++ b/Src/FluentAssertions/Equivalency/MemberFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency
 {
@@ -18,6 +19,18 @@ namespace FluentAssertions.Equivalency
             }
 
             throw new NotSupportedException($"Don't know how to deal with a {memberInfo.MemberType}");
+        }
+
+        internal static IMember Find(object target, string memberName, Type preferredMemberType, INode parent)
+        {
+            PropertyInfo property = target.GetType().FindProperty(memberName, preferredMemberType);
+            if ((property is not null) && !property.IsIndexer())
+            {
+                return new Property(property, parent);
+            }
+
+            FieldInfo field = target.GetType().FindField(memberName, preferredMemberType);
+            return (field is not null) ? new Field(field, parent) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Equivalency/Node.cs
@@ -21,7 +21,7 @@ namespace FluentAssertions.Equivalency
 
         public string PathAndName => Path.Combine(Name);
 
-        public string Name { get; protected set; }
+        public string Name { get; set; }
 
         public virtual string Description => $"{GetSubjectId().Combine(PathAndName)}";
 

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -822,7 +822,7 @@ namespace FluentAssertions.Equivalency
             return (TSelf)this;
         }
 
-        private TSelf AddMatchingRule(IMemberMatchingRule matchingRule)
+        protected TSelf AddMatchingRule(IMemberMatchingRule matchingRule)
         {
             matchingRules.Insert(0, matchingRule);
             return (TSelf)this;

--- a/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
@@ -62,6 +62,13 @@ namespace FluentAssertions.Equivalency.Steps
                     CompileTimeType = selectedMember.Type
                 };
 
+                if (selectedMember.Name != matchingMember.Name)
+                {
+                    // In case the matching process selected a different member on the subject,
+                    // adjust the current member so that assertion failures report the proper name.
+                    selectedMember.Name = matchingMember.Name;
+                }
+
                 parent.RecursivelyAssertEquality(nestedComparands, context.AsNestedMember(selectedMember));
             }
         }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -756,6 +756,10 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping(string expectationMemberPath, string subjectMemberPath) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TSubject>(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expectationMemberPath, System.Linq.Expressions.Expression<System.Func<TSubject, object>> subjectMemberPath) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(System.Linq.Expressions.Expression<System.Func<TNestedExpectation, object>> expectationMember, System.Linq.Expressions.Expression<System.Func<TNestedSubject, object>> subjectMember) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(string expectationMemberName, string subjectMemberName) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
     }
     public enum EquivalencyResult
@@ -880,7 +884,7 @@ namespace FluentAssertions.Equivalency
         string Description { get; }
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
-        string Name { get; }
+        string Name { get; set; }
         string Path { get; }
         string PathAndName { get; }
         bool RootIsCollection { get; }
@@ -968,6 +972,7 @@ namespace FluentAssertions.Equivalency
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        protected TSelf AddMatchingRule(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
         public TSelf ComparingByMembers(System.Type type) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -756,6 +756,10 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping(string expectationMemberPath, string subjectMemberPath) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TSubject>(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expectationMemberPath, System.Linq.Expressions.Expression<System.Func<TSubject, object>> subjectMemberPath) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(System.Linq.Expressions.Expression<System.Func<TNestedExpectation, object>> expectationMember, System.Linq.Expressions.Expression<System.Func<TNestedSubject, object>> subjectMember) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(string expectationMemberName, string subjectMemberName) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
     }
     public enum EquivalencyResult
@@ -880,7 +884,7 @@ namespace FluentAssertions.Equivalency
         string Description { get; }
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
-        string Name { get; }
+        string Name { get; set; }
         string Path { get; }
         string PathAndName { get; }
         bool RootIsCollection { get; }
@@ -968,6 +972,7 @@ namespace FluentAssertions.Equivalency
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        protected TSelf AddMatchingRule(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
         public TSelf ComparingByMembers(System.Type type) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -756,6 +756,10 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping(string expectationMemberPath, string subjectMemberPath) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TSubject>(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expectationMemberPath, System.Linq.Expressions.Expression<System.Func<TSubject, object>> subjectMemberPath) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(System.Linq.Expressions.Expression<System.Func<TNestedExpectation, object>> expectationMember, System.Linq.Expressions.Expression<System.Func<TNestedSubject, object>> subjectMember) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(string expectationMemberName, string subjectMemberName) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
     }
     public enum EquivalencyResult
@@ -880,7 +884,7 @@ namespace FluentAssertions.Equivalency
         string Description { get; }
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
-        string Name { get; }
+        string Name { get; set; }
         string Path { get; }
         string PathAndName { get; }
         bool RootIsCollection { get; }
@@ -968,6 +972,7 @@ namespace FluentAssertions.Equivalency
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        protected TSelf AddMatchingRule(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
         public TSelf ComparingByMembers(System.Type type) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -749,6 +749,10 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping(string expectationMemberPath, string subjectMemberPath) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TSubject>(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expectationMemberPath, System.Linq.Expressions.Expression<System.Func<TSubject, object>> subjectMemberPath) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(System.Linq.Expressions.Expression<System.Func<TNestedExpectation, object>> expectationMember, System.Linq.Expressions.Expression<System.Func<TNestedSubject, object>> subjectMember) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(string expectationMemberName, string subjectMemberName) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
     }
     public enum EquivalencyResult
@@ -873,7 +877,7 @@ namespace FluentAssertions.Equivalency
         string Description { get; }
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
-        string Name { get; }
+        string Name { get; set; }
         string Path { get; }
         string PathAndName { get; }
         bool RootIsCollection { get; }
@@ -961,6 +965,7 @@ namespace FluentAssertions.Equivalency
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        protected TSelf AddMatchingRule(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
         public TSelf ComparingByMembers(System.Type type) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -756,6 +756,10 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping(string expectationMemberPath, string subjectMemberPath) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TSubject>(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expectationMemberPath, System.Linq.Expressions.Expression<System.Func<TSubject, object>> subjectMemberPath) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(System.Linq.Expressions.Expression<System.Func<TNestedExpectation, object>> expectationMember, System.Linq.Expressions.Expression<System.Func<TNestedSubject, object>> subjectMember) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(string expectationMemberName, string subjectMemberName) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
     }
     public enum EquivalencyResult
@@ -880,7 +884,7 @@ namespace FluentAssertions.Equivalency
         string Description { get; }
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
-        string Name { get; }
+        string Name { get; set; }
         string Path { get; }
         string PathAndName { get; }
         bool RootIsCollection { get; }
@@ -968,6 +972,7 @@ namespace FluentAssertions.Equivalency
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        protected TSelf AddMatchingRule(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
         public TSelf ComparingByMembers(System.Type type) { }

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -16,18 +16,6 @@ namespace FluentAssertions.Specs.Equivalency
 {
     public class BasicEquivalencySpecs
     {
-        public enum LocalOtherType : byte
-        {
-            Default,
-            NonDefault
-        }
-
-        public enum LocalType : byte
-        {
-            Default,
-            NonDefault
-        }
-
         #region General
 
         [Fact]
@@ -745,6 +733,18 @@ namespace FluentAssertions.Specs.Equivalency
         #endregion
 
         #region Selection Rules
+
+        public enum LocalOtherType : byte
+        {
+            Default,
+            NonDefault
+        }
+
+        public enum LocalType : byte
+        {
+            Default,
+            NonDefault
+        }
 
         [Fact]
         public void When_specific_properties_have_been_specified_it_should_ignore_the_other_properties()
@@ -2155,8 +2155,6 @@ namespace FluentAssertions.Specs.Equivalency
 
 #endif
 
-        #endregion
-
         public interface IInterfaceWithTwoProperties
         {
             int Value1 { get; set; }
@@ -2214,6 +2212,8 @@ namespace FluentAssertions.Specs.Equivalency
                 .Including(a => a.Value2)
                 .RespectingRuntimeTypes());
         }
+
+        #endregion
 
         #region Matching Rules
 
@@ -3461,6 +3461,576 @@ namespace FluentAssertions.Specs.Equivalency
         }
 
         #endregion
+
+        public class MemberMapping
+        {
+            [Fact]
+            public void Nested_properties_can_be_mapped_using_a_nested_expression()
+            {
+                // Arrange
+                var subject = new ParentOfSubjectWithProperty1(new[]
+                {
+                    new SubjectWithProperty1
+                    {
+                        Property1 = "Hello"
+                    }
+                });
+
+                var expectation = new ParentOfExpectationWithProperty2(new[]
+                {
+                    new ExpectationWithProperty2
+                    {
+                        Property2 = "Hello"
+                    }
+                });
+
+                // Act / Assert
+                subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping<ParentOfSubjectWithProperty1>(
+                            e => e.Parent[0].Property2,
+                            s => s.Parent[0].Property1));
+            }
+
+            [Fact]
+            public void Nested_properties_can_be_mapped_using_a_nested_type_and_property_names()
+            {
+                // Arrange
+                var subject = new ParentOfSubjectWithProperty1(new[]
+                {
+                    new SubjectWithProperty1
+                    {
+                        Property1 = "Hello"
+                    }
+                });
+
+                var expectation = new ParentOfExpectationWithProperty2(new[]
+                {
+                    new ExpectationWithProperty2
+                    {
+                        Property2 = "Hello"
+                    }
+                });
+
+                // Act / Assert
+                subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping<ExpectationWithProperty2, SubjectWithProperty1>("Property2", "Property1"));
+            }
+
+            [Fact]
+            public void Nested_fields_can_be_mapped_using_a_nested_type_and_field_names()
+            {
+                // Arrange
+                var subject = new ClassWithSomeFieldsAndProperties
+                {
+                    Field1 = "John",
+                    Field2 = "Mary"
+                };
+
+                var expectation = new ClassWithSomeFieldsAndProperties
+                {
+                    Field1 = "Mary",
+                    Field2 = "John"
+                };
+
+                // Act / Assert
+                subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping<ClassWithSomeFieldsAndProperties, ClassWithSomeFieldsAndProperties>("Field1", "Field2")
+                        .WithMapping<ClassWithSomeFieldsAndProperties, ClassWithSomeFieldsAndProperties>("Field2", "Field1"));
+            }
+
+            [Fact]
+            public void Nested_properties_can_be_mapped_using_a_nested_type_and_a_property_expression()
+            {
+                // Arrange
+                var subject = new ParentOfSubjectWithProperty1(new[]
+                {
+                    new SubjectWithProperty1
+                    {
+                        Property1 = "Hello"
+                    }
+                });
+
+                var expectation = new ParentOfExpectationWithProperty2(new[]
+                {
+                    new ExpectationWithProperty2
+                    {
+                        Property2 = "Hello"
+                    }
+                });
+
+                // Act / Assert
+                subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping<ExpectationWithProperty2, SubjectWithProperty1>(
+                            e => e.Property2, s => s.Property1));
+            }
+
+            [Fact]
+            public void Nested_properties_on_a_collection_can_be_mapped_using_a_dotted_path()
+            {
+                // Arrange
+                var subject = new
+                {
+                    Parent = new[]
+                    {
+                        new SubjectWithProperty1
+                        {
+                            Property1 = "Hello"
+                        }
+                    }
+                };
+
+                var expectation = new
+                {
+                    Parent = new[]
+                    {
+                        new ExpectationWithProperty2
+                        {
+                            Property2 = "Hello"
+                        }
+                    }
+                };
+
+                // Act / Assert
+                subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping("Parent[].Property2", "Parent[].Property1"));
+            }
+
+            [Fact]
+            public void Properties_can_be_mapped_by_name()
+            {
+                // Arrange
+                var subject = new SubjectWithProperty1
+                {
+                    Property1 = "Hello"
+                };
+
+                var expectation = new ExpectationWithProperty2
+                {
+                    Property2 = "Hello"
+                };
+
+                // Act / Assert
+                subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                    .WithMapping("Property2", "Property1"));
+            }
+
+            [Fact]
+            public void Fields_can_be_mapped_by_name()
+            {
+                // Arrange
+                var subject = new ClassWithSomeFieldsAndProperties
+                {
+                    Field1 = "Hello",
+                    Field2 = "John"
+                };
+
+                var expectation = new ClassWithSomeFieldsAndProperties
+                {
+                    Field1 = "John",
+                    Field2 = "Hello"
+                };
+
+                // Act / Assert
+                subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                    .WithMapping("Field2", "Field1")
+                    .WithMapping("Field1", "Field2"));
+            }
+
+            [Fact]
+            public void Fields_can_be_mapped_to_a_property_by_name()
+            {
+                // Arrange
+                var subject = new ClassWithSomeFieldsAndProperties
+                {
+                    Property1 = "John"
+                };
+
+                var expectation = new ClassWithSomeFieldsAndProperties
+                {
+                    Field1 = "John",
+                };
+
+                // Act / Assert
+                subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping("Field1", "Property1")
+                        .Including(e => e.Field1));
+            }
+
+            [Fact]
+            public void Properties_can_be_mapped_to_a_field_by_expression()
+            {
+                // Arrange
+                var subject = new ClassWithSomeFieldsAndProperties
+                {
+                     Field1 = "John",
+                };
+
+                var expectation = new ClassWithSomeFieldsAndProperties
+                {
+                    Property1 = "John"
+                };
+
+                // Act / Assert
+                subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                    .WithMapping<ClassWithSomeFieldsAndProperties>(e => e.Property1, s => s.Field1)
+                    .Including(e => e.Property1));
+            }
+
+            [Fact]
+            public void Properties_can_be_mapped_to_inherited_properties()
+            {
+                // Arrange
+                var subject = new Derived
+                {
+                     BaseProperty = "Hello World"
+                };
+
+                var expectation = new
+                {
+                    AnotherProperty = "Hello World"
+                };
+
+                // Act / Assert
+                subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                    .WithMapping<Derived>(e => e.AnotherProperty, s => s.BaseProperty));
+            }
+
+            [Fact]
+            public void A_failed_assertion_reports_the_subjects_mapped_property()
+            {
+                // Arrange
+                var subject = new SubjectWithProperty1
+                {
+                    Property1 = "Hello"
+                };
+
+                var expectation = new ExpectationWithProperty2
+                {
+                    Property2 = "Hello2"
+                };
+
+                // Act
+                Action act = () => subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                    .WithMapping<SubjectWithProperty1>(e => e.Property2, e => e.Property1));
+
+                // Assert
+                act.Should()
+                    .Throw<XunitException>()
+                    .WithMessage("Expected property subject.Property1 to be*Hello*");
+            }
+
+            [Fact]
+            public void An_empty_expectation_member_path_is_not_allowed()
+            {
+                var subject = new SubjectWithProperty1();
+                var expectation = new ExpectationWithProperty2();
+
+                // Act
+                Action act = () => subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping("", "Parent[0].Property1"));
+
+                // Assert
+                act.Should()
+                    .Throw<ArgumentException>()
+                    .WithMessage("*member path*");
+            }
+
+            [Fact]
+            public void An_empty_subject_member_path_is_not_allowed()
+            {
+                var subject = new SubjectWithProperty1();
+                var expectation = new ExpectationWithProperty2();
+
+                // Act
+                Action act = () => subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping("Parent[0].Property1", ""));
+
+                // Assert
+                act.Should()
+                    .Throw<ArgumentException>()
+                    .WithMessage("*member path*");
+            }
+
+            [Fact]
+            public void Null_as_the_expectation_member_path_is_not_allowed()
+            {
+                var subject = new SubjectWithProperty1();
+                var expectation = new ExpectationWithProperty2();
+
+                // Act
+                Action act = () => subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping(null, "Parent[0].Property1"));
+
+                // Assert
+                act.Should()
+                    .Throw<ArgumentException>()
+                    .WithMessage("*member path*");
+            }
+
+            [Fact]
+            public void Null_as_the_subject_member_path_is_not_allowed()
+            {
+                var subject = new SubjectWithProperty1();
+                var expectation = new ExpectationWithProperty2();
+
+                // Act
+                Action act = () => subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping("Parent[0].Property1", null));
+
+                // Assert
+                act.Should()
+                    .Throw<ArgumentException>()
+                    .WithMessage("*member path*");
+            }
+
+            [Fact]
+            public void Subject_and_expectation_member_paths_must_have_the_same_parent()
+            {
+                var subject = new SubjectWithProperty1();
+                var expectation = new ExpectationWithProperty2();
+
+                // Act
+                Action act = () => subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping("Parent[].Property1", "OtherParent[].Property2"));
+
+                // Assert
+                act.Should()
+                    .Throw<ArgumentException>()
+                    .WithMessage("*parent*");
+            }
+
+            [Fact]
+            public void Numeric_indexes_in_the_path_are_not_allowed()
+            {
+                var subject = new
+                {
+                    Parent = new[]
+                    {
+                        new SubjectWithProperty1
+                        {
+                            Property1 = "Hello"
+                        }
+                    }
+                };
+
+                var expectation = new
+                {
+                    Parent = new[]
+                    {
+                        new ExpectationWithProperty2
+                        {
+                            Property2 = "Hello"
+                        }
+                    }
+                };
+
+                // Act
+                Action act = () => subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping("Parent[0].Property2", "Parent[0].Property1"));
+
+                // Assert
+                act.Should()
+                    .Throw<ArgumentException>()
+                    .WithMessage("*without specific index*");
+            }
+
+            [Fact]
+            public void Mapping_to_a_non_existing_subject_member_is_not_allowed()
+            {
+                // Arrange
+                var subject = new SubjectWithProperty1
+                {
+                    Property1 = "Hello"
+                };
+
+                var expectation = new ExpectationWithProperty2
+                {
+                    Property2 = "Hello"
+                };
+
+                // Act
+                Action act = () => subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping("Property2", "NonExistingProperty"));
+
+                // Assert
+                act.Should()
+                    .Throw<ArgumentException>()
+                    .WithMessage("*not have member NonExistingProperty*");
+            }
+
+            [Fact]
+            public void A_null_subject_should_result_in_a_normal_assertion_failure()
+            {
+                // Arrange
+                SubjectWithProperty1 subject = null;
+
+                ExpectationWithProperty2 expectation = new()
+                {
+                    Property2 = "Hello"
+                };
+
+                // Act
+                Action act = () => subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping("Property2", "Property1"));
+
+                // Assert
+                act.Should()
+                    .Throw<XunitException>()
+                    .WithMessage("*Expected*ExpectationWithProperty2*found <null>*");
+            }
+
+            [Fact]
+            public void Nested_types_and_dotted_expectation_member_paths_cannot_be_combined()
+            {
+                // Arrange
+                var subject = new ParentOfSubjectWithProperty1(new[]
+                {
+                    new SubjectWithProperty1
+                    {
+                        Property1 = "Hello"
+                    }
+                });
+
+                var expectation = new ParentOfExpectationWithProperty2(new[]
+                {
+                    new ExpectationWithProperty2
+                    {
+                        Property2 = "Hello"
+                    }
+                });
+
+                // Act
+                Action act = () => subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping<ExpectationWithProperty2, SubjectWithProperty1>("Parent.Property2", "Property1"));
+
+                // Assert
+                act.Should()
+                    .Throw<ArgumentException>()
+                    .WithMessage("*cannot be a nested path*");
+            }
+
+            [Fact]
+            public void Nested_types_and_dotted_subject_member_paths_cannot_be_combined()
+            {
+                // Arrange
+                var subject = new ParentOfSubjectWithProperty1(new[]
+                {
+                    new SubjectWithProperty1
+                    {
+                        Property1 = "Hello"
+                    }
+                });
+
+                var expectation = new ParentOfExpectationWithProperty2(new[]
+                {
+                    new ExpectationWithProperty2
+                    {
+                        Property2 = "Hello"
+                    }
+                });
+
+                // Act
+                Action act = () => subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping<ExpectationWithProperty2, SubjectWithProperty1>("Property2", "Parent.Property1"));
+
+                // Assert
+                act.Should()
+                    .Throw<ArgumentException>()
+                    .WithMessage("*cannot be a nested path*");
+            }
+
+            [Fact]
+            public void The_member_name_on_a_nested_type_mapping_must_be_a_valid_member()
+            {
+                // Arrange
+                var subject = new ParentOfSubjectWithProperty1(new[]
+                {
+                    new SubjectWithProperty1
+                    {
+                        Property1 = "Hello"
+                    }
+                });
+
+                var expectation = new ParentOfExpectationWithProperty2(new[]
+                {
+                    new ExpectationWithProperty2
+                    {
+                        Property2 = "Hello"
+                    }
+                });
+
+                // Act
+                Action act = () => subject.Should()
+                    .BeEquivalentTo(expectation, opt => opt
+                        .WithMapping<ExpectationWithProperty2, SubjectWithProperty1>("Property2", "NonExistingProperty"));
+
+                // Assert
+                act.Should()
+                    .Throw<ArgumentException>()
+                    .WithMessage("*does not have member NonExistingProperty*");
+            }
+
+            internal class ParentOfExpectationWithProperty2
+            {
+                public ExpectationWithProperty2[] Parent { get; }
+
+                public ParentOfExpectationWithProperty2(ExpectationWithProperty2[] parent)
+                {
+                    Parent = parent;
+                }
+            }
+
+            internal class ParentOfSubjectWithProperty1
+            {
+                public SubjectWithProperty1[] Parent { get; }
+
+                public ParentOfSubjectWithProperty1(SubjectWithProperty1[] parent)
+                {
+                    Parent = parent;
+                }
+            }
+
+            internal class SubjectWithProperty1
+            {
+                public string Property1 { get; set; }
+            }
+
+            internal class ExpectationWithProperty2
+            {
+                public string Property2 { get; set; }
+            }
+
+            internal class Base
+            {
+                public string BaseProperty { get; set; }
+            }
+
+            internal class Derived : Base
+            {
+                public string DerivedProperty { get; set; }
+            }
+        }
 
         #region Cyclic References
 

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -174,6 +174,48 @@ orderDto.Should().BeEquivalentTo(order, options => options
 
 This configuration affects the initial inclusion of members and happens before any `Exclude`s or other `IMemberSelectionRule`s. This configuration also affects matching. For example, that if properties are excluded, properties will not be inspected when looking for a match on the expected object.
 
+### Comparing members with different names
+
+Imagine you want to compare an `Order` and an `OrderDto` using `BeEquivalentTo`, but the first type has a `Name` property and the second has a `OrderName` property. You can map those using the following option:
+
+```csharp
+// Using names with the expectation member name first. Then the subject's member name.
+orderDto.Should().BeEquivalentTo(order, options => options
+    .WithMapping("Name", "OrderName"));
+
+// Using expressions, but again, with expectation first, subject last.
+orderDto.Should().BeEquivalentTo(order, options => options
+    .WithMapping<OrderDto>(e => e.Name, s => s.OrderName));
+```
+
+Another option is to map two deeply nested members to each other. In that case, your path must start at the root:
+
+```csharp
+// Using dotted property paths 
+rootSubject.Should().BeEquivalentTo(rootExpectation, options => options
+    .WithMapping("Parent.Collection[].Member", "Parent.Collection[].Member"));
+
+// Using expressions
+rootSubject.Should().BeEquivalentTo(rootExpectation, options => options
+    .WithMapping<SubjectType>(e => e.Parent.Collection[0].Member, s => s.Parent.Collection[0].Member));
+```
+
+Note that collection indices in string-based paths are not allowed. Within expressions, you must use an index to make it a valid property path, but it'll be ignored. So both the examples are equivalent. Also, such nested paths must have the same parent. So mapping properties or fields at different levels is not (yet) supported.
+
+Now imagine those types appear somewhere in the object graph. Then you can use this overload:
+
+```csharp
+// Using names
+orderDto.Should().BeEquivalentTo(order, options => options
+    .WithMapping<Order, OrderDto>("Name", "OrderName"));
+
+// Using expressions
+orderDto.Should().BeEquivalentTo(order, options => options
+    .WithMapping<Order, OrderDto>(e => e.Name, s => s.OrderName));
+```
+
+Notice that you can also map properties to fields and vice-versa.
+
 ### Equivalency Comparison Behavior
 
 In addition to influencing the members that are including in the comparison, you can also override the actual assertion operation that is executed on a particular member.

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,8 @@ sidebar:
 
 ### What's New
 
+* Added `WithMapping` option to `BeEquivalentTo` to map members with different names between the subject and expectation - [#1742](https://github.com/fluentassertions/fluentassertions/pull/1742)
+
 ### Fixes
 
 ## 6.4.0


### PR DESCRIPTION
Closes #535 

* [x] Release notes
* [x] Documentation examples
* [x] XML docs on `WithMapping` overloads