### PR TITLE
Add code coverage reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
 
     runs-on: windows-latest
 
+    env:
+      DOTNET_NOLOGO: true
+
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,31 +18,22 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup .NET 5
+    - name: Setup .NET SDKs
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
-
-    - name: Setup .NET 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.x
-
-    - name: Setup .NET 2.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 2.1.x
+        dotnet-version: |
+          2.1.x
+          3.1.x
+          5.0.x
 
     - name: Run NUKE
       run: ./build.ps1
       env:
         BranchSpec: ${{ github.ref }}
-        BuildNumber: ${{ github.run_number}}
+        BuildNumber: ${{ github.run_number }}
         ApiKey: ${{ secrets.NUGETAPIKEY }}
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
         path: ./Artifacts/*
-
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,12 @@ jobs:
         BuildNumber: ${{ github.run_number }}
         ApiKey: ${{ secrets.NUGETAPIKEY }}
 
+    - name: coveralls
+      uses: coverallsapp/github-action@1.1.3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: TestResults/reports/lcov.info
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -66,7 +66,7 @@ class Build : NukeBuild
                     "Branch spec {branchspec} is a pull request. Adding build number {buildnumber}",
                     BranchSpec, BuildNumber);
 
-                SemVer = string.Join('.', GitVersion.SemVer.Split('.').Take(3).Union(new [] { BuildNumber }));
+                SemVer = string.Join('.', GitVersion.SemVer.Split('.').Take(3).Union(new[] { BuildNumber }));
             }
 
             Serilog.Log.Information("SemVer = {semver}", SemVer);
@@ -91,6 +91,7 @@ class Build : NukeBuild
             DotNetBuild(s => s
                 .SetProjectFile(Solution)
                 .SetConfiguration("CI")
+                .EnableNoLogo()
                 .EnableNoRestore()
                 .SetAssemblyVersion(GitVersion.AssemblySemVer)
                 .SetFileVersion(GitVersion.AssemblySemFileVer)
@@ -178,6 +179,8 @@ class Build : NukeBuild
                 .SetProject(Solution.Core.FluentAssertions)
                 .SetOutputDirectory(ArtifactsDirectory)
                 .SetConfiguration("Release")
+                .EnableNoLogo()
+                .EnableNoRestore()
                 .EnableContinuousIntegrationBuild() // Necessary for deterministic builds
                 .SetVersion(SemVer));
         });
@@ -187,7 +190,7 @@ class Build : NukeBuild
         .OnlyWhenDynamic(() => IsTag)
         .Executes(() =>
         {
-            var packages = GlobFiles(ArtifactsDirectory, "*.nupkg");
+            IReadOnlyCollection<string> packages = GlobFiles(ArtifactsDirectory, "*.nupkg");
 
             Assert.NotEmpty(packages.ToList());
 
@@ -201,5 +204,4 @@ class Build : NukeBuild
         });
 
     bool IsTag => BranchSpec != null && BranchSpec.Contains("refs/tags", StringComparison.InvariantCultureIgnoreCase);
-
 }

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -133,6 +133,8 @@ class Build : NukeBuild
                 .SetProjectFile(Solution.Specs.FluentAssertions_Specs)
                 .SetConfiguration("Debug")
                 .EnableNoBuild()
+                .SetDataCollector("XPlat Code Coverage")
+                .SetResultsDirectory(RootDirectory / "TestResults")
                 .CombineWith(
                     Solution.Specs.FluentAssertions_Specs.GetTargetFrameworks().Except(new[] { "net47" }),
                     (_, v) => _.SetFramework(v)));

--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageDownload Include="GitVersion.Tool" Version="[5.8.1]" />
     <PackageDownload Include="NSpec" Version="[3.1.0]" />
+    <PackageDownload Include="ReportGenerator" Version="[5.0.4]" />
     <PackageDownload Include="xunit.runner.console" Version="[2.4.1]" />
     <PackageReference Include="Nuke.Common" Version="6.0.1" />
   </ItemGroup>

--- a/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
+++ b/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
@@ -56,6 +56,9 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.StaFact" Version="1.1.5-alpha" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.1" PrivateAssets="all">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -60,6 +60,9 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.StaFact" Version="1.1.5-alpha" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.1" PrivateAssets="all">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">


### PR DESCRIPTION
* Adds code coverage to the build
* On local builds, report generator will generate an HTML report
  * Link to the report file is added to the output, if your terminal supports it, it's clickable
    ![image](https://user-images.githubusercontent.com/10671831/154530638-7728c3fc-f7d4-4e15-af11-7e14811ce493.png)

* On CI builds, results will be added coveralls
  * https://coveralls.io/github/fluentassertions/fluentassertions
* After the first build with coverage is merged with master, subsequent PR's will have code coverage reported in the PR by coveralls


* Very small lay-out fixes (spaces, new-lines, etc.)

Didn't add it to the release notes as it's not modifying the library itself.