### PR TITLE
Adds ThatAre(Not)Virtual to MethodInfoSelector

### DIFF
--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -152,6 +152,24 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
+        /// Only return methods that are virtual. 
+        /// </summary>
+        public MethodInfoSelector ThatAreVirtual()
+        {
+            selectedMethods = selectedMethods.Where(method => !method.IsNonVirtual());
+            return this;
+        }
+
+        /// <summary>
+        /// Only return methods that are not virtual. 
+        /// </summary>
+        public MethodInfoSelector ThatAreNotVirtual()
+        {
+            selectedMethods = selectedMethods.Where(method => method.IsNonVirtual());
+            return this;
+        }
+
+        /// <summary>
         /// Select return types of the methods
         /// </summary>
         public TypeSelector ReturnTypes()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2351,6 +2351,8 @@ namespace FluentAssertions.Types
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
         public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
         public System.Reflection.MethodInfo[] ToArray() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -2353,6 +2353,8 @@ namespace FluentAssertions.Types
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
         public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
         public System.Reflection.MethodInfo[] ToArray() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -2353,6 +2353,8 @@ namespace FluentAssertions.Types
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
         public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
         public System.Reflection.MethodInfo[] ToArray() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2304,6 +2304,8 @@ namespace FluentAssertions.Types
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
         public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
         public System.Reflection.MethodInfo[] ToArray() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2353,6 +2353,8 @@ namespace FluentAssertions.Types
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
         public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
         public System.Reflection.MethodInfo[] ToArray() { }

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -302,6 +302,38 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
+        public void When_selecting_methods_that_are_virtual_it_should_only_return_the_applicable_methods()
+        {
+            // Arrange
+            Type type = typeof(TestClassForMethodSelector);
+
+            // Act
+            MethodInfo[] methods = type.Methods().ThatAreVirtual().ToArray();
+
+            // Assert
+            methods.Should()
+                .NotBeEmpty()
+                .And.Contain(m => m.Name == "PublicVirtualVoidMethodWithAttribute")
+                .And.Contain(m => m.Name == "ProtectedVirtualVoidMethodWithAttribute");
+        }
+
+        [Fact]
+        public void When_selecting_methods_that_are_not_virtual_it_should_only_return_the_applicable_methods()
+        {
+            // Arrange
+            Type type = typeof(TestClassForMethodSelector);
+
+            // Act
+            MethodInfo[] methods = type.Methods().ThatAreNotVirtual().ToArray();
+
+            // Assert
+            methods.Should()
+                .NotBeEmpty()
+                .And.NotContain(m => m.Name == "PublicVirtualVoidMethodWithAttribute")
+                .And.NotContain(m => m.Name == "ProtectedVirtualVoidMethodWithAttribute");
+        }
+
+        [Fact]
         public void When_selecting_methods_not_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_methods()
         {
             // Arrange

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,7 +11,7 @@ sidebar:
 
 ### What's New
 * Adding `ThatAreAsync()` and `ThatAreNotAsync()` for filtering in method assertions - [#1725](https://github.com/fluentassertions/fluentassertions/pull/1725)
-
+* Adding `ThatAreVirtual()` and `ThatAreNotVirtual()` for filtering in method assertions - [#1744](https://github.com/fluentassertions/fluentassertions/pull/1744)
 ### Fixes
 
 ## 6.2.0


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).