### PR TITLE
Caller identification does not handle all arguments using `new`

### DIFF
--- a/Src/FluentAssertions/CallerIdentification/AddNonEmptySymbolParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/AddNonEmptySymbolParsingStrategy.cs
@@ -4,12 +4,29 @@ namespace FluentAssertions.CallerIdentification
 {
     internal class AddNonEmptySymbolParsingStrategy : IParsingStrategy
     {
+        private Mode mode = Mode.RemoveAllWhitespace;
+        private char? precedingSymbol;
+
         public ParsingState Parse(char symbol, StringBuilder statement)
         {
             if (!char.IsWhiteSpace(symbol))
             {
                 statement.Append(symbol);
+                mode = Mode.RemoveSuperfluousWhitespace;
             }
+            else if (mode is Mode.RemoveSuperfluousWhitespace)
+            {
+                if (precedingSymbol.HasValue && !char.IsWhiteSpace(precedingSymbol.Value))
+                {
+                    statement.Append(symbol);
+                }
+            }
+            else
+            {
+                // skip the rest
+            }
+
+            precedingSymbol = symbol;
 
             return ParsingState.GoToNextSymbol;
         }
@@ -21,6 +38,21 @@ namespace FluentAssertions.CallerIdentification
 
         public void NotifyEndOfLineReached()
         {
+            // Assume all new lines start with whitespace
+            mode = Mode.RemoveAllWhitespace;
+        }
+
+        private enum Mode
+        {
+            /// <summary>
+            /// Remove all whitespace until we find a non-whitespace character
+            /// </summary>
+            RemoveAllWhitespace,
+
+            /// <summary>
+            /// Only keep one whitespace character if more than one follow each other.
+            /// </summary>
+            RemoveSuperfluousWhitespace,
         }
     }
 }

--- a/Src/FluentAssertions/CallerIdentification/AwaitParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/AwaitParsingStrategy.cs
@@ -4,7 +4,7 @@ namespace FluentAssertions.CallerIdentification
 {
     internal class AwaitParsingStrategy : IParsingStrategy
     {
-        private const string KeywordToSkip = "await";
+        private const string KeywordToSkip = "await ";
 
         public ParsingState Parse(char symbol, StringBuilder statement)
         {

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -235,7 +235,7 @@ namespace FluentAssertions
 
         private static bool StartsWithNewKeyword(string candidate)
         {
-            return Regex.IsMatch(candidate, @"(^|s+)new(?:\s?\[|\s?\{|\s\w+)");
+            return Regex.IsMatch(candidate, @"(?:^|s+)new(?:\s?\[|\s?\{|\s\w+)");
         }
 
         private static bool IsStringLiteral(string candidate)

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -173,7 +173,7 @@ namespace FluentAssertions
             {
                 Logger(statement);
                 if (!IsBooleanLiteral(statement) && !IsNumeric(statement) && !IsStringLiteral(statement) &&
-                    !UsesNewKeyword(statement))
+                    !StartsWithNewKeyword(statement))
                 {
                     caller = statement;
                 }
@@ -233,9 +233,9 @@ namespace FluentAssertions
             return sb.ToString();
         }
 
-        private static bool UsesNewKeyword(string candidate)
+        private static bool StartsWithNewKeyword(string candidate)
         {
-            return Regex.IsMatch(candidate, @"new(?:\s?\[|\s?\{|\s\w+)");
+            return Regex.IsMatch(candidate, @"(^|s+)new(?:\s?\[|\s?\{|\s\w+)");
         }
 
         private static bool IsStringLiteral(string candidate)

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -158,7 +160,7 @@ namespace FluentAssertions.Specs.Execution
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected foo.GetFoo(test1).GetFooStatic(\"test\"+2).GetFoo(foo.Field) to be <null>*");
+                .WithMessage("Expected foo.GetFoo(test1).GetFooStatic(\"test\" + 2).GetFoo(foo.Field) to be <null>*");
         }
 
         [Fact]
@@ -181,7 +183,7 @@ namespace FluentAssertions.Specs.Execution
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected foo.GetFoo(test1).GetFooStatic(\"test\"+2).GetFoo(foo.Field) to be <null>*");
+                .WithMessage("Expected foo.GetFoo(test1).GetFooStatic(\"test\" + 2).GetFoo(foo.Field) to be <null>*");
         }
 
         [Fact]
@@ -256,7 +258,7 @@ namespace FluentAssertions.Specs.Execution
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected foo.BarMethod(@\"test\",argument2:$@\"test2\",argument3:@$\"test3\") to be <null>*");
+                .WithMessage("Expected foo.BarMethod(@\"test\", argument2: $@\"test2\", argument3: @$\"test3\") to be <null>*");
         }
 
         [Fact]
@@ -302,7 +304,7 @@ namespace FluentAssertions.Specs.Execution
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected foo.BarMethod(\"1\"+2) to be <null>*");
+                .WithMessage("Expected foo.BarMethod(\"1\" + 2) to be <null>*");
         }
 
         [Fact]
@@ -319,7 +321,7 @@ namespace FluentAssertions.Specs.Execution
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected foo.BarMethod(\"abc\"+\"def\") to be <null>*");
+                .WithMessage("Expected foo.BarMethod(\"abc\"+ \"def\") to be <null>*");
         }
 
         [Fact]
@@ -467,6 +469,76 @@ namespace FluentAssertions.Specs.Execution
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("*someText*", "it should capture the variable name");
+        }
+
+        [Fact]
+        public void A_method_taking_an_array_initializer_is_an_identifier()
+        {
+            // Arrange
+            var foo = new Foo();
+
+            // Act
+            Action act = () => foo.GetFoo(new[] { 1, 2, 3 }.Sum() + "")
+                .Should()
+                .BeNull();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected foo.GetFoo(new[] { 1, 2, 3 }.Sum() + \"\") to be <null>*");
+        }
+
+        [Fact]
+        public void A_method_taking_a_target_typed_new_expression_is_an_identifier()
+        {
+            // Arrange
+            var foo = new Foo();
+
+            // Act
+            Action act = () => foo.GetFoo(new('a', 10))
+                .Should()
+                .BeNull();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected foo.GetFoo(new('a', 10)) to be <null>*");
+        }
+
+        [Fact]
+        public void A_method_taking_a_list_is_an_identifier()
+        {
+            // Arrange
+            var foo = new Foo();
+
+            // Act
+            Action act = () => foo.GetFoo(new List<int> { 1, 2, 3 }.Sum() + "")
+                .Should()
+                .BeNull();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected foo.GetFoo(new List<int> { 1, 2, 3 }*");
+        }
+
+        [Fact]
+        public void An_array_initializer_preceding_an_assertion_is_not_an_identifier()
+        {
+            // Act
+            Action act = () => new[] { 1, 2, 3 }.Should().BeEmpty();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection to be empty*");
+        }
+
+        [Fact]
+        public void An_object_initializer_preceding_an_assertion_is_not_an_identifier()
+        {
+            // Act
+            Action act = () => new { Property = "blah" }.Should().BeNull();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected object to be*");
         }
     }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,6 +14,7 @@ sidebar:
 
 ### Fixes 
 * Improved the documentation on `BeLowerCased` and `BeUpperCased` for strings with non-alphabetic characters - [#1792](https://github.com/fluentassertions/fluentassertions/pull/1792)
+* Caller identification does not handle all arguments using `new` - [#1794](https://github.com/fluentassertions/fluentassertions/pull/1794)
 
 ### Fixes (Extensibility)
 * Fixed a continuation issue when using `ClearExpectation` - [#1791](https://github.com/fluentassertions/fluentassertions/pull/1791)


### PR DESCRIPTION
Certain constructs where `new` is used when constructing the argument of a method were not properly detected by the caller identification feature. 

Fixes #1695 

