### PR TITLE
Prevent multiple enumeration in `ContainSingle()`

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1014,7 +1014,7 @@ namespace FluentAssertions.Collections
                             .FailWith("Expected {context:collection} to contain a single item{reason}, but the collection is empty.");
                         break;
                     case 1: // Success Condition
-                        match = actualItems.SingleOrDefault();
+                        match = actualItems.Single();
                         break;
                     default: // Fail, Collection contains more than a single item
                         Execute.Assertion

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1005,7 +1005,8 @@ namespace FluentAssertions.Collections
 
             if (success)
             {
-                switch (Subject.Count())
+                ICollection<T> actualItems = Subject.ConvertOrCastToCollection();
+                switch (actualItems.Count)
                 {
                     case 0: // Fail, Collection is empty
                         Execute.Assertion
@@ -1013,7 +1014,7 @@ namespace FluentAssertions.Collections
                             .FailWith("Expected {context:collection} to contain a single item{reason}, but the collection is empty.");
                         break;
                     case 1: // Success Condition
-                        match = Subject.SingleOrDefault();
+                        match = actualItems.SingleOrDefault();
                         break;
                     default: // Fail, Collection contains more than a single item
                         Execute.Assertion

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
@@ -246,6 +246,34 @@ namespace FluentAssertions.Specs.Collections
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
 
+        [Fact]
+        public void When_collection_is_IEnumerable_it_should_be_evaluated_only_once_with_predicate()
+        {
+            // Arrange
+            int evalCount = 0;
+            IEnumerable<int> collection = new[] { 1 }.Select(_ => evalCount++);
+
+            // Act
+            collection.Should().ContainSingle(_ => true);
+
+            // Assert
+            evalCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void When_collection_is_IEnumerable_it_should_be_evaluated_only_once()
+        {
+            // Arrange
+            int evalCount = 0;
+            IEnumerable<int> collection = new[] { 1 }.Select(_ => evalCount++);
+
+            // Act
+            collection.Should().ContainSingle();
+
+            // Assert
+            evalCount.Should().Be(1);
+        }
+
         #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
@@ -250,28 +250,26 @@ namespace FluentAssertions.Specs.Collections
         public void When_collection_is_IEnumerable_it_should_be_evaluated_only_once_with_predicate()
         {
             // Arrange
-            int evalCount = 0;
-            IEnumerable<int> collection = new[] { 1 }.Select(_ => evalCount++);
+            IEnumerable<int> collection = new OneTimeEnumerable<int>(1);
 
             // Act
-            collection.Should().ContainSingle(_ => true);
+            Action act = () => collection.Should().ContainSingle(_ => true);
 
             // Assert
-            evalCount.Should().Be(1);
+            act.Should().NotThrow();
         }
 
         [Fact]
         public void When_collection_is_IEnumerable_it_should_be_evaluated_only_once()
         {
             // Arrange
-            int evalCount = 0;
-            IEnumerable<int> collection = new[] { 1 }.Select(_ => evalCount++);
+            IEnumerable<int> collection = new OneTimeEnumerable<int>(1);
 
             // Act
-            collection.Should().ContainSingle();
+            Action act = () => collection.Should().ContainSingle();
 
             // Assert
-            evalCount.Should().Be(1);
+            act.Should().NotThrow();
         }
 
         #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,7 @@ sidebar:
 * Adding `ThatAreAsync()` and `ThatAreNotAsync()` for filtering in method assertions - [#1725](https://github.com/fluentassertions/fluentassertions/pull/1725)
 * Adding `ThatAreVirtual()` and `ThatAreNotVirtual()` for filtering in method assertions - [#1744](https://github.com/fluentassertions/fluentassertions/pull/1744)
 ### Fixes
+* Prevent multiple enumeration of `IEnuermable`s in parameter-less `ContainSingle()` - [#1752](https://github.com/fluentassertions/fluentassertions/issues/1752)
 
 ## 6.2.0
 
@@ -27,7 +28,7 @@ sidebar:
 * `At` now retains the `DateTimeKind` and keeps sub-second precision when using a `TimeSpan` - [#1687](https://github.com/fluentassertions/fluentassertions/pull/1687).
 * Removed iteration over enumerable when generating the `BeEmpty` assertion failure message - [#1692](https://github.com/fluentassertions/fluentassertions/pull/1692).
 * Prevent `ArgumentNullException` when formatting a lambda expression containing an extension method - [#1696](https://github.com/fluentassertions/fluentassertions/pull/1696)
-* `IgnoringCyclicReferences` in `BeEquivalentTo` now works while comparing value types using `ComparingByMembers` - [#1708](https://github.com/fluentassertions/fluentassertions/pull/1708) 
+* `IgnoringCyclicReferences` in `BeEquivalentTo` now works while comparing value types using `ComparingByMembers` - [#1708](https://github.com/fluentassertions/fluentassertions/pull/1708)
 * Using `BeEquivalentTo` on a collection with nested collections would complain about missing members - [#1713](https://github.com/fluentassertions/fluentassertions/pull/1713)
 * Formatting a lambda expression containing lifted operators - [#1714](https://github.com/fluentassertions/fluentassertions/pull/1714).
 * Performance improvements in `BeEquivalentTo` by caching expensive Reflection operations - [#1719](https://github.com/fluentassertions/fluentassertions/pull/1719)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,7 +13,7 @@ sidebar:
 * Adding `ThatAreAsync()` and `ThatAreNotAsync()` for filtering in method assertions - [#1725](https://github.com/fluentassertions/fluentassertions/pull/1725)
 * Adding `ThatAreVirtual()` and `ThatAreNotVirtual()` for filtering in method assertions - [#1744](https://github.com/fluentassertions/fluentassertions/pull/1744)
 ### Fixes
-* Prevent multiple enumeration of `IEnuermable`s in parameter-less `ContainSingle()` - [#1752](https://github.com/fluentassertions/fluentassertions/issues/1752)
+* Prevent multiple enumeration of `IEnumerable`s in parameter-less `ContainSingle()` - [#1752](https://github.com/fluentassertions/fluentassertions/issues/1752)
 
 ## 6.2.0
 


### PR DESCRIPTION
## IMPORTANT 

* [X] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [X] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [X] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).