### PR TITLE
Guard against unformattable caller name

### DIFF
--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -91,7 +91,14 @@ namespace FluentAssertions.Execution
         {
             string[] values = failureArgs.Select(a => Formatter.ToString(a, formattingOptions)).ToArray();
 
-            return string.Format(CultureInfo.InvariantCulture, failureMessage, values);
+            try
+            {
+                return string.Format(CultureInfo.InvariantCulture, failureMessage, values);
+            }
+            catch (FormatException formatException)
+            {
+                return $"**WARNING** failure message '{failureMessage}' could not be formatted with string.Format{Environment.NewLine}{formatException.StackTrace}";
+            }
         }
 
         private string SanitizeReason(string reason)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -21,6 +21,7 @@ sidebar:
 * `OccurredEvent` ordering on monitored object is now done via thread-safe counter - [#1773](https://github.com/fluentassertions/fluentassertions/pull/1773)
 * Avoid a `NullReferenceException` when testing an application compiled with .NET Native - [#1776](https://github.com/fluentassertions/fluentassertions/pull/1776)
 * `[Not]Contain(key, value)` for dictionary-like enumerables incorrectly checked if the key was present - [#1786](https://github.com/fluentassertions/fluentassertions/pull/1786)
+* Avoid throwing a `FormatException` when caller name determination returns an unformattable string - [#1788](https://github.com/fluentassertions/fluentassertions/pull/1788)
 
 ## 6.3.0
 


### PR DESCRIPTION
`DetermineCallerIdentity` is inherently unreliable (read: it's known that it's not perfect), especially in release mode.
Yet, we still use its result in `string.Format`, which may throw an unexpected `FormatException`.
This PR does not attempt to resolve the underlying issue, but takes the easy way out to fix tests unexpectedly failing.

I speculated about if we could determine if an assembly was usable for determining caller identity, but I didn't find any reliable way.
* `Assembly.GetEntryAssembly` returns `null` for net48
* net5.0 assemblies were annotated with `DebuggableAttribute` in both debug and release mode.


This partly resolves #1781.