### PR TITLE
Fix uninvoked actions

### DIFF
--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -401,7 +401,7 @@ namespace FluentAssertions.Execution
             }
             else
             {
-                IDictionary<string,object> reportable = contextData.GetReportable();
+                IDictionary<string, object> reportable = contextData.GetReportable();
 
                 if (tracing.Length > 0)
                 {

--- a/Tests/FluentAssertions.Specs/AndWhichConstraintSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AndWhichConstraintSpecs.cs
@@ -16,7 +16,7 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () =>
             {
-                var item = continuation.Which;
+                _ = continuation.Which;
             };
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1714,7 +1714,7 @@ namespace FluentAssertions.Specs.Collections
             // Act
             Action action = () =>
             {
-                string item = collection.Should().ContainMatch("* failed").Which;
+                _ = collection.Should().ContainMatch("* failed").Which;
             };
 
             // Assert

--- a/Tests/FluentAssertions.Specs/ConfigurationSpecs.cs
+++ b/Tests/FluentAssertions.Specs/ConfigurationSpecs.cs
@@ -19,10 +19,10 @@ namespace FluentAssertions.Specs
                 {
                     MaxDegreeOfParallelism = 8
                 },
-                _ =>
+                __ =>
                 {
                     Configuration.Current.ValueFormatterAssembly = string.Empty;
-                    var mode = Configuration.Current.ValueFormatterDetectionMode;
+                    _ = Configuration.Current.ValueFormatterDetectionMode;
                 }
             );
 

--- a/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
@@ -59,7 +59,6 @@ namespace FluentAssertions.Specs.Formatting
         public void When_condition_contains_linq_extension_method_then_extension_method_must_be_formatted()
         {
             // Arrange
-            var actual = new[] { 4 };
             var allowed = new[] { 1, 2, 3 };
 
             // Act

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -3657,7 +3657,7 @@ namespace FluentAssertions.Specs.Primitives
             string actual = "a1";
 
             // Act / Assert
-            Action act = () => actual.Should().NotBeUpperCased();
+            actual.Should().NotBeUpperCased();
         }
 
         [Fact]
@@ -3792,7 +3792,7 @@ namespace FluentAssertions.Specs.Primitives
             string actual = "A1";
 
             // Act / Assert
-            Action act = () => actual.Should().NotBeLowerCased();
+            actual.Should().NotBeLowerCased();
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -332,7 +332,7 @@ namespace FluentAssertions.Specs.Types
                 .And.NotContain(m => m.Name == "PublicVirtualVoidMethodWithAttribute")
                 .And.NotContain(m => m.Name == "ProtectedVirtualVoidMethodWithAttribute");
         }
-        
+
         [Fact]
         public void When_selecting_methods_that_are_static_it_should_only_return_the_applicable_methods()
         {


### PR DESCRIPTION
Found two `Action`s in `StringAssertionSpecs.cs` that were never invoked.
While checking if we had done the same mistake more places I found some formatting to clean up.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).