### PR TITLE
Fill gaps in System.Data unit testing

### DIFF
--- a/Src/FluentAssertions/Data/DataRowAssertions.cs
+++ b/Src/FluentAssertions/Data/DataRowAssertions.cs
@@ -43,13 +43,13 @@ namespace FluentAssertions.Data
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:DataRow} to contain a column named '{0}'{reason}, but found <null>.", expectedColumnName);
+                    .FailWith("Expected {context:DataRow} to contain a column named {0}{reason}, but found <null>.", expectedColumnName);
             }
             else if (!Subject.Table.Columns.Contains(expectedColumnName))
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:DataRow} to contain a column named '{0}'{reason}, but it does not.", expectedColumnName);
+                    .FailWith("Expected {context:DataRow} to contain a column named {0}{reason}, but it does not.", expectedColumnName);
             }
             else
             {
@@ -93,7 +93,7 @@ namespace FluentAssertions.Data
                 Execute.Assertion
                     .ForCondition(Subject.Table.Columns.Contains(expectedColumnName))
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected table containing {context:DataRow} to contain a column named '{0}'{reason}, but it does not.", expectedColumnName);
+                    .FailWith("Expected table containing {context:DataRow} to contain a column named {0}{reason}, but it does not.", expectedColumnName);
             }
 
             return new AndConstraint<DataRowAssertions<TDataRow>>(this);

--- a/Src/FluentAssertions/Data/DataSetAssertions.cs
+++ b/Src/FluentAssertions/Data/DataSetAssertions.cs
@@ -73,13 +73,13 @@ namespace FluentAssertions.Data
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:DataSet} to contain a table named '{0}'{reason}, but found <null>.", expectedTableName);
+                    .FailWith("Expected {context:DataSet} to contain a table named {0}{reason}, but found <null>.", expectedTableName);
             }
             else if (!Subject.Tables.Contains(expectedTableName))
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:DataSet} to contain a table named '{0}'{reason}, but it does not.", expectedTableName);
+                    .FailWith("Expected {context:DataSet} to contain a table named {0}{reason}, but it does not.", expectedTableName);
             }
             else
             {
@@ -123,7 +123,7 @@ namespace FluentAssertions.Data
                 Execute.Assertion
                     .ForCondition(Subject.Tables.Contains(expectedTableName))
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:DataSet} to contain a table named '{0}'{reason}, but it does not.", expectedTableName);
+                    .FailWith("Expected {context:DataSet} to contain a table named {0}{reason}, but it does not.", expectedTableName);
             }
 
             return new AndConstraint<DataSetAssertions<TDataSet>>(this);

--- a/Src/FluentAssertions/Data/DataTableAssertions.cs
+++ b/Src/FluentAssertions/Data/DataTableAssertions.cs
@@ -73,13 +73,13 @@ namespace FluentAssertions.Data
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:DataTable} to contain a column named '{0}'{reason}, but found <null>.", expectedColumnName);
+                    .FailWith("Expected {context:DataTable} to contain a column named {0}{reason}, but found <null>.", expectedColumnName);
             }
             else if (!Subject.Columns.Contains(expectedColumnName))
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:DataTable} to contain a column named '{0}'{reason}, but it does not.", expectedColumnName);
+                    .FailWith("Expected {context:DataTable} to contain a column named {0}{reason}, but it does not.", expectedColumnName);
             }
             else
             {
@@ -123,7 +123,7 @@ namespace FluentAssertions.Data
                 Execute.Assertion
                     .ForCondition(Subject.Columns.Contains(expectedColumnName))
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:DataTable} to contain a column named '{0}'{reason}, but it does not.", expectedColumnName);
+                    .FailWith("Expected {context:DataTable} to contain a column named {0}{reason}, but it does not.", expectedColumnName);
             }
 
             return new AndConstraint<DataTableAssertions<TDataTable>>(this);

--- a/Src/FluentAssertions/Equivalency/Steps/DataRelationEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRelationEquivalencyStep.cs
@@ -59,7 +59,7 @@ namespace FluentAssertions.Equivalency.Steps
             {
                 AssertionScope.Current
                     .ForCondition(subject.RelationName == expectation.RelationName)
-                    .FailWith("Expected {context:DataRelation} to have RelationName of '{0}'{reason}, but found '{1}'",
+                    .FailWith("Expected {context:DataRelation} to have RelationName of {0}{reason}, but found {1}",
                         expectation.RelationName, subject.RelationName);
             }
 
@@ -67,7 +67,7 @@ namespace FluentAssertions.Equivalency.Steps
             {
                 AssertionScope.Current
                     .ForCondition(subject.Nested == expectation.Nested)
-                    .FailWith("Expected {context:DataRelation} to have Nested value of '{0}'{reason}, but found '{1}'",
+                    .FailWith("Expected {context:DataRelation} to have Nested value of {0}{reason}, but found {1}",
                         expectation.Nested, subject.Nested);
             }
 

--- a/Src/FluentAssertions/Equivalency/Steps/DataRowCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRowCollectionEquivalencyStep.cs
@@ -99,7 +99,7 @@ namespace FluentAssertions.Equivalency.Steps
             if ((table.PrimaryKey is null) || (table.PrimaryKey.Length == 0))
             {
                 AssertionScope.Current
-                    .FailWith("Table '{0}' containing {1} {context:DataRowCollection} does not have a primary key. RowMatchMode.PrimaryKey cannot be applied.", table.TableName, comparisonTerm);
+                    .FailWith("Table {0} containing {1} {context:DataRowCollection} does not have a primary key. RowMatchMode.PrimaryKey cannot be applied.", table.TableName, comparisonTerm);
             }
             else
             {

--- a/Src/FluentAssertions/Equivalency/Steps/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRowEquivalencyStep.cs
@@ -91,10 +91,10 @@ namespace FluentAssertions.Equivalency.Steps
             DataRow subject, DataRow expectation, DataEquivalencyAssertionOptions<DataSet> dataSetConfig,
             DataEquivalencyAssertionOptions<DataTable> dataTableConfig, DataEquivalencyAssertionOptions<DataRow> dataRowConfig)
         {
-            IEnumerable<string> expectationColumnNames = expectation.Table.Columns.OfType<DataColumn>()
+            IEnumerable<string> expectationColumnNames = expectation.Table.Columns.Cast<DataColumn>()
                 .Select(col => col.ColumnName);
 
-            IEnumerable<string> subjectColumnNames = subject.Table.Columns.OfType<DataColumn>()
+            IEnumerable<string> subjectColumnNames = subject.Table.Columns.Cast<DataColumn>()
                 .Select(col => col.ColumnName);
 
             bool ignoreUnmatchedColumns =

--- a/Src/FluentAssertions/Equivalency/Steps/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRowEquivalencyStep.cs
@@ -50,7 +50,7 @@ namespace FluentAssertions.Equivalency.Steps
                     {
                         AssertionScope.Current
                             .ForCondition(subject.GetType() == expectation.GetType())
-                            .FailWith("Expected {context:DataRow} to be of type '{0}'{reason}, but found '{1}'",
+                            .FailWith("Expected {context:DataRow} to be of type {0}{reason}, but found {1}",
                                 expectation.GetType(), subject.GetType());
                     }
 
@@ -74,7 +74,7 @@ namespace FluentAssertions.Equivalency.Steps
             {
                 AssertionScope.Current
                     .ForCondition(subject.HasErrors == expectation.HasErrors)
-                    .FailWith("Expected {context:DataRow} to have HasErrors value of '{0}'{reason}, but found '{1}' instead",
+                    .FailWith("Expected {context:DataRow} to have HasErrors value of {0}{reason}, but found {1} instead",
                         expectation.HasErrors, subject.HasErrors);
             }
 
@@ -82,7 +82,7 @@ namespace FluentAssertions.Equivalency.Steps
             {
                 AssertionScope.Current
                     .ForCondition(subject.RowState == expectation.RowState)
-                    .FailWith("Expected {context:DataRow} to have RowState value of '{0}'{reason}, but found '{1}' instead",
+                    .FailWith("Expected {context:DataRow} to have RowState value of {0}{reason}, but found {1} instead",
                         expectation.RowState, subject.RowState);
             }
         }
@@ -139,11 +139,11 @@ namespace FluentAssertions.Equivalency.Steps
                 {
                     AssertionScope.Current
                         .ForCondition(subjectColumn is not null)
-                        .FailWith("Expected {context:DataRow} to have column '{0}'{reason}, but found none", columnName);
+                        .FailWith("Expected {context:DataRow} to have column {0}{reason}, but found none", columnName);
 
                     AssertionScope.Current
                         .ForCondition(expectationColumn is not null)
-                        .FailWith("Found unexpected column '{0}' in {context:DataRow}", columnName);
+                        .FailWith("Found unexpected column {0} in {context:DataRow}", columnName);
                 }
 
                 if ((subjectColumn is not null) && (expectationColumn is not null))

--- a/Src/FluentAssertions/Equivalency/Steps/DataSetEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataSetEquivalencyStep.cs
@@ -41,7 +41,7 @@ namespace FluentAssertions.Equivalency.Steps
                     {
                         AssertionScope.Current
                             .ForCondition(subject.GetType() == expectation.GetType())
-                            .FailWith("Expected {context:DataSet} to be of type '{0}'{reason}, but found '{1}'", expectation.GetType(), subject.GetType());
+                            .FailWith("Expected {context:DataSet} to be of type {0}{reason}, but found {1}", expectation.GetType(), subject.GetType());
                     }
 
                     var selectedMembers = GetMembersFromExpectation(comparands, context.CurrentNode, context.Options)
@@ -64,63 +64,63 @@ namespace FluentAssertions.Equivalency.Steps
             {
                 AssertionScope.Current
                     .ForCondition(subject.DataSetName == expectation.DataSetName)
-                    .FailWith("Expected {context:DataSet} to have DataSetName '{0}'{reason}, but found '{1}' instead", expectation.DataSetName, subject.DataSetName);
+                    .FailWith("Expected {context:DataSet} to have DataSetName {0}{reason}, but found {1} instead", expectation.DataSetName, subject.DataSetName);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.CaseSensitive)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.CaseSensitive == expectation.CaseSensitive)
-                    .FailWith("Expected {context:DataSet} to have CaseSensitive value of '{0}'{reason}, but found '{1}' instead", expectation.CaseSensitive, subject.CaseSensitive);
+                    .FailWith("Expected {context:DataSet} to have CaseSensitive value of {0}{reason}, but found {1} instead", expectation.CaseSensitive, subject.CaseSensitive);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.EnforceConstraints)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.EnforceConstraints == expectation.EnforceConstraints)
-                    .FailWith("Expected {context:DataSet} to have EnforceConstraints value of '{0}'{reason}, but found '{1}' instead", expectation.EnforceConstraints, subject.EnforceConstraints);
+                    .FailWith("Expected {context:DataSet} to have EnforceConstraints value of {0}{reason}, but found {1} instead", expectation.EnforceConstraints, subject.EnforceConstraints);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.HasErrors)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.HasErrors == expectation.HasErrors)
-                    .FailWith("Expected {context:DataSet} to have HasErrors value of '{0}'{reason}, but found '{1}' instead", expectation.HasErrors, subject.HasErrors);
+                    .FailWith("Expected {context:DataSet} to have HasErrors value of {0}{reason}, but found {1} instead", expectation.HasErrors, subject.HasErrors);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.Locale)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.Locale == expectation.Locale)
-                    .FailWith("Expected {context:DataSet} to have Locale value of '{0}'{reason}, but found '{1}' instead", expectation.Locale, subject.Locale);
+                    .FailWith("Expected {context:DataSet} to have Locale value of {0}{reason}, but found {1} instead", expectation.Locale, subject.Locale);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.Namespace)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.Namespace == expectation.Namespace)
-                    .FailWith("Expected {context:DataSet} to have Namespace value of '{0}'{reason}, but found '{1}' instead", expectation.Namespace, subject.Namespace);
+                    .FailWith("Expected {context:DataSet} to have Namespace value of {0}{reason}, but found {1} instead", expectation.Namespace, subject.Namespace);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.Prefix)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.Prefix == expectation.Prefix)
-                    .FailWith("Expected {context:DataSet} to have Prefix value of '{0}'{reason}, but found '{1}' instead", expectation.Prefix, subject.Prefix);
+                    .FailWith("Expected {context:DataSet} to have Prefix value of {0}{reason}, but found {1} instead", expectation.Prefix, subject.Prefix);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.RemotingFormat)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.RemotingFormat == expectation.RemotingFormat)
-                    .FailWith("Expected {context:DataSet} to have RemotingFormat value of '{0}'{reason}, but found '{1}' instead", expectation.RemotingFormat, subject.RemotingFormat);
+                    .FailWith("Expected {context:DataSet} to have RemotingFormat value of {0}{reason}, but found {1} instead", expectation.RemotingFormat, subject.RemotingFormat);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.SchemaSerializationMode)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.SchemaSerializationMode == expectation.SchemaSerializationMode)
-                    .FailWith("Expected {context:DataSet} to have SchemaSerializationMode value of '{0}'{reason}, but found '{1}' instead", expectation.SchemaSerializationMode, subject.SchemaSerializationMode);
+                    .FailWith("Expected {context:DataSet} to have SchemaSerializationMode value of {0}{reason}, but found {1} instead", expectation.SchemaSerializationMode, subject.SchemaSerializationMode);
             }
         }
 
@@ -210,10 +210,10 @@ namespace FluentAssertions.Equivalency.Steps
 
             bool success = AssertionScope.Current
                 .ForCondition(subjectTable is not null)
-                .FailWith("Expected {context:DataSet} to contain table '{0}'{reason}, but did not find it", tableName)
+                .FailWith("Expected {context:DataSet} to contain table {0}{reason}, but did not find it", tableName)
                 .Then
                 .ForCondition(expectationTable is not null)
-                .FailWith("Found unexpected table '{0}' in DataSet", tableName);
+                .FailWith("Found unexpected table {0} in DataSet", tableName);
 
             if (success)
             {

--- a/Src/FluentAssertions/Equivalency/Steps/DataSetEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataSetEquivalencyStep.cs
@@ -185,9 +185,9 @@ namespace FluentAssertions.Equivalency.Steps
                     }
                 }
 
-                IEnumerable<string> expectationTableNames = expectation.Tables.OfType<DataTable>()
+                IEnumerable<string> expectationTableNames = expectation.Tables.Cast<DataTable>()
                     .Select(table => table.TableName);
-                IEnumerable<string> subjectTableNames = subject.Tables.OfType<DataTable>()
+                IEnumerable<string> subjectTableNames = subject.Tables.Cast<DataTable>()
                     .Select(table => table.TableName);
 
                 foreach (string tableName in expectationTableNames.Union(subjectTableNames))

--- a/Src/FluentAssertions/Equivalency/Steps/DataTableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataTableEquivalencyStep.cs
@@ -45,7 +45,7 @@ namespace FluentAssertions.Equivalency.Steps
                     {
                         AssertionScope.Current
                             .ForCondition(subject.GetType() == expectation.GetType())
-                            .FailWith("Expected {context:DataTable} to be of type '{0}'{reason}, but found '{1}'", expectation.GetType(), subject.GetType());
+                            .FailWith("Expected {context:DataTable} to be of type {0}{reason}, but found {1}", expectation.GetType(), subject.GetType());
                     }
 
                     var selectedMembers = GetMembersFromExpectation(context.CurrentNode, comparands, context.Options)
@@ -68,56 +68,56 @@ namespace FluentAssertions.Equivalency.Steps
             {
                 AssertionScope.Current
                     .ForCondition(subject.TableName == expectation.TableName)
-                    .FailWith("Expected {context:DataTable} to have TableName '{0}'{reason}, but found '{1}' instead", expectation.TableName, subject.TableName);
+                    .FailWith("Expected {context:DataTable} to have TableName {0}{reason}, but found {1} instead", expectation.TableName, subject.TableName);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.CaseSensitive)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.CaseSensitive == expectation.CaseSensitive)
-                    .FailWith("Expected {context:DataTable} to have CaseSensitive value of '{0}'{reason}, but found '{1}' instead", expectation.CaseSensitive, subject.CaseSensitive);
+                    .FailWith("Expected {context:DataTable} to have CaseSensitive value of {0}{reason}, but found {1} instead", expectation.CaseSensitive, subject.CaseSensitive);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.DisplayExpression)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.DisplayExpression == expectation.DisplayExpression)
-                    .FailWith("Expected {context:DataTable} to have DisplayExpression value of '{0}'{reason}, but found '{1}' instead", expectation.DisplayExpression, subject.DisplayExpression);
+                    .FailWith("Expected {context:DataTable} to have DisplayExpression value of {0}{reason}, but found {1} instead", expectation.DisplayExpression, subject.DisplayExpression);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.HasErrors)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.HasErrors == expectation.HasErrors)
-                    .FailWith("Expected {context:DataTable} to have HasErrors value of '{0}'{reason}, but found '{1}' instead", expectation.HasErrors, subject.HasErrors);
+                    .FailWith("Expected {context:DataTable} to have HasErrors value of {0}{reason}, but found {1} instead", expectation.HasErrors, subject.HasErrors);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.Locale)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.Locale == expectation.Locale)
-                    .FailWith("Expected {context:DataTable} to have Locale value of '{0}'{reason}, but found '{1}' instead", expectation.Locale, subject.Locale);
+                    .FailWith("Expected {context:DataTable} to have Locale value of {0}{reason}, but found {1} instead", expectation.Locale, subject.Locale);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.Namespace)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.Namespace == expectation.Namespace)
-                    .FailWith("Expected {context:DataTable} to have Namespace value of '{0}'{reason}, but found '{1}' instead", expectation.Namespace, subject.Namespace);
+                    .FailWith("Expected {context:DataTable} to have Namespace value of {0}{reason}, but found {1} instead", expectation.Namespace, subject.Namespace);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.Prefix)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.Prefix == expectation.Prefix)
-                    .FailWith("Expected {context:DataTable} to have Prefix value of '{0}'{reason}, but found '{1}' instead", expectation.Prefix, subject.Prefix);
+                    .FailWith("Expected {context:DataTable} to have Prefix value of {0}{reason}, but found {1} instead", expectation.Prefix, subject.Prefix);
             }
 
             if (selectedMembers.ContainsKey(nameof(expectation.RemotingFormat)))
             {
                 AssertionScope.Current
                     .ForCondition(subject.RemotingFormat == expectation.RemotingFormat)
-                    .FailWith("Expected {context:DataTable} to have RemotingFormat value of '{0}'{reason}, but found '{1}' instead", expectation.RemotingFormat, subject.RemotingFormat);
+                    .FailWith("Expected {context:DataTable} to have RemotingFormat value of {0}{reason}, but found {1} instead", expectation.RemotingFormat, subject.RemotingFormat);
             }
         }
 

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -343,7 +343,7 @@ namespace FluentAssertions.Equivalency.Specs
 
             var dataRow = dataSet.TypedDataTable1[0];
 
-            string expectedColumnName = dataSet.TypedDataTable1.Columns.OfType<DataColumn>().Last().ColumnName;
+            string expectedColumnName = dataSet.TypedDataTable1.Columns.Cast<DataColumn>().Last().ColumnName;
 
             // Act & Assert
             dataRow.Should().HaveColumn(expectedColumnName);
@@ -373,7 +373,7 @@ namespace FluentAssertions.Equivalency.Specs
 
             var dataRow = dataSet.TypedDataTable1[0];
 
-            var subsetOfColumnNames = dataRow.Table.Columns.OfType<DataColumn>()
+            var subsetOfColumnNames = dataRow.Table.Columns.Cast<DataColumn>()
                 .Take(dataRow.Table.Columns.Count - 2)
                 .Select(column => column.ColumnName);
 
@@ -389,7 +389,7 @@ namespace FluentAssertions.Equivalency.Specs
 
             var dataRow = dataSet.TypedDataTable1[0];
 
-            var subsetOfColumnNamesWithUnicorn = dataRow.Table.Columns.OfType<DataColumn>()
+            var subsetOfColumnNamesWithUnicorn = dataRow.Table.Columns.Cast<DataColumn>()
                 .Take(dataRow.Table.Columns.Count - 2)
                 .Select(column => column.ColumnName)
                 .Concat(new[] { "Unicorn" });

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -5,328 +5,328 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Equivalency.Specs
 {
-        public class DataRowSpecs : DataSpecs
+    public class DataRowSpecs : DataSpecs
+    {
+        [Fact]
+        public void When_DataRows_are_identical_it_should_succeed()
         {
-            [Fact]
-            public void When_DataRows_are_identical_it_should_succeed()
-            {
-                // Arrange
-                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-                var dataSet2 = new TypedDataSetSubclass(dataSet1);
-
-                var dataTable1 = dataSet1.TypedDataTable1;
-                var dataTable2 = dataSet2.TypedDataTable1;
-
-                // Act & Assert
-                dataTable1[0].Should().BeEquivalentTo(dataTable2[0]);
-            }
-
-            [Fact]
-            public void When_DataRows_are_both_null_it_should_succeed()
-            {
-                // Act & Assert
-                ((DataRow)null).Should().BeEquivalentTo(null);
-            }
-
-            [Fact]
-            public void When_DataRow_is_null_and_isnt_expected_to_be_it_should_fail()
-            {
-                // Arrange
-                var dataSet = CreateDummyDataSet<TypedDataSet>();
-
-                var dataTable = dataSet.TypedDataTable1;
-
-                // Act
-                Action action = () => ((DataRow)null).Should().BeEquivalentTo(dataTable[0]);
-
-                // Assert
-                action.Should().Throw<XunitException>().WithMessage(
-                    "Expected *to be non-null, but found null*");
-            }
-
-            [Fact]
-            public void When_DataRow_is_expected_to_be_null_and_isnt_it_should_fail()
-            {
-                // Arrange
-                var dataSet = CreateDummyDataSet<TypedDataSet>();
-
-                var dataTable = dataSet.TypedDataTable1;
-
-                // Act
-                Action action = () => dataTable[0].Should().BeEquivalentTo(null);
-
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
-
-            [Fact]
-            public void When_DataRow_subject_is_deleted_and_RowState_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-                var dataSet2 = new TypedDataSetSubclass(dataSet1);
-
-                var dataTable1 = dataSet1.TypedDataTable2;
-                var dataTable2 = dataSet2.TypedDataTable2;
-
-                var dataRow1 = dataTable1[0];
-                var dataRow2 = dataTable2[0];
-
-                dataRow1.Delete();
-
-                // Act & Assert
-                dataRow1.Should().BeEquivalentTo(dataRow2, config => config
-                    .Excluding(row => row.RowState));
-            }
-
-            [Fact]
-            public void When_DataRow_expectation_is_deleted_and_RowState_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-                var dataSet2 = new TypedDataSetSubclass(dataSet1);
-
-                var dataTable1 = dataSet1.TypedDataTable2;
-                var dataTable2 = dataSet2.TypedDataTable2;
-
-                var dataRow1 = dataTable1[0];
-                var dataRow2 = dataTable2[0];
-
-                dataRow2.Delete();
-
-                // Act & Assert
-                dataRow1.Should().BeEquivalentTo(dataRow2, config => config
-                    .Excluding(row => row.RowState));
-            }
-
-            [Fact]
-            public void When_DataRow_is_deleted_it_should_succeed()
-            {
-                // Arrange
-                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-                var dataSet2 = new TypedDataSetSubclass(dataSet1);
-
-                var dataTable1 = dataSet1.TypedDataTable2;
-                var dataTable2 = dataSet2.TypedDataTable2;
-
-                var dataRow1 = dataTable1[0];
-                var dataRow2 = dataTable2[0];
+            // Arrange
+            var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+            var dataTable1 = dataSet1.TypedDataTable1;
+            var dataTable2 = dataSet2.TypedDataTable1;
+
+            // Act & Assert
+            dataTable1[0].Should().BeEquivalentTo(dataTable2[0]);
+        }
+
+        [Fact]
+        public void When_DataRows_are_both_null_it_should_succeed()
+        {
+            // Act & Assert
+            ((DataRow)null).Should().BeEquivalentTo(null);
+        }
+
+        [Fact]
+        public void When_DataRow_is_null_and_isnt_expected_to_be_it_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSet>();
+
+            var dataTable = dataSet.TypedDataTable1;
+
+            // Act
+            Action action = () => ((DataRow)null).Should().BeEquivalentTo(dataTable[0]);
+
+            // Assert
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected *to be non-null, but found null*");
+        }
+
+        [Fact]
+        public void When_DataRow_is_expected_to_be_null_and_isnt_it_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSet>();
+
+            var dataTable = dataSet.TypedDataTable1;
+
+            // Act
+            Action action = () => dataTable[0].Should().BeEquivalentTo(null);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_DataRow_subject_is_deleted_and_RowState_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+            var dataTable1 = dataSet1.TypedDataTable2;
+            var dataTable2 = dataSet2.TypedDataTable2;
+
+            var dataRow1 = dataTable1[0];
+            var dataRow2 = dataTable2[0];
+
+            dataRow1.Delete();
+
+            // Act & Assert
+            dataRow1.Should().BeEquivalentTo(dataRow2, config => config
+                .Excluding(row => row.RowState));
+        }
+
+        [Fact]
+        public void When_DataRow_expectation_is_deleted_and_RowState_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+            var dataTable1 = dataSet1.TypedDataTable2;
+            var dataTable2 = dataSet2.TypedDataTable2;
+
+            var dataRow1 = dataTable1[0];
+            var dataRow2 = dataTable2[0];
+
+            dataRow2.Delete();
+
+            // Act & Assert
+            dataRow1.Should().BeEquivalentTo(dataRow2, config => config
+                .Excluding(row => row.RowState));
+        }
+
+        [Fact]
+        public void When_DataRow_is_deleted_it_should_succeed()
+        {
+            // Arrange
+            var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+            var dataTable1 = dataSet1.TypedDataTable2;
+            var dataTable2 = dataSet2.TypedDataTable2;
+
+            var dataRow1 = dataTable1[0];
+            var dataRow2 = dataTable2[0];
+
+            dataRow1.Delete();
+            dataRow2.Delete();
+
+            // Act & Assert
+            dataRow1.Should().BeEquivalentTo(dataRow2);
+        }
 
-                dataRow1.Delete();
-                dataRow2.Delete();
-
-                // Act & Assert
-                dataRow1.Should().BeEquivalentTo(dataRow2);
-            }
+        [Fact]
+        public void When_DataRow_is_modified_and_original_data_differs_it_should_fail()
+        {
+            // Arrange
+            var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
-            [Fact]
-            public void When_DataRow_is_modified_and_original_data_differs_it_should_fail()
-            {
-                // Arrange
-                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+            var dataTable1 = dataSet1.TypedDataTable2;
+            var dataTable2 = dataSet2.TypedDataTable2;
 
-                var dataTable1 = dataSet1.TypedDataTable2;
-                var dataTable2 = dataSet2.TypedDataTable2;
+            var dataRow1 = dataTable1[0];
+            var dataRow2 = dataTable2[0];
 
-                var dataRow1 = dataTable1[0];
-                var dataRow2 = dataTable2[0];
+            dataRow1.Decimal++;
+            dataTable1.AcceptChanges();
+            dataRow1.Decimal--;
+
+            dataRow2.Decimal--;
+            dataTable2.AcceptChanges();
+            dataRow2.Decimal++;
 
-                dataRow1.Decimal++;
-                dataTable1.AcceptChanges();
-                dataRow1.Decimal--;
+            // Act
+            Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
 
-                dataRow2.Decimal--;
-                dataTable2.AcceptChanges();
-                dataRow2.Decimal++;
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
 
-                // Act
-                Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
+        [Fact]
+        public void When_DataRow_is_modified_and_original_data_differs_and_original_data_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
+            var dataTable1 = dataSet1.TypedDataTable2;
+            var dataTable2 = dataSet2.TypedDataTable2;
 
-            [Fact]
-            public void When_DataRow_is_modified_and_original_data_differs_and_original_data_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+            var dataRow1 = dataTable1[0];
+            var dataRow2 = dataTable2[0];
 
-                var dataTable1 = dataSet1.TypedDataTable2;
-                var dataTable2 = dataSet2.TypedDataTable2;
+            dataRow1.Decimal++;
+            dataTable1.AcceptChanges();
+            dataRow1.Decimal--;
 
-                var dataRow1 = dataTable1[0];
-                var dataRow2 = dataTable2[0];
+            dataRow2.Decimal--;
+            dataTable2.AcceptChanges();
+            dataRow2.Decimal++;
 
-                dataRow1.Decimal++;
-                dataTable1.AcceptChanges();
-                dataRow1.Decimal--;
+            // Act & Assert
+            dataRow1.Should().BeEquivalentTo(dataRow2, config => config
+                .ExcludingOriginalData());
+        }
 
-                dataRow2.Decimal--;
-                dataTable2.AcceptChanges();
-                dataRow2.Decimal++;
+        [Fact]
+        public void When_DataRow_type_does_not_match_and_AllowMismatchedType_not_enabled_it_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
+            var dataSet2 = new TypedDataSetSubclass(dataSet);
 
-                // Act & Assert
-                dataRow1.Should().BeEquivalentTo(dataRow2, config => config
-                    .ExcludingOriginalData());
-            }
+            var dataTable = dataSet.TypedDataTable1;
+            var dataTableOfMismatchedType = dataSet2.TypedDataTable2;
 
-            [Fact]
-            public void When_DataRow_type_does_not_match_and_AllowMismatchedType_not_enabled_it_should_fail()
-            {
-                // Arrange
-                var dataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
-                var dataSet2 = new TypedDataSetSubclass(dataSet);
+            dataSet2.Tables.Remove(dataTable.TableName);
+            dataTableOfMismatchedType.TableName = dataTable.TableName;
 
-                var dataTable = dataSet.TypedDataTable1;
-                var dataTableOfMismatchedType = dataSet2.TypedDataTable2;
+            // Act
+            Action action = () => dataTable[0].Should().BeEquivalentTo(dataTableOfMismatchedType[0]);
 
-                dataSet2.Tables.Remove(dataTable.TableName);
-                dataTableOfMismatchedType.TableName = dataTable.TableName;
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
 
-                // Act
-                Action action = () => dataTable[0].Should().BeEquivalentTo(dataTableOfMismatchedType[0]);
+        [Fact]
+        public void When_DataRow_type_does_not_match_and_AllowMismatchedType_is_enabled_it_should_succeed()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
+            var dataSet2 = new TypedDataSetSubclass(dataSet);
 
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
+            var dataTable = dataSet.TypedDataTable1;
+            var dataTableOfMismatchedType = dataSet2.TypedDataTable2;
 
-            [Fact]
-            public void When_DataRow_type_does_not_match_and_AllowMismatchedType_is_enabled_it_should_succeed()
-            {
-                // Arrange
-                var dataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
-                var dataSet2 = new TypedDataSetSubclass(dataSet);
+            dataSet2.Tables.Remove(dataTable.TableName);
+            dataTableOfMismatchedType.TableName = dataTable.TableName;
 
-                var dataTable = dataSet.TypedDataTable1;
-                var dataTableOfMismatchedType = dataSet2.TypedDataTable2;
+            // Act & Assert
+            dataTable[0].Should().BeEquivalentTo(dataTableOfMismatchedType[0], options => options.AllowingMismatchedTypes());
+        }
 
-                dataSet2.Tables.Remove(dataTable.TableName);
-                dataTableOfMismatchedType.TableName = dataTable.TableName;
+        [Fact]
+        public void When_HasErrors_does_not_match_and_property_is_not_excluded_it_should_fail()
+        {
+            // Arrange
+            var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-                // Act & Assert
-                dataTable[0].Should().BeEquivalentTo(dataTableOfMismatchedType[0], options => options.AllowingMismatchedTypes());
-            }
+            var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
-            [Fact]
-            public void When_HasErrors_does_not_match_and_property_is_not_excluded_it_should_fail()
-            {
-                // Arrange
-                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataRow1 = dataSet1.TypedDataTable1[0];
+            var dataRow2 = dataSet2.TypedDataTable1[0];
 
-                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+            dataRow2.RowError = "Manually added error";
 
-                var dataRow1 = dataSet1.TypedDataTable1[0];
-                var dataRow2 = dataSet2.TypedDataTable1[0];
+            // Act
+            Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
 
-                dataRow2.RowError = "Manually added error";
+            // Assert
+            action.Should().Throw<XunitException>().Which.Message.Should().Contain("HasErrors");
+        }
 
-                // Act
-                Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
+        [Fact]
+        public void When_HasErrors_does_not_match_and_property_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-                // Assert
-                action.Should().Throw<XunitException>().Which.Message.Should().Contain("HasErrors");
-            }
+            var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
-            [Fact]
-            public void When_HasErrors_does_not_match_and_property_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataRow1 = dataSet1.TypedDataTable1[0];
+            var dataRow2 = dataSet2.TypedDataTable1[0];
 
-                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+            dataRow2.RowError = "Manually added error";
 
-                var dataRow1 = dataSet1.TypedDataTable1[0];
-                var dataRow2 = dataSet2.TypedDataTable1[0];
+            // Act & Assert
+            dataRow1.Should().BeEquivalentTo(dataRow2, config => config.Excluding(dataRow => dataRow.HasErrors));
+        }
 
-                dataRow2.RowError = "Manually added error";
+        [Fact]
+        public void When_RowState_does_not_match_and_property_is_not_excluded_it_should_fail()
+        {
+            // Arrange
+            var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-                // Act & Assert
-                dataRow1.Should().BeEquivalentTo(dataRow2, config => config.Excluding(dataRow => dataRow.HasErrors));
-            }
+            var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
-            [Fact]
-            public void When_RowState_does_not_match_and_property_is_not_excluded_it_should_fail()
-            {
-                // Arrange
-                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataRow1 = dataSet1.TypedDataTable1[0];
+            var dataRow2 = dataSet2.TypedDataTable1[0];
 
-                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+            dataRow1.DateTime = DateTime.UtcNow;
+            dataRow2.DateTime = dataRow1.DateTime;
 
-                var dataRow1 = dataSet1.TypedDataTable1[0];
-                var dataRow2 = dataSet2.TypedDataTable1[0];
+            dataSet2.AcceptChanges();
 
-                dataRow1.DateTime = DateTime.UtcNow;
-                dataRow2.DateTime = dataRow1.DateTime;
+            // Act
+            Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
 
-                dataSet2.AcceptChanges();
+            // Assert
+            action.Should().Throw<XunitException>().Which.Message.Should().Contain("RowState");
+        }
 
-                // Act
-                Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
+        [Fact]
+        public void When_RowState_does_not_match_and_property_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-                // Assert
-                action.Should().Throw<XunitException>().Which.Message.Should().Contain("RowState");
-            }
+            var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
-            [Fact]
-            public void When_RowState_does_not_match_and_property_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataRow1 = dataSet1.TypedDataTable1[0];
+            var dataRow2 = dataSet2.TypedDataTable1[0];
 
-                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+            dataRow1.DateTime = DateTime.UtcNow;
+            dataRow2.DateTime = dataRow1.DateTime;
 
-                var dataRow1 = dataSet1.TypedDataTable1[0];
-                var dataRow2 = dataSet2.TypedDataTable1[0];
+            dataSet2.AcceptChanges();
 
-                dataRow1.DateTime = DateTime.UtcNow;
-                dataRow2.DateTime = dataRow1.DateTime;
+            // Act & Assert
+            dataRow1.Should().BeEquivalentTo(dataRow2, config => config.Excluding(dataRow => dataRow.RowState));
+        }
 
-                dataSet2.AcceptChanges();
+        [Fact]
+        public void When_data_does_not_match_and_column_is_not_excluded_it_should_fail()
+        {
+            // Arrange
+            var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-                // Act & Assert
-                dataRow1.Should().BeEquivalentTo(dataRow2, config => config.Excluding(dataRow => dataRow.RowState));
-            }
+            var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
-            [Fact]
-            public void When_data_does_not_match_and_column_is_not_excluded_it_should_fail()
-            {
-                // Arrange
-                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataRow1 = dataSet1.TypedDataTable1[0];
+            var dataRow2 = dataSet2.TypedDataTable1[0];
 
-                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+            dataRow2.String = Guid.NewGuid().ToString();
+            dataSet2.AcceptChanges();
 
-                var dataRow1 = dataSet1.TypedDataTable1[0];
-                var dataRow2 = dataSet2.TypedDataTable1[0];
+            // Act
+            Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
 
-                dataRow2.String = Guid.NewGuid().ToString();
-                dataSet2.AcceptChanges();
+            // Assert
+            action.Should().Throw<XunitException>().Which.Message.Should().Contain(dataRow2.String);
+        }
 
-                // Act
-                Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
+        [Fact]
+        public void When_data_does_not_match_and_column_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-                // Assert
-                action.Should().Throw<XunitException>().Which.Message.Should().Contain(dataRow2.String);
-            }
+            var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
-            [Fact]
-            public void When_data_does_not_match_and_column_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataRow1 = dataSet1.TypedDataTable1[0];
+            var dataRow2 = dataSet2.TypedDataTable1[0];
 
-                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+            dataRow2.DateTime = DateTime.UtcNow;
+            dataSet2.AcceptChanges();
 
-                var dataRow1 = dataSet1.TypedDataTable1[0];
-                var dataRow2 = dataSet2.TypedDataTable1[0];
-
-                dataRow2.DateTime = DateTime.UtcNow;
-                dataSet2.AcceptChanges();
-
-                // Act & Assert
-                dataRow1.Should().BeEquivalentTo(dataRow2, config => config.ExcludingColumn(dataSet2.TypedDataTable1.DateTimeColumn));
-            }
+            // Act & Assert
+            dataRow1.Should().BeEquivalentTo(dataRow2, config => config.ExcludingColumn(dataSet2.TypedDataTable1.DateTimeColumn));
         }
     }
+}

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -59,7 +59,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataTable[0].Should().BeEquivalentTo(null);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataTable[0] value to be null, but found *");
         }
 
         [Fact]
@@ -147,7 +147,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataRow1[Decimal, DataRowVersion.Original] to be *, but found *");
         }
 
         [Fact]
@@ -196,7 +196,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataTable[0].Should().BeEquivalentTo(dataTableOfMismatchedType[0]);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataTable[0] to be of type *TypedDataRow2, but found *TypedDataRow1*");
         }
 
         [Fact]
@@ -362,7 +362,7 @@ namespace FluentAssertions.Equivalency.Specs
                 () => dataRow.Should().HaveColumn("Unicorn");
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataRow to contain a column named *Unicorn*");
         }
 
         [Fact]
@@ -399,7 +399,7 @@ namespace FluentAssertions.Equivalency.Specs
                 () => dataRow.Should().HaveColumns(subsetOfColumnNamesWithUnicorn);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected table containing dataRow to contain a column named *Unicorn*");
         }
 
         [Fact]
@@ -420,7 +420,7 @@ namespace FluentAssertions.Equivalency.Specs
                 () => dataRow.Should().HaveColumns(columnNames);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected table containing dataRow to contain a column named *Unicorn*");
         }
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -163,6 +163,9 @@ namespace FluentAssertions.Equivalency.Specs
             var dataRow1 = dataTable1[0];
             var dataRow2 = dataTable2[0];
 
+            // Set the Decimal property to be the same for both rows, but by doing ++ and -- in
+            // different orders, the AcceptChanges call will load different values into the
+            // original data for each row.
             dataRow1.Decimal++;
             dataTable1.AcceptChanges();
             dataRow1.Decimal--;
@@ -340,8 +343,10 @@ namespace FluentAssertions.Equivalency.Specs
 
             var dataRow = dataSet.TypedDataTable1[0];
 
+            string expectedColumnName = dataSet.TypedDataTable1.Columns.OfType<DataColumn>().Last().ColumnName;
+
             // Act & Assert
-            dataRow.Should().HaveColumn("ForeignRowID");
+            dataRow.Should().HaveColumn(expectedColumnName);
         }
 
         [Fact]
@@ -368,12 +373,12 @@ namespace FluentAssertions.Equivalency.Specs
 
             var dataRow = dataSet.TypedDataTable1[0];
 
-            var columnNames = dataRow.Table.Columns.OfType<DataColumn>()
-                .Take(3)
+            var subsetOfColumnNames = dataRow.Table.Columns.OfType<DataColumn>()
+                .Take(dataRow.Table.Columns.Count - 2)
                 .Select(column => column.ColumnName);
 
             // Act & Assert
-            dataRow.Should().HaveColumns(columnNames);
+            dataRow.Should().HaveColumns(subsetOfColumnNames);
         }
 
         [Fact]
@@ -384,14 +389,14 @@ namespace FluentAssertions.Equivalency.Specs
 
             var dataRow = dataSet.TypedDataTable1[0];
 
-            var columnNames = dataRow.Table.Columns.OfType<DataColumn>()
-                .Take(3)
+            var subsetOfColumnNamesWithUnicorn = dataRow.Table.Columns.OfType<DataColumn>()
+                .Take(dataRow.Table.Columns.Count - 2)
                 .Select(column => column.ColumnName)
                 .Concat(new[] { "Unicorn" });
 
             // Act
             Action action =
-                () => dataRow.Should().HaveColumns(columnNames);
+                () => dataRow.Should().HaveColumns(subsetOfColumnNamesWithUnicorn);
 
             // Assert
             action.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -11,7 +11,7 @@ namespace FluentAssertions.Equivalency.Specs
     public class DataRowSpecs : DataSpecs
     {
         [Fact]
-        public void When_DataRows_are_identical_it_should_succeed()
+        public void When_data_rows_are_identical_equivalency_test_should_succeed()
         {
             // Arrange
             var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -25,14 +25,14 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataRows_are_both_null_it_should_succeed()
+        public void When_data_rows_are_both_null_equivalency_test_should_succeed()
         {
             // Act & Assert
             ((DataRow)null).Should().BeEquivalentTo(null);
         }
 
         [Fact]
-        public void When_DataRow_is_null_and_isnt_expected_to_be_it_should_fail()
+        public void When_data_row_is_null_and_isnt_expected_to_be_then_equivalency_test_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSet>();
@@ -48,7 +48,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataRow_is_expected_to_be_null_and_isnt_it_should_fail()
+        public void When_data_row_is_expected_to_be_null_and_isnt_then_equivalency_test_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSet>();
@@ -63,7 +63,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataRow_subject_is_deleted_and_RowState_is_excluded_it_should_succeed()
+        public void When_data_row_subject_is_deleted_and_expectation_is_not_but_the_row_state_is_excluded_equivalency_test_should_succeed()
         {
             // Arrange
             var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -83,7 +83,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataRow_expectation_is_deleted_and_RowState_is_excluded_it_should_succeed()
+        public void When_data_row_expectation_is_deleted_and_subject_is_not_but_the_row_state_is_excluded_equivalency_test_should_succeed()
         {
             // Arrange
             var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -103,7 +103,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataRow_is_deleted_it_should_succeed()
+        public void When_data_row_is_deleted_equivalency_test_should_succeed()
         {
             // Arrange
             var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -123,7 +123,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataRow_is_modified_and_original_data_differs_it_should_fail()
+        public void When_data_row_is_modified_and_original_data_differs_equivalency_test_should_fail()
         {
             // Arrange
             var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -151,7 +151,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataRow_is_modified_and_original_data_differs_and_original_data_is_excluded_it_should_succeed()
+        public void When_data_row_is_modified_and_original_data_differs_but_original_data_is_excluded_then_equivalency_test_should_succeed()
         {
             // Arrange
             var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -177,7 +177,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataRow_type_does_not_match_and_AllowMismatchedType_not_enabled_it_should_fail()
+        public void When_data_row_type_does_not_match_and_mismatched_types_are_not_allowed_then_equivalency_test_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
@@ -197,7 +197,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataRow_type_does_not_match_and_AllowMismatchedType_is_enabled_it_should_succeed()
+        public void When_data_row_type_does_not_match_but_mismatched_types_are_allowed_then_equivalency_test_should_succeed()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
@@ -214,7 +214,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_HasErrors_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_one_data_row_has_errors_and_the_other_does_not_and_the_corresponding_property_is_not_excluded_then_equivalency_test_should_fail()
         {
             // Arrange
             var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -234,7 +234,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_HasErrors_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_one_data_row_has_errors_and_the_other_does_not_but_the_corresponding_property_is_excluded_then_equivalency_test_should_succeed()
         {
             // Arrange
             var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -251,7 +251,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_RowState_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_the_data_row_state_does_not_match_and_the_corresponding_property_is_not_excluded_equivalency_test_should_fail()
         {
             // Arrange
             var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -274,7 +274,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_RowState_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_the_data_row_state_does_not_match_but_the_corresponding_property_is_excluded_equivalency_test_should_succeed()
         {
             // Arrange
             var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -294,7 +294,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_data_does_not_match_and_column_is_not_excluded_it_should_fail()
+        public void When_data_row_data_does_not_match_and_the_column_in_question_is_not_excluded_then_equivalency_test_should_fail()
         {
             // Arrange
             var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -315,7 +315,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_data_does_not_match_and_column_is_excluded_it_should_succeed()
+        public void When_data_row_data_does_not_match_but_the_column_is_excluded_then_equivalency_test_should_succeed()
         {
             // Arrange
             var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -333,7 +333,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_data_has_column_asserting_HaveColumn_should_succeed()
+        public void When_data_row_has_column_then_asserting_that_it_has_that_column_should_succeed()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -345,7 +345,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_data_does_not_have_column_asserting_HaveColumn_should_fail()
+        public void When_data_row_does_not_have_column_then_asserting_that_it_has_that_column_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -361,7 +361,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_data_has_all_columns_asserting_HaveColumns_should_succeed()
+        public void When_data_row_data_has_all_columns_being_asserted_then_it_should_succeed()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -377,7 +377,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_data_has_only_some_columns_asserting_HaveColumns_should_fail()
+        public void When_data_row_data_has_only_some_of_the_columns_being_asserted_then_it_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -398,7 +398,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_data_has_no_matching_columns_asserting_HaveColumns_should_fail()
+        public void When_data_row_data_has_none_of_the_columns_being_asserted_then_it_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data;
+using System.Linq;
+
 using Xunit;
 using Xunit.Sdk;
 
@@ -327,6 +330,92 @@ namespace FluentAssertions.Equivalency.Specs
 
             // Act & Assert
             dataRow1.Should().BeEquivalentTo(dataRow2, config => config.ExcludingColumn(dataSet2.TypedDataTable1.DateTimeColumn));
+        }
+
+        [Fact]
+        public void When_data_has_column_asserting_HaveColumn_should_succeed()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataRow = dataSet.TypedDataTable1[0];
+
+            // Act & Assert
+            dataRow.Should().HaveColumn("ForeignRowID");
+        }
+
+        [Fact]
+        public void When_data_does_not_have_column_asserting_HaveColumn_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataRow = dataSet.TypedDataTable1[0];
+
+            // Act
+            Action action =
+                () => dataRow.Should().HaveColumn("Unicorn");
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_data_has_all_columns_asserting_HaveColumns_should_succeed()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataRow = dataSet.TypedDataTable1[0];
+
+            var columnNames = dataRow.Table.Columns.OfType<DataColumn>()
+                .Take(3)
+                .Select(column => column.ColumnName);
+
+            // Act & Assert
+            dataRow.Should().HaveColumns(columnNames);
+        }
+
+        [Fact]
+        public void When_data_has_only_some_columns_asserting_HaveColumns_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataRow = dataSet.TypedDataTable1[0];
+
+            var columnNames = dataRow.Table.Columns.OfType<DataColumn>()
+                .Take(3)
+                .Select(column => column.ColumnName)
+                .Concat(new[] { "Unicorn" });
+
+            // Act
+            Action action =
+                () => dataRow.Should().HaveColumns(columnNames);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_data_has_no_matching_columns_asserting_HaveColumns_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataRow = dataSet.TypedDataTable1[0];
+
+            var columnNames = new List<string>();
+
+            columnNames.Add("Unicorn");
+            columnNames.Add("Dragon");
+
+            // Act
+            Action action =
+                () => dataRow.Should().HaveColumns(columnNames);
+
+            // Assert
+            action.Should().Throw<XunitException>();
         }
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
@@ -61,7 +61,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet.Should().BeEquivalentTo(null);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet value to be null, but found *");
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet.Should().BeEquivalentTo(dataSetOfMismatchedType);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet to be of type *TypedDataSetSubclass, but found System.Data.DataSet*");
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet1 to have DataSetName *different*");
         }
 
         [Fact]
@@ -153,7 +153,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet1 to have CaseSensitive value of True, but found False instead*");
         }
 
         [Fact]
@@ -190,7 +190,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet1 to have EnforceConstraints value of False, but found True instead*");
         }
 
         [Fact]
@@ -266,7 +266,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet1 to have Locale value of fr-CA, but found en-US instead*");
         }
 
         [Fact]
@@ -304,7 +304,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet1 to have Namespace value of *different*");
         }
 
         [Fact]
@@ -344,7 +344,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet1 to have Prefix value of *different*");
         }
 
         [Fact]
@@ -384,7 +384,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet1 to have RemotingFormat value of SerializationFormat.Binary*, but found *Xml* instead*");
         }
 
         [Fact]
@@ -427,7 +427,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected *dataSet1.ExtendedProperties* to be *, but *");
         }
 
         [Theory]
@@ -490,7 +490,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected *dataSet1.Relations* to *, but *");
         }
 
         [Theory]
@@ -592,7 +592,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet1.Relations[0].ExtendedProperties* to reference column *ForeignRowID* in table *Different*, but found a reference to *ForeignRowID* in table *TypedDataTable2* instead*");
         }
 
         [Fact]
@@ -612,7 +612,7 @@ namespace FluentAssertions.Equivalency.Specs
             Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet1[TypedDataTable2].Rows[0] to have RowState value of *Modified*, but found *Unchanged* instead*");
         }
 
         [Fact]
@@ -642,7 +642,7 @@ namespace FluentAssertions.Equivalency.Specs
                 () => dataSet.Should().HaveTableCount(incorrectTableCount);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet to contain exactly 3 table(s), but found 2.");
         }
 
         [Fact]
@@ -670,7 +670,7 @@ namespace FluentAssertions.Equivalency.Specs
                 () => dataSet.Should().HaveTable(nonExistingTableName);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet to contain a table named *Unicorn*");
         }
 
         [Fact]
@@ -701,7 +701,7 @@ namespace FluentAssertions.Equivalency.Specs
                 () => dataSet.Should().HaveTables(tableNames);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet to contain a table named *Unicorn*, but it does not.");
         }
 
         [Fact]
@@ -717,7 +717,7 @@ namespace FluentAssertions.Equivalency.Specs
                 () => dataSet.Should().HaveTables(nonExistentTableNames);
 
             // Assert
-            action.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>().WithMessage("Expected dataSet to contain a table named *Unicorn*, but it does not.");
         }
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
@@ -2,6 +2,8 @@
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
+
 using Xunit;
 using Xunit.Sdk;
 
@@ -606,6 +608,109 @@ namespace FluentAssertions.Equivalency.Specs
 
             // Act
             Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_asserting_table_count_if_it_matches_it_should_succeed()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var correctTableCount = dataSet.Tables.Count;
+
+            // Act & Assert
+            dataSet.Should().HaveTableCount(correctTableCount);
+        }
+
+        [Fact]
+        public void When_asserting_table_count_if_it_does_not_match_it_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var correctTableCount = dataSet.Tables.Count;
+
+            // Act
+            Action action =
+                () => dataSet.Should().HaveTableCount(correctTableCount + 1);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_asserting_HaveTable_and_table_is_present_it_should_succeed()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var existingTableName = dataSet.Tables[0].TableName;
+
+            // Act & Assert
+            dataSet.Should().HaveTable(existingTableName);
+        }
+
+        [Fact]
+        public void When_asserting_HaveTable_and_table_is_not_present_it_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            string nonExistingTableName = "Unicorn";
+
+            // Act
+            Action action =
+                () => dataSet.Should().HaveTable(nonExistingTableName);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_asserting_HaveTables_and_all_tables_are_present_it_should_succeed()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var existingTableNames = dataSet.Tables.OfType<DataTable>()
+                .Select(table => table.TableName);
+
+            // Act & Assert
+            dataSet.Should().HaveTables(existingTableNames);
+        }
+
+        [Fact]
+        public void When_asserting_HaveTables_and_at_least_one_table_is_not_present_it_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var tableNames = dataSet.Tables.OfType<DataTable>()
+                .Select(table => table.TableName)
+                .Concat(new[] { "Unicorn" });
+
+            // Act
+            Action action =
+                () => dataSet.Should().HaveTables(tableNames);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_asserting_HaveTables_and_none_of_the_tables_is_present_it_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var nonExistentTableNames = new[] { "Unicorn", "Dragon" };
+
+            // Act
+            Action action =
+                () => dataSet.Should().HaveTables(nonExistentTableNames);
 
             // Assert
             action.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
@@ -12,7 +12,7 @@ namespace FluentAssertions.Equivalency.Specs
     public class DataSetSpecs : DataSpecs
     {
         [Fact]
-        public void When_DataSets_are_identical_it_should_succeed()
+        public void When_data_sets_are_identical_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -27,14 +27,14 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataSets_are_both_null_it_should_succeed()
+        public void When_data_sets_are_both_null_equivalence_test_should_succeed()
         {
             // Act & Assert
             ((DataSet)null).Should().BeEquivalentTo(null);
         }
 
         [Fact]
-        public void When_DataSet_is_null_and_isnt_expected_to_be_it_should_fail()
+        public void When_data_set_is_null_and_isnt_expected_to_be_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet = CreateDummyDataSet<TypedDataSet>();
@@ -50,7 +50,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataSet_is_expected_to_be_null_and_isnt_it_should_fail()
+        public void When_data_set_is_expected_to_be_null_and_isnt_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet = CreateDummyDataSet<TypedDataSet>();
@@ -65,7 +65,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataSet_type_does_not_match_and_AllowMismatchedType_not_enabled_it_should_fail()
+        public void When_data_set_type_does_not_match_and_not_allowing_msimatched_types_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet = CreateDummyDataSet<TypedDataSet>();
@@ -82,7 +82,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataSet_type_does_not_match_and_AllowMismatchedType_is_enabled_it_should_succeed()
+        public void When_data_set_type_does_not_match_but_mismatched_types_are_allowed_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet = CreateDummyDataSet<TypedDataSet>();
@@ -98,7 +98,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataSetName_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_set_name_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -118,7 +118,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataSetName_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_set_name_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -137,7 +137,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_CaseSensitive_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_one_data_set_is_configured_to_be_case_sensitive_and_the_other_is_not_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -157,7 +157,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_CaseSensitive_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_one_data_set_is_configured_to_be_case_sensitive_and_the_other_is_not_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -174,7 +174,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_EnforceConstraints_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_one_data_set_is_configured_to_enforce_constraints_and_the_other_is_not_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -194,7 +194,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_EnforceConstraints_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_one_data_set_is_configured_to_enforce_constraints_and_the_other_is_not_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -211,7 +211,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_HasErrors_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_one_data_set_has_errors_and_the_other_does_not_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -231,7 +231,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_HasErrors_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_one_data_set_has_errors_and_the_other_does_not_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -249,7 +249,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Locale_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_sets_have_mismatched_locale_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -269,7 +269,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Locale_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_set_locale_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -286,7 +286,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Namespace_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_set_namespace_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -306,7 +306,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Namespace_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_set_namespace_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -326,7 +326,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Prefix_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_set_prefix_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -346,7 +346,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Prefix_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_set_prefix_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -363,7 +363,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_RemotingFormat_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_set_remoting_format_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -386,7 +386,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_RemotingFormat_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_set_remoting_format_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -409,7 +409,7 @@ namespace FluentAssertions.Equivalency.Specs
 
         [Theory]
         [MemberData(nameof(AllChangeTypes))]
-        public void When_ExtendedProperties_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+        public void When_data_set_extended_properties_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(ChangeType changeType)
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -430,7 +430,7 @@ namespace FluentAssertions.Equivalency.Specs
 
         [Theory]
         [MemberData(nameof(AllChangeTypes))]
-        public void When_ExtendedProperties_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+        public void When_data_set_extended_properties_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(ChangeType changeType)
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -449,7 +449,7 @@ namespace FluentAssertions.Equivalency.Specs
         [Theory]
         [MemberData(nameof(AllChangeTypes))]
         [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "All enum values are accounted for.")]
-        public void When_Relations_does_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+        public void When_data_set_relations_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(ChangeType changeType)
         {
             // Arrange
             TypedDataSetSubclass typedDataSet1;
@@ -494,7 +494,7 @@ namespace FluentAssertions.Equivalency.Specs
         [Theory]
         [MemberData(nameof(AllChangeTypes))]
         [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "All enum values are accounted for.")]
-        public void When_Relations_does_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+        public void When_data_set_relations_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(ChangeType changeType)
         {
             // Arrange
             TypedDataSetSubclass typedDataSet1;
@@ -539,7 +539,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Tables_are_the_same_but_in_a_different_order_it_should_succeed()
+        public void When_data_set_tables_are_the_same_but_in_a_different_order_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -554,7 +554,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Tables_count_does_not_match_it_should_fail()
+        public void When_data_set_table_count_does_not_match_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -574,7 +574,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Tables_count_matches_but_tables_are_different_it_should_fail()
+        public void When_data_set_table_count_matches_but_tables_are_different_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -594,7 +594,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Tables_contain_different_data_it_should_fail()
+        public void When_data_set_tables_contain_different_data_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -614,7 +614,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_table_count_if_it_matches_it_should_succeed()
+        public void When_data_set_table_count_has_expected_value_equivalence_test_should_succeed()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -626,7 +626,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_table_count_if_it_does_not_match_it_should_fail()
+        public void When_data_set_table_count_has_unexpected_value_equivalence_test_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -642,7 +642,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveTable_and_table_is_present_it_should_succeed()
+        public void When_data_set_contains_expected_table_and_asserting_that_it_has_that_table_it_should_succeed()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -654,7 +654,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveTable_and_table_is_not_present_it_should_fail()
+        public void When_data_set_does_not_contain_expected_table_asserting_that_it_has_that_table_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -670,7 +670,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveTables_and_all_tables_are_present_it_should_succeed()
+        public void When_data_set_has_all_expected_tables_asserting_that_it_has_them_should_succeed()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -683,7 +683,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveTables_and_at_least_one_table_is_not_present_it_should_fail()
+        public void When_data_set_has_some_of_the_expected_tables_but_not_all_then_asserting_that_it_has_them_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -701,7 +701,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveTables_and_none_of_the_tables_is_present_it_should_fail()
+        public void When_data_set_has_none_of_the_expected_tables_then_asserting_that_it_has_them_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();

--- a/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
@@ -679,7 +679,7 @@ namespace FluentAssertions.Equivalency.Specs
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
 
-            var existingTableNames = dataSet.Tables.OfType<DataTable>()
+            var existingTableNames = dataSet.Tables.Cast<DataTable>()
                 .Select(table => table.TableName);
 
             // Act & Assert
@@ -692,7 +692,7 @@ namespace FluentAssertions.Equivalency.Specs
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
 
-            var tableNames = dataSet.Tables.OfType<DataTable>()
+            var tableNames = dataSet.Tables.Cast<DataTable>()
                 .Select(table => table.TableName)
                 .Concat(new[] { "Unicorn" });
 

--- a/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
@@ -256,6 +256,7 @@ namespace FluentAssertions.Equivalency.Specs
 
             var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
+            typedDataSet1.Locale = new CultureInfo("en-US");
             typedDataSet2.Locale = new CultureInfo("fr-CA");
 
             var dataSet1 = typedDataSet1.ToUntypedDataSet();
@@ -276,6 +277,7 @@ namespace FluentAssertions.Equivalency.Specs
 
             var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
+            typedDataSet1.Locale = new CultureInfo("en-US");
             typedDataSet2.Locale = new CultureInfo("fr-CA");
 
             var dataSet1 = typedDataSet1.ToUntypedDataSet();
@@ -633,9 +635,11 @@ namespace FluentAssertions.Equivalency.Specs
 
             var correctTableCount = dataSet.Tables.Count;
 
+            var incorrectTableCount = correctTableCount + 1;
+
             // Act
             Action action =
-                () => dataSet.Should().HaveTableCount(correctTableCount + 1);
+                () => dataSet.Should().HaveTableCount(incorrectTableCount);
 
             // Assert
             action.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Equivalency.Specs/DataSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSpecs.cs
@@ -525,7 +525,7 @@ namespace FluentAssertions.Equivalency.Specs
         {
             var row = table.NewRow();
 
-            foreach (var column in table.Columns.OfType<DataColumn>())
+            foreach (var column in table.Columns.Cast<DataColumn>())
             {
                 if (column.ColumnName.StartsWith("Foreign", StringComparison.Ordinal))
                 {

--- a/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
@@ -8,692 +8,692 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Equivalency.Specs
 {
-        public class DataTableSpecs : DataSpecs
+    public class DataTableSpecs : DataSpecs
+    {
+        [Fact]
+        public void When_DataTables_are_identical_it_should_succeed()
         {
-            [Fact]
-            public void When_DataTables_are_identical_it_should_succeed()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2);
-            }
-
-            [Fact]
-            public void When_DataTables_are_both_null_it_should_succeed()
-            {
-                // Act & Assert
-                ((DataTable)null).Should().BeEquivalentTo(null);
-            }
-
-            [Fact]
-            public void When_DataTable_is_null_and_isnt_expected_to_be_it_should_fail()
-            {
-                // Arrange
-                var typedDataSet = CreateDummyDataSet<TypedDataSet>();
-
-                var dataTable = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                // Act
-                Action action = () => ((DataTable)null).Should().BeEquivalentTo(dataTable);
-
-                // Assert
-                action.Should().Throw<XunitException>().WithMessage(
-                    "Expected *to be non-null, but found null*");
-            }
-
-            [Fact]
-            public void When_DataTable_is_expected_to_be_null_and_isnt_it_should_fail()
-            {
-                // Arrange
-                var typedDataSet = CreateDummyDataSet<TypedDataSet>();
-
-                var dataTable = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                // Act
-                Action action = () => dataTable.Should().BeEquivalentTo(null);
-
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
-
-            [Fact]
-            public void When_DataTable_type_does_not_match_and_AllowMismatchedType_not_enabled_it_should_fail()
-            {
-                // Arrange
-                var typedDataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet);
-
-                var dataTable = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTableOfMismatchedType = typedDataSet2.TypedDataTable1;
-
-                // Act
-                Action action = () => dataTable.Should().BeEquivalentTo(dataTableOfMismatchedType);
-
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
-
-            [Fact]
-            public void When_DataTable_type_does_not_match_and_AllowMismatchedType_is_enabled_it_should_succeed()
-            {
-                // Arrange
-                var typedDataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet);
-
-                var dataTable = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTableOfMismatchedType = typedDataSet2.TypedDataTable1;
-
-                // Act & Assert
-                dataTable.Should().BeEquivalentTo(dataTableOfMismatchedType, options => options.AllowingMismatchedTypes());
-            }
-
-            [Fact]
-            public void When_TableName_does_not_match_and_property_is_not_excluded_it_should_fail()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2);
+        }
+
+        [Fact]
+        public void When_DataTables_are_both_null_it_should_succeed()
+        {
+            // Act & Assert
+            ((DataTable)null).Should().BeEquivalentTo(null);
+        }
+
+        [Fact]
+        public void When_DataTable_is_null_and_isnt_expected_to_be_it_should_fail()
+        {
+            // Arrange
+            var typedDataSet = CreateDummyDataSet<TypedDataSet>();
+
+            var dataTable = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            // Act
+            Action action = () => ((DataTable)null).Should().BeEquivalentTo(dataTable);
+
+            // Assert
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected *to be non-null, but found null*");
+        }
+
+        [Fact]
+        public void When_DataTable_is_expected_to_be_null_and_isnt_it_should_fail()
+        {
+            // Arrange
+            var typedDataSet = CreateDummyDataSet<TypedDataSet>();
+
+            var dataTable = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            // Act
+            Action action = () => dataTable.Should().BeEquivalentTo(null);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_DataTable_type_does_not_match_and_AllowMismatchedType_not_enabled_it_should_fail()
+        {
+            // Arrange
+            var typedDataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet);
+
+            var dataTable = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTableOfMismatchedType = typedDataSet2.TypedDataTable1;
+
+            // Act
+            Action action = () => dataTable.Should().BeEquivalentTo(dataTableOfMismatchedType);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_DataTable_type_does_not_match_and_AllowMismatchedType_is_enabled_it_should_succeed()
+        {
+            // Arrange
+            var typedDataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet);
 
-                dataTable2.TableName += "different";
+            var dataTable = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTableOfMismatchedType = typedDataSet2.TypedDataTable1;
 
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+            // Act & Assert
+            dataTable.Should().BeEquivalentTo(dataTableOfMismatchedType, options => options.AllowingMismatchedTypes());
+        }
 
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
+        [Fact]
+        public void When_TableName_does_not_match_and_property_is_not_excluded_it_should_fail()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-            [Fact]
-            public void When_TableName_does_not_match_and_property_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>(identicalTables: true);
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
 
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+            dataTable2.TableName += "different";
 
-                dataTable2.TableName += "different";
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
 
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(
-                    dataTable2,
-                    options => options
-                    .Excluding(dataTable => dataTable.TableName)
-                    .ExcludingRelated((DataColumn dataColumn) => dataColumn.Table)
-                    .ExcludingRelated((Constraint constraint) => constraint.Table));
-            }
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
 
-            [Fact]
-            public void When_CaseSensitive_does_not_match_and_property_is_not_excluded_it_should_fail()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+        [Fact]
+        public void When_TableName_does_not_match_and_property_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>(identicalTables: true);
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
 
-                typedDataSet2.CaseSensitive = !typedDataSet2.CaseSensitive;
+            dataTable2.TableName += "different";
 
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(
+                dataTable2,
+                options => options
+                .Excluding(dataTable => dataTable.TableName)
+                .ExcludingRelated((DataColumn dataColumn) => dataColumn.Table)
+                .ExcludingRelated((Constraint constraint) => constraint.Table));
+        }
 
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+        [Fact]
+        public void When_CaseSensitive_does_not_match_and_property_is_not_excluded_it_should_fail()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-            [Fact]
-            public void When_CaseSensitive_does_not_match_and_property_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            typedDataSet2.CaseSensitive = !typedDataSet2.CaseSensitive;
 
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
 
-                typedDataSet2.CaseSensitive = !typedDataSet2.CaseSensitive;
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
 
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
 
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.CaseSensitive));
-            }
+        [Fact]
+        public void When_CaseSensitive_does_not_match_and_property_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-            [Fact]
-            public void When_DisplayExpression_does_not_match_and_property_is_not_excluded_it_should_fail()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+            typedDataSet2.CaseSensitive = !typedDataSet2.CaseSensitive;
 
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
 
-                dataTable2.DisplayExpression = typedDataSet2.TypedDataTable1.StringColumn.ColumnName;
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.CaseSensitive));
+        }
 
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+        [Fact]
+        public void When_DisplayExpression_does_not_match_and_property_is_not_excluded_it_should_fail()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-            [Fact]
-            public void When_DisplayExpression_does_not_match_and_property_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
 
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+            dataTable2.DisplayExpression = typedDataSet2.TypedDataTable1.StringColumn.ColumnName;
 
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
 
-                dataTable2.DisplayExpression = typedDataSet2.TypedDataTable1.StringColumn.ColumnName;
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
 
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.DisplayExpression));
-            }
+        [Fact]
+        public void When_DisplayExpression_does_not_match_and_property_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-            [Fact]
-            public void When_HasErrors_does_not_match_and_property_is_not_excluded_it_should_fail()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
 
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+            dataTable2.DisplayExpression = typedDataSet2.TypedDataTable1.StringColumn.ColumnName;
 
-                dataTable2.Rows[0].RowError = "Manually added error";
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.DisplayExpression));
+        }
 
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+        [Fact]
+        public void When_HasErrors_does_not_match_and_property_is_not_excluded_it_should_fail()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-                // Assert
-                action.Should().Throw<XunitException>().Which.Message.Should().Contain("HasErrors");
-            }
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-            [Fact]
-            public void When_HasErrors_does_not_match_and_property_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
 
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+            dataTable2.Rows[0].RowError = "Manually added error";
 
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
 
-                dataTable2.Rows[0].RowError = "Manually added error";
+            // Assert
+            action.Should().Throw<XunitException>().Which.Message.Should().Contain("HasErrors");
+        }
 
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2, config => config
-                    .Excluding(dataTable => dataTable.HasErrors)
-                    .ExcludingRelated((DataRow dataRow) => dataRow.HasErrors));
-            }
+        [Fact]
+        public void When_HasErrors_does_not_match_and_property_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-            [Fact]
-            public void When_Locale_does_not_match_and_property_is_not_excluded_it_should_fail()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
 
-                typedDataSet2.Locale = new CultureInfo("fr-CA");
+            dataTable2.Rows[0].RowError = "Manually added error";
 
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, config => config
+                .Excluding(dataTable => dataTable.HasErrors)
+                .ExcludingRelated((DataRow dataRow) => dataRow.HasErrors));
+        }
 
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+        [Fact]
+        public void When_Locale_does_not_match_and_property_is_not_excluded_it_should_fail()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-            [Fact]
-            public void When_Locale_does_not_match_and_property_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            typedDataSet2.Locale = new CultureInfo("fr-CA");
 
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
 
-                typedDataSet2.Locale = new CultureInfo("fr-CA");
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
 
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
 
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.Locale));
-            }
+        [Fact]
+        public void When_Locale_does_not_match_and_property_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-            [Fact]
-            public void When_Namespace_does_not_match_and_property_is_not_excluded_it_should_fail()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+            typedDataSet2.Locale = new CultureInfo("fr-CA");
 
-                typedDataSet2.Namespace += "different";
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
 
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.Locale));
+        }
 
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+        [Fact]
+        public void When_Namespace_does_not_match_and_property_is_not_excluded_it_should_fail()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-            [Fact]
-            public void When_Namespace_does_not_match_and_property_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            typedDataSet2.Namespace += "different";
 
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
 
-                typedDataSet2.Namespace += "different";
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
 
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
 
-                // Act & Assert
+        [Fact]
+        public void When_Namespace_does_not_match_and_property_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            typedDataSet2.Namespace += "different";
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                .Excluding(dataTable => dataTable.Namespace)
+                .ExcludingRelated((DataColumn dataColumn) => dataColumn.Namespace));
+        }
+
+        [Fact]
+        public void When_Prefix_does_not_match_and_property_is_not_excluded_it_should_fail()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            dataTable2.Prefix += "different";
+
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_Prefix_does_not_match_and_property_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            dataTable2.Prefix += "different";
+
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.Prefix));
+        }
+
+        [Fact]
+        public void When_RemotingFormat_does_not_match_and_property_is_not_excluded_it_should_fail()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            typedDataSet2.RemotingFormat =
+                (typedDataSet2.RemotingFormat == SerializationFormat.Binary)
+                ? SerializationFormat.Xml
+                : SerializationFormat.Binary;
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_RemotingFormat_does_not_match_and_property_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            typedDataSet2.RemotingFormat =
+                (typedDataSet2.RemotingFormat == SerializationFormat.Binary)
+                ? SerializationFormat.Xml
+                : SerializationFormat.Binary;
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            // LAST ONE
+
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.RemotingFormat));
+        }
+
+        [Theory]
+        [MemberData(nameof(AllChangeTypes))]
+        public void When_Columns_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            ApplyChange(dataTable2.Columns, changeType);
+
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(AllChangeTypes))]
+        public void When_Columns_do_not_match_and_Columns_and_Rows_are_excluded_it_should_succeed(ChangeType changeType)
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            ApplyChange(dataTable2.Columns, changeType);
+
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                .Excluding(dataTable => dataTable.Columns)
+                .Excluding(dataTable => dataTable.Rows));
+        }
+
+        [Theory]
+        [MemberData(nameof(AllChangeTypes))]
+        public void When_ExtendedProperties_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            ApplyChange(dataTable2.ExtendedProperties, changeType);
+
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(AllChangeTypes))]
+        public void When_ExtendedProperties_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            ApplyChange(dataTable2.ExtendedProperties, changeType);
+
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.ExtendedProperties));
+        }
+
+        [Fact]
+        public void When_PrimaryKey_does_not_match_and_property_is_not_excluded_it_should_fail()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
+
+            dataTable2.PrimaryKey = dataTable2.Columns.Cast<DataColumn>().Skip(2).ToArray();
+            dataTable2.Columns[0].Unique = true;
+
+            // Act
+            Action action = () =>
                 dataTable1.Should().BeEquivalentTo(dataTable2, options => options
-                    .Excluding(dataTable => dataTable.Namespace)
-                    .ExcludingRelated((DataColumn dataColumn) => dataColumn.Namespace));
-            }
-
-            [Fact]
-            public void When_Prefix_does_not_match_and_property_is_not_excluded_it_should_fail()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                dataTable2.Prefix += "different";
-
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
-
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
-
-            [Fact]
-            public void When_Prefix_does_not_match_and_property_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                dataTable2.Prefix += "different";
-
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.Prefix));
-            }
-
-            [Fact]
-            public void When_RemotingFormat_does_not_match_and_property_is_not_excluded_it_should_fail()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                typedDataSet2.RemotingFormat =
-                    (typedDataSet2.RemotingFormat == SerializationFormat.Binary)
-                    ? SerializationFormat.Xml
-                    : SerializationFormat.Binary;
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
-
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
-
-            [Fact]
-            public void When_RemotingFormat_does_not_match_and_property_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                typedDataSet2.RemotingFormat =
-                    (typedDataSet2.RemotingFormat == SerializationFormat.Binary)
-                    ? SerializationFormat.Xml
-                    : SerializationFormat.Binary;
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                // LAST ONE
-
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.RemotingFormat));
-            }
-
-            [Theory]
-            [MemberData(nameof(AllChangeTypes))]
-            public void When_Columns_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                ApplyChange(dataTable2.Columns, changeType);
-
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
-
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
-
-            [Theory]
-            [MemberData(nameof(AllChangeTypes))]
-            public void When_Columns_do_not_match_and_Columns_and_Rows_are_excluded_it_should_succeed(ChangeType changeType)
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                ApplyChange(dataTable2.Columns, changeType);
-
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
-                    .Excluding(dataTable => dataTable.Columns)
-                    .Excluding(dataTable => dataTable.Rows));
-            }
-
-            [Theory]
-            [MemberData(nameof(AllChangeTypes))]
-            public void When_ExtendedProperties_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                ApplyChange(dataTable2.ExtendedProperties, changeType);
-
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
-
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
-
-            [Theory]
-            [MemberData(nameof(AllChangeTypes))]
-            public void When_ExtendedProperties_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                ApplyChange(dataTable2.ExtendedProperties, changeType);
-
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.ExtendedProperties));
-            }
-
-            [Fact]
-            public void When_PrimaryKey_does_not_match_and_property_is_not_excluded_it_should_fail()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
-
-                dataTable2.PrimaryKey = dataTable2.Columns.Cast<DataColumn>().Skip(2).ToArray();
-                dataTable2.Columns[0].Unique = true;
-
-                // Act
-                Action action = () =>
-                    dataTable1.Should().BeEquivalentTo(dataTable2, options => options
-                        .Excluding(dataTable => dataTable.Constraints));
-
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
-
-            [Fact]
-            public void When_PrimaryKey_does_not_match_and_property_is_excluded_it_should_succeed()
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                for (int i = 2; i < typedDataSet1.TypedDataTable2.Columns.Count; i++)
-                {
-                    typedDataSet1.TypedDataTable2.Columns[i].AllowDBNull = false;
-                }
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
-
-                dataTable2.PrimaryKey = dataTable2.Columns.Cast<DataColumn>().Skip(2).ToArray();
-                dataTable2.Columns[0].Unique = true;
-
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
-                    .Excluding(dataTable => dataTable.PrimaryKey)
                     .Excluding(dataTable => dataTable.Constraints));
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_PrimaryKey_does_not_match_and_property_is_excluded_it_should_succeed()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            for (int i = 2; i < typedDataSet1.TypedDataTable2.Columns.Count; i++)
+            {
+                typedDataSet1.TypedDataTable2.Columns[i].AllowDBNull = false;
             }
 
-            public enum NumberOfColumnsInConstraintDifference
-            {
-                SingleColumn,
-                MultipleColumns,
-            }
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-            [Theory]
-            [InlineData(NumberOfColumnsInConstraintDifference.SingleColumn)]
-            [InlineData(NumberOfColumnsInConstraintDifference.MultipleColumns)]
-            public void When_columns_for_constraint_do_not_match_message_should_list_all_columns_involved(NumberOfColumnsInConstraintDifference difference)
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
 
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+            dataTable2.PrimaryKey = dataTable2.Columns.Cast<DataColumn>().Skip(2).ToArray();
+            dataTable2.Columns[0].Unique = true;
 
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                .Excluding(dataTable => dataTable.PrimaryKey)
+                .Excluding(dataTable => dataTable.Constraints));
+        }
 
-                int differenceCount =
-                    difference switch
-                    {
-                        NumberOfColumnsInConstraintDifference.SingleColumn => 1,
-                        NumberOfColumnsInConstraintDifference.MultipleColumns => 2,
+        public enum NumberOfColumnsInConstraintDifference
+        {
+            SingleColumn,
+            MultipleColumns,
+        }
 
-                        _ => throw new Exception("Sanity failure")
-                    };
+        [Theory]
+        [InlineData(NumberOfColumnsInConstraintDifference.SingleColumn)]
+        [InlineData(NumberOfColumnsInConstraintDifference.MultipleColumns)]
+        public void When_columns_for_constraint_do_not_match_message_should_list_all_columns_involved(NumberOfColumnsInConstraintDifference difference)
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
 
-                var dataTable1ColumnsForConstraint = dataTable1.Columns.OfType<DataColumn>()
-                    .Take(dataTable1.Columns.Count - differenceCount)
-                    .ToArray();
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
-                var dataTable2ColumnsForConstraint = dataTable2.Columns.OfType<DataColumn>()
-                    .Skip(differenceCount)
-                    .ToArray();
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
 
-                const string ConstraintName = "TestSubjectConstraint";
-
-                dataTable1.Constraints.Add(new UniqueConstraint(ConstraintName, dataTable1ColumnsForConstraint));
-                dataTable2.Constraints.Add(new UniqueConstraint(ConstraintName, dataTable2ColumnsForConstraint));
-
-                var missingColumnNames = dataTable2ColumnsForConstraint.Select(col => col.ColumnName)
-                    .Except(dataTable1ColumnsForConstraint.Select(col => col.ColumnName));
-                var extraColumnNames = dataTable1ColumnsForConstraint.Select(col => col.ColumnName)
-                    .Except(dataTable2ColumnsForConstraint.Select(col => col.ColumnName));
-
-                string columnsNoun = differenceCount == 1
-                    ? "column"
-                    : "columns";
-
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
-
-                // Assert
-                action.Should().Throw<XunitException>().WithMessage(
-                    $"Expected *{ConstraintName}* to include {columnsNoun} {string.Join("*", missingColumnNames)}*" +
-                    $"Did not expect *{ConstraintName}* to include {columnsNoun} {string.Join("*", extraColumnNames)}*");
-            }
-
-            [Theory]
-            [MemberData(nameof(AllChangeTypes))]
-            public void When_Constraints_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
-
-                ApplyChange(dataTable2.Constraints, dataTable2.Columns["Decimal"], changeType);
-
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
-
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
-
-            [Theory]
-            [MemberData(nameof(AllChangeTypes))]
-            public void When_Constraints_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
-
-                ApplyChange(dataTable2.Constraints, dataTable2.Columns["Decimal"], changeType);
-
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
-                    .Excluding(dataTable => dataTable.Constraints)
-                    .ExcludingRelated((DataColumn dataColumn) => dataColumn.Unique));
-            }
-
-            [Theory]
-            [MemberData(nameof(AllChangeTypesWithAcceptChangesValues))]
-            public void When_Rows_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType, bool acceptChanges)
-            {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                ApplyChange(dataTable2.Rows, dataTable2, changeType);
-
-                if (acceptChanges)
+            int differenceCount =
+                difference switch
                 {
-                    dataTable2.AcceptChanges();
-                }
+                    NumberOfColumnsInConstraintDifference.SingleColumn => 1,
+                    NumberOfColumnsInConstraintDifference.MultipleColumns => 2,
 
-                // Act
-                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+                    _ => throw new Exception("Sanity failure")
+                };
 
-                // Assert
-                action.Should().Throw<XunitException>();
-            }
+            var dataTable1ColumnsForConstraint = dataTable1.Columns.OfType<DataColumn>()
+                .Take(dataTable1.Columns.Count - differenceCount)
+                .ToArray();
 
-            [Theory]
-            [MemberData(nameof(AllChangeTypesWithAcceptChangesValues))]
-            public void When_Rows_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType, bool acceptChanges)
+            var dataTable2ColumnsForConstraint = dataTable2.Columns.OfType<DataColumn>()
+                .Skip(differenceCount)
+                .ToArray();
+
+            const string ConstraintName = "TestSubjectConstraint";
+
+            dataTable1.Constraints.Add(new UniqueConstraint(ConstraintName, dataTable1ColumnsForConstraint));
+            dataTable2.Constraints.Add(new UniqueConstraint(ConstraintName, dataTable2ColumnsForConstraint));
+
+            var missingColumnNames = dataTable2ColumnsForConstraint.Select(col => col.ColumnName)
+                .Except(dataTable1ColumnsForConstraint.Select(col => col.ColumnName));
+            var extraColumnNames = dataTable1ColumnsForConstraint.Select(col => col.ColumnName)
+                .Except(dataTable2ColumnsForConstraint.Select(col => col.ColumnName));
+
+            string columnsNoun = differenceCount == 1
+                ? "column"
+                : "columns";
+
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+            // Assert
+            action.Should().Throw<XunitException>().WithMessage(
+                $"Expected *{ConstraintName}* to include {columnsNoun} {string.Join("*", missingColumnNames)}*" +
+                $"Did not expect *{ConstraintName}* to include {columnsNoun} {string.Join("*", extraColumnNames)}*");
+        }
+
+        [Theory]
+        [MemberData(nameof(AllChangeTypes))]
+        public void When_Constraints_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
+
+            ApplyChange(dataTable2.Constraints, dataTable2.Columns["Decimal"], changeType);
+
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(AllChangeTypes))]
+        public void When_Constraints_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
+
+            ApplyChange(dataTable2.Constraints, dataTable2.Columns["Decimal"], changeType);
+
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                .Excluding(dataTable => dataTable.Constraints)
+                .ExcludingRelated((DataColumn dataColumn) => dataColumn.Unique));
+        }
+
+        [Theory]
+        [MemberData(nameof(AllChangeTypesWithAcceptChangesValues))]
+        public void When_Rows_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType, bool acceptChanges)
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            ApplyChange(dataTable2.Rows, dataTable2, changeType);
+
+            if (acceptChanges)
             {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                ApplyChange(dataTable2.Rows, dataTable2, changeType);
-
-                if (acceptChanges)
-                {
-                    dataTable2.AcceptChanges();
-                }
-
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.Rows));
+                dataTable2.AcceptChanges();
             }
 
-            [Fact]
-            public void When_data_matches_in_different_order_and_RowMatchMode_is_PrimaryKey_it_should_succeed()
+            // Act
+            Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(AllChangeTypesWithAcceptChangesValues))]
+        public void When_Rows_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType, bool acceptChanges)
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            ApplyChange(dataTable2.Rows, dataTable2, changeType);
+
+            if (acceptChanges)
             {
-                // Arrange
-                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
-
-                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1, randomizeRowOrder: true);
-
-                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
-                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
-
-                // Act & Assert
-                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.UsingRowMatchMode(RowMatchMode.PrimaryKey));
+                dataTable2.AcceptChanges();
             }
+
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.Rows));
+        }
+
+        [Fact]
+        public void When_data_matches_in_different_order_and_RowMatchMode_is_PrimaryKey_it_should_succeed()
+        {
+            // Arrange
+            var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1, randomizeRowOrder: true);
+
+            var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+            var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+            // Act & Assert
+            dataTable1.Should().BeEquivalentTo(dataTable2, options => options.UsingRowMatchMode(RowMatchMode.PrimaryKey));
         }
     }
+}

--- a/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
@@ -254,6 +254,7 @@ namespace FluentAssertions.Equivalency.Specs
 
             var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
+            typedDataSet1.Locale = new CultureInfo("en-US");
             typedDataSet2.Locale = new CultureInfo("fr-CA");
 
             var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
@@ -274,6 +275,7 @@ namespace FluentAssertions.Equivalency.Specs
 
             var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
+            typedDataSet1.Locale = new CultureInfo("en-US");
             typedDataSet2.Locale = new CultureInfo("fr-CA");
 
             var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
@@ -704,10 +706,10 @@ namespace FluentAssertions.Equivalency.Specs
 
             var dataTable = dataSet.TypedDataTable1;
 
-            int rowCount = dataTable.Rows.Count;
+            int correctRowCount = dataTable.Rows.Count;
 
             // Act & Assert
-            dataTable.Should().HaveRowCount(rowCount);
+            dataTable.Should().HaveRowCount(correctRowCount);
         }
 
         [Fact]
@@ -733,11 +735,13 @@ namespace FluentAssertions.Equivalency.Specs
 
             var dataTable = dataSet.TypedDataTable1;
 
-            int rowCount = dataTable.Rows.Count;
+            int correctRowCount = dataTable.Rows.Count;
+
+            int incorrectRowCount = correctRowCount * 2;
 
             // Act
             Action action =
-                () => dataTable.Should().HaveRowCount(rowCount * 2);
+                () => dataTable.Should().HaveRowCount(incorrectRowCount);
 
             // Assert
             action.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
@@ -695,5 +695,135 @@ namespace FluentAssertions.Equivalency.Specs
             // Act & Assert
             dataTable1.Should().BeEquivalentTo(dataTable2, options => options.UsingRowMatchMode(RowMatchMode.PrimaryKey));
         }
+
+        [Fact]
+        public void When_asserting_HaveRowCount_if_the_row_count_matches_it_should_succeed()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataTable = dataSet.TypedDataTable1;
+
+            int rowCount = dataTable.Rows.Count;
+
+            // Act & Assert
+            dataTable.Should().HaveRowCount(rowCount);
+        }
+
+        [Fact]
+        public void When_asserting_HaveRowCount_on_empty_table_if_the_row_count_matches_it_should_succeed()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataTable = dataSet.TypedDataTable2;
+
+            dataTable.Rows.Clear();
+            dataTable.AcceptChanges();
+
+            // Act & Assert
+            dataTable.Should().HaveRowCount(0);
+        }
+
+        [Fact]
+        public void When_asserting_HaveRowCount_if_the_row_count_does_not_match_it_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataTable = dataSet.TypedDataTable1;
+
+            int rowCount = dataTable.Rows.Count;
+
+            // Act
+            Action action =
+                () => dataTable.Should().HaveRowCount(rowCount * 2);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_asserting_HaveColumn_if_the_column_is_present_it_should_succeed()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataTable = dataSet.TypedDataTable1;
+
+            var expectedColumnName = dataTable.Columns[0].ColumnName;
+
+            // Act & Assert
+            dataTable.Should().HaveColumn(expectedColumnName);
+        }
+
+        [Fact]
+        public void When_asserting_HaveColumn_if_the_column_is_not_present_it_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataTable = dataSet.TypedDataTable1;
+
+            // Act
+            Action action =
+                () => dataTable.Should().HaveColumn("Unicorn");
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_asserting_HaveColumns_and_all_columns_are_present_it_should_succeed()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataTable = dataSet.TypedDataTable1;
+
+            var existingColumnNames = dataTable.Columns.OfType<DataColumn>()
+                .Select(column => column.ColumnName);
+
+            // Act & Assert
+            dataTable.Should().HaveColumns(existingColumnNames);
+        }
+
+        [Fact]
+        public void When_asserting_HaveColumns_and_at_least_one_column_is_not_present_it_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataTable = dataSet.TypedDataTable1;
+
+            var columnNames = dataTable.Columns.OfType<DataColumn>()
+                .Select(column => column.ColumnName)
+                .Concat(new[] { "Unicorn" });
+
+            // Act
+            Action action =
+                () => dataTable.Should().HaveColumns(columnNames);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_asserting_HaveColumns_and_none_of_the_columns_is_present_it_should_fail()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataTable = dataSet.TypedDataTable1;
+
+            var nonExistingColumnNames = new[] { "Unicorn", "Dragon" };
+
+            // Act
+            Action action =
+                () => dataTable.Should().HaveColumns(nonExistingColumnNames);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
@@ -11,7 +11,7 @@ namespace FluentAssertions.Equivalency.Specs
     public class DataTableSpecs : DataSpecs
     {
         [Fact]
-        public void When_DataTables_are_identical_it_should_succeed()
+        public void When_data_tables_are_identical_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -25,14 +25,14 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataTables_are_both_null_it_should_succeed()
+        public void When_data_tables_are_both_null_equivalence_test_should_succeed()
         {
             // Act & Assert
             ((DataTable)null).Should().BeEquivalentTo(null);
         }
 
         [Fact]
-        public void When_DataTable_is_null_and_isnt_expected_to_be_it_should_fail()
+        public void When_data_table_is_null_and_isnt_expected_to_be_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet = CreateDummyDataSet<TypedDataSet>();
@@ -48,7 +48,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataTable_is_expected_to_be_null_and_isnt_it_should_fail()
+        public void When_data_table_is_expected_to_be_null_and_isnt_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet = CreateDummyDataSet<TypedDataSet>();
@@ -63,7 +63,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataTable_type_does_not_match_and_AllowMismatchedType_not_enabled_it_should_fail()
+        public void When_data_table_type_does_not_match_and_assertion_is_not_configured_to_allow_mismatched_types_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
@@ -80,7 +80,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DataTable_type_does_not_match_and_AllowMismatchedType_is_enabled_it_should_succeed()
+        public void When_data_table_type_does_not_match_but_assertion_is_configured_to_allow_mismatched_types_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
@@ -94,7 +94,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_TableName_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_table_name_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -113,7 +113,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_TableName_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_table_name_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>(identicalTables: true);
@@ -134,7 +134,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_CaseSensitive_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_table_case_sensitivity_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -154,7 +154,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_CaseSensitive_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_table_case_sensitivity_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -171,7 +171,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DisplayExpression_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_table_display_expression_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -191,7 +191,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_DisplayExpression_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_table_display_expression_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -208,7 +208,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_HasErrors_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_one_data_table_has_errors_and_the_other_does_not_and_the_property_that_indicates_the_presence_of_errors_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -228,7 +228,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_HasErrors_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_one_data_table_has_errors_and_the_other_does_not_but_the_property_that_indicates_the_presence_of_errors_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -247,7 +247,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Locale_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_table_locale_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -267,7 +267,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Locale_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_table_locale_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -284,7 +284,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Namespace_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_table_namespace_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -304,7 +304,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Namespace_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_table_namespace_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -323,7 +323,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Prefix_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_table_prefix_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -343,7 +343,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_Prefix_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_table_prefix_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -360,7 +360,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_RemotingFormat_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_table_remoting_format_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -383,7 +383,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_RemotingFormat_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_table_remoting_format_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -406,7 +406,7 @@ namespace FluentAssertions.Equivalency.Specs
 
         [Theory]
         [MemberData(nameof(AllChangeTypes))]
-        public void When_Columns_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+        public void When_data_table_columns_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(ChangeType changeType)
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -427,7 +427,7 @@ namespace FluentAssertions.Equivalency.Specs
 
         [Theory]
         [MemberData(nameof(AllChangeTypes))]
-        public void When_Columns_do_not_match_and_Columns_and_Rows_are_excluded_it_should_succeed(ChangeType changeType)
+        public void When_data_table_columns_do_not_match_but_columns_and_rows_are_excluded_equivalence_test_should_succeed(ChangeType changeType)
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -447,7 +447,7 @@ namespace FluentAssertions.Equivalency.Specs
 
         [Theory]
         [MemberData(nameof(AllChangeTypes))]
-        public void When_ExtendedProperties_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+        public void When_data_table_extended_properties_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(ChangeType changeType)
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -468,7 +468,7 @@ namespace FluentAssertions.Equivalency.Specs
 
         [Theory]
         [MemberData(nameof(AllChangeTypes))]
-        public void When_ExtendedProperties_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+        public void When_data_table_extended_properties_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(ChangeType changeType)
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -485,7 +485,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_PrimaryKey_does_not_match_and_property_is_not_excluded_it_should_fail()
+        public void When_data_table_primary_key_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -508,7 +508,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_PrimaryKey_does_not_match_and_property_is_excluded_it_should_succeed()
+        public void When_data_table_primary_key_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -541,7 +541,7 @@ namespace FluentAssertions.Equivalency.Specs
         [Theory]
         [InlineData(NumberOfColumnsInConstraintDifference.SingleColumn)]
         [InlineData(NumberOfColumnsInConstraintDifference.MultipleColumns)]
-        public void When_columns_for_constraint_do_not_match_message_should_list_all_columns_involved(NumberOfColumnsInConstraintDifference difference)
+        public void When_columns_for_constraint_in_data_table_do_not_match_message_should_list_all_columns_involved(NumberOfColumnsInConstraintDifference difference)
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -593,7 +593,7 @@ namespace FluentAssertions.Equivalency.Specs
 
         [Theory]
         [MemberData(nameof(AllChangeTypes))]
-        public void When_Constraints_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+        public void When_data_table_constraints_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(ChangeType changeType)
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -614,7 +614,7 @@ namespace FluentAssertions.Equivalency.Specs
 
         [Theory]
         [MemberData(nameof(AllChangeTypes))]
-        public void When_Constraints_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+        public void When_data_table_constraints_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(ChangeType changeType)
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -634,7 +634,7 @@ namespace FluentAssertions.Equivalency.Specs
 
         [Theory]
         [MemberData(nameof(AllChangeTypesWithAcceptChangesValues))]
-        public void When_Rows_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType, bool acceptChanges)
+        public void When_data_table_rows_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(ChangeType changeType, bool acceptChanges)
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -660,7 +660,7 @@ namespace FluentAssertions.Equivalency.Specs
 
         [Theory]
         [MemberData(nameof(AllChangeTypesWithAcceptChangesValues))]
-        public void When_Rows_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType, bool acceptChanges)
+        public void When_data_table_rows_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(ChangeType changeType, bool acceptChanges)
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -682,7 +682,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_data_matches_in_different_order_and_RowMatchMode_is_PrimaryKey_it_should_succeed()
+        public void When_data_table_data_matches_in_different_order_and_the_row_match_mode_is_by_primary_key_equivalence_test_should_succeed()
         {
             // Arrange
             var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -697,7 +697,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveRowCount_if_the_row_count_matches_it_should_succeed()
+        public void When_data_table_has_expected_row_count_it_should_succeed()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -711,7 +711,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveRowCount_on_empty_table_if_the_row_count_matches_it_should_succeed()
+        public void When_empty_data_table_has_expected_row_count_of_zero_it_should_succeed()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -726,7 +726,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveRowCount_if_the_row_count_does_not_match_it_should_fail()
+        public void When_data_table_does_not_have_expected_row_count_does_not_match_it_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -744,7 +744,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveColumn_if_the_column_is_present_it_should_succeed()
+        public void When_data_table_has_expected_column_it_should_succeed()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -758,7 +758,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveColumn_if_the_column_is_not_present_it_should_fail()
+        public void When_data_table_does_not_have_expected_column_it_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -774,7 +774,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveColumns_and_all_columns_are_present_it_should_succeed()
+        public void When_data_table_has_all_expected_columns_it_should_succeed()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -789,7 +789,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveColumns_and_at_least_one_column_is_not_present_it_should_fail()
+        public void When_data_table_has_only_some_expected_columns_then_asserting_that_it_has_all_of_them_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -809,7 +809,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_asserting_HaveColumns_and_none_of_the_columns_is_present_it_should_fail()
+        public void When_data_table_has_none_of_the_expected_columns_then_asserting_that_it_has_all_of_them_should_fail()
         {
             // Arrange
             var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();

--- a/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
@@ -565,11 +565,11 @@ namespace FluentAssertions.Equivalency.Specs
                     _ => throw new Exception("Sanity failure")
                 };
 
-            var dataTable1ColumnsForConstraint = dataTable1.Columns.OfType<DataColumn>()
+            var dataTable1ColumnsForConstraint = dataTable1.Columns.Cast<DataColumn>()
                 .Take(dataTable1.Columns.Count - differenceCount)
                 .ToArray();
 
-            var dataTable2ColumnsForConstraint = dataTable2.Columns.OfType<DataColumn>()
+            var dataTable2ColumnsForConstraint = dataTable2.Columns.Cast<DataColumn>()
                 .Skip(differenceCount)
                 .ToArray();
 
@@ -808,7 +808,7 @@ namespace FluentAssertions.Equivalency.Specs
 
             var dataTable = dataSet.TypedDataTable1;
 
-            var existingColumnNames = dataTable.Columns.OfType<DataColumn>()
+            var existingColumnNames = dataTable.Columns.Cast<DataColumn>()
                 .Select(column => column.ColumnName);
 
             // Act & Assert
@@ -823,7 +823,7 @@ namespace FluentAssertions.Equivalency.Specs
 
             var dataTable = dataSet.TypedDataTable1;
 
-            var columnNames = dataTable.Columns.OfType<DataColumn>()
+            var columnNames = dataTable.Columns.Cast<DataColumn>()
                 .Select(column => column.ColumnName)
                 .Concat(new[] { "Unicorn" });
 


### PR DESCRIPTION
This PR backfills missing automated tests for System.Data.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).