### PR TITLE
Annotated [Not]MatchRegex with [StringSyntax("Regex")]

### DIFF
--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.RegularExpressions;
 using FluentAssertions.Common;
@@ -399,7 +400,8 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> MatchRegex([RegexPattern] string regularExpression, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> MatchRegex([RegexPattern][StringSyntax("Regex")] string regularExpression,
+            string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
 
@@ -475,7 +477,8 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotMatchRegex([RegexPattern] string regularExpression, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotMatchRegex([RegexPattern][StringSyntax("Regex")] string regularExpression,
+            string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.");
 

--- a/Src/FluentAssertions/StringSyntaxAttribute.cs
+++ b/Src/FluentAssertions/StringSyntaxAttribute.cs
@@ -1,0 +1,52 @@
+﻿// copied from https://raw.githubusercontent.com/dotnet/runtime/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
+#if !NET7_0_OR_GREATER
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies the syntax used in a string.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    sealed class StringSyntaxAttribute : Attribute
+    {
+        /// <summary>Initializes the <see cref="StringSyntaxAttribute"/> with the identifier of the syntax used.</summary>
+        /// <param name="syntax">The syntax identifier.</param>
+        public StringSyntaxAttribute(string syntax)
+        {
+            Syntax = syntax;
+            Arguments = Array.Empty<object?>();
+        }
+
+        /// <summary>Initializes the <see cref="StringSyntaxAttribute"/> with the identifier of the syntax used.</summary>
+        /// <param name="syntax">The syntax identifier.</param>
+        /// <param name="arguments">Optional arguments associated with the specific syntax employed.</param>
+        public StringSyntaxAttribute(string syntax, params object?[] arguments)
+        {
+            Syntax = syntax;
+            Arguments = arguments;
+        }
+
+        /// <summary>Gets the identifier of the syntax used.</summary>
+        public string Syntax { get; }
+
+        /// <summary>Optional arguments associated with the specific syntax employed.</summary>
+        public object?[] Arguments { get; }
+
+        /// <summary>The syntax identifier for strings containing date and time format specifiers.</summary>
+        public const string DateTimeFormat = nameof(DateTimeFormat);
+
+        /// <summary>The syntax identifier for strings containing JavaScript Object Notation (JSON).</summary>
+        public const string Json = nameof(Json);
+
+        /// <summary>The syntax identifier for strings containing regular expressions.</summary>
+        public const string Regex = nameof(Regex);
+    }
+}
+#endif

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,6 +10,7 @@ sidebar:
 ## Unreleased
 
 ### What's New
+* Annotated `[Not]MatchRegex(string)` with `[StringSyntax("Regex")]` which IDEs can use to colorize the regular expression argument - [#1816](https://github.com/fluentassertions/fluentassertions/pull/1816)
 
 ### Fixes
 


### PR DESCRIPTION
With Visual Studio 17.2 you can annotate arguments and properties with `StringSyntaxAttribute`, e.g. to analyze and colorize regular expressions.
So I've added this to `[Not]MatchRegex(string)`.
As VS does not look at the _actual_ type of the attribute, but only the name and namespace, we can deliver this to all TFMs by adding an internal attribute.
I assume this is the same approach Rider uses with the `[RegexPattern]` from `JetBrains.Annotations` that we already use.

Using VS 17.2.0 Preview 1.0 here's how this PR changes the looks of `When_a_string_matches_a_regular_expression_string_it_should_not_throw`.
Before:
![image](https://user-images.githubusercontent.com/919634/154714462-7d4bca3f-96d4-47f1-9bcc-5e970dd9dd6f.png)

After:
![image](https://user-images.githubusercontent.com/919634/154714505-bd426c91-9a7e-40b9-92f0-99de9936f7e0.png)

For more info about `StringSyntaxAttribute`:
* https://github.com/dotnet/runtime/issues/62505
* Demo: https://youtu.be/rwfNDyBBgks?t=1119