### PR TITLE
Fix typo in comment for ComparingRecordsByMembers

### DIFF
--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -576,7 +576,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Ensures records by default are compared by its members even though it may override
+        /// Ensures records by default are compared by their members even though they override 
         /// the <see cref="object.Equals(object)" /> method.
         /// </summary>
         /// <remarks>

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -576,7 +576,8 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Ensures records by default are compared by value instead of their members.
+        /// Ensures records by default are compared by its members even though it may override
+        /// the <see cref="object.Equals(object)" /> method.
         /// </summary>
         /// <remarks>
         /// This is the default.


### PR DESCRIPTION
This appeared to be copy/pasted from `ComparingRecordsByValue`

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).