### PR TITLE
Take sync work into account in CompleteWithinAsync

### DIFF
--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -46,22 +46,32 @@ namespace FluentAssertions.Specialized
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:task} to complete within {0}{reason}, but found <null>.", timeSpan);
 
-            using var timeoutCancellationTokenSource = new CancellationTokenSource();
+            ITimer timer = Clock.StartTimer();
             TTask task = Subject.Invoke();
+            TimeSpan remainingTime = timeSpan - timer.Elapsed;
 
-            Task completedTask =
-                await Task.WhenAny(task, Clock.DelayAsync(timeSpan, timeoutCancellationTokenSource.Token));
-
-            if (completedTask == task)
-            {
-                timeoutCancellationTokenSource.Cancel();
-                await completedTask;
-            }
-
-            Execute.Assertion
-                .ForCondition(completedTask == task)
+            bool success = Execute.Assertion
+                .ForCondition(remainingTime >= TimeSpan.Zero)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
+
+            if (success)
+            {
+                using var timeoutCancellationTokenSource = new CancellationTokenSource();
+                Task completedTask =
+                    await Task.WhenAny(task, Clock.DelayAsync(remainingTime, timeoutCancellationTokenSource.Token));
+
+                if (completedTask == task)
+                {
+                    timeoutCancellationTokenSource.Cancel();
+                    await completedTask;
+                }
+
+                Execute.Assertion
+                    .ForCondition(completedTask == task)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Specialized/FunctionAssertionHelpers.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertionHelpers.cs
@@ -4,7 +4,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Specialized
 {
-    internal class FunctionAssertionHelpers
+    internal static class FunctionAssertionHelpers
     {
         internal static T NotThrow<T>(Func<T> subject, string because, object[] becauseArgs)
         {

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -122,6 +122,32 @@ namespace FluentAssertions.Specs.Specialized
             await action.Should().ThrowAsync<XunitException>();
         }
 
+        [Fact]
+        public async Task Sync_work_in_async_method_is_taken_into_account()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<int>();
+
+            // Act
+            Func<Task> action = () =>
+            {
+                Func<Task<int>> func = () =>
+                {
+                    timer.Delay(101.Milliseconds());
+                    return taskFactory.Task;
+                };
+
+                return func.Should(timer).CompleteWithinAsync(100.Milliseconds());
+            };
+
+            taskFactory.SetResult(99);
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>();
+        }
+
         #endregion
 
         #region NotThrowAfterAsync

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,9 +13,11 @@ sidebar:
 * Adding `ThatAreAsync()` and `ThatAreNotAsync()` for filtering in method assertions - [#1725](https://github.com/fluentassertions/fluentassertions/pull/1725)
 * Adding `ThatAreVirtual()` and `ThatAreNotVirtual()` for filtering in method assertions - [#1744](https://github.com/fluentassertions/fluentassertions/pull/1744)
 * Adding collection content to assertion messages for `HaveCountGreaterThan()`, `HaveCountGreaterThanOrEqualTo()`, `HaveCountLessThan()` and `HaveCountLessThanOrEqualTo()` - [#1760](https://github.com/fluentassertions/fluentassertions/pull/1760)
+
 ### Fixes
 * Prevent multiple enumeration of `IEnumerable`s in parameter-less `ContainSingle()` - [#1753](https://github.com/fluentassertions/fluentassertions/pull/1753)
 * Change `HaveCount()` assertion message order to state expected and actual collection count before dumping its content` - [#1760](https://github.com/fluentassertions/fluentassertions/pull/1760)
+* `CompleteWithinAsync` did not take initial sync computation into account when measuring execution time - [1762](https://github.com/fluentassertions/fluentassertions/pull/1762).
 
 ## 6.2.0
 


### PR DESCRIPTION
If an async method has some initial sync computation, i.e. before first use of `await`, we didn't take the execution time of the sync work into account.

This fixes #1761 