### PR TITLE
Better support for NaN in numeric assertions on floats and doubles

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -631,7 +631,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<float> Should(this float actualValue)
         {
-            return new NumericAssertions<float>(actualValue);
+            return new FloatAssertions(actualValue);
         }
 
         /// <summary>
@@ -651,7 +651,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<double> Should(this double actualValue)
         {
-            return new NumericAssertions<double>(actualValue);
+            return new DoubleAssertions(actualValue);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Numeric/DoubleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/DoubleAssertions.cs
@@ -1,0 +1,12 @@
+﻿namespace FluentAssertions.Numeric
+{
+    internal class DoubleAssertions : NumericAssertions<double>
+    {
+        public DoubleAssertions(double value) 
+            : base(value)
+        {
+        }
+
+        private protected override bool IsNaN(double value) => double.IsNaN(value);
+    }
+}

--- a/Src/FluentAssertions/Numeric/FloatAssertions.cs
+++ b/Src/FluentAssertions/Numeric/FloatAssertions.cs
@@ -1,0 +1,12 @@
+﻿namespace FluentAssertions.Numeric
+{
+    internal class FloatAssertions : NumericAssertions<float>
+    {
+        public FloatAssertions(float value)
+            : base(value)
+        {
+        }
+
+        private protected override bool IsNaN(float value) => float.IsNaN(value);
+    }
+}

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -165,7 +165,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(default(T)) < 0)
+                .ForCondition(Subject.HasValue && !IsNaN(Subject.Value) && Subject.Value.CompareTo(default(T)) < 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be negative{reason}, but found {0}.", Subject);
 
@@ -185,8 +185,13 @@ namespace FluentAssertions.Numeric
         /// </param>
         public AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs)
         {
+            if (IsNaN(expected))
+            {
+                throw new ArgumentException("A value can never be less than NaN", nameof(expected));
+            }
+           
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
+                .ForCondition(Subject.HasValue && !IsNaN(Subject.Value) && Subject.Value.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be less than {0}{reason}, but found {1}.", expected, Subject);
 
@@ -207,8 +212,13 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "",
             params object[] becauseArgs)
         {
+            if (IsNaN(expected))
+            {
+                throw new ArgumentException("A value can never be less than or equal to NaN", nameof(expected));
+            }
+            
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
+                .ForCondition(Subject.HasValue && !IsNaN(Subject.Value) && Subject.Value.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be less than or equal to {0}{reason}, but found {1}.", expected, Subject);
 
@@ -232,6 +242,11 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "",
             params object[] becauseArgs)
         {
+            if (IsNaN(expected))
+            {
+                throw new ArgumentException("A value can never be greater than NaN", nameof(expected));
+            }
+
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
                 .BecauseOf(because, becauseArgs)
@@ -254,6 +269,11 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "",
             params object[] becauseArgs)
         {
+            if (IsNaN(expected))
+            {
+                throw new ArgumentException("A value can never be greater than or equal to a NaN", nameof(expected));
+            }
+            
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)
@@ -287,6 +307,11 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "",
             params object[] becauseArgs)
         {
+            if (IsNaN(minimumValue) || IsNaN(maximumValue))
+            {
+                throw new ArgumentException("A range cannot begin or end with NaN");  
+            }
+            
             Execute.Assertion
                 .ForCondition(Subject.HasValue && (Subject.Value.CompareTo(minimumValue) >= 0) && (Subject.Value.CompareTo(maximumValue) <= 0))
                 .BecauseOf(because, becauseArgs)
@@ -318,6 +343,11 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "",
             params object[] becauseArgs)
         {
+            if (IsNaN(minimumValue) || IsNaN(maximumValue))
+            {
+                throw new ArgumentException("A range cannot begin or end with NaN");
+            }
+            
             Execute.Assertion
                 .ForCondition(Subject.HasValue && !((Subject.Value.CompareTo(minimumValue) >= 0) && (Subject.Value.CompareTo(maximumValue) <= 0)))
                 .BecauseOf(because, becauseArgs)
@@ -449,5 +479,7 @@ namespace FluentAssertions.Numeric
         /// <inheritdoc/>
         public override bool Equals(object obj) =>
             throw new NotSupportedException("Calling Equals on Assertion classes is not supported.");
+
+        private protected virtual bool IsNaN(T value) => false; 
     }
 }

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -752,6 +752,11 @@ namespace FluentAssertions
             float expectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
+            if (float.IsNaN(expectedValue))
+            {
+                throw new ArgumentException("Cannot determine approximation of a float to NaN", nameof(expectedValue)); 
+            }
+            
             if (precision < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
@@ -879,6 +884,11 @@ namespace FluentAssertions
             double expectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
+            if (double.IsNaN(expectedValue))
+            {
+                throw new ArgumentException("Cannot determine approximation of a double to NaN", nameof(expectedValue)); 
+            }
+            
             if (precision < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
@@ -1137,6 +1147,11 @@ namespace FluentAssertions
             float unexpectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
+            if (float.IsNaN(unexpectedValue))
+            {
+                throw new ArgumentException("Cannot determine approximation of a float to NaN", nameof(unexpectedValue)); 
+            }
+            
             if (precision < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
@@ -1262,6 +1277,11 @@ namespace FluentAssertions
             double unexpectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
+            if (double.IsNaN(unexpectedValue))
+            {
+                throw new ArgumentException("Cannot determine approximation of a double to NaN", nameof(unexpectedValue));
+            }
+            
             if (precision < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");

--- a/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.cs
@@ -199,899 +199,966 @@ namespace FluentAssertions.Specs.Numeric
             int? nullableIntegerB = 2;
 
             // Act
-            Action act = () => nullableIntegerA.Should().Be(nullableIntegerB, "because we want to test the failure {0}", "message");
+            Action act = () =>
+                nullableIntegerA.Should().Be(nullableIntegerB, "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected*2 because we want to test the failure message, but found 1.");
         }
 
-        #region Be Approximately
-
-        [Fact]
-        public void When_approximating_a_nullable_double_with_a_negative_precision_it_should_throw()
+        public class BeApproximately
         {
-            // Arrange
-            double? value = 3.1415927;
+            [Fact]
+            public void When_approximating_a_nullable_double_with_a_negative_precision_it_should_throw()
+            {
+                // Arrange
+                double? value = 3.1415927;
 
-            // Act
-            Action act = () => value.Should().BeApproximately(3.14, -0.1);
+                // Act
+                Action act = () => value.Should().BeApproximately(3.14, -0.1);
 
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_approximating_two_nullable_doubles_with_a_negative_precision_it_should_throw()
+            {
+                // Arrange
+                double? value = 3.1415927;
+                double? expected = 3.14;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, -0.1);
+
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_nullable_double_is_indeed_approximating_a_value_it_should_not_throw()
+            {
+                // Arrange
+                double? value = 3.1415927;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(3.14, 0.1);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_nullable_double_is_indeed_approximating_a_nullable_value_it_should_not_throw()
+            {
+                // Arrange
+                double? value = 3.1415927;
+                double? expected = 3.142;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_nullable_double_is_null_approximating_a_nullable_null_value_it_should_not_throw()
+            {
+                // Arrange
+                double? value = null;
+                double? expected = null;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_nullable_double_with_value_is_not_approximating_a_non_null_nullable_value_it_should_throw()
+            {
+                // Arrange
+                double? value = 13;
+                double? expected = 12;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected*12.0*0.1*13.0*");
+            }
+
+            [Fact]
+            public void When_nullable_double_is_null_approximating_a_non_null_nullable_value_it_should_throw()
+            {
+                // Arrange
+                double? value = null;
+                double? expected = 12;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected value to approximate 12.0 +/- 0.1, but it was <null>.");
+            }
+
+            [Fact]
+            public void When_nullable_double_is_not_null_approximating_a_null_value_it_should_throw()
+            {
+                // Arrange
+                double? value = 12;
+                double? expected = null;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected value to approximate <null> +/- 0.1, but it was 12.0.");
+            }
+
+            [Fact]
+            public void When_nullable_double_has_no_value_it_should_throw()
+            {
+                // Arrange
+                double? value = null;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(3.14, 0.001);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected value to approximate 3.14 +/- 0.001, but it was <null>.");
+            }
+
+            [Fact]
+            public void When_nullable_double_is_not_approximating_a_value_it_should_throw()
+            {
+                // Arrange
+                double? value = 3.1415927F;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(1.0, 0.1);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected value to approximate 1.0 +/- 0.1, but 3.14* differed by*");
+            }
+            
+            [Fact]
+            public void A_double_cannot_approximate_NaN()
+            {
+                // Arrange
+                double? value = 3.1415927F;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(double.NaN, 0.1);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+            
+            [Fact]
+            public void When_approximating_a_nullable_float_with_a_negative_precision_it_should_throw()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(3.14F, -0.1F);
+
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_approximating_two_nullable_floats_with_a_negative_precision_it_should_throw()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+                float? expected = 3.14F;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, -0.1F);
+
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_nullable_float_is_indeed_approximating_a_value_it_should_not_throw()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(3.14F, 0.1F);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_nullable_float_is_indeed_approximating_a_nullable_value_it_should_not_throw()
+            {
+                // Arrange
+                float? value = 3.1415927f;
+                float? expected = 3.142f;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1f);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_nullable_float_is_null_approximating_a_nullable_null_value_it_should_not_throw()
+            {
+                // Arrange
+                float? value = null;
+                float? expected = null;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1f);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_nullable_float_with_value_is_not_approximating_a_non_null_nullable_value_it_should_throw()
+            {
+                // Arrange
+                float? value = 13;
+                float? expected = 12;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1f);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected*12*0.1*13*");
+            }
+
+            [Fact]
+            public void When_nullable_float_is_null_approximating_a_non_null_nullable_value_it_should_throw()
+            {
+                // Arrange
+                float? value = null;
+                float? expected = 12;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1f);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected value to approximate 12F +/- 0.1F, but it was <null>.");
+            }
+
+            [Fact]
+            public void When_nullable_float_is_not_null_approximating_a_null_value_it_should_throw()
+            {
+                // Arrange
+                float? value = 12;
+                float? expected = null;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1f);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected value to approximate <null> +/- 0.1F, but it was 12F.");
+            }
+
+            [Fact]
+            public void When_nullable_float_is_not_approximating_a_value_it_should_throw()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(1.0F, 0.1F);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected value to approximate *1* +/- *0.1* but 3.14* differed by*");
+            }
+            
+            [Fact]
+            public void A_float_cannot_approximate_NaN()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(float.NaN, 0.1F);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void When_approximating_a_nullable_decimal_with_a_negative_precision_it_should_throw()
+            {
+                // Arrange
+                decimal? value = 3.1415927m;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(3.14m, -0.1m);
+
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_approximating_two_nullable_decimals_with_a_negative_precision_it_should_throw()
+            {
+                // Arrange
+                decimal? value = 3.1415927m;
+                decimal? expected = 3.14m;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, -0.1m);
+
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_nullable_decimal_is_indeed_approximating_a_value_it_should_not_throw()
+            {
+                // Arrange
+                decimal? value = 3.1415927m;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(3.14m, 0.1m);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_nullable_decimal_is_indeed_approximating_a_nullable_value_it_should_not_throw()
+            {
+                // Arrange
+                decimal? value = 3.1415927m;
+                decimal? expected = 3.142m;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1m);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_nullable_decimal_is_null_approximating_a_nullable_null_value_it_should_not_throw()
+            {
+                // Arrange
+                decimal? value = null;
+                decimal? expected = null;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1m);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_nullable_decimal_with_value_is_not_approximating_a_non_null_nullable_value_it_should_throw()
+            {
+                // Arrange
+                decimal? value = 13;
+                decimal? expected = 12;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1m);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected*12*0.1*13*");
+            }
+
+            [Fact]
+            public void When_nullable_decimal_is_null_approximating_a_non_null_nullable_value_it_should_throw()
+            {
+                // Arrange
+                decimal? value = null;
+                decimal? expected = 12;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1m);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected value to approximate 12M +/- 0.1M, but it was <null>.");
+            }
+
+            [Fact]
+            public void When_nullable_decimal_is_not_null_approximating_a_null_value_it_should_throw()
+            {
+                // Arrange
+                decimal? value = 12;
+                decimal? expected = null;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(expected, 0.1m);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected value to approximate <null> +/- 0.1M, but it was 12M.");
+            }
+
+            [Fact]
+            public void When_nullable_decimal_has_no_value_it_should_throw()
+            {
+                // Arrange
+                decimal? value = null;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(3.14m, 0.001m);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected value to approximate*3.14* +/-*0.001*, but it was <null>.");
+            }
+
+            [Fact]
+            public void When_nullable_decimal_is_not_approximating_a_value_it_should_throw()
+            {
+                // Arrange
+                decimal? value = 3.1415927m;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(1.0m, 0.1m);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected value to approximate*1.0* +/-*0.1*, but 3.14* differed by*");
+            }
         }
 
-        [Fact]
-        public void When_approximating_two_nullable_doubles_with_a_negative_precision_it_should_throw()
+        public class NotBeApproximately
         {
-            // Arrange
-            double? value = 3.1415927;
-            double? expected = 3.14;
+            [Fact]
+            public void When_not_approximating_a_nullable_double_with_a_negative_precision_it_should_throw()
+            {
+                // Arrange
+                double? value = 3.1415927;
 
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, -0.1);
+                // Act
+                Action act = () => value.Should().NotBeApproximately(3.14, -0.1);
 
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_not_approximating_two_nullable_doubles_with_a_negative_precision_it_should_throw()
+            {
+                // Arrange
+                double? value = 3.1415927;
+                double? expected = 3.14;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, -0.1);
+
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_double_is_not_approximating_a_value_it_should_not_throw()
+            {
+                // Arrange
+                double? value = 3.1415927;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(1.0, 0.1);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_double_has_no_value_it_should_throw()
+            {
+                // Arrange
+                double? value = null;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(3.14, 0.001);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_double_is_indeed_approximating_a_value_it_should_throw()
+            {
+                // Arrange
+                double? value = 3.1415927;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(3.14, 0.1);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected value to not approximate 3.14 +/- 0.1, but 3.14*only differed by*");
+            }
+
+            [Fact]
+            public void
+                When_asserting_not_approximately_and_nullable_double_is_not_approximating_a_nullable_value_it_should_not_throw()
+            {
+                // Arrange
+                double? value = 3.1415927;
+                double? expected = 1.0;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_double_is_not_approximating_a_null_value_it_should_throw()
+            {
+                // Arrange
+                double? value = 3.1415927;
+                double? expected = null;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void
+                When_asserting_not_approximately_and_null_double_is_not_approximating_a_nullable_double_value_it_should_throw()
+            {
+                // Arrange
+                double? value = null;
+                double? expected = 20.0;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_null_double_is_not_approximating_a_null_value_it_should_not_throw()
+            {
+                // Arrange
+                double? value = null;
+                double? expected = null;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*null*0.1*but*null*");
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_double_is_approximating_a_nullable_value_it_should_throw()
+            {
+                // Arrange
+                double? value = 3.1415927;
+                double? expected = 3.1;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1F);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+            
+            [Fact]
+            public void A_double_cannot_approximate_NaN()
+            {
+                // Arrange
+                double? value = 3.1415927F;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(double.NaN, 0.1);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void When_not_approximating_a_nullable_float_with_a_negative_precision_it_should_throw()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(3.14F, -0.1F);
+
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_not_approximating_two_nullable_floats_with_a_negative_precision_it_should_throw()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+                float? expected = 3.14F;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, -0.1F);
+
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_float_is_not_approximating_a_value_it_should_not_throw()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(1.0F, 0.1F);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_float_has_no_value_it_should_throw()
+            {
+                // Arrange
+                float? value = null;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(3.14F, 0.001F);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_float_is_indeed_approximating_a_value_it_should_throw()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(3.14F, 0.1F);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected value to not approximate *3.14F* +/- *0.1F* but 3.14* only differed by*");
+            }
+
+            [Fact]
+            public void
+                When_asserting_not_approximately_and_nullable_float_is_not_approximating_a_nullable_value_it_should_not_throw()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+                float? expected = 1.0F;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1F);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_float_is_not_approximating_a_null_value_it_should_throw()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+                float? expected = null;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1F);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void
+                When_asserting_not_approximately_and_null_float_is_not_approximating_a_nullable_float_value_it_should_throw()
+            {
+                // Arrange
+                float? value = null;
+                float? expected = 20.0f;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1F);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_null_float_is_not_approximating_a_null_value_it_should_not_throw()
+            {
+                // Arrange
+                float? value = null;
+                float? expected = null;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1F);
+
+                // Assert
+                act.Should().Throw<XunitException>("Expected*<null>*+/-*0.1F*<null>*");
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_float_is_approximating_a_nullable_value_it_should_throw()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+                float? expected = 3.1F;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1F);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+            
+            [Fact]
+            public void A_float_cannot_approximate_NaN()
+            {
+                // Arrange
+                float? value = 3.1415927F;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(float.NaN, 0.1F);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void When_not_approximating_a_nullable_decimal_with_a_negative_precision_it_should_throw()
+            {
+                // Arrange
+                decimal? value = 3.1415927m;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(3.14m, -0.1m);
+
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_not_approximating_two_nullable_decimals_with_a_negative_precision_it_should_throw()
+            {
+                // Arrange
+                decimal? value = 3.1415927m;
+                decimal? expected = 3.14m;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, -0.1m);
+
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_decimal_is_not_approximating_a_value_it_should_not_throw()
+            {
+                // Arrange
+                decimal? value = 3.1415927m;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(1.0m, 0.1m);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_decimal_has_no_value_it_should_throw()
+            {
+                // Arrange
+                decimal? value = null;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(3.14m, 0.001m);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_decimal_is_indeed_approximating_a_value_it_should_throw()
+            {
+                // Arrange
+                decimal? value = 3.1415927m;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(3.14m, 0.1m);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected value to not approximate*3.14* +/-*0.1*, but*3.14*only differed by*");
+            }
+
+            [Fact]
+            public void
+                When_asserting_not_approximately_and_nullable_decimal_is_not_approximating_a_nullable_value_it_should_not_throw()
+            {
+                // Arrange
+                decimal? value = 3.1415927m;
+                decimal? expected = 1.0m;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1m);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_decimal_is_not_approximating_a_null_value_it_should_throw()
+            {
+                // Arrange
+                decimal? value = 3.1415927m;
+                decimal? expected = null;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1m);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void
+                When_asserting_not_approximately_and_null_decimal_is_not_approximating_a_nullable_decimal_value_it_should_throw()
+            {
+                // Arrange
+                decimal? value = null;
+                decimal? expected = 20.0m;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1m);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_null_decimal_is_not_approximating_a_null_value_it_should_not_throw()
+            {
+                // Arrange
+                decimal? value = null;
+                decimal? expected = null;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1m);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*<null>*0.1M*<null>*");
+            }
+
+            [Fact]
+            public void When_asserting_not_approximately_and_nullable_decimal_is_approximating_a_nullable_value_it_should_throw()
+            {
+                // Arrange
+                decimal? value = 3.1415927m;
+                decimal? expected = 3.1m;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(expected, 0.1m);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
         }
 
-        [Fact]
-        public void When_nullable_double_is_indeed_approximating_a_value_it_should_not_throw()
+        public class Match
         {
-            // Arrange
-            double? value = 3.1415927;
+            [Fact]
+            public void When_nullable_value_satisfies_predicate_it_should_not_throw()
+            {
+                // Arrange
+                int? nullableInteger = 1;
 
-            // Act
-            Action act = () => value.Should().BeApproximately(3.14, 0.1);
+                // Act / Assert
+                nullableInteger.Should().Match(o => o.HasValue);
+            }
 
-            // Assert
-            act.Should().NotThrow();
+            [Fact]
+            public void When_nullable_value_does_not_match_the_predicate_it_should_throw()
+            {
+                // Arrange
+                int? nullableInteger = 1;
+
+                // Act
+                Action act = () =>
+                    nullableInteger.Should().Match(o => !o.HasValue, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected value to match Not(o.HasValue) because we want to test the failure message, but found 1.");
+            }
+
+            [Fact]
+            public void When_nullable_value_is_matched_against_a_null_it_should_throw()
+            {
+                // Arrange
+                int? nullableInteger = 1;
+
+                // Act
+                Action act = () => nullableInteger.Should().Match(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("predicate");
+            }
         }
-
-        [Fact]
-        public void When_nullable_double_is_indeed_approximating_a_nullable_value_it_should_not_throw()
-        {
-            // Arrange
-            double? value = 3.1415927;
-            double? expected = 3.142;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_nullable_double_is_null_approximating_a_nullable_null_value_it_should_not_throw()
-        {
-            // Arrange
-            double? value = null;
-            double? expected = null;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_nullable_double_with_value_is_not_approximating_a_non_null_nullable_value_it_should_throw()
-        {
-            // Arrange
-            double? value = 13;
-            double? expected = 12;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*12.0*0.1*13.0*");
-        }
-
-        [Fact]
-        public void When_nullable_double_is_null_approximating_a_non_null_nullable_value_it_should_throw()
-        {
-            // Arrange
-            double? value = null;
-            double? expected = 12;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected value to approximate 12.0 +/- 0.1, but it was <null>.");
-        }
-
-        [Fact]
-        public void When_nullable_double_is_not_null_approximating_a_null_value_it_should_throw()
-        {
-            // Arrange
-            double? value = 12;
-            double? expected = null;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected value to approximate <null> +/- 0.1, but it was 12.0.");
-        }
-
-        [Fact]
-        public void When_nullable_double_has_no_value_it_should_throw()
-        {
-            // Arrange
-            double? value = null;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(3.14, 0.001);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected value to approximate 3.14 +/- 0.001, but it was <null>.");
-        }
-
-        [Fact]
-        public void When_nullable_double_is_not_approximating_a_value_it_should_throw()
-        {
-            // Arrange
-            double? value = 3.1415927F;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(1.0, 0.1);
-
-            // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected value to approximate 1.0 +/- 0.1, but 3.14* differed by*");
-        }
-
-        [Fact]
-        public void When_approximating_a_nullable_float_with_a_negative_precision_it_should_throw()
-        {
-            // Arrange
-            float? value = 3.1415927F;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(3.14F, -0.1F);
-
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
-        }
-
-        [Fact]
-        public void When_approximating_two_nullable_floats_with_a_negative_precision_it_should_throw()
-        {
-            // Arrange
-            float? value = 3.1415927F;
-            float? expected = 3.14F;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, -0.1F);
-
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
-        }
-
-        [Fact]
-        public void When_nullable_float_is_indeed_approximating_a_value_it_should_not_throw()
-        {
-            // Arrange
-            float? value = 3.1415927F;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(3.14F, 0.1F);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_nullable_float_is_indeed_approximating_a_nullable_value_it_should_not_throw()
-        {
-            // Arrange
-            float? value = 3.1415927f;
-            float? expected = 3.142f;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1f);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_nullable_float_is_null_approximating_a_nullable_null_value_it_should_not_throw()
-        {
-            // Arrange
-            float? value = null;
-            float? expected = null;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1f);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_nullable_float_with_value_is_not_approximating_a_non_null_nullable_value_it_should_throw()
-        {
-            // Arrange
-            float? value = 13;
-            float? expected = 12;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1f);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*12*0.1*13*");
-        }
-
-        [Fact]
-        public void When_nullable_float_is_null_approximating_a_non_null_nullable_value_it_should_throw()
-        {
-            // Arrange
-            float? value = null;
-            float? expected = 12;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1f);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected value to approximate 12F +/- 0.1F, but it was <null>.");
-        }
-
-        [Fact]
-        public void When_nullable_float_is_not_null_approximating_a_null_value_it_should_throw()
-        {
-            // Arrange
-            float? value = 12;
-            float? expected = null;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1f);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected value to approximate <null> +/- 0.1F, but it was 12F.");
-        }
-
-        [Fact]
-        public void When_nullable_float_is_not_approximating_a_value_it_should_throw()
-        {
-            // Arrange
-            float? value = 3.1415927F;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(1.0F, 0.1F);
-
-            // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected value to approximate *1* +/- *0.1* but 3.14* differed by*");
-        }
-
-        [Fact]
-        public void When_approximating_a_nullable_decimal_with_a_negative_precision_it_should_throw()
-        {
-            // Arrange
-            decimal? value = 3.1415927m;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(3.14m, -0.1m);
-
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
-        }
-
-        [Fact]
-        public void When_approximating_two_nullable_decimals_with_a_negative_precision_it_should_throw()
-        {
-            // Arrange
-            decimal? value = 3.1415927m;
-            decimal? expected = 3.14m;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, -0.1m);
-
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
-        }
-
-        [Fact]
-        public void When_nullable_decimal_is_indeed_approximating_a_value_it_should_not_throw()
-        {
-            // Arrange
-            decimal? value = 3.1415927m;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(3.14m, 0.1m);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_nullable_decimal_is_indeed_approximating_a_nullable_value_it_should_not_throw()
-        {
-            // Arrange
-            decimal? value = 3.1415927m;
-            decimal? expected = 3.142m;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1m);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_nullable_decimal_is_null_approximating_a_nullable_null_value_it_should_not_throw()
-        {
-            // Arrange
-            decimal? value = null;
-            decimal? expected = null;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1m);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_nullable_decimal_with_value_is_not_approximating_a_non_null_nullable_value_it_should_throw()
-        {
-            // Arrange
-            decimal? value = 13;
-            decimal? expected = 12;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1m);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*12*0.1*13*");
-        }
-
-        [Fact]
-        public void When_nullable_decimal_is_null_approximating_a_non_null_nullable_value_it_should_throw()
-        {
-            // Arrange
-            decimal? value = null;
-            decimal? expected = 12;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1m);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected value to approximate 12M +/- 0.1M, but it was <null>.");
-        }
-
-        [Fact]
-        public void When_nullable_decimal_is_not_null_approximating_a_null_value_it_should_throw()
-        {
-            // Arrange
-            decimal? value = 12;
-            decimal? expected = null;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(expected, 0.1m);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected value to approximate <null> +/- 0.1M, but it was 12M.");
-        }
-
-        [Fact]
-        public void When_nullable_decimal_has_no_value_it_should_throw()
-        {
-            // Arrange
-            decimal? value = null;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(3.14m, 0.001m);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected value to approximate*3.14* +/-*0.001*, but it was <null>.");
-        }
-
-        [Fact]
-        public void When_nullable_decimal_is_not_approximating_a_value_it_should_throw()
-        {
-            // Arrange
-            decimal? value = 3.1415927m;
-
-            // Act
-            Action act = () => value.Should().BeApproximately(1.0m, 0.1m);
-
-            // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected value to approximate*1.0* +/-*0.1*, but 3.14* differed by*");
-        }
-
-        #endregion
-
-        #region Not Be Approximately
-
-        [Fact]
-        public void When_not_approximating_a_nullable_double_with_a_negative_precision_it_should_throw()
-        {
-            // Arrange
-            double? value = 3.1415927;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(3.14, -0.1);
-
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
-        }
-
-        [Fact]
-        public void When_not_approximating_two_nullable_doubles_with_a_negative_precision_it_should_throw()
-        {
-            // Arrange
-            double? value = 3.1415927;
-            double? expected = 3.14;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, -0.1);
-
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_double_is_not_approximating_a_value_it_should_not_throw()
-        {
-            // Arrange
-            double? value = 3.1415927;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(1.0, 0.1);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_double_has_no_value_it_should_throw()
-        {
-            // Arrange
-            double? value = null;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(3.14, 0.001);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_double_is_indeed_approximating_a_value_it_should_throw()
-        {
-            // Arrange
-            double? value = 3.1415927;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(3.14, 0.1);
-
-            // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected value to not approximate 3.14 +/- 0.1, but 3.14*only differed by*");
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_double_is_not_approximating_a_nullable_value_it_should_not_throw()
-        {
-            // Arrange
-            double? value = 3.1415927;
-            double? expected = 1.0;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_double_is_not_approximating_a_null_value_it_should_throw()
-        {
-            // Arrange
-            double? value = 3.1415927;
-            double? expected = null;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_null_double_is_not_approximating_a_nullable_double_value_it_should_throw()
-        {
-            // Arrange
-            double? value = null;
-            double? expected = 20.0;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_null_double_is_not_approximating_a_null_value_it_should_not_throw()
-        {
-            // Arrange
-            double? value = null;
-            double? expected = null;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*null*0.1*but*null*");
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_double_is_approximating_a_nullable_value_it_should_throw()
-        {
-            // Arrange
-            double? value = 3.1415927;
-            double? expected = 3.1;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1F);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_not_approximating_a_nullable_float_with_a_negative_precision_it_should_throw()
-        {
-            // Arrange
-            float? value = 3.1415927F;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(3.14F, -0.1F);
-
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
-        }
-
-        [Fact]
-        public void When_not_approximating_two_nullable_floats_with_a_negative_precision_it_should_throw()
-        {
-            // Arrange
-            float? value = 3.1415927F;
-            float? expected = 3.14F;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, -0.1F);
-
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_float_is_not_approximating_a_value_it_should_not_throw()
-        {
-            // Arrange
-            float? value = 3.1415927F;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(1.0F, 0.1F);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_float_has_no_value_it_should_throw()
-        {
-            // Arrange
-            float? value = null;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(3.14F, 0.001F);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_float_is_indeed_approximating_a_value_it_should_throw()
-        {
-            // Arrange
-            float? value = 3.1415927F;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(3.14F, 0.1F);
-
-            // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected value to not approximate *3.14F* +/- *0.1F* but 3.14* only differed by*");
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_float_is_not_approximating_a_nullable_value_it_should_not_throw()
-        {
-            // Arrange
-            float? value = 3.1415927F;
-            float? expected = 1.0F;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1F);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_float_is_not_approximating_a_null_value_it_should_throw()
-        {
-            // Arrange
-            float? value = 3.1415927F;
-            float? expected = null;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1F);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_null_float_is_not_approximating_a_nullable_float_value_it_should_throw()
-        {
-            // Arrange
-            float? value = null;
-            float? expected = 20.0f;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1F);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_null_float_is_not_approximating_a_null_value_it_should_not_throw()
-        {
-            // Arrange
-            float? value = null;
-            float? expected = null;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1F);
-
-            // Assert
-            act.Should().Throw<XunitException>("Expected*<null>*+/-*0.1F*<null>*");
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_float_is_approximating_a_nullable_value_it_should_throw()
-        {
-            // Arrange
-            float? value = 3.1415927F;
-            float? expected = 3.1F;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1F);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_not_approximating_a_nullable_decimal_with_a_negative_precision_it_should_throw()
-        {
-            // Arrange
-            decimal? value = 3.1415927m;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(3.14m, -0.1m);
-
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
-        }
-
-        [Fact]
-        public void When_not_approximating_two_nullable_decimals_with_a_negative_precision_it_should_throw()
-        {
-            // Arrange
-            decimal? value = 3.1415927m;
-            decimal? expected = 3.14m;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, -0.1m);
-
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_decimal_is_not_approximating_a_value_it_should_not_throw()
-        {
-            // Arrange
-            decimal? value = 3.1415927m;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(1.0m, 0.1m);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_decimal_has_no_value_it_should_throw()
-        {
-            // Arrange
-            decimal? value = null;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(3.14m, 0.001m);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_decimal_is_indeed_approximating_a_value_it_should_throw()
-        {
-            // Arrange
-            decimal? value = 3.1415927m;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(3.14m, 0.1m);
-
-            // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected value to not approximate*3.14* +/-*0.1*, but*3.14*only differed by*");
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_decimal_is_not_approximating_a_nullable_value_it_should_not_throw()
-        {
-            // Arrange
-            decimal? value = 3.1415927m;
-            decimal? expected = 1.0m;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1m);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_decimal_is_not_approximating_a_null_value_it_should_throw()
-        {
-            // Arrange
-            decimal? value = 3.1415927m;
-            decimal? expected = null;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1m);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_null_decimal_is_not_approximating_a_nullable_decimal_value_it_should_throw()
-        {
-            // Arrange
-            decimal? value = null;
-            decimal? expected = 20.0m;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1m);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_null_decimal_is_not_approximating_a_null_value_it_should_not_throw()
-        {
-            // Arrange
-            decimal? value = null;
-            decimal? expected = null;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1m);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*<null>*0.1M*<null>*");
-        }
-
-        [Fact]
-        public void When_asserting_not_approximately_and_nullable_decimal_is_approximating_a_nullable_value_it_should_throw()
-        {
-            // Arrange
-            decimal? value = 3.1415927m;
-            decimal? expected = 3.1m;
-
-            // Act
-            Action act = () => value.Should().NotBeApproximately(expected, 0.1m);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        #endregion
-
-        #region Match
-
-        [Fact]
-        public void When_nullable_value_satisfies_predicate_it_should_not_throw()
-        {
-            // Arrange
-            int? nullableInteger = 1;
-
-            // Act / Assert
-            nullableInteger.Should().Match(o => o.HasValue);
-        }
-
-        [Fact]
-        public void When_nullable_value_does_not_match_the_predicate_it_should_throw()
-        {
-            // Arrange
-            int? nullableInteger = 1;
-
-            // Act
-            Action act = () => nullableInteger.Should().Match(o => !o.HasValue, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected value to match Not(o.HasValue) because we want to test the failure message, but found 1.");
-        }
-
-        [Fact]
-        public void When_nullable_value_is_matched_against_a_null_it_should_throw()
-        {
-            // Arrange
-            int? nullableInteger = 1;
-
-            // Act
-            Action act = () => nullableInteger.Should().Match(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("predicate");
-        }
-
-        #endregion
 
         [Fact]
         public void Should_support_chaining_constraints_with_and()

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -48,6 +48,32 @@ namespace FluentAssertions.Specs.Numeric
             }
 
             [Fact]
+            public void NaN_is_never_a_positive_float()
+            {
+                // Arrange
+                float value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().BePositive();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*but found NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_a_positive_double()
+            {
+                // Arrange
+                double value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().BePositive();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*but found NaN*");
+            }
+
+            [Fact]
             public void When_a_negative_value_is_positive_it_should_throw_with_descriptive_message()
             {
                 // Arrange
@@ -60,6 +86,21 @@ namespace FluentAssertions.Specs.Numeric
                 act
                     .Should().Throw<XunitException>()
                     .WithMessage("Expected value to be positive because we want to test the failure message, but found -1.");
+            }
+
+            [Fact]
+            public void When_a_nullable_numeric_null_value_is_not_positive_it_should_throw()
+            {
+                // Arrange
+                int? value = null;
+
+                // Act
+                Action act = () => value.Should().BePositive();
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*null*");
             }
 
             [Fact]
@@ -132,18 +173,29 @@ namespace FluentAssertions.Specs.Numeric
             }
 
             [Fact]
-            public void When_a_nullable_numeric_null_value_is_not_positive_it_should_throw()
+            public void NaN_is_never_a_negative_float()
             {
                 // Arrange
-                int? value = null;
+                float value = float.NaN;
 
                 // Act
-                Action act = () => value.Should().BePositive();
+                Action act = () => value.Should().BeNegative();
 
                 // Assert
-                act
-                    .Should().Throw<XunitException>()
-                    .WithMessage("*null*");
+                act.Should().Throw<XunitException>().WithMessage("*but found NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_a_negative_double()
+            {
+                // Arrange
+                double value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().BeNegative();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*but found NaN*");
             }
         }
 
@@ -513,6 +565,57 @@ namespace FluentAssertions.Specs.Numeric
                     .Should().Throw<XunitException>()
                     .WithMessage("Expected value to be*3.5*, but found <null>.");
             }
+
+            [Fact]
+            public void Nan_is_never_equal_to_a_normal_float()
+            {
+                // Arrange
+                float value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().Be(3.4F);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected value to be *3.4F, but found NaN*");
+            }
+
+            [Fact]
+            public void NaN_can_be_compared_to_NaN_when_its_a_float()
+            {
+                // Arrange
+                float value = float.NaN;
+
+                // Act
+                value.Should().Be(float.NaN);
+            }
+
+            [Fact]
+            public void Nan_is_never_equal_to_a_normal_double()
+            {
+                // Arrange
+                double value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().Be(3.4D);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected value to be *3.4, but found NaN*");
+            }
+
+            [Fact]
+            public void NaN_can_be_compared_to_NaN_when_its_a_double()
+            {
+                // Arrange
+                double value = double.NaN;
+
+                // Act
+                value.Should().Be(double.NaN);
+            }
         }
 
         public class BeGreaterThanOrEqualTo
@@ -574,6 +677,54 @@ namespace FluentAssertions.Specs.Numeric
                 act
                     .Should().Throw<XunitException>()
                     .WithMessage("Expected value to be greater than 3 because we want to test the failure message, but found 2.");
+            }
+            
+            [Fact]
+            public void NaN_is_never_greater_than_another_float()
+            {
+                // Act
+                Action act = () => float.NaN.Should().BeGreaterThan(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_float_cannot_be_greater_than_NaN()
+            {
+                // Act
+                Action act = () => 3.4F.Should().BeGreaterThan(float.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_greater_than_another_double()
+            {
+                // Act
+                Action act = () => double.NaN.Should().BeGreaterThan(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_double_can_never_be_greater_than_NaN()
+            {
+                // Act
+                Action act = () => 3.4D.Should().BeGreaterThan(double.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
             }
 
             [Fact]
@@ -666,6 +817,54 @@ namespace FluentAssertions.Specs.Numeric
                     .Should().Throw<XunitException>()
                     .WithMessage("*null*");
             }
+
+            [Fact]
+            public void NaN_is_never_greater_than_or_equal_to_another_float()
+            {
+                // Act
+                Action act = () => float.NaN.Should().BeGreaterThanOrEqualTo(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_float_cannot_be_greater_than_or_equal_to_NaN()
+            {
+                // Act
+                Action act = () => 3.4F.Should().BeGreaterThanOrEqualTo(float.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_greater_or_equal_to_another_double()
+            {
+                // Act
+                Action act = () => double.NaN.Should().BeGreaterThanOrEqualTo(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_double_can_never_be_greater_or_equal_to_NaN()
+            {
+                // Act
+                Action act = () => 3.4D.Should().BeGreaterThanOrEqualTo(double.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
         }
 
         public class LessThanOrEqualTo
@@ -726,6 +925,54 @@ namespace FluentAssertions.Specs.Numeric
                 act
                     .Should().Throw<XunitException>()
                     .WithMessage("Expected value to be less than 1 because we want to test the failure message, but found 2.");
+            }
+
+            [Fact]
+            public void NaN_is_never_less_than_another_float()
+            {
+                // Act
+                Action act = () => float.NaN.Should().BeLessThan(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_float_can_never_be_less_than_NaN()
+            {
+                // Act
+                Action act = () => 3.4F.Should().BeLessThan(float.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_less_than_another_double()
+            {
+                // Act
+                Action act = () => double.NaN.Should().BeLessThan(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_double_can_never_be_less_than_NaN()
+            {
+                // Act
+                Action act = () => 3.4D.Should().BeLessThan(double.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
             }
 
             [Fact]
@@ -817,6 +1064,54 @@ namespace FluentAssertions.Specs.Numeric
                     .Should().Throw<XunitException>()
                     .WithMessage("*null*");
             }
+
+            [Fact]
+            public void NaN_is_never_less_than_or_equal_to_another_float()
+            {
+                // Act
+                Action act = () => float.NaN.Should().BeLessThanOrEqualTo(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_float_can_never_be_less_than_or_equal_to_NaN()
+            {
+                // Act
+                Action act = () => 3.4F.Should().BeLessThanOrEqualTo(float.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_less_than_or_equal_to_another_double()
+            {
+                // Act
+                Action act = () => double.NaN.Should().BeLessThanOrEqualTo(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_double_can_never_be_less_than_or_equal_to_NaN()
+            {
+                // Act
+                Action act = () => 3.4D.Should().BeLessThanOrEqualTo(double.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
         }
 
         public class InRange
@@ -864,6 +1159,74 @@ namespace FluentAssertions.Specs.Numeric
                     .Should().Throw<XunitException>()
                     .WithMessage("*null*");
             }
+
+            [Fact]
+            public void NaN_is_never_in_range_of_two_floats()
+            {
+                // Arrange
+                float value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().BeInRange(4, 5);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected value to be between*4* and*5*, but found*NaN*");
+            }
+
+            [Theory]
+            [InlineData(float.NaN, 5F)]
+            [InlineData(5F, float.NaN)]
+            public void A_float_can_never_be_in_a_range_containing_NaN(float minimumValue, float maximumValue)
+            {
+                // Arrange
+                float value = 4.5F;
+
+                // Act
+                Action act = () => value.Should().BeInRange(minimumValue, maximumValue);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage(
+                        "*NaN*");
+            }
+
+            [Fact]
+            public void A_NaN_is_never_in_range_of_two_doubles()
+            {
+                // Arrange
+                float value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().BeInRange(4, 5);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected value to be between*4* and*5*, but found*NaN*");
+            }
+
+            [Theory]
+            [InlineData(double.NaN, 5)]
+            [InlineData(5, double.NaN)]
+            public void A_double_can_never_be_in_a_range_containing_NaN(double minimumValue, double maximumValue)
+            {
+                // Arrange
+                double value = 4.5D;
+
+                // Act
+                Action act = () => value.Should().BeInRange(minimumValue, maximumValue);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage(
+                        "*NaN*");
+            }
         }
 
         public class NotInRange
@@ -910,6 +1273,60 @@ namespace FluentAssertions.Specs.Numeric
                 act
                     .Should().Throw<XunitException>()
                     .WithMessage("*null*");
+            }
+
+            [Fact]
+            public void NaN_is_never_inside_any_range_of_floats()
+            {
+                // Arrange
+                float value = float.NaN;
+
+                // Act / Assert
+                value.Should().NotBeInRange(4, 5);
+            }
+
+            [Theory]
+            [InlineData(float.NaN, 1F)]
+            [InlineData(1F, float.NaN)]
+            public void Cannot_use_NaN_in_a_range_of_floats(float minimumValue, float maximumValue)
+            {
+                // Arrange
+                float value = 4.5F;
+
+                // Act
+                Action act = () => value.Should().NotBeInRange(minimumValue, maximumValue);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_inside_any_range_of_doubles()
+            {
+                // Arrange
+                double value = double.NaN;
+
+                // Act / Assert
+                value.Should().NotBeInRange(4, 5);
+            }
+
+            [Theory]
+            [InlineData(double.NaN, 1D)]
+            [InlineData(1D, double.NaN)]
+            public void Cannot_use_NaN_in_a_range_of_doubles(double minimumValue, double maximumValue)
+            {
+                // Arrange
+                double value = 4.5D;
+
+                // Act
+                Action act = () => value.Should().NotBeInRange(minimumValue, maximumValue);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
             }
         }
 
@@ -971,6 +1388,56 @@ namespace FluentAssertions.Specs.Numeric
                 act
                     .Should().Throw<XunitException>()
                     .WithMessage("*null*");
+            }
+
+            [Fact]
+            public void Two_floats_that_are_NaN_can_be_compared()
+            {
+                // Arrange
+                float value = float.NaN;
+
+                // Act / Assert
+                value.Should().BeOneOf(float.NaN, 4.5F);
+            }
+
+            [Fact]
+            public void Floats_are_never_equal_to_NaN()
+            {
+                // Arrange
+                float value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().BeOneOf(1.5F, 4.5F);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected*1.5F*found*NaN*");
+            }
+
+            [Fact]
+            public void Two_doubles_that_are_NaN_can_be_compared()
+            {
+                // Arrange
+                double value = double.NaN;
+
+                // Act / Assert
+                value.Should().BeOneOf(double.NaN, 4.5F);
+            }
+
+            [Fact]
+            public void Doubles_are_never_equal_to_NaN()
+            {
+                // Arrange
+                double value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().BeOneOf(1.5D, 4.5D);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected*1.5*found NaN*");
             }
         }
 
@@ -1297,6 +1764,32 @@ namespace FluentAssertions.Specs.Numeric
             }
 
             [Fact]
+            public void NaN_can_never_be_close_to_any_float()
+            {
+                // Arrange
+                float value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(float.MinValue, 0.1F);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_float_can_never_be_close_to_NaN()
+            {
+                // Arrange
+                float value = float.MinValue;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(float.NaN, 0.1F);
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage("*NaN*");
+            }
+
+            [Fact]
             public void When_a_nullable_float_has_no_value_it_should_throw()
             {
                 // Arrange
@@ -1444,7 +1937,33 @@ namespace FluentAssertions.Specs.Numeric
             }
 
             [Fact]
-            public void When_approximating_a_decimale_with_a_negative_precision_it_should_throw()
+            public void NaN_can_never_be_close_to_any_double()
+            {
+                // Arrange
+                double value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(double.MinValue, 0.1F);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void A_double_can_never_be_close_to_NaN()
+            {
+                // Arrange
+                double value = double.MinValue;
+
+                // Act
+                Action act = () => value.Should().BeApproximately(double.NaN, 0.1F);
+
+                // Assert
+                act.Should().Throw<ArgumentException>();
+            }
+
+            [Fact]
+            public void When_approximating_a_decimal_with_a_negative_precision_it_should_throw()
             {
                 // Arrange
                 decimal value = 3.1415927M;
@@ -1687,6 +2206,32 @@ namespace FluentAssertions.Specs.Numeric
             }
 
             [Fact]
+            public void NaN_can_never_be_close_to_any_float()
+            {
+                // Arrange
+                float value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(float.MinValue, 0.1F);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_float_can_never_be_close_to_NaN()
+            {
+                // Arrange
+                float value = float.MinValue;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(float.NaN, 0.1F);
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage("*NaN*");
+            }
+
+            [Fact]
             public void When_not_approximating_a_double_with_a_negative_precision_it_should_throw()
             {
                 // Arrange
@@ -1831,6 +2376,32 @@ namespace FluentAssertions.Specs.Numeric
 
                 // Assert
                 act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void NaN_can_never_be_close_to_any_double()
+            {
+                // Arrange
+                double value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(double.MinValue, 0.1F);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_double_can_never_be_close_to_NaN()
+            {
+                // Arrange
+                double value = double.MinValue;
+
+                // Act
+                Action act = () => value.Should().NotBeApproximately(double.NaN, 0.1F);
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage("*NaN*");
             }
 
             [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,6 +16,7 @@ sidebar:
 ### Fixes
 * `EnumAssertions.Be` did not determine the caller name - [#1835](https://github.com/fluentassertions/fluentassertions/pull/1835)
 * Ensure `ExcludingMissingMembers` doesn't undo usage of `WithMapping` in `BeEquivalentTo` - [#1838](https://github.com/fluentassertions/fluentassertions/pull/1838)
+* Better handling of NaN in various numeric assertions - [#1822](https://github.com/fluentassertions/fluentassertions/pull/1822)
 
 ### Fixes (Extensibility)
 


### PR DESCRIPTION
Assertions where floats and doubles were compared to NaN did not always work as expected, especially when "larger than",  "smaller than", ranges and approximation were involved. Also, using NaN as an argument is also no longer supported (and not desired).

Fixes #1690

**Note** Review without whitespace

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).