### PR TITLE
Bump Nuke/GitVersion, improve PR numbering, simplify Yaml script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,13 +32,12 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 2.1.x
-    
-    - name: Install NUKE
-      run: |
-        dotnet tool install --global Nuke.GlobalTool
-        
+
     - name: Run NUKE
-      run: nuke
+      run: ./build.ps1
+      env:
+        BranchSpec: ${{ github.ref }}
+        BuildNumber: ${{ github.run_number}}
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: build
 
 on:
   pull_request:
-    paths-ignore: 
+    paths-ignore:
       - docs/**
   push:
-    paths-ignore: 
+    paths-ignore:
       - docs/**
 
 jobs:
@@ -17,17 +17,17 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    
+
     - name: Setup .NET 5
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 5.0.x
-    
+
     - name: Setup .NET 3.1
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
-        
+
     - name: Setup .NET 2.1
       uses: actions/setup-dotnet@v1
       with:
@@ -38,15 +38,11 @@ jobs:
       env:
         BranchSpec: ${{ github.ref }}
         BuildNumber: ${{ github.run_number}}
+        ApiKey: ${{ secrets.NUGETAPIKEY }}
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
         path: ./Artifacts/*
-        
-    - name: Push to Nuget
-      run: dotnet nuget push .\artifacts\*.nupkg --api-key "$env:ApiKey" --skip-duplicate --no-symbols true --source https://api.nuget.org/v3/index.json
-      if: contains(github.ref, 'refs/tags/')
-      env:
-        ApiKey: ${{ secrets.NUGETAPIKEY }}
-      
+
+

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -6,6 +6,14 @@
     "build": {
       "type": "object",
       "properties": {
+        "BranchSpec": {
+          "type": "string",
+          "description": "A branch specification such as develop or refs/pull/1775/merge"
+        },
+        "BuildNumber": {
+          "type": "string",
+          "description": "An incrementing build number as provided by the build engine"
+        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
@@ -64,6 +72,7 @@
             "type": "string",
             "enum": [
               "ApiChecks",
+              "CalculateNugetVersion",
               "Clean",
               "Compile",
               "Pack",
@@ -84,6 +93,7 @@
             "type": "string",
             "enum": [
               "ApiChecks",
+              "CalculateNugetVersion",
               "Clean",
               "Compile",
               "Pack",

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -6,6 +6,10 @@
     "build": {
       "type": "object",
       "properties": {
+        "ApiKey": {
+          "type": "string",
+          "description": "The key to push to Nuget"
+        },
         "BranchSpec": {
           "type": "string",
           "description": "A branch specification such as develop or refs/pull/1775/merge"
@@ -76,6 +80,7 @@
               "Clean",
               "Compile",
               "Pack",
+              "Push",
               "Restore",
               "TestFrameworks",
               "UnitTests"
@@ -97,6 +102,7 @@
               "Clean",
               "Compile",
               "Pack",
+              "Push",
               "Restore",
               "TestFrameworks",
               "UnitTests"

--- a/Build/.editorconfig
+++ b/Build/.editorconfig
@@ -9,5 +9,8 @@ csharp_style_expression_bodied_properties = true:warning
 csharp_style_expression_bodied_indexers = true:warning
 csharp_style_expression_bodied_accessors = true:warning
 
-dotnet_diagnostic.IDE0044.severity = none
-dotnet_diagnostic.IDE0051.severity = none
+dotnet_diagnostic.ide0044.severity = none
+dotnet_diagnostic.ide0051.severity = none
+
+# ReSharper properties
+resharper_place_field_attribute_on_same_line = false

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -78,11 +78,18 @@ class Build : NukeBuild
         {
             if (EnvironmentInfo.IsWin)
             {
-                Xunit2(s => s
-                    .SetFramework("net47")
-                    .AddTargetAssemblies(GlobFiles(
+                Xunit2(s =>
+                {
+                    IReadOnlyCollection<string> testAssemblies = GlobFiles(
                         Solution.Specs.FluentAssertions_Specs.Directory,
-                        "bin/Debug/net47/*.Specs.dll").NotEmpty()));
+                        "bin/Debug/net47/*.Specs.dll");
+
+                    Assert.NotEmpty(testAssemblies.ToList());
+
+                    return s
+                        .SetFramework("net47")
+                        .AddTargetAssemblies(testAssemblies);
+                });
             }
 
             DotNetTest(s => s

--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -8,9 +8,9 @@
     <NukeScriptDirectory>..\</NukeScriptDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <PackageDownload Include="GitVersion.Tool" Version="[5.7.0]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[5.8.1]" />
     <PackageDownload Include="NSpec" Version="[3.1.0]" />
     <PackageDownload Include="xunit.runner.console" Version="[2.4.1]" />
-    <PackageReference Include="Nuke.Common" Version="5.3.0" />
+    <PackageReference Include="Nuke.Common" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,5 +3,11 @@ branches:
   release:
     regex: releases?[/-]
     tag: rc
+  pull-request:
+    mode: ContinuousDeployment
+    regex: ((pull|pull\-requests|pr)[/-]|[/-](merge))
+    tag: pr
+    tag-number-pattern: '[/-]?(?<number>\d+)'
+    prevent-increment-of-merged-branch-version: false
 ignore:
   sha: []

--- a/build.ps1
+++ b/build.ps1
@@ -14,15 +14,16 @@ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 ###########################################################################
 
 $BuildProjectFile = "$PSScriptRoot\build\_build.csproj"
-$TempDirectory = "$PSScriptRoot\\.nuke\temp"
+$TempDirectory = "$PSScriptRoot\.nuke\temp"
 
-$DotNetGlobalFile = "$PSScriptRoot\\global.json"
+$DotNetGlobalFile = "$PSScriptRoot\global.json"
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
 $DotNetChannel = "Current"
 
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
 $env:DOTNET_MULTILEVEL_LOOKUP = 0
+$env:DOTNET_ROLL_FORWARD = "Major"
 $env:NUKE_TELEMETRY_OPTOUT = 1
 
 ###########################################################################
@@ -34,9 +35,18 @@ function ExecSafe([scriptblock] $cmd) {
     if ($LASTEXITCODE) { exit $LASTEXITCODE }
 }
 
+# Print environment variables
+# WARNING: Make sure that secrets are actually scrambled in build log
+# Get-Item -Path Env:* | Sort-Object -Property Name | ForEach-Object {"{0}={1}" -f $_.Name,$_.Value}
+
+# Check if any dotnet is installed
+if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue)) {
+    ExecSafe { & dotnet --info }
+}
+
 # If dotnet CLI is installed globally and it matches requested version, use for execution
 if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue) -and `
-     $(dotnet --version) -and $LASTEXITCODE -eq 0) {
+    $(dotnet --version) -and $LASTEXITCODE -eq 0) {
     $env:DOTNET_EXE = (Get-Command "dotnet").Path
 }
 else {
@@ -66,5 +76,5 @@ else {
 
 Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
 
-ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
+ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -10,15 +10,16 @@ SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 ###########################################################################
 
 BUILD_PROJECT_FILE="$SCRIPT_DIR/Build/_build.csproj"
-TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
+TEMP_DIRECTORY="$SCRIPT_DIR/.nuke/temp"
 
-DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
+DOTNET_GLOBAL_FILE="$SCRIPT_DIR/global.json"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
 DOTNET_CHANNEL="Current"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_MULTILEVEL_LOOKUP=0
+export DOTNET_ROLL_FORWARD="Major"
 export NUKE_TELEMETRY_OPTOUT=1
 
 ###########################################################################
@@ -28,6 +29,15 @@ export NUKE_TELEMETRY_OPTOUT=1
 function FirstJsonValue {
     perl -nle 'print $1 if m{"'"$1"'": "([^"]+)",?}' <<< "${@:2}"
 }
+
+# Print environment variables
+# WARNING: Make sure that secrets are actually scrambled in build log
+# env | sort
+
+# Check if any dotnet is installed
+if [[ -x "$(command -v dotnet)" ]]; then
+    dotnet --info
+fi
 
 # If dotnet CLI is installed globally and it matches requested version, use for execution
 if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
@@ -59,5 +69,5 @@ fi
 
 echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
 
-"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"


### PR DESCRIPTION
* Bump Nuke/GitVersion to their latest
* PRs get a unique build number prepanded 
* Move Nuget pushing from Yaml into Nuke