### PR TITLE
`ContainItemsAssignableTo` Now Expects At Least One Item Assignable to `T`

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -946,7 +946,7 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Asserts that the current collection contains items that are assignable to the type <typeparamref name="TExpectation" />.
+        /// Asserts that the current collection contains at least one element that is assignable to the type <typeparamref name="TExpectation" />.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -957,21 +957,16 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> ContainItemsAssignableTo<TExpectation>(string because = "", params object[] becauseArgs)
         {
-            bool success = Execute.Assertion
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:collection} to contain at least one element assignable to type {0}{reason}, ",
+                    typeof(TExpectation).FullName)
                 .ForCondition(Subject is not null)
-                .FailWith("Expected {context:collection} to contain element assignable to type {0}{reason}, but found <null>.",
-                    typeof(TExpectation));
-
-            if (success)
-            {
-                var actualItems = Subject.ConvertOrCastToCollection();
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .WithExpectation("Expected {context:collection} to contain element assignable to type {0}{reason}, ", typeof(TExpectation).FullName)
-                    .ForCondition(actualItems.Any(x => typeof(TExpectation).IsAssignableFrom(GetType(x))))
-                    .FailWith("but found {0}.", actualItems.Select(x => x.GetType()));
-            }
+                .FailWith("but found <null>.")
+                .Then
+                .Given(() => Subject.ConvertOrCastToCollection())
+                .ForCondition(subject => subject.Any(x => typeof(TExpectation).IsAssignableFrom(GetType(x))))
+                .FailWith("but found {0}.", subject => subject.Select(x => x.GetType()));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -969,13 +969,8 @@ namespace FluentAssertions.Collections
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .WithExpectation("Expected {context:collection} to contain element assignable to type {0}{reason}, ", typeof(TExpectation).FullName)
-                    .ForCondition(actualItems.Any())
-                    .FailWith("but was empty.")
-                    .Then
                     .ForCondition(actualItems.Any(x => typeof(TExpectation).IsAssignableFrom(GetType(x))))
-                    .FailWith("but found {0}.", actualItems.Select(x => x.GetType()))
-                    .Then
-                    .ClearExpectation();
+                    .FailWith("but found {0}.", actualItems.Select(x => x.GetType()));
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -965,20 +965,18 @@ namespace FluentAssertions.Collections
 
             if (success)
             {
-                int index = 0;
-                foreach (T item in Subject)
-                {
-                    if (item is not TExpectation)
-                    {
-                        Execute.Assertion
-                            .BecauseOf(because, becauseArgs)
-                            .FailWith(
-                                "Expected {context:collection} to contain only items of type {0}{reason}" +
-                                ", but item {1} at index {2} is of type {3}.", typeof(TExpectation), item, index, item.GetType());
-                    }
-
-                    ++index;
-                }
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .WithExpectation("Expected {context:collection} to contain element assignable to type {0}{reason}, ", typeof(TExpectation).FullName)
+                    .Given(() => Subject)
+                    .ForCondition(subject => subject.Any())
+                    .FailWith("but was empty.")
+                    .Then
+                    .ForCondition(subject => subject.Any(x => typeof(TExpectation).IsAssignableFrom(GetType(x))))
+                    .FailWith("but found {0}.",
+                        subject => $"[{string.Join(", ", subject.Select(x => GetType(x).FullName))}]")
+                    .Then
+                    .ClearExpectation();
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -966,7 +966,7 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(() => Subject.ConvertOrCastToCollection())
                 .ForCondition(subject => subject.Any(x => typeof(TExpectation).IsAssignableFrom(GetType(x))))
-                .FailWith("but found {0}.", subject => subject.Select(x => x.GetType()))
+                .FailWith("but found {0}.", subject => subject.Select(x => GetType(x)))
                 .Then
                 .ClearExpectation();
 

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -966,7 +966,9 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(() => Subject.ConvertOrCastToCollection())
                 .ForCondition(subject => subject.Any(x => typeof(TExpectation).IsAssignableFrom(GetType(x))))
-                .FailWith("but found {0}.", subject => subject.Select(x => x.GetType()));
+                .FailWith("but found {0}.", subject => subject.Select(x => x.GetType()))
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -946,7 +946,7 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Asserts that the current collection only contains items that are assignable to the type <typeparamref name="TExpectation" />.
+        /// Asserts that the current collection contains items that are assignable to the type <typeparamref name="TExpectation" />.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -965,16 +965,15 @@ namespace FluentAssertions.Collections
 
             if (success)
             {
+                var actualItems = Subject.ConvertOrCastToCollection();
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .WithExpectation("Expected {context:collection} to contain element assignable to type {0}{reason}, ", typeof(TExpectation).FullName)
-                    .Given(() => Subject)
-                    .ForCondition(subject => subject.Any())
+                    .ForCondition(actualItems.Any())
                     .FailWith("but was empty.")
                     .Then
-                    .ForCondition(subject => subject.Any(x => typeof(TExpectation).IsAssignableFrom(GetType(x))))
-                    .FailWith("but found {0}.",
-                        subject => $"[{string.Join(", ", subject.Select(x => GetType(x).FullName))}]")
+                    .ForCondition(actualItems.Any(x => typeof(TExpectation).IsAssignableFrom(GetType(x))))
+                    .FailWith("but found {0}.", actualItems.Select(x => x.GetType()))
                     .Then
                     .ClearExpectation();
             }

--- a/Src/FluentAssertions/Common/Configuration.cs
+++ b/Src/FluentAssertions/Common/Configuration.cs
@@ -76,7 +76,7 @@ namespace FluentAssertions.Common
 
         /// <summary>
         /// Gets or sets the assembly name to scan for custom value formatters in case <see cref="ValueFormatterDetectionMode"/>
-        /// is set to <see cref="ValueFormatterDetectionMode.Specific"/>.
+        /// is set to <see cref="Common.ValueFormatterDetectionMode.Specific"/>.
         /// </summary>
         public string ValueFormatterAssembly
         {

--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -49,7 +49,7 @@ namespace FluentAssertions.Execution
         /// The <paramref name="selector"/> will not be invoked if the prior assertion failed,
         /// nor will <see cref="FailWith(string, Func{T,object}[])"/> throw any exceptions.
         /// </remarks>
-        /// <inheritdoc cref="IAssertionScope.Given"/>
+        /// <inheritdoc cref="IAssertionScope.Given{T}"/>
         public GivenSelector<TOut> Given<TOut>(Func<T, TOut> selector)
         {
             Guard.ThrowIfArgumentIsNull(selector, nameof(selector));

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
@@ -52,7 +52,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain element assignable to type System.String because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to contain at least one element assignable to type \"System.String\" because we want to test the behaviour with a null subject, but found <null>.");
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace FluentAssertions.Specs.Collections
             Action act = () => collection.Should().ContainItemsAssignableTo<int>();
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection to contain element assignable to type \"System.Int32\", but found {empty}.");
+            act.Should().Throw<XunitException>().WithMessage("Expected collection to contain at least one element assignable to type \"System.Int32\", but found {empty}.");
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace FluentAssertions.Specs.Collections
             Action act = () => collection.Should().ContainItemsAssignableTo<int>();
 
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain element assignable to type \"System.Int32\", but found {System.String, System.Decimal}.");
+                .WithMessage("Expected collection to contain at least one element assignable to type \"System.Int32\", but found {System.String, System.Decimal}.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
@@ -24,7 +24,7 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
-        public void Should_fail_when_asserting_collection_with_items_of_different_types_only_contains_item_of_one_type()
+        public void Should_succeed_when_asserting_collection_with_items_of_different_types_only_contains_item_of_one_type()
         {
             // Arrange
             var collection = new List<object>
@@ -33,50 +33,8 @@ namespace FluentAssertions.Specs.Collections
                 "2"
             };
 
-            // Act
-            Action act = () => collection.Should().ContainItemsAssignableTo<string>();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_a_collection_contains_anything_other_than_strings_it_should_throw_and_report_details()
-        {
-            // Arrange
-            var collection = new List<object>
-            {
-                1,
-                "2"
-            };
-
-            // Act
-            Action act = () => collection.Should().ContainItemsAssignableTo<string>();
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain only items of type System.String, but item 1 at index 0 is of type System.Int32.");
-        }
-
-        [Fact]
-        public void When_a_collection_contains_anything_other_than_strings_it_should_use_the_reason()
-        {
-            // Arrange
-            var collection = new List<object>
-            {
-                1,
-                "2"
-            };
-
-            // Act
-            Action act = () => collection.Should().ContainItemsAssignableTo<string>(
-                "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected collection to contain only items of type System.String because we want to test the failure message" +
-                        ", but item 1 at index 0 is of type System.Int32.");
+            // Act / Assert
+            collection.Should().ContainItemsAssignableTo<string>();
         }
 
         [Fact]
@@ -95,6 +53,30 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected collection to contain element assignable to type System.String because we want to test the behaviour with a null subject, but found <null>.");
+        }
+
+        [Fact]
+        public void When_a_collection_is_empty_an_exception_should_be_thrown()
+        {
+            // Arrange
+            int[] collection = Array.Empty<int>();
+
+            // Act
+            Action act = () => collection.Should().ContainItemsAssignableTo<int>();
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected collection to contain element assignable to type \"System.Int32\", but was empty.");
+        }
+
+        [Fact]
+        public void Should_throw_exception_when_asserting_collection_for_missing_item_type()
+        {
+            var collection = new object[] { "1", 1.0m };
+
+            Action act = () => collection.Should().ContainItemsAssignableTo<int>();
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection to contain element assignable to type \"System.Int32\", but found \"[System.String, System.Decimal]\".");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
@@ -76,7 +76,7 @@ namespace FluentAssertions.Specs.Collections
             Action act = () => collection.Should().ContainItemsAssignableTo<int>();
 
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain element assignable to type \"System.Int32\", but found \"[System.String, System.Decimal]\".");
+                .WithMessage("Expected collection to contain element assignable to type \"System.Int32\", but found {System.String, System.Decimal}.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
@@ -65,7 +65,7 @@ namespace FluentAssertions.Specs.Collections
             Action act = () => collection.Should().ContainItemsAssignableTo<int>();
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection to contain element assignable to type \"System.Int32\", but was empty.");
+            act.Should().Throw<XunitException>().WithMessage("Expected collection to contain element assignable to type \"System.Int32\", but found {empty}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
@@ -24,7 +24,7 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
-        public void Should_succeed_when_asserting_collection_with_items_of_different_types_only_contains_item_of_one_type()
+        public void Should_succeed_when_asserting_collection_with_items_of_different_types_contains_item_of_expected_type()
         {
             // Arrange
             var collection = new List<object>

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's New
 
 ### Fixes
+* `ContainItemsAssignableTo` Now Expects At Least One Item Assignable to `T` - [#1765](https://github.com/fluentassertions/fluentassertions/pull/1765)
 
 ## 6.3.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,7 +12,7 @@ sidebar:
 ### What's New
 
 ### Fixes
-* `ContainItemsAssignableTo` Now Expects At Least One Item Assignable to `T` - [#1765](https://github.com/fluentassertions/fluentassertions/pull/1765)
+* `ContainItemsAssignableTo` now expects at least one item assignable to `T` - [#1765](https://github.com/fluentassertions/fluentassertions/pull/1765)
 
 ## 6.3.0
 


### PR DESCRIPTION
Closes Issue https://github.com/fluentassertions/fluentassertions/issues/1618
Previously, `ContainItemsAssignableTo` behaved exactly the same as `AllBeAssignableTo`. `ContainItemsAssignableTo` has been changed to expect at least one item assignable to `T`.

## IMPORTANT 

* [X] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [X] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

