### PR TITLE
Relax When_the_execution_time_of_an_async_action_is_less_than_a_limit_it_should_not_throw

### DIFF
--- a/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -163,7 +163,7 @@ namespace FluentAssertions.Specs.Specialized
             Func<Task> someAction = () => Task.Delay(TimeSpan.FromMilliseconds(100));
 
             // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessThan(2.Seconds());
+            Action act = () => someAction.ExecutionTime().Should().BeLessThan(20.Seconds());
 
             // Assert
             act.Should().NotThrow();


### PR DESCRIPTION
```
Failed FluentAssertions.Specs.Specialized.ExecutionTimeAssertionsSpecs.When_the_execution_time_of_an_async_action_is_less_than_a_limit_it_should_not_throw [2 s]
    Error Message:
     Did not expect any exception, but found Xunit.Sdk.XunitException with message "Execution of the action should be less than 2s, but it required exactly 2s, 555ms and 889.6µs."
```

https://github.com/fluentassertions/fluentassertions/runs/4832382920?check_suite_focus=true