### PR TITLE
Fix typos

### DIFF
--- a/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
@@ -177,7 +177,7 @@ namespace FluentAssertions.Data
              && (unaryExpression.NodeType == ExpressionType.Convert))
             {
                 // If the expression is a value type, then accessing it will involve an
-                // implicit boxing convertion to type object that we need to ignore.
+                // implicit boxing conversion to type object that we need to ignore.
                 expression = unaryExpression.Operand;
             }
 

--- a/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
@@ -22,7 +22,7 @@ namespace FluentAssertions.Equivalency.Selection
             string currentPath = currentNode.PathAndName;
 
             // If we're part of a collection comparison, the selected path will not include an index,
-            // so we need to to remove it from the current node as well.
+            // so we need to remove it from the current node as well.
             if (!ContainsIndexingQualifiers(selectedPath))
             {
                 currentPath = RemoveIndexQualifiers(currentPath);

--- a/Src/FluentAssertions/Execution/IAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/IAssertionScope.cs
@@ -44,7 +44,7 @@ namespace FluentAssertions.Execution
         Continuation FailWith(string message);
 
         /// <summary>
-        /// Sets the failure message when the assertion is not met, or completes the failure message set to aprior call to
+        /// Sets the failure message when the assertion is not met, or completes the failure message set to a prior call to
         /// <see cref="AssertionScope.WithExpectation"/>.
         /// <paramref name="failReasonFunc"/> will not be called unless the assertion is not met.
         /// </summary>

--- a/Tests/FluentAssertions.Specs/Execution/GivenSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/GivenSelectorSpecs.cs
@@ -10,7 +10,7 @@ namespace FluentAssertions.Specs.Execution
         [Fact]
         public void A_consecutive_subject_should_be_selected()
         {
-            // Arange
+            // Arrange
             string value = string.Empty;
 
             // Act
@@ -26,7 +26,7 @@ namespace FluentAssertions.Specs.Execution
         [Fact]
         public void After_a_failed_condition_a_consecutive_subject_should_be_ignored()
         {
-            // Arange
+            // Arrange
             string value = string.Empty;
 
             // Act

--- a/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
@@ -63,7 +63,7 @@ namespace FluentAssertions.Specs.Specialized
             Assembly assemblyB = FindAssembly.Containing<ClassB>();
 
             // Act
-            Action act = () => assemblyA.Should().NotReference(assemblyB, "we want to to test the failure {0}", "message");
+            Action act = () => assemblyA.Should().NotReference(assemblyB, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -140,7 +140,7 @@ namespace FluentAssertions.Specs.Specialized
             Assembly assemblyB = FindAssembly.Containing<ClassB>();
 
             // Act
-            Action act = () => assemblyA.Should().Reference(assemblyB, "we want to to test the failure {0}", "message");
+            Action act = () => assemblyA.Should().Reference(assemblyB, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -207,7 +207,7 @@ namespace FluentAssertions.Specs.Specialized
             // Act
             Action act = () =>
                 thisAssembly.Should().DefineType(GetType().Namespace, "WellKnownClassWithAttribute",
-                    "we want to to test the failure {0}", "message");
+                    "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -24,6 +24,7 @@ sidebar:
 * Adding `ThatAreAsync()` and `ThatAreNotAsync()` for filtering in method assertions - [#1725](https://github.com/fluentassertions/fluentassertions/pull/1725)
 * Adding `ThatAreVirtual()` and `ThatAreNotVirtual()` for filtering in method assertions - [#1744](https://github.com/fluentassertions/fluentassertions/pull/1744)
 * Adding collection content to assertion messages for `HaveCountGreaterThan()`, `HaveCountGreaterThanOrEqualTo()`, `HaveCountLessThan()` and `HaveCountLessThanOrEqualTo()` - [#1760](https://github.com/fluentassertions/fluentassertions/pull/1760)
+
 ### Fixes
 * Prevent multiple enumeration of `IEnumerable`s in parameter-less `ContainSingle()` - [#1753](https://github.com/fluentassertions/fluentassertions/pull/1753)
 * Change `HaveCount()` assertion message order to state expected and actual collection count before dumping its content` - [#1760](https://github.com/fluentassertions/fluentassertions/pull/1760)


### PR DESCRIPTION
Noticed this indentation bug on the [release page](https://fluentassertions.com/releases/#630)
![image](https://user-images.githubusercontent.com/919634/149088235-58acf33d-bdfd-4c67-ba8d-991fcb7e103f.png)

Took the opportunity to run a spellchecker as well.