### PR TITLE
Replace non-generic collection examples with generic collections in documentation

### DIFF
--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -11,7 +11,7 @@ A collection object in .NET is so versatile that the number of assertions on the
 Most, if not all, are so self-explanatory that we'll just list them here.
 
 ```csharp
-IEnumerable collection = new[] { 1, 2, 5, 8 };
+IEnumerable<int> collection = new[] { 1, 2, 5, 8 };
 
 collection.Should().NotBeEmpty()
     .And.HaveCount(4)
@@ -76,8 +76,8 @@ collection.Should().BeEmpty();
 collection.Should().BeNullOrEmpty();
 collection.Should().NotBeNullOrEmpty();
 
-IEnumerable otherCollection = new[] { 1, 2, 5, 8, 1 };
-IEnumerable anotherCollection = new[] { 10, 20, 50, 80, 10 };
+IEnumerable<int> otherCollection = new[] { 1, 2, 5, 8, 1 };
+IEnumerable<int> anotherCollection = new[] { 10, 20, 50, 80, 10 };
 collection.Should().IntersectWith(otherCollection);
 collection.Should().NotIntersectWith(anotherCollection);
 ```


### PR DESCRIPTION
Support for non-generic collections was dropped as part of a breaking change in version 6.0. This causes some of the examples presented in the collections documentation to no longer be valid examples.

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).