### PR TITLE
Change HaveCount assertion message order to state number before dumpi…

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1299,7 +1299,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.Count())
                 .ForCondition(actualCount => actualCount >= expected)
-                .FailWith("but found {0}: {1}.", actualCount => actualCount, actualCount => Subject)
+                .FailWith("but found {0}: {1}.", actualCount => actualCount, _ => Subject)
                 .Then
                 .ClearExpectation();
 
@@ -1331,7 +1331,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.Count())
                 .ForCondition(actualCount => actualCount > expected)
-                .FailWith("but found {0}: {1}.", actualCount => actualCount, actualCount => Subject)
+                .FailWith("but found {0}: {1}.", actualCount => actualCount, _ => Subject)
                 .Then
                 .ClearExpectation();
 
@@ -1360,7 +1360,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.Count())
                 .ForCondition(actualCount => actualCount <= expected)
-                .FailWith("but found {0}: {1}.", actualCount => actualCount, actualCount => Subject)
+                .FailWith("but found {0}: {1}.", actualCount => actualCount, _ => Subject)
                 .Then
                 .ClearExpectation();
 
@@ -1392,7 +1392,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.Count())
                 .ForCondition(actualCount => actualCount < expected)
-                .FailWith("but found {0}: {1}.", actualCount => actualCount, actualCount => Subject)
+                .FailWith("but found {0}: {1}.", actualCount => actualCount, _ => Subject)
                 .Then
                 .ClearExpectation();
 
@@ -2431,7 +2431,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.ConvertOrCastToCollection())
                 .ForCondition(actualItems => !actualItems.SequenceEqual(unexpected))
-                .FailWith("Did not expect collections {0} and {1} to be equal{reason}.", actualItems => unexpected, actualItems => actualItems);
+                .FailWith("Did not expect collections {0} and {1} to be equal{reason}.", _ => unexpected, actualItems => actualItems);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -2493,7 +2493,7 @@ namespace FluentAssertions.Collections
                 .ForCondition(subject => !ReferenceEquals(subject, otherCollection))
                 .FailWith(
                     "Expected {context:collection} {0} to not have the same count as {1}{reason}, but they both reference the same object.",
-                    subject => subject, subject => otherCollection)
+                    subject => subject, _ => otherCollection)
                 .Then
                 .Given(subject => (actual: subject.Count(), expected: otherCollection.Count()))
                 .ForCondition(count => count.actual != count.expected)
@@ -2532,13 +2532,13 @@ namespace FluentAssertions.Collections
                 .ForCondition(subject => !ReferenceEquals(subject, otherCollection))
                 .FailWith(
                     "Did not expect {context:collection} {0} to intersect with {1}{reason}, but they both reference the same object.",
-                    subject => subject, subject => otherCollection)
+                    subject => subject, _ => otherCollection)
                 .Then
                 .Given(subject => subject.Intersect(otherCollection))
                 .ForCondition(sharedItems => !sharedItems.Any())
                 .FailWith(
                     "Did not expect {context:collection} to intersect with {0}{reason}, but found the following shared items {1}.",
-                    sharedItems => otherCollection, sharedItems => sharedItems);
+                    _ => otherCollection, sharedItems => sharedItems);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1299,7 +1299,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.Count())
                 .ForCondition(actualCount => actualCount >= expected)
-                .FailWith("but found {0}: {1}.", Subject.Count(), Subject)
+                .FailWith("but found {0}: {1}.", actualCount => actualCount, actualCount => Subject)
                 .Then
                 .ClearExpectation();
 
@@ -1331,7 +1331,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.Count())
                 .ForCondition(actualCount => actualCount > expected)
-                .FailWith("but found {0}: {1}.", Subject.Count(), Subject)
+                .FailWith("but found {0}: {1}.", actualCount => actualCount, actualCount => Subject)
                 .Then
                 .ClearExpectation();
 
@@ -1360,7 +1360,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.Count())
                 .ForCondition(actualCount => actualCount <= expected)
-                .FailWith("but found {0}: {1}.", Subject.Count(), Subject)
+                .FailWith("but found {0}: {1}.", actualCount => actualCount, actualCount => Subject)
                 .Then
                 .ClearExpectation();
 
@@ -1392,7 +1392,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.Count())
                 .ForCondition(actualCount => actualCount < expected)
-                .FailWith("but found {0}: {1}.", Subject.Count(), Subject)
+                .FailWith("but found {0}: {1}.", actualCount => actualCount, actualCount => Subject)
                 .Then
                 .ClearExpectation();
 

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1230,8 +1230,8 @@ namespace FluentAssertions.Collections
                     .ForCondition(actualCount == expected)
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
-                        "Expected {context:collection} {0} to contain {1} item(s){reason}, but found {2}.",
-                        Subject, expected, actualCount);
+                        "Expected {context:collection} to contain {0} item(s){reason}, but found {1}: {2}.",
+                        expected, actualCount, Subject);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -1269,8 +1269,8 @@ namespace FluentAssertions.Collections
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} {0} to have a count {1}{reason}, but count is {2}.",
-                            Subject, countPredicate.Body, actualCount);
+                        .FailWith("Expected {context:collection} to have a count {0}{reason}, but count is {1}: {2}.",
+                            countPredicate.Body, actualCount, Subject);
                 }
             }
 
@@ -1299,7 +1299,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.Count())
                 .ForCondition(actualCount => actualCount >= expected)
-                .FailWith("but found {0}.", actualCount => actualCount)
+                .FailWith("but found {0}: {1}.", Subject.Count(), Subject)
                 .Then
                 .ClearExpectation();
 
@@ -1331,7 +1331,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.Count())
                 .ForCondition(actualCount => actualCount > expected)
-                .FailWith("but found {0}.", actualCount => actualCount)
+                .FailWith("but found {0}: {1}.", Subject.Count(), Subject)
                 .Then
                 .ClearExpectation();
 
@@ -1360,7 +1360,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.Count())
                 .ForCondition(actualCount => actualCount <= expected)
-                .FailWith("but found {0}.", actualCount => actualCount)
+                .FailWith("but found {0}: {1}.", Subject.Count(), Subject)
                 .Then
                 .ClearExpectation();
 
@@ -1392,7 +1392,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => subject.Count())
                 .ForCondition(actualCount => actualCount < expected)
-                .FailWith("but found {0}.", actualCount => actualCount)
+                .FailWith("but found {0}: {1}.", Subject.Count(), Subject)
                 .Then
                 .ClearExpectation();
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCount.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCount.cs
@@ -46,7 +46,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection*1*2*3* to contain 4 item(s) because we want to test the failure message, but found 3.");
+                .WithMessage("Expected collection to contain 4 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to have a count (c >= 4) because a minimum of 4 is required, but count is 3.");
+                "Expected collection to have a count (c >= 4) because a minimum of 4 is required, but count is 3: {1, 2, 3}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThan.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThan.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*more than*3*because we want to test the failure message*3*");
+                .WithMessage("Expected collection to contain more than 3 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
@@ -46,7 +46,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*at least*4*because we want to test the failure message*3*");
+                .WithMessage("Expected collection to contain at least 4 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThan.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThan.cs
@@ -46,7 +46,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*fewer than*3*because we want to test the failure message*3*");
+                .WithMessage("Expected collection to contain fewer than 3 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
@@ -46,7 +46,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*at most*2*because we want to test the failure message*3*");
+                .WithMessage("Expected collection to contain at most 2 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1075,7 +1075,7 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection {\"one\", \"two\", \"three\"} to contain 4 item(s) because we want to test the failure message, but found 3.");
+                    "Expected collection to contain 4 item(s) because we want to test the failure message, but found 3: {\"one\", \"two\", \"three\"}.");
         }
 
         [Fact]
@@ -1089,7 +1089,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {\"one\", \"two\", \"three\"} to have a count (c >= 4) because a minimum of 4 is required, but count is 3.");
+                "Expected collection to have a count (c >= 4) because a minimum of 4 is required, but count is 3: {\"one\", \"two\", \"three\"}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -172,7 +172,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"} to contain 4 item(s) because we want to test the failure message, but found 3.");
+                .WithMessage("Expected dictionary to contain 4 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -206,7 +206,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"} to have a count (c >= 4) because a minimum of 4 is required, but count is 3.");
+                "Expected dictionary to have a count (c >= 4) because a minimum of 4 is required, but count is 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -378,7 +378,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*more than*3*because we want to test the failure message*3*");
+                .WithMessage("Expected dictionary to contain more than 3 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -447,7 +447,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*at least*4*because we want to test the failure message*3*");
+                .WithMessage("Expected dictionary to contain at least 4 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -516,7 +516,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*fewer than*3*because we want to test the failure message*3*");
+                .WithMessage("Expected dictionary to contain fewer than 3 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -585,7 +585,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*at most*2*because we want to test the failure message*3*");
+                .WithMessage("Expected dictionary to contain at most 2 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,8 +12,10 @@ sidebar:
 ### What's New
 * Adding `ThatAreAsync()` and `ThatAreNotAsync()` for filtering in method assertions - [#1725](https://github.com/fluentassertions/fluentassertions/pull/1725)
 * Adding `ThatAreVirtual()` and `ThatAreNotVirtual()` for filtering in method assertions - [#1744](https://github.com/fluentassertions/fluentassertions/pull/1744)
+* Adding collection content to assertion messages for `HaveCountGreaterThan()`, `HaveCountGreaterThanOrEqualTo()`, `HaveCountLessThan()` and `HaveCountLessThanOrEqualTo()` - [#1760](https://github.com/fluentassertions/fluentassertions/pull/1760)
 ### Fixes
 * Prevent multiple enumeration of `IEnumerable`s in parameter-less `ContainSingle()` - [#1753](https://github.com/fluentassertions/fluentassertions/pull/1753)
+* Change `HaveCount()` assertion message order to state expected and actual collection count before dumping its content` - [#1760](https://github.com/fluentassertions/fluentassertions/pull/1760)
 
 ## 6.2.0
 


### PR DESCRIPTION
…ng object contents

Fixes Issue - https://github.com/fluentassertions/fluentassertions/issues/1735

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).