### PR TITLE
Fix and improve tracing for nested AssertionScopes

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -865,7 +865,6 @@ namespace FluentAssertions.Collections
                         new EquivalencyValidator().AssertEquality(comparands, context);
 
                         string[] failures = scope.Discard();
-
                         if (!failures.Any())
                         {
                             return new AndWhichConstraint<TAssertions, T>((TAssertions)this, actualItem);

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -62,13 +62,14 @@ namespace FluentAssertions.Equivalency
 
         private void RunStepsUntilEquivalencyIsProven(Comparands comparands, IEquivalencyValidationContext context)
         {
+            using var _ = context.Tracer.WriteBlock(node => node.Description);
+
             foreach (IEquivalencyStep step in AssertionOptions.EquivalencyPlan)
             {
                 var result = step.Handle(comparands, context, this);
-                context.Tracer.WriteLine(_ => $"Step {step.GetType().Name} returned {result}");
-
                 if (result == EquivalencyResult.AssertionCompleted)
                 {
+                    context.Tracer.WriteLine(_ => $"Equivalency was proven by {step.GetType().Name}");
                     return;
                 }
             }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -22,7 +22,7 @@ namespace FluentAssertions.Equivalency
 
             if (context.TraceWriter is not null)
             {
-                scope.AddReportable("trace", context.TraceWriter.ToString());
+                scope.AppendTracing(context.TraceWriter.ToString());
             }
         }
 

--- a/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Equivalency.Steps
                 context.Tracer.WriteLine(member =>
                 {
                     string strategyName = (strategy == EqualityStrategy.Equals)
-                        ? "Equals must be used" : "object overrides Equals";
+                        ? $"{expectationType} overrides Equals" : "we are forced to use Equals";
 
                     return $"Treating {member.Description} as a value type because {strategyName}.";
                 });

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1255,6 +1255,7 @@ namespace FluentAssertions.Execution
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
+        public void AppendTracing(string tracingBlock) { }
         public void AssumeSingleCaller() { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1255,6 +1255,7 @@ namespace FluentAssertions.Execution
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
+        public void AppendTracing(string tracingBlock) { }
         public void AssumeSingleCaller() { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1255,6 +1255,7 @@ namespace FluentAssertions.Execution
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
+        public void AppendTracing(string tracingBlock) { }
         public void AssumeSingleCaller() { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1207,6 +1207,7 @@ namespace FluentAssertions.Execution
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
+        public void AppendTracing(string tracingBlock) { }
         public void AssumeSingleCaller() { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1255,6 +1255,7 @@ namespace FluentAssertions.Execution
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
+        public void AppendTracing(string tracingBlock) { }
         public void AssumeSingleCaller() { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainEquivalentOf.cs
@@ -199,6 +199,33 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
+        public void Tracing_should_be_included_in_the_assertion_output()
+        {
+            // Arrange
+            var collection = new[]
+            {
+                new Customer
+                {
+                    Name = "John",
+                    Age = 18
+                },
+                new Customer
+                {
+                    Name = "Jane",
+                    Age = 18
+                }
+            };
+
+            var item = new Customer { Name = "John", Age = 21 };
+
+            // Act
+            Action act = () => collection.Should().ContainEquivalentOf(item, options => options.WithTracing());
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*Equivalency was proven*");
+        }
+
+        [Fact]
         public void When_injecting_a_null_config_to_ContainEquivalentOf_it_should_throw()
         {
             // Arrange

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,6 +17,7 @@ sidebar:
 * Improved the documentation on `BeLowerCased` and `BeUpperCased` for strings with non-alphabetic characters - [#1792](https://github.com/fluentassertions/fluentassertions/pull/1792)
 * Caller identification does not handle all arguments using `new` - [#1794](https://github.com/fluentassertions/fluentassertions/pull/1794)
 * Resolve an issue preventing `HaveAccessModifier` from correctly recognizing internal interfaces and enums - [#1793](https://github.com/fluentassertions/fluentassertions/issues/1793)
+* Improved tracing for nested `AssertionScope`s - [#1797](https://github.com/fluentassertions/fluentassertions/pull/1797)
 
 ### Fixes (Extensibility)
 * Fixed a continuation issue when using `ClearExpectation` - [#1791](https://github.com/fluentassertions/fluentassertions/pull/1791)


### PR DESCRIPTION
Fixes #1796 where tracing doesn't work for nested `AssertionScope`s. Also improves the tracing output a little bit.

**After**
```
 With trace:
  collection
  {
    property collection.Name
    {
      Equivalency was proven by ReferenceEqualityEquivalencyStep
    }
    property collection.Age
    {
      Treating property collection.Age as a value type because System.Int32 overrides Equals.
      Equivalency was proven by ValueTypeEquivalencyStep
    }
    property collection.Birthdate
    {
      Treating property collection.Birthdate as a value type because System.DateTime overrides Equals.
      Equivalency was proven by ValueTypeEquivalencyStep
    }
    property collection.Id
    {
      Treating property collection.Id as a value type because System.Int64 overrides Equals.
      Equivalency was proven by ValueTypeEquivalencyStep
    }
    Equivalency was proven by StructuralEqualityEquivalencyStep
  }
  collection
  {
    property collection.Name
    {
      Equivalency was proven by ReferenceEqualityEquivalencyStep
    }
    property collection.Age
    {
      Treating property collection.Age as a value type because System.Int32 overrides Equals.
      Equivalency was proven by ValueTypeEquivalencyStep
    }
    property collection.Birthdate
    {
      Treating property collection.Birthdate as a value type because System.DateTime overrides Equals.
      Equivalency was proven by ValueTypeEquivalencyStep
    }
    property collection.Id
    {
      Treating property collection.Id as a value type because System.Int64 overrides Equals.
      Equivalency was proven by ValueTypeEquivalencyStep
    }
    Equivalency was proven by StructuralEqualityEquivalencyStep
  }
  collection
  {
    property collection.Name
    {
      Equivalency was proven by StringEqualityEquivalencyStep
    }
    property collection.Age
    {
      Treating property collection.Age as a value type because System.Int32 overrides Equals.
      Equivalency was proven by ValueTypeEquivalencyStep
    }
    property collection.Birthdate
    {
      Treating property collection.Birthdate as a value type because System.DateTime overrides Equals.
      Equivalency was proven by ValueTypeEquivalencyStep
    }
    property collection.Id
    {
      Treating property collection.Id as a value type because System.Int64 overrides Equals.
      Equivalency was proven by ValueTypeEquivalencyStep
    }
    Equivalency was proven by StructuralEqualityEquivalencyStep
  }
```
**Before**
```
With trace:
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned ContinueWithNext
  Step EnumEqualityStep returned ContinueWithNext
  Step ValueTypeEquivalencyStep returned ContinueWithNext
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned AssertionCompleted
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned ContinueWithNext
  Step EnumEqualityStep returned ContinueWithNext
  Treating property collection.Age as a value type because Equals must be used.
  Step ValueTypeEquivalencyStep returned AssertionCompleted
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned ContinueWithNext
  Step EnumEqualityStep returned ContinueWithNext
  Treating property collection.Birthdate as a value type because Equals must be used.
  Step ValueTypeEquivalencyStep returned AssertionCompleted
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned ContinueWithNext
  Step EnumEqualityStep returned ContinueWithNext
  Treating property collection.Id as a value type because Equals must be used.
  Step ValueTypeEquivalencyStep returned AssertionCompleted
  Step StructuralEqualityEquivalencyStep returned AssertionCompleted
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned ContinueWithNext
  Step EnumEqualityStep returned ContinueWithNext
  Step ValueTypeEquivalencyStep returned ContinueWithNext
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned AssertionCompleted
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned ContinueWithNext
  Step EnumEqualityStep returned ContinueWithNext
  Treating property collection.Age as a value type because Equals must be used.
  Step ValueTypeEquivalencyStep returned AssertionCompleted
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned ContinueWithNext
  Step EnumEqualityStep returned ContinueWithNext
  Treating property collection.Birthdate as a value type because Equals must be used.
  Step ValueTypeEquivalencyStep returned AssertionCompleted
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned ContinueWithNext
  Step EnumEqualityStep returned ContinueWithNext
  Treating property collection.Id as a value type because Equals must be used.
  Step ValueTypeEquivalencyStep returned AssertionCompleted
  Step StructuralEqualityEquivalencyStep returned AssertionCompleted
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned ContinueWithNext
  Step EnumEqualityStep returned ContinueWithNext
  Step ValueTypeEquivalencyStep returned ContinueWithNext
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned AssertionCompleted
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned ContinueWithNext
  Step EnumEqualityStep returned ContinueWithNext
  Treating property collection.Age as a value type because Equals must be used.
  Step ValueTypeEquivalencyStep returned AssertionCompleted
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned ContinueWithNext
  Step EnumEqualityStep returned ContinueWithNext
  Treating property collection.Birthdate as a value type because Equals must be used.
  Step ValueTypeEquivalencyStep returned AssertionCompleted
  Step RunAllUserStepsEquivalencyStep returned ContinueWithNext
  Step AutoConversionStep returned ContinueWithNext
  Step ReferenceEqualityEquivalencyStep returned ContinueWithNext
  Step GenericDictionaryEquivalencyStep returned ContinueWithNext
  Step DataSetEquivalencyStep returned ContinueWithNext
  Step DataTableEquivalencyStep returned ContinueWithNext
  Step DataColumnEquivalencyStep returned ContinueWithNext
  Step DataRelationEquivalencyStep returned ContinueWithNext
  Step DataRowCollectionEquivalencyStep returned ContinueWithNext
  Step DataRowEquivalencyStep returned ContinueWithNext
  Step XDocumentEquivalencyStep returned ContinueWithNext
  Step XElementEquivalencyStep returned ContinueWithNext
  Step XAttributeEquivalencyStep returned ContinueWithNext
  Step ConstraintCollectionEquivalencyStep returned ContinueWithNext
  Step ConstraintEquivalencyStep returned ContinueWithNext
  Step DictionaryEquivalencyStep returned ContinueWithNext
  Step MultiDimensionalArrayEquivalencyStep returned ContinueWithNext
  Step GenericEnumerableEquivalencyStep returned ContinueWithNext
  Step EnumerableEquivalencyStep returned ContinueWithNext
  Step StringEqualityEquivalencyStep returned ContinueWithNext
  Step EnumEqualityStep returned ContinueWithNext
  Treating property collection.Id as a value type because Equals must be used.
  Step ValueTypeEquivalencyStep returned AssertionCompleted
  Step StructuralEqualityEquivalencyStep returned AssertionCompleted

```