### PR TITLE
Properly recognized non-class types as internal when using HaveAccessModifier assertion

### DIFF
--- a/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
+++ b/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
@@ -87,7 +87,7 @@ namespace FluentAssertions.Common
                 return CSharpAccessModifier.Protected;
             }
 
-            if (type.IsNestedAssembly || (type.IsClass && type.IsNotPublic))
+            if (type.IsNestedAssembly || type.IsNotPublic)
             {
                 return CSharpAccessModifier.Internal;
             }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveAccessModifier.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveAccessModifier.cs
@@ -59,6 +59,36 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
+        public void When_asserting_an_internal_member_is_internal_it_succeeds()
+        {
+            // Arrange
+            Type type = typeof(IInternalInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_an_internal_member_is_protected_internal_it_throws()
+        {
+            // Arrange
+            Type type = typeof(IInternalInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveAccessModifier(
+                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type IInternalInterface to be ProtectedInternal *failure message*, but it is Internal.");
+        }
+
+        [Fact]
         public void When_asserting_an_internal_type_is_protected_internal_it_throws()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -136,6 +136,8 @@ namespace FluentAssertions.Specs.Types
 
     public interface IPublicInterface { }
 
+    internal interface IInternalInterface { }
+
     internal class InternalClass { }
 
     internal class Nested

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,6 +14,8 @@ sidebar:
 
 ### Fixes
 
+* Resolve an issue preventing HaveAccessModifier from correctly recognizing internal interfaces and enums - [#1741](https://github.com/fluentassertions/fluentassertions/issues/1741)
+
 ## 6.2.0
 
 ### What's New


### PR DESCRIPTION
Removes `IsClass` check preventing enums and interfaces from being recognized as internal types when not nested.

Fixes #1741 

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).