### PR TITLE
Variable name is not captured after await assertion

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -40,13 +40,11 @@ namespace FluentAssertions
                         frame => !IsCurrentAssembly(frame));
                 }
 
-                int firstFluentAssertionsCodeIndex = Array.FindLastIndex(
+                int lastUserStackFrameBeforeFluentAssertionsCodeIndex = Array.FindIndex(
                     allStackFrames,
-                    searchStart,
-                    frame => IsCurrentAssembly(frame));
-
-                int lastUserStackFrameBeforeFluentAssertionsCodeIndex =
-                    firstFluentAssertionsCodeIndex + 1;
+                    startIndex: 0,
+                    count: searchStart + 1,
+                    frame => !IsCurrentAssembly(frame) && !IsDotNet(frame));
 
                 for (int i = lastUserStackFrameBeforeFluentAssertionsCodeIndex; i < allStackFrames.Length; i++)
                 {

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -452,6 +452,22 @@ namespace FluentAssertions.Specs.Execution
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected foo.ShouldReturnSomeBool() to be false*");
         }
+
+        [UIFact]
+        public async Task Caller_identification_should_also_work_for_statements_following_async_code()
+        {
+            // Arrange
+            const string someText = "Hello";
+            Func<Task> task = async () => await Task.Yield();
+
+            // Act
+            await task.Should().NotThrowAsync();
+            Action act = () => someText.Should().Be("Hi");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*someText*", "it should capture the variable name");
+        }
     }
 
     [SuppressMessage("The name of a C# element does not begin with an upper-case letter", "SA1300")]

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -143,21 +143,5 @@ namespace FluentAssertions.Specs.Specialized
                 SynchronizationContext.Current.Should().NotBeNull();
             }
         }
-
-        [UIFact]
-        public async Task When_resolving_async_to_main_thread_variable_name_used_for_assertion_should_be_detected()
-        {
-            // Arrange
-            const string someText = "Hello";
-            Func<Task> task = async () => await Task.Yield();
-
-            // Act
-            await task.Should().NotThrowAsync();
-            Action act = () => someText.Should().Be("Hi");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*someText*", "it should capture the variable name");
-        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -143,5 +143,21 @@ namespace FluentAssertions.Specs.Specialized
                 SynchronizationContext.Current.Should().NotBeNull();
             }
         }
+
+        [UIFact]
+        public async Task When_resolving_async_to_main_thread_variable_name_used_for_assertion_should_be_detected()
+        {
+            // Arrange
+            const string someText = "Hello";
+            Func<Task> task = async () => await Task.Yield();
+
+            // Act
+            await task.Should().NotThrowAsync();
+            Action act = () => someText.Should().Be("Hi");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*someText*", "it should capture the variable name");
+        }
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,6 +16,7 @@ sidebar:
 ### Fixes
 * `ContainItemsAssignableTo` now expects at least one item assignable to `T` - [#1765](https://github.com/fluentassertions/fluentassertions/pull/1765)
 * Querying methods on classes, e.g. `typeof(MyController).Methods()`, now also includes static methods - [#1740](https://github.com/fluentassertions/fluentassertions/pull/1740)
+* Variable name is not captured after await assertion - [#1770](https://github.com/fluentassertions/fluentassertions/pull/1770)
 
 ## 6.3.0
 


### PR DESCRIPTION
Fixes #1755 

## IMPORTANT 

* [X] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [X] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).