### PR TITLE
Fix ordering collections by the identity function

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -2993,13 +2993,11 @@ namespace FluentAssertions.Collections
                     direction,
                     unordered);
 
-                string orderString = GetExpressionOrderString(propertyExpression);
-
                 Execute.Assertion
                     .ForCondition(unordered.SequenceEqual(expectation))
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} {0} to be ordered {1}{reason} and result in {2}.",
-                        Subject, orderString, expectation);
+                        () => Subject, () => GetExpressionOrderString(propertyExpression), () => expectation);
 
                 return new AndConstraint<SubsequentOrderingAssertions<T>>(
                     new SubsequentOrderingAssertions<T>(Subject, expectation));
@@ -3188,11 +3186,13 @@ namespace FluentAssertions.Collections
             Guard.ThrowIfArgumentIsNull(propertyExpression, nameof(propertyExpression),
                 "Cannot assert collection ordering without specifying a property.");
 
+            propertyExpression.ValidateMemberPath();
+
             return Execute.Assertion
-                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
                 .FailWith("Expected {context:collection} to be ordered by {0}{reason} but found <null>.",
-                    propertyExpression.GetMemberPath());
+                    () => propertyExpression.GetMemberPath());
         }
 
         private AndConstraint<TAssertions> NotBeOrderedBy<TSelector>(
@@ -3214,13 +3214,11 @@ namespace FluentAssertions.Collections
                     direction,
                     unordered);
 
-                string orderString = GetExpressionOrderString(propertyExpression);
-
                 Execute.Assertion
                     .ForCondition(!unordered.SequenceEqual(expectation))
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} {0} to not be ordered {1}{reason} and not result in {2}.",
-                        Subject, orderString, expectation);
+                        () => Subject, () => GetExpressionOrderString(propertyExpression), () => expectation);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Common/MemberPath.cs
+++ b/Src/FluentAssertions/Common/MemberPath.cs
@@ -31,9 +31,9 @@ namespace FluentAssertions.Common
 
         public MemberPath(string dottedPath)
         {
-            Guard.ThrowIfArgumentIsNullOrEmpty(
+            Guard.ThrowIfArgumentIsNull(
                 dottedPath, nameof(dottedPath),
-                "A member path cannot be null or empty");
+                "A member path cannot be null");
 
             this.dottedPath = dottedPath;
         }

--- a/Src/FluentAssertions/Equivalency/Matching/MappedPathMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedPathMatchingRule.cs
@@ -14,6 +14,11 @@ namespace FluentAssertions.Equivalency.Matching
 
         public MappedPathMatchingRule(string expectationMemberPath, string subjectMemberPath)
         {
+            Guard.ThrowIfArgumentIsNullOrEmpty(expectationMemberPath,
+                nameof(expectationMemberPath), "A member path cannot be null");
+            Guard.ThrowIfArgumentIsNullOrEmpty(subjectMemberPath,
+                nameof(subjectMemberPath), "A member path cannot be null");
+
             expectationPath = new MemberPath(expectationMemberPath);
             subjectPath = new MemberPath(subjectMemberPath);
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
@@ -81,6 +81,19 @@ namespace FluentAssertions.Specs.Collections
                     " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
         }
 
+        [Fact]
+        public void Items_can_be_ordered_by_the_identity_function()
+        {
+            // Arrange
+            var collection = new[] { 1, 2 };
+
+            // Act
+            Action action = () => collection.Should().BeInAscendingOrder(x => x);
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
         #endregion
 
         #region Not Be In Ascending Order

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's New
 
 ### Fixes
+* Fix regression introduced in 6.5.0 where `collection.Should().BeInAscendingOrder(x => x)` would fail - [#1802](https://github.com/fluentassertions/fluentassertions/pull/1802)
 
 ### Fixes (Extensibility)
 


### PR DESCRIPTION
216646a32f392c8bd437c4daa0ebf8fa839b3b34 made the empty path prohibited as part of creating a mapping between two properties.
But the empty member path corresponds to the [identity function](https://en.wikipedia.org/wiki/Identity_function) which is a perfectly valid expression to e.g. order collections by.

```cs
collection.Should().BeInAscendingOrder(x => x)
```

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).