### PR TITLE
Add release notes template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+changelog:
+  exclude:
+    labels:
+      - changelog-ignore
+    authors: [ ]
+  categories:
+    - title: Breaking Changes
+      labels:
+        - "breaking change"
+    - title: New features
+      labels:
+        - "feature"
+    - title: Improvements
+      labels:
+        - "enhancement"
+        - "performance"
+    - title: Fixes
+      labels:
+        - "bug"
+        - "regression"
+    - title: Fixes (extensibility)
+      labels:
+        - "extensibility"
+    - title: Documentation
+      labels:
+        - "documentation"
+    - title: Others
+      labels: 
+        - "*"


### PR DESCRIPTION
As discussed [here](https://github.com/fluentassertions/fluentassertions/discussions/1804) we can improve the auto-generated release notes by adding a [`release.yml`](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options) which can group changes by label.

I looked at the existing labels we have used to make the categories.