### PR TITLE
Fixed a continuation issue in the fluent assertion API

### DIFF
--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -101,7 +101,7 @@ namespace FluentAssertions.Execution
         public ContinuationOfGiven<T> ClearExpectation()
         {
             predecessor.ClearExpectation();
-            return new ContinuationOfGiven<T>(this, predecessor.Succeeded);
+            return new ContinuationOfGiven<T>(this, continueAsserting);
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Execution/GivenSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/GivenSelectorSpecs.cs
@@ -201,5 +201,44 @@ namespace FluentAssertions.Specs.Execution
             act.Should().Throw<XunitException>()
                 .WithMessage("Failure");
         }
+
+        [Fact]
+        public void Clearing_the_expectation_does_not_affect_a_successful_assertion()
+        {
+            // Act
+            bool result = Execute.Assertion
+                .WithExpectation("Expectation ")
+                .Given(() => "Don't care")
+                .ForCondition(_ => true)
+                .FailWith("Should not fail")
+                .Then
+                .ClearExpectation();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Clearing_the_expectation_does_not_affect_a_failed_assertion()
+        {
+            // Act
+            using var scope = new AssertionScope();
+
+            bool result = Execute.Assertion
+                .WithExpectation("Expectation ")
+                .Given(() => "Don't care")
+                .ForCondition(_ => false)
+                .FailWith("Should fail")
+                .Then
+                .ClearExpectation();
+
+            scope.Discard();
+
+            // Assert
+            if (result)
+            {
+                throw new XunitException("the assertion failed and should return false");
+            }
+        }
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,7 +13,8 @@ sidebar:
 
 * Added `WithMapping` option to `BeEquivalentTo` to map members with different names between the subject and expectation - [#1742](https://github.com/fluentassertions/fluentassertions/pull/1742)
 
-### Fixes
+### Fixes (Extensibility)
+* Fixed a continuation issue when using `ClearExpectation` - [#1791](https://github.com/fluentassertions/fluentassertions/pull/1791)
 
 ## 6.4.0
 


### PR DESCRIPTION
Given the below example

```cs
bool result = Execute.Assertion
    .WithExpectation("Expectation ")
    .Given(() => "Don't care")
    .ForCondition(_ => true)
    .FailWith("Should not fail")
    .Then
    .ClearExpectation();
```

Even none of the assertions failed, `result` would be `false` instead of `true`