### PR TITLE
Properly recognized non-class types as internal when using HaveAccessModifier assertion

### DIFF
--- a/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
+++ b/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
@@ -87,7 +87,7 @@ namespace FluentAssertions.Common
                 return CSharpAccessModifier.Protected;
             }
 
-            if (type.IsNestedAssembly || (type.IsClass && type.IsNotPublic))
+            if (type.IsNestedAssembly || type.IsNotPublic)
             {
                 return CSharpAccessModifier.Internal;
             }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveAccessModifier.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveAccessModifier.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.Specs.Types
                 }
 
                 [Fact]
-                public void An_internal_class_should_have_an_internal_access_modifier()
+                public void An_internal_class_has_an_internal_access_modifier()
                 {
                     // Arrange
                     Type type = typeof(InternalClass);

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveAccessModifier.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveAccessModifier.cs
@@ -11,521 +11,569 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region HaveAccessModifier
-
-        [Fact]
-        public void When_asserting_a_public_type_is_public_it_succeeds()
+        public class NotHaveAccessModifier
         {
-            // Arrange
-            Type type = typeof(IPublicInterface);
+            public class HaveAccessModifier
+            {
+                [Fact]
+                public void When_asserting_a_public_type_is_public_it_succeeds()
+                {
+                    // Arrange
+                    Type type = typeof(IPublicInterface);
 
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Public);
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(CSharpAccessModifier.Public);
 
-            // Assert
-            act.Should().NotThrow();
+                    // Assert
+                    act.Should().NotThrow();
+                }
+
+                [Fact]
+                public void When_asserting_a_public_member_is_internal_it_throws()
+                {
+                    // Arrange
+                    Type type = typeof(IPublicInterface);
+
+                    // Act
+                    Action act = () =>
+                        type
+                            .Should()
+                            .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
+
+                    // Assert
+                    act.Should().Throw<XunitException>()
+                        .WithMessage("Expected type IPublicInterface to be Internal *failure message*, but it is Public.");
+                }
+
+                [Fact]
+                public void An_internal_class_should_have_an_internal_access_modifier()
+                {
+                    // Arrange
+                    Type type = typeof(InternalClass);
+
+                    // Act / Assert
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+                }
+
+                [Fact]
+                public void An_internal_interface_has_an_internal_access_modifier()
+                {
+                    // Arrange
+                    Type type = typeof(IInternalInterface);
+
+                    // Act / Assert
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+                }
+
+                [Fact]
+                public void An_internal_struct_has_an_internal_access_modifier()
+                {
+                    // Arrange
+                    Type type = typeof(InternalStruct);
+
+                    // Act / Assert
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+                }
+
+                [Fact]
+                public void An_internal_enum_has_an_internal_access_modifier()
+                {
+                    // Arrange
+                    Type type = typeof(InternalEnum);
+
+                    // Act / Assert
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+                }
+
+                [Fact]
+                public void An_internal_class_does_not_have_a_protected_internal_modifier()
+                {
+                    // Arrange
+                    Type type = typeof(InternalClass);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(
+                            CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+                    // Assert
+                    act.Should().Throw<XunitException>()
+                        .WithMessage("Expected type InternalClass to be ProtectedInternal *failure message*, but it is Internal.");
+                }
+
+                [Fact]
+                public void An_internal_interface_does_not_have_a_protected_internal_modifier()
+                {
+                    // Arrange
+                    Type type = typeof(IInternalInterface);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(
+                            CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+                    // Assert
+                    act.Should().Throw<XunitException>()
+                        .WithMessage(
+                            "Expected type IInternalInterface to be ProtectedInternal *failure message*, but it is Internal.");
+                }
+
+                [Fact]
+                public void An_internal_struct_does_not_have_a_protected_internal_modifier()
+                {
+                    // Arrange
+                    Type type = typeof(InternalStruct);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(
+                            CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+                    // Assert
+                    act.Should().Throw<XunitException>()
+                        .WithMessage("Expected type InternalStruct to be ProtectedInternal *failure message*, but it is Internal.");
+                }
+
+                [Fact]
+                public void An_internal_enum_does_not_have_a_protected_internal_modifier()
+                {
+                    // Arrange
+                    Type type = typeof(InternalEnum);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(
+                            CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+                    // Assert
+                    act.Should().Throw<XunitException>()
+                        .WithMessage("Expected type InternalEnum to be ProtectedInternal *failure message*, but it is Internal.");
+                }
+
+                [Fact]
+                public void When_asserting_a_nested_private_type_is_private_it_succeeds()
+                {
+                    // Arrange
+                    Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(CSharpAccessModifier.Private);
+
+                    // Assert
+                    act.Should().NotThrow();
+                }
+
+                [Fact]
+                public void When_asserting_a_nested_private_type_is_protected_it_throws()
+                {
+                    // Arrange
+                    Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the failure {0}",
+                            "message");
+
+                    // Assert
+                    act.Should().Throw<XunitException>()
+                        .WithMessage("Expected type PrivateClass to be Protected *failure message*, but it is Private.");
+                }
+
+                [Fact]
+                public void When_asserting_a_nested_protected_type_is_protected_it_succeeds()
+                {
+                    // Arrange
+                    Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(CSharpAccessModifier.Protected);
+
+                    // Assert
+                    act.Should().NotThrow();
+                }
+
+                [Fact]
+                public void When_asserting_a_nested_protected_type_is_public_it_throws()
+                {
+                    // Arrange
+                    Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(CSharpAccessModifier.Public);
+
+                    // Assert
+                    act.Should().Throw<XunitException>()
+                        .WithMessage("Expected type ProtectedEnum to be Public, but it is Protected.");
+                }
+
+                [Fact]
+                public void When_asserting_a_nested_public_type_is_public_it_succeeds()
+                {
+                    // Arrange
+                    Type type = typeof(Nested.IPublicInterface);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(CSharpAccessModifier.Public);
+
+                    // Assert
+                    act.Should().NotThrow();
+                }
+
+                [Fact]
+                public void When_asserting_a_nested_public_member_is_internal_it_throws()
+                {
+                    // Arrange
+                    Type type = typeof(Nested.IPublicInterface);
+
+                    // Act
+                    Action act = () =>
+                        type
+                            .Should()
+                            .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
+
+                    // Assert
+                    act.Should().Throw<XunitException>()
+                        .WithMessage("Expected type IPublicInterface to be Internal *failure message*, but it is Public.");
+                }
+
+                [Fact]
+                public void When_asserting_a_nested_internal_type_is_internal_it_succeeds()
+                {
+                    // Arrange
+                    Type type = typeof(Nested.InternalClass);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+
+                    // Assert
+                    act.Should().NotThrow();
+                }
+
+                [Fact]
+                public void When_asserting_a_nested_internal_type_is_protected_internal_it_throws()
+                {
+                    // Arrange
+                    Type type = typeof(Nested.InternalClass);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(
+                            CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+                    // Assert
+                    act.Should().Throw<XunitException>()
+                        .WithMessage("Expected type InternalClass to be ProtectedInternal *failure message*, but it is Internal.");
+                }
+
+                [Fact]
+                public void When_asserting_a_nested_protected_internal_member_is_protected_internal_it_succeeds()
+                {
+                    // Arrange
+                    Type type = typeof(Nested.IProtectedInternalInterface);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
+
+                    // Assert
+                    act.Should().NotThrow();
+                }
+
+                [Fact]
+                public void When_asserting_a_nested_protected_internal_member_is_private_it_throws()
+                {
+                    // Arrange
+                    Type type = typeof(Nested.IProtectedInternalInterface);
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(CSharpAccessModifier.Private, "we want to test the failure {0}", "message");
+
+                    // Assert
+                    act.Should().Throw<XunitException>()
+                        .WithMessage(
+                            "Expected type IProtectedInternalInterface to be Private *failure message*, but it is ProtectedInternal.");
+                }
+
+                [Fact]
+                public void When_subject_is_null_have_access_modifier_should_fail()
+                {
+                    // Arrange
+                    Type type = null;
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+                    // Assert
+                    act.Should().Throw<XunitException>()
+                        .WithMessage("Expected type to be Public *failure message*, but type is <null>.");
+                }
+
+                [Fact]
+                public void When_asserting_a_type_has_an_access_modifier_with_an_invalid_enum_value_it_should_throw()
+                {
+                    // Arrange
+                    Type type = null;
+
+                    // Act
+                    Action act = () =>
+                        type.Should().HaveAccessModifier((CSharpAccessModifier)int.MaxValue);
+
+                    // Assert
+                    act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                        .WithParameterName("accessModifier");
+                }
+            }
+
+            [Fact]
+            public void When_asserting_a_public_type_is_not_private_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(IPublicInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(CSharpAccessModifier.Private);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_public_member_is_not_public_it_throws()
+            {
+                // Arrange
+                Type type = typeof(IPublicInterface);
+
+                // Act
+                Action act = () =>
+                    type
+                        .Should()
+                        .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type IPublicInterface not to be Public *failure message*, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_an_internal_type_is_not_protected_internal_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(InternalClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_internal_type_is_not_internal_it_throws()
+            {
+                // Arrange
+                Type type = typeof(InternalClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}",
+                        "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type InternalClass not to be Internal *failure message*, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_private_type_is_not_protected_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(CSharpAccessModifier.Protected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_private_type_is_not_private_it_throws()
+            {
+                // Arrange
+                Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(CSharpAccessModifier.Private, "we want to test the failure {0}",
+                        "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type PrivateClass not to be Private *failure message*, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_protected_type_is_not_internal_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_protected_type_is_not_protected_it_throws()
+            {
+                // Arrange
+                Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(CSharpAccessModifier.Protected);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type ProtectedEnum not to be Protected, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_public_type_is_not_private_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(Nested.IPublicInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(CSharpAccessModifier.Private);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_public_member_is_not_public_it_throws()
+            {
+                // Arrange
+                Type type = typeof(Nested.IPublicInterface);
+
+                // Act
+                Action act = () =>
+                    type
+                        .Should()
+                        .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type IPublicInterface not to be Public *failure message*, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_internal_type_is_not_protected_internal_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(Nested.InternalClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_internal_type_is_not_internal_it_throws()
+            {
+                // Arrange
+                Type type = typeof(Nested.InternalClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}",
+                        "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type InternalClass not to be Internal *failure message*, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_protected_internal_member_is_not_public_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(Nested.IProtectedInternalInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(CSharpAccessModifier.Public);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_protected_internal_member_is_not_protected_internal_it_throws()
+            {
+                // Arrange
+                Type type = typeof(Nested.IProtectedInternalInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(
+                        CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type IProtectedInternalInterface not to be ProtectedInternal *failure message*, but it is.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_have_access_modifier_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}",
+                        "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type not to be Public *failure message*, but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_access_modifier_with_an_invalid_enum_value_it_should_throw()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveAccessModifier((CSharpAccessModifier)int.MaxValue);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                    .WithParameterName("accessModifier");
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_public_member_is_internal_it_throws()
-        {
-            // Arrange
-            Type type = typeof(IPublicInterface);
-
-            // Act
-            Action act = () =>
-                type
-                    .Should()
-                    .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IPublicInterface to be Internal *failure message*, but it is Public.");
-        }
-
-        [Fact]
-        public void When_asserting_an_internal_type_is_internal_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(InternalClass);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_internal_member_is_internal_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(IInternalInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_internal_member_is_protected_internal_it_throws()
-        {
-            // Arrange
-            Type type = typeof(IInternalInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(
-                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IInternalInterface to be ProtectedInternal *failure message*, but it is Internal.");
-        }
-
-        [Fact]
-        public void When_asserting_an_internal_type_is_protected_internal_it_throws()
-        {
-            // Arrange
-            Type type = typeof(InternalClass);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(
-                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type InternalClass to be ProtectedInternal *failure message*, but it is Internal.");
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_private_type_is_private_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Private);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_private_type_is_protected_it_throws()
-        {
-            // Arrange
-            Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type PrivateClass to be Protected *failure message*, but it is Private.");
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_protected_type_is_protected_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Protected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_protected_type_is_public_it_throws()
-        {
-            // Arrange
-            Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Public);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type ProtectedEnum to be Public, but it is Protected.");
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_public_type_is_public_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(Nested.IPublicInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Public);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_public_member_is_internal_it_throws()
-        {
-            // Arrange
-            Type type = typeof(Nested.IPublicInterface);
-
-            // Act
-            Action act = () =>
-                type
-                    .Should()
-                    .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IPublicInterface to be Internal *failure message*, but it is Public.");
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_internal_type_is_internal_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(Nested.InternalClass);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_internal_type_is_protected_internal_it_throws()
-        {
-            // Arrange
-            Type type = typeof(Nested.InternalClass);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(
-                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type InternalClass to be ProtectedInternal *failure message*, but it is Internal.");
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_protected_internal_member_is_protected_internal_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(Nested.IProtectedInternalInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_protected_internal_member_is_private_it_throws()
-        {
-            // Arrange
-            Type type = typeof(Nested.IProtectedInternalInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Private, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type IProtectedInternalInterface to be Private *failure message*, but it is ProtectedInternal.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_have_access_modifier_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be Public *failure message*, but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_access_modifier_with_an_invalid_enum_value_it_should_throw()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier((CSharpAccessModifier)int.MaxValue);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentOutOfRangeException>()
-                .WithParameterName("accessModifier");
-        }
-
-        #endregion
-
-        #region NotHaveAccessModifier
-
-        [Fact]
-        public void When_asserting_a_public_type_is_not_private_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(IPublicInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Private);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_public_member_is_not_public_it_throws()
-        {
-            // Arrange
-            Type type = typeof(IPublicInterface);
-
-            // Act
-            Action act = () =>
-                type
-                    .Should()
-                    .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IPublicInterface not to be Public *failure message*, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_an_internal_type_is_not_protected_internal_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(InternalClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_internal_type_is_not_internal_it_throws()
-        {
-            // Arrange
-            Type type = typeof(InternalClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type InternalClass not to be Internal *failure message*, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_private_type_is_not_protected_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Protected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_private_type_is_not_private_it_throws()
-        {
-            // Arrange
-            Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Private, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type PrivateClass not to be Private *failure message*, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_protected_type_is_not_internal_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_protected_type_is_not_protected_it_throws()
-        {
-            // Arrange
-            Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Protected);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type ProtectedEnum not to be Protected, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_public_type_is_not_private_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(Nested.IPublicInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Private);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_public_member_is_not_public_it_throws()
-        {
-            // Arrange
-            Type type = typeof(Nested.IPublicInterface);
-
-            // Act
-            Action act = () =>
-                type
-                    .Should()
-                    .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IPublicInterface not to be Public *failure message*, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_internal_type_is_not_protected_internal_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(Nested.InternalClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_internal_type_is_not_internal_it_throws()
-        {
-            // Arrange
-            Type type = typeof(Nested.InternalClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type InternalClass not to be Internal *failure message*, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_protected_internal_member_is_not_public_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(Nested.IProtectedInternalInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Public);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_nested_protected_internal_member_is_not_protected_internal_it_throws()
-        {
-            // Arrange
-            Type type = typeof(Nested.IProtectedInternalInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(
-                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type IProtectedInternalInterface not to be ProtectedInternal *failure message*, but it is.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_access_modifier_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be Public *failure message*, but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_access_modifier_with_an_invalid_enum_value_it_should_throw()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier((CSharpAccessModifier)int.MaxValue);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentOutOfRangeException>()
-                .WithParameterName("accessModifier");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveAccessModifier.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveAccessModifier.cs
@@ -59,6 +59,36 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
+        public void When_asserting_an_internal_member_is_internal_it_succeeds()
+        {
+            // Arrange
+            Type type = typeof(IInternalInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_an_internal_member_is_protected_internal_it_throws()
+        {
+            // Arrange
+            Type type = typeof(IInternalInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveAccessModifier(
+                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type IInternalInterface to be ProtectedInternal *failure message*, but it is Internal.");
+        }
+
+        [Fact]
         public void When_asserting_an_internal_type_is_protected_internal_it_throws()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -136,6 +136,8 @@ namespace FluentAssertions.Specs.Types
 
     public interface IPublicInterface { }
 
+    internal interface IInternalInterface { }
+
     internal class InternalClass { }
 
     internal class Nested

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -140,6 +140,14 @@ namespace FluentAssertions.Specs.Types
 
     internal class InternalClass { }
 
+    internal struct InternalStruct { }
+
+    internal enum InternalEnum
+    {
+        Value1,
+        Value2
+    }
+
     internal class Nested
     {
         private class PrivateClass { }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,10 +13,12 @@ sidebar:
 
 * Added `WithMapping` option to `BeEquivalentTo` to map members with different names between the subject and expectation - [#1742](https://github.com/fluentassertions/fluentassertions/pull/1742)
 
+### Fixes
+* Improved the documentation on `BeLowerCased` and `BeUpperCased` for strings with non-alphabetic characters - [#1792](https://github.com/fluentassertions/fluentassertions/pull/1792)
+* Resolve an issue preventing `HaveAccessModifier` from correctly recognizing internal interfaces and enums - [#1741](https://github.com/fluentassertions/fluentassertions/issues/1741)
+
 ### Fixes (Extensibility)
 * Fixed a continuation issue when using `ClearExpectation` - [#1791](https://github.com/fluentassertions/fluentassertions/pull/1791)
-
-* Improved the documentation on `BeLowerCased` and `BeUpperCased` for strings with non-alphabetic characters - [#1792](https://github.com/fluentassertions/fluentassertions/pull/1792)
 
 ## 6.4.0
 
@@ -45,8 +47,6 @@ sidebar:
 * Prevent multiple enumeration of `IEnumerable`s in parameter-less `ContainSingle()` - [#1753](https://github.com/fluentassertions/fluentassertions/pull/1753)
 * Change `HaveCount()` assertion message order to state expected and actual collection count before dumping its content` - [#1760](https://github.com/fluentassertions/fluentassertions/pull/1760)
 * `CompleteWithinAsync` did not take initial sync computation into account when measuring execution time - [1762](https://github.com/fluentassertions/fluentassertions/pull/1762).
-
-* Resolve an issue preventing HaveAccessModifier from correctly recognizing internal interfaces and enums - [#1741](https://github.com/fluentassertions/fluentassertions/issues/1741)
 
 ## 6.2.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -46,6 +46,8 @@ sidebar:
 * Change `HaveCount()` assertion message order to state expected and actual collection count before dumping its content` - [#1760](https://github.com/fluentassertions/fluentassertions/pull/1760)
 * `CompleteWithinAsync` did not take initial sync computation into account when measuring execution time - [1762](https://github.com/fluentassertions/fluentassertions/pull/1762).
 
+* Resolve an issue preventing HaveAccessModifier from correctly recognizing internal interfaces and enums - [#1741](https://github.com/fluentassertions/fluentassertions/issues/1741)
+
 ## 6.2.0
 
 ### What's New

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -15,7 +15,7 @@ sidebar:
 
 ### Fixes
 * Improved the documentation on `BeLowerCased` and `BeUpperCased` for strings with non-alphabetic characters - [#1792](https://github.com/fluentassertions/fluentassertions/pull/1792)
-* Resolve an issue preventing `HaveAccessModifier` from correctly recognizing internal interfaces and enums - [#1741](https://github.com/fluentassertions/fluentassertions/issues/1741)
+* Resolve an issue preventing `HaveAccessModifier` from correctly recognizing internal interfaces and enums - [#1793](https://github.com/fluentassertions/fluentassertions/issues/1793)
 
 ### Fixes (Extensibility)
 * Fixed a continuation issue when using `ClearExpectation` - [#1791](https://github.com/fluentassertions/fluentassertions/pull/1791)


### PR DESCRIPTION
Removes IsClass check preventing enums and interfaces from being recognized as internal types when not nested.

Fixes #1741

**Note** Review without whitespace changes, e.g. https://github.com/fluentassertions/fluentassertions/pull/1793/files?diff=split&w=1