### PR TITLE
Fix TryGetValue for dictionary like enumerables

### DIFF
--- a/Src/FluentAssertions/Common/DictionaryHelpers.cs
+++ b/Src/FluentAssertions/Common/DictionaryHelpers.cs
@@ -58,9 +58,17 @@ namespace FluentAssertions.Common
             static bool TryGetValue(TCollection collection, TKey key, out TValue value)
             {
                 Func<TKey, TKey, bool> areSameOrEqual = ObjectExtensions.GetComparer<TKey>();
-                KeyValuePair<TKey, TValue> matchingPair = collection.FirstOrDefault(kvp => areSameOrEqual(kvp.Key, key));
-                value = matchingPair.Value;
-                return matchingPair.Equals(default(KeyValuePair<TKey, TValue>));
+                foreach (var kvp in collection)
+                {
+                    if (areSameOrEqual(kvp.Key, key))
+                    {
+                        value = kvp.Value;
+                        return true;
+                    }
+                }
+
+                value = default;
+                return false;
             }
         }
 

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -874,7 +874,7 @@ namespace FluentAssertions.Specs.Collections
             dictionary.Should().NotBeEmpty();
         }
 
-        #if !NET5_0_OR_GREATER
+#if !NET5_0_OR_GREATER
 
         [Fact]
         public void When_asserting_dictionary_with_items_is_not_empty_it_should_enumerate_the_dictionary_only_once()
@@ -889,7 +889,7 @@ namespace FluentAssertions.Specs.Collections
             trackingDictionary.Enumerator.LoopCount.Should().Be(1);
         }
 
-        #endif
+#endif
 
         [Fact]
         public void When_asserting_dictionary_without_items_is_not_empty_it_should_fail()
@@ -2640,6 +2640,15 @@ namespace FluentAssertions.Specs.Collections
 
         [Theory]
         [MemberData(nameof(SingleDictionaryData))]
+        public void When_a_dictionary_like_collection_contains_the_expected_key_and_value_it_should_succeed<T>(T subject)
+            where T : IEnumerable<KeyValuePair<int, int>>
+        {
+            // Assert
+            subject.Should().Contain(1, 42);
+        }
+
+        [Theory]
+        [MemberData(nameof(SingleDictionaryData))]
         public void When_a_dictionary_like_collection_contains_the_expected_value_it_should_succeed<T>(T subject)
             where T : IEnumerable<KeyValuePair<int, int>>
         {
@@ -2673,6 +2682,19 @@ namespace FluentAssertions.Specs.Collections
                 new TrueReadOnlyDictionary<int, int>(new Dictionary<int, int>() { [1] = 42 }),
                 new List<KeyValuePair<int, int>> { new KeyValuePair<int, int>(1, 42) }
             };
+        }
+
+        [Fact]
+        public void When_a_dictionary_like_collection_contains_the_default_key_it_should_succeed()
+        {
+            // Arrange
+            var subject = new List<KeyValuePair<int, int>>() { new(0, 0) };
+
+            // Act
+            Action act = () => subject.Should().Contain(0, 0);
+
+            // Assert
+            act.Should().NotThrow();
         }
 
         /// <summary>

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -20,6 +20,7 @@ sidebar:
 * Variable name is not captured after await assertion - [#1770](https://github.com/fluentassertions/fluentassertions/pull/1770)
 * `OccurredEvent` ordering on monitored object is now done via thread-safe counter - [#1773](https://github.com/fluentassertions/fluentassertions/pull/1773)
 * Avoid a `NullReferenceException` when testing an application compiled with .NET Native - [#1776](https://github.com/fluentassertions/fluentassertions/pull/1776)
+* `[Not]Contain(key, value)` for dictionary-like enumerables incorrectly checked if the key was present - [#1786](https://github.com/fluentassertions/fluentassertions/pull/1786)
 
 ## 6.3.0
 


### PR DESCRIPTION
When I added `DictionaryHelpers` in #1298 I recall I did check that we had tests covering all the methods for `IEnumerable<KeyValuePair<TKey, TValue>>`.
Now I see that `DictionaryHelpers.TryGetValue` was only hit from `GenericDictionaryAssertions.ContainKey` which ignores the return value of `TryGetValue`.

This fixes #1783