### PR TITLE
Add the ability to exclude non-browsabe members from equivalency tests

### DIFF
--- a/Src/FluentAssertions/Equivalency/Execution/CollectionMemberAssertionOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CollectionMemberAssertionOptionsDecorator.cs
@@ -61,6 +61,8 @@ namespace FluentAssertions.Equivalency.Execution
 
         public MemberVisibility IncludedFields => inner.IncludedFields;
 
+        public bool ExcludeNonBrowsable => inner.ExcludeNonBrowsable;
+
         public bool CompareRecordsByValue => inner.CompareRecordsByValue;
 
         public EqualityStrategy GetEqualityStrategy(Type type)

--- a/Src/FluentAssertions/Equivalency/Field.cs
+++ b/Src/FluentAssertions/Equivalency/Field.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Reflection;
 using FluentAssertions.Common;
 
@@ -26,6 +27,12 @@ namespace FluentAssertions.Equivalency
             Name = fieldInfo.Name;
             Type = fieldInfo.FieldType;
             RootIsCollection = parent.RootIsCollection;
+
+            bool isNonBrowsable =
+                (fieldInfo.GetCustomAttribute<EditorBrowsableAttribute>() is EditorBrowsableAttribute attribute) &&
+                (attribute.State == EditorBrowsableState.Never);
+
+            IsBrowsable = !isNonBrowsable;
         }
 
         public Type ReflectedType { get; }
@@ -42,5 +49,7 @@ namespace FluentAssertions.Equivalency
         public CSharpAccessModifier GetterAccessibility => fieldInfo.GetCSharpAccessModifier();
 
         public CSharpAccessModifier SetterAccessibility => fieldInfo.GetCSharpAccessModifier();
+
+        public bool IsBrowsable { get; private set; }
     }
 }

--- a/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+
 using FluentAssertions.Equivalency.Tracing;
 
 namespace FluentAssertions.Equivalency
@@ -70,6 +72,12 @@ namespace FluentAssertions.Equivalency
         /// Gets a value indicating whether and which fields should be considered.
         /// </summary>
         MemberVisibility IncludedFields { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether members marked with [EditorBrowsable]
+        /// and an EditorBrowsableState of Never should be excluded.
+        /// </summary>
+        bool ExcludeNonBrowsable { get; }
 
         /// <summary>
         /// Gets a value indicating whether records should be compared by value instead of their members

--- a/Src/FluentAssertions/Equivalency/IMember.cs
+++ b/Src/FluentAssertions/Equivalency/IMember.cs
@@ -32,5 +32,10 @@ namespace FluentAssertions.Equivalency
         /// Gets the access modifier for the setter of this member.
         /// </summary>
         CSharpAccessModifier SetterAccessibility { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the member is browsable in the source code editor. This is controlled with the [EditorBrowsable] attribute.
+        /// </summary>
+        bool IsBrowsable { get; }
     }
 }

--- a/Src/FluentAssertions/Equivalency/Property.cs
+++ b/Src/FluentAssertions/Equivalency/Property.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Reflection;
 using FluentAssertions.Common;
 
@@ -27,6 +28,12 @@ namespace FluentAssertions.Equivalency
             Path = parent.PathAndName;
             GetSubjectId = parent.GetSubjectId;
             RootIsCollection = parent.RootIsCollection;
+
+            bool isNonBrowsable =
+                (propertyInfo.GetCustomAttribute<EditorBrowsableAttribute>() is EditorBrowsableAttribute attribute) &&
+                (attribute.State == EditorBrowsableState.Never);
+
+            IsBrowsable = !isNonBrowsable;
         }
 
         public object GetValue(object obj)
@@ -43,5 +50,7 @@ namespace FluentAssertions.Equivalency
         public CSharpAccessModifier GetterAccessibility => propertyInfo.GetGetMethod(nonPublic: true).GetCSharpAccessModifier();
 
         public CSharpAccessModifier SetterAccessibility => propertyInfo.GetSetMethod(nonPublic: true).GetCSharpAccessModifier();
+
+        public bool IsBrowsable { get; private set; }
     }
 }

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -56,6 +56,7 @@ namespace FluentAssertions.Equivalency
 
         private MemberVisibility includedProperties;
         private MemberVisibility includedFields;
+        private bool excludeNonBrowsable;
 
         private bool compareRecordsByValue;
 
@@ -80,6 +81,7 @@ namespace FluentAssertions.Equivalency
             useRuntimeTyping = defaults.UseRuntimeTyping;
             includedProperties = defaults.IncludedProperties;
             includedFields = defaults.IncludedFields;
+            excludeNonBrowsable = defaults.ExcludeNonBrowsable;
             compareRecordsByValue = defaults.CompareRecordsByValue;
 
             ConversionSelector = defaults.ConversionSelector.Clone();
@@ -161,6 +163,8 @@ namespace FluentAssertions.Equivalency
         MemberVisibility IEquivalencyAssertionOptions.IncludedProperties => includedProperties;
 
         MemberVisibility IEquivalencyAssertionOptions.IncludedFields => includedFields;
+
+        bool IEquivalencyAssertionOptions.ExcludeNonBrowsable => excludeNonBrowsable;
 
         public bool CompareRecordsByValue => compareRecordsByValue;
 
@@ -309,6 +313,26 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingProperties()
         {
             includedProperties = MemberVisibility.None;
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Instructs the comparison to include non-browsable members (members with an EditorBrowsableState of Never).
+        /// </summary>
+        /// <returns></returns>
+        public TSelf IncludingNonBrowsableMembers()
+        {
+            excludeNonBrowsable = false;
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Instructs the comparison to exclude non-browsable members (members with an EditorBrowsableState of Never).
+        /// </summary>
+        /// <returns></returns>
+        public TSelf ExcludingNonBrowsableMembers()
+        {
+            excludeNonBrowsable = true;
             return (TSelf)this;
         }
 
@@ -724,6 +748,15 @@ namespace FluentAssertions.Equivalency
             else
             {
                 builder.AppendLine("- Compare records by their members");
+            }
+
+            if (excludeNonBrowsable)
+            {
+                builder.AppendLine("- Exclude non-browsable members");
+            }
+            else
+            {
+                builder.AppendLine("- Include non-browsable members");
             }
 
             foreach (Type valueType in valueTypes)

--- a/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
@@ -55,21 +55,24 @@ namespace FluentAssertions.Equivalency.Steps
             IMember matchingMember = FindMatchFor(selectedMember, context.CurrentNode, comparands.Subject, options);
             if (matchingMember is not null)
             {
-                var nestedComparands = new Comparands
+                if (matchingMember.IsBrowsable || !options.ExcludeNonBrowsable)
                 {
-                    Subject = matchingMember.GetValue(comparands.Subject),
-                    Expectation = selectedMember.GetValue(comparands.Expectation),
-                    CompileTimeType = selectedMember.Type
-                };
+                    var nestedComparands = new Comparands
+                    {
+                        Subject = matchingMember.GetValue(comparands.Subject),
+                        Expectation = selectedMember.GetValue(comparands.Expectation),
+                        CompileTimeType = selectedMember.Type
+                    };
 
-                if (selectedMember.Name != matchingMember.Name)
-                {
-                    // In case the matching process selected a different member on the subject,
-                    // adjust the current member so that assertion failures report the proper name.
-                    selectedMember.Name = matchingMember.Name;
+                    if (selectedMember.Name != matchingMember.Name)
+                    {
+                        // In case the matching process selected a different member on the subject,
+                        // adjust the current member so that assertion failures report the proper name.
+                        selectedMember.Name = matchingMember.Name;
+                    }
+
+                    parent.RecursivelyAssertEquality(nestedComparands, context.AsNestedMember(selectedMember));
                 }
-
-                parent.RecursivelyAssertEquality(nestedComparands, context.AsNestedMember(selectedMember));
             }
         }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -803,6 +803,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -823,6 +824,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool ExcludeNonBrowsable { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -858,6 +860,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        bool IsBrowsable { get; }
         System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -961,6 +964,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -989,6 +993,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
@@ -998,6 +1003,7 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -803,6 +803,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -823,6 +824,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool ExcludeNonBrowsable { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -858,6 +860,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        bool IsBrowsable { get; }
         System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -961,6 +964,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -989,6 +993,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
@@ -998,6 +1003,7 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -803,6 +803,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -823,6 +824,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool ExcludeNonBrowsable { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -858,6 +860,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        bool IsBrowsable { get; }
         System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -961,6 +964,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -989,6 +993,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
@@ -998,6 +1003,7 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -796,6 +796,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -816,6 +817,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool ExcludeNonBrowsable { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -851,6 +853,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        bool IsBrowsable { get; }
         System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -954,6 +957,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -982,6 +986,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
@@ -991,6 +996,7 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -803,6 +803,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -823,6 +824,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool ExcludeNonBrowsable { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -858,6 +860,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        bool IsBrowsable { get; }
         System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -961,6 +964,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -989,6 +993,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
@@ -998,6 +1003,7 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
+++ b/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
@@ -69,6 +69,8 @@ namespace Benchmarks
 
             public MemberVisibility IncludedFields => throw new NotImplementedException();
 
+            public bool ExcludeNonBrowsable => throw new NotImplementedException();
+
             public bool CompareRecordsByValue => throw new NotImplementedException();
 
             public ITraceWriter TraceWriter => throw new NotImplementedException();


### PR DESCRIPTION
This PR:

* Adds a property `ExcludeNonBrowsable` to `IEquivalencyAssertionOptions`, and implements it in `SelfReferenceEquivalencyAssertionOptions`, `CollectionMemberAssertionOptionsDecorator` and UsersOfGetClosedGenericInterfaces`.
* Adds a property `IsBrowsable` to ``IMember` and implements it in `Field` and `Property`.
* Uses the new properties in `AssertMemberEquality` in `StructuralEqualityEquivalencyStep` to allow for non-browsable members to be skipped when checking equivalence.
* Adds automated tests of the new functionality to `SelectionRulesSpec`.
* Accepted API changes into the approved API.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).