### PR TITLE
Add the ability to exclude non-browsable members from equivalency tests

### DIFF
--- a/Src/FluentAssertions/Equivalency/Execution/CollectionMemberAssertionOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CollectionMemberAssertionOptionsDecorator.cs
@@ -61,7 +61,9 @@ namespace FluentAssertions.Equivalency.Execution
 
         public MemberVisibility IncludedFields => inner.IncludedFields;
 
-        public bool ExcludeNonBrowsable => inner.ExcludeNonBrowsable;
+        public bool IgnoreNonBrowsableOnSubject => inner.IgnoreNonBrowsableOnSubject;
+
+        public bool ExcludeNonBrowsableOnExpectation => inner.ExcludeNonBrowsableOnExpectation;
 
         public bool CompareRecordsByValue => inner.CompareRecordsByValue;
 

--- a/Src/FluentAssertions/Equivalency/Execution/CollectionMemberAssertionOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CollectionMemberAssertionOptionsDecorator.cs
@@ -61,6 +61,8 @@ namespace FluentAssertions.Equivalency.Execution
 
         public MemberVisibility IncludedFields => inner.IncludedFields;
 
+        public bool ExcludeNonBrowsable => inner.ExcludeNonBrowsable;
+
         public bool CompareRecordsByValue => inner.CompareRecordsByValue;
 
         public EqualityStrategy GetEqualityStrategy(Type type)

--- a/Src/FluentAssertions/Equivalency/Field.cs
+++ b/Src/FluentAssertions/Equivalency/Field.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Reflection;
 using FluentAssertions.Common;
 
@@ -10,6 +11,7 @@ namespace FluentAssertions.Equivalency
     public class Field : Node, IMember
     {
         private readonly FieldInfo fieldInfo;
+        private bool? isBrowsable;
 
         public Field(FieldInfo fieldInfo, INode parent)
             : this(fieldInfo.ReflectedType, fieldInfo, parent)
@@ -42,5 +44,18 @@ namespace FluentAssertions.Equivalency
         public CSharpAccessModifier GetterAccessibility => fieldInfo.GetCSharpAccessModifier();
 
         public CSharpAccessModifier SetterAccessibility => fieldInfo.GetCSharpAccessModifier();
+
+        public bool IsBrowsable
+        {
+            get
+            {
+                if (isBrowsable == null)
+                {
+                    isBrowsable = fieldInfo.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
+                }
+
+                return isBrowsable.Value;
+            }
+        }
     }
 }

--- a/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+
 using FluentAssertions.Equivalency.Tracing;
 
 namespace FluentAssertions.Equivalency
@@ -70,6 +72,12 @@ namespace FluentAssertions.Equivalency
         /// Gets a value indicating whether and which fields should be considered.
         /// </summary>
         MemberVisibility IncludedFields { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether members marked with [EditorBrowsable]
+        /// and an EditorBrowsableState of Never should be excluded.
+        /// </summary>
+        bool ExcludeNonBrowsable { get; }
 
         /// <summary>
         /// Gets a value indicating whether records should be compared by value instead of their members

--- a/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
@@ -74,10 +74,16 @@ namespace FluentAssertions.Equivalency
         MemberVisibility IncludedFields { get; }
 
         /// <summary>
-        /// Gets a value indicating whether members marked with [EditorBrowsable]
+        /// Gets a value indicating whether members on the subject marked with [EditorBrowsable]
+        /// and an EditorBrowsableState of Never should be treated as though they don't exist.
+        /// </summary>
+        bool IgnoreNonBrowsableOnSubject { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether members on the expectation marked with [EditorBrowsable]
         /// and an EditorBrowsableState of Never should be excluded.
         /// </summary>
-        bool ExcludeNonBrowsable { get; }
+        bool ExcludeNonBrowsableOnExpectation { get; }
 
         /// <summary>
         /// Gets a value indicating whether records should be compared by value instead of their members

--- a/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
@@ -74,14 +74,14 @@ namespace FluentAssertions.Equivalency
         MemberVisibility IncludedFields { get; }
 
         /// <summary>
-        /// Gets a value indicating whether members on the subject marked with [EditorBrowsable]
-        /// and an EditorBrowsableState of Never should be treated as though they don't exist.
+        /// Gets a value indicating whether members on the subject marked with [<see cref="EditorBrowsableAttribute"/>]
+        /// and <see cref="EditorBrowsableState.Never"/> should be treated as though they don't exist.
         /// </summary>
         bool IgnoreNonBrowsableOnSubject { get; }
 
         /// <summary>
-        /// Gets a value indicating whether members on the expectation marked with [EditorBrowsable]
-        /// and an EditorBrowsableState of Never should be excluded.
+        /// Gets a value indicating whether members on the expectation marked with [<see cref="EditorBrowsableAttribute"/>]
+        /// and <see cref="EditorBrowsableState.Never"/> should be excluded.
         /// </summary>
         bool ExcludeNonBrowsableOnExpectation { get; }
 

--- a/Src/FluentAssertions/Equivalency/IMember.cs
+++ b/Src/FluentAssertions/Equivalency/IMember.cs
@@ -32,5 +32,10 @@ namespace FluentAssertions.Equivalency
         /// Gets the access modifier for the setter of this member.
         /// </summary>
         CSharpAccessModifier SetterAccessibility { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the member is browsable in the source code editor. This is controlled with the [EditorBrowsable] attribute.
+        /// </summary>
+        bool IsBrowsable { get; }
     }
 }

--- a/Src/FluentAssertions/Equivalency/IMember.cs
+++ b/Src/FluentAssertions/Equivalency/IMember.cs
@@ -1,4 +1,6 @@
 using System;
+using System.ComponentModel;
+
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency
@@ -34,7 +36,8 @@ namespace FluentAssertions.Equivalency
         CSharpAccessModifier SetterAccessibility { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the member is browsable in the source code editor. This is controlled with the [EditorBrowsable] attribute.
+        /// Gets a value indicating whether the member is browsable in the source code editor. This is controlled with
+        /// <see cref="EditorBrowsableAttribute"/>.
         /// </summary>
         bool IsBrowsable { get; }
     }

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -36,6 +36,13 @@ namespace FluentAssertions.Equivalency.Matching
                     $"Expectation has {expectedMember.Description} that the other object does not have.");
             }
 
+            if (config.IgnoreNonBrowsableOnSubject && !subjectMember.IsBrowsable)
+            {
+                Execute.Assertion.FailWith(
+                    $"Expectation has {expectedMember.Description} that is non-browsable in the other object, and non-browsable " +
+                    $"members on the subject are ignored with the current configuration");
+            }
+
             return subjectMember;
         }
 

--- a/Src/FluentAssertions/Equivalency/Property.cs
+++ b/Src/FluentAssertions/Equivalency/Property.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Reflection;
 using FluentAssertions.Common;
 
@@ -11,6 +12,7 @@ namespace FluentAssertions.Equivalency
     public class Property : Node, IMember
     {
         private readonly PropertyInfo propertyInfo;
+        private bool? isBrowsable;
 
         public Property(PropertyInfo propertyInfo, INode parent)
             : this(propertyInfo.ReflectedType, propertyInfo, parent)
@@ -43,5 +45,18 @@ namespace FluentAssertions.Equivalency
         public CSharpAccessModifier GetterAccessibility => propertyInfo.GetGetMethod(nonPublic: true).GetCSharpAccessModifier();
 
         public CSharpAccessModifier SetterAccessibility => propertyInfo.GetSetMethod(nonPublic: true).GetCSharpAccessModifier();
+
+        public bool IsBrowsable
+        {
+            get
+            {
+                if (isBrowsable == null)
+                {
+                    isBrowsable = propertyInfo.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
+                }
+
+                return isBrowsable.Value;
+            }
+        }
     }
 }

--- a/Src/FluentAssertions/Equivalency/Selection/ExcludeNonBrowsableMembersRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/ExcludeNonBrowsableMembersRule.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FluentAssertions.Equivalency.Selection
+{
+    internal class ExcludeNonBrowsableMembersRule : IMemberSelectionRule
+    {
+        public bool IncludesMembers => false;
+
+        public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers, MemberSelectionContext context)
+        {
+            return selectedMembers.Where(member => member.IsBrowsable);
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/Selection/ExcludeNonBrowsableMembersRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/ExcludeNonBrowsableMembersRule.cs
@@ -10,7 +10,7 @@ namespace FluentAssertions.Equivalency.Selection
 
         public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers, MemberSelectionContext context)
         {
-            return selectedMembers.Where(member => member.IsBrowsable);
+            return selectedMembers.Where(member => member.IsBrowsable).ToList();
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -326,19 +327,9 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Instructs the comparison to include non-browsable members (members with an EditorBrowsableState of Never).
-        /// </summary>
-        /// <returns></returns>
-        public TSelf IncludingNonBrowsableMembers()
-        {
-            excludeNonBrowsableOnExpectation = false;
-            return (TSelf)this;
-        }
-
-        /// <summary>
-        /// Instructs the comparison to exclude non-browsable members (members with an EditorBrowsableState of Never).
-        /// They can be marked non-browsable in the subject or the expectation. It is not required that they be marked
-        /// non-browsable in both the subject and the expectation.
+        /// Instructs the comparison to exclude non-browsable members in the expectation (members set to
+        /// <see cref="EditorBrowsableState.Never"/>). It is not required that they be marked non-browsable in the subject. Use
+        /// <see cref="IgnoringNonBrowsableMembersOnSubject"/> to ignore non-browsable members in the subject.
         /// </summary>
         /// <returns></returns>
         public TSelf ExcludingNonBrowsableMembers()
@@ -347,6 +338,11 @@ namespace FluentAssertions.Equivalency
             return (TSelf)this;
         }
 
+        /// <summary>
+        /// Instructs the comparison to treat non-browsable members in the subject as though they do not exist. If you need to
+        /// ignore non-browsable members in the expectation, use <see cref="ExcludingNonBrowsableMembers"/>.
+        /// </summary>
+        /// <returns></returns>
         public TSelf IgnoringNonBrowsableMembersOnSubject()
         {
             ignoreNonBrowsableOnSubject = true;

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -56,6 +56,7 @@ namespace FluentAssertions.Equivalency
 
         private MemberVisibility includedProperties;
         private MemberVisibility includedFields;
+        private bool excludeNonBrowsable;
 
         private bool compareRecordsByValue;
 
@@ -80,6 +81,7 @@ namespace FluentAssertions.Equivalency
             useRuntimeTyping = defaults.UseRuntimeTyping;
             includedProperties = defaults.IncludedProperties;
             includedFields = defaults.IncludedFields;
+            excludeNonBrowsable = defaults.ExcludeNonBrowsable;
             compareRecordsByValue = defaults.CompareRecordsByValue;
 
             ConversionSelector = defaults.ConversionSelector.Clone();
@@ -161,6 +163,8 @@ namespace FluentAssertions.Equivalency
         MemberVisibility IEquivalencyAssertionOptions.IncludedProperties => includedProperties;
 
         MemberVisibility IEquivalencyAssertionOptions.IncludedFields => includedFields;
+
+        bool IEquivalencyAssertionOptions.ExcludeNonBrowsable => excludeNonBrowsable;
 
         public bool CompareRecordsByValue => compareRecordsByValue;
 
@@ -309,6 +313,26 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingProperties()
         {
             includedProperties = MemberVisibility.None;
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Instructs the comparison to include non-browsable members (members with an EditorBrowsableState of Never).
+        /// </summary>
+        /// <returns></returns>
+        public TSelf IncludingNonBrowsableMembers()
+        {
+            excludeNonBrowsable = false;
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Instructs the comparison to exclude non-browsable members (members with an EditorBrowsableState of Never).
+        /// </summary>
+        /// <returns></returns>
+        public TSelf ExcludingNonBrowsableMembers()
+        {
+            excludeNonBrowsable = true;
             return (TSelf)this;
         }
 
@@ -725,6 +749,15 @@ namespace FluentAssertions.Equivalency
             else
             {
                 builder.AppendLine("- Compare records by their members");
+            }
+
+            if (excludeNonBrowsable)
+            {
+                builder.AppendLine("- Exclude non-browsable members");
+            }
+            else
+            {
+                builder.AppendLine("- Include non-browsable members");
             }
 
             foreach (Type valueType in valueTypes)

--- a/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
@@ -55,21 +55,24 @@ namespace FluentAssertions.Equivalency.Steps
             IMember matchingMember = FindMatchFor(selectedMember, context.CurrentNode, comparands.Subject, options);
             if (matchingMember is not null)
             {
-                var nestedComparands = new Comparands
+                if (!options.ExcludeNonBrowsable || matchingMember.IsBrowsable)
                 {
-                    Subject = matchingMember.GetValue(comparands.Subject),
-                    Expectation = selectedMember.GetValue(comparands.Expectation),
-                    CompileTimeType = selectedMember.Type
-                };
+                    var nestedComparands = new Comparands
+                    {
+                        Subject = matchingMember.GetValue(comparands.Subject),
+                        Expectation = selectedMember.GetValue(comparands.Expectation),
+                        CompileTimeType = selectedMember.Type
+                    };
 
-                if (selectedMember.Name != matchingMember.Name)
-                {
-                    // In case the matching process selected a different member on the subject,
-                    // adjust the current member so that assertion failures report the proper name.
-                    selectedMember.Name = matchingMember.Name;
+                    if (selectedMember.Name != matchingMember.Name)
+                    {
+                        // In case the matching process selected a different member on the subject,
+                        // adjust the current member so that assertion failures report the proper name.
+                        selectedMember.Name = matchingMember.Name;
+                    }
+
+                    parent.RecursivelyAssertEquality(nestedComparands, context.AsNestedMember(selectedMember));
                 }
-
-                parent.RecursivelyAssertEquality(nestedComparands, context.AsNestedMember(selectedMember));
             }
         }
 

--- a/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
@@ -55,24 +55,21 @@ namespace FluentAssertions.Equivalency.Steps
             IMember matchingMember = FindMatchFor(selectedMember, context.CurrentNode, comparands.Subject, options);
             if (matchingMember is not null)
             {
-                if (!options.ExcludeNonBrowsable || matchingMember.IsBrowsable)
+                var nestedComparands = new Comparands
                 {
-                    var nestedComparands = new Comparands
-                    {
-                        Subject = matchingMember.GetValue(comparands.Subject),
-                        Expectation = selectedMember.GetValue(comparands.Expectation),
-                        CompileTimeType = selectedMember.Type
-                    };
+                    Subject = matchingMember.GetValue(comparands.Subject),
+                    Expectation = selectedMember.GetValue(comparands.Expectation),
+                    CompileTimeType = selectedMember.Type
+                };
 
-                    if (selectedMember.Name != matchingMember.Name)
-                    {
-                        // In case the matching process selected a different member on the subject,
-                        // adjust the current member so that assertion failures report the proper name.
-                        selectedMember.Name = matchingMember.Name;
-                    }
-
-                    parent.RecursivelyAssertEquality(nestedComparands, context.AsNestedMember(selectedMember));
+                if (selectedMember.Name != matchingMember.Name)
+                {
+                    // In case the matching process selected a different member on the subject,
+                    // adjust the current member so that assertion failures report the proper name.
+                    selectedMember.Name = matchingMember.Name;
                 }
+
+                parent.RecursivelyAssertEquality(nestedComparands, context.AsNestedMember(selectedMember));
             }
         }
 
@@ -84,6 +81,11 @@ namespace FluentAssertions.Equivalency.Steps
                 let match = rule.Match(selectedMember, subject, currentNode, config)
                 where match is not null
                 select match;
+
+            if (config.IgnoreNonBrowsableOnSubject)
+            {
+                query = query.Where(member => member.IsBrowsable);
+            }
 
             return query.FirstOrDefault();
         }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -824,7 +824,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
-        bool ExcludeNonBrowsable { get; }
+        bool ExcludeNonBrowsableOnExpectation { get; }
+        bool IgnoreNonBrowsableOnSubject { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -996,6 +997,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
+        public TSelf IgnoringNonBrowsableMembersOnSubject() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf IncludingAllDeclaredProperties() { }
         public TSelf IncludingAllRuntimeProperties() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -803,6 +803,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -823,6 +824,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool ExcludeNonBrowsable { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -858,6 +860,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        bool IsBrowsable { get; }
         System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -961,6 +964,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -989,6 +993,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
@@ -998,6 +1003,7 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1005,7 +1005,6 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
-        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1017,7 +1017,6 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
-        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -815,6 +815,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -835,6 +836,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool ExcludeNonBrowsableOnExpectation { get; }
+        bool IgnoreNonBrowsableOnSubject { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -870,6 +873,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        bool IsBrowsable { get; }
         System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -973,6 +977,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -1001,8 +1006,10 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
+        public TSelf IgnoringNonBrowsableMembersOnSubject() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf IncludingAllDeclaredProperties() { }
         public TSelf IncludingAllRuntimeProperties() { }
@@ -1010,6 +1017,7 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -824,7 +824,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
-        bool ExcludeNonBrowsable { get; }
+        bool ExcludeNonBrowsableOnExpectation { get; }
+        bool IgnoreNonBrowsableOnSubject { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -996,6 +997,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
+        public TSelf IgnoringNonBrowsableMembersOnSubject() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf IncludingAllDeclaredProperties() { }
         public TSelf IncludingAllRuntimeProperties() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -803,6 +803,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -823,6 +824,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool ExcludeNonBrowsable { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -858,6 +860,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        bool IsBrowsable { get; }
         System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -961,6 +964,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -989,6 +993,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
@@ -998,6 +1003,7 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1005,7 +1005,6 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
-        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -824,7 +824,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
-        bool ExcludeNonBrowsable { get; }
+        bool ExcludeNonBrowsableOnExpectation { get; }
+        bool IgnoreNonBrowsableOnSubject { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -996,6 +997,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
+        public TSelf IgnoringNonBrowsableMembersOnSubject() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf IncludingAllDeclaredProperties() { }
         public TSelf IncludingAllRuntimeProperties() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -803,6 +803,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -823,6 +824,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool ExcludeNonBrowsable { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -858,6 +860,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        bool IsBrowsable { get; }
         System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -961,6 +964,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -989,6 +993,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
@@ -998,6 +1003,7 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1005,7 +1005,6 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
-        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -998,7 +998,6 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
-        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -817,7 +817,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
-        bool ExcludeNonBrowsable { get; }
+        bool ExcludeNonBrowsableOnExpectation { get; }
+        bool IgnoreNonBrowsableOnSubject { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -989,6 +990,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
+        public TSelf IgnoringNonBrowsableMembersOnSubject() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf IncludingAllDeclaredProperties() { }
         public TSelf IncludingAllRuntimeProperties() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -796,6 +796,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -816,6 +817,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool ExcludeNonBrowsable { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -851,6 +853,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        bool IsBrowsable { get; }
         System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -954,6 +957,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -982,6 +986,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
@@ -991,6 +996,7 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -824,7 +824,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
-        bool ExcludeNonBrowsable { get; }
+        bool ExcludeNonBrowsableOnExpectation { get; }
+        bool IgnoreNonBrowsableOnSubject { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -996,6 +997,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
+        public TSelf IgnoringNonBrowsableMembersOnSubject() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf IncludingAllDeclaredProperties() { }
         public TSelf IncludingAllRuntimeProperties() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -803,6 +803,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -823,6 +824,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool ExcludeNonBrowsable { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
@@ -858,6 +860,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        bool IsBrowsable { get; }
         System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -961,6 +964,7 @@ namespace FluentAssertions.Equivalency
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
         public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
@@ -989,6 +993,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
@@ -998,6 +1003,7 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1005,7 +1005,6 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingInternalFields() { }
         public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
-        public TSelf IncludingNonBrowsableMembers() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }

--- a/Tests/Benchmarks/CheckIfMemberIsBrowsable.cs
+++ b/Tests/Benchmarks/CheckIfMemberIsBrowsable.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel;
+using System.Reflection;
+
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks
+{
+    [MemoryDiagnoser]
+    public class CheckIfMemberIsBrowsableBenchmarks
+    {
+        [Params(true, false)]
+        public bool IsBrowsable { get; set; }
+
+        public int BrowsableField;
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int NonBrowsableField;
+
+        public FieldInfo SubjectField => typeof(CheckIfMemberIsBrowsableBenchmarks)
+            .GetField(IsBrowsable ? nameof(BrowsableField) : nameof(NonBrowsableField));
+
+        [Benchmark]
+        public void CheckIfMemberIsBrowsable()
+        {
+            bool _ =
+                SubjectField.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
+        }
+    }
+}

--- a/Tests/Benchmarks/Program.cs
+++ b/Tests/Benchmarks/Program.cs
@@ -22,7 +22,7 @@ namespace Benchmarks
 
             var config = ManualConfig.CreateMinimumViable().AddExporter(exporter);
 
-            _ = BenchmarkRunner.Run<BeEquivalentToWithDeeplyNestedStructures>(config);
+            _ = BenchmarkRunner.Run<CheckIfMemberIsBrowsableBenchmarks>(config);
         }
     }
 }

--- a/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
+++ b/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
@@ -68,7 +68,9 @@ namespace Benchmarks
 
             public MemberVisibility IncludedFields => throw new NotImplementedException();
 
-            public bool ExcludeNonBrowsable => throw new NotImplementedException();
+            public bool IgnoreNonBrowsableOnSubject => throw new NotImplementedException();
+
+            public bool ExcludeNonBrowsableOnExpectation => throw new NotImplementedException();
 
             public bool CompareRecordsByValue => throw new NotImplementedException();
 

--- a/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
+++ b/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
@@ -68,6 +68,8 @@ namespace Benchmarks
 
             public MemberVisibility IncludedFields => throw new NotImplementedException();
 
+            public bool ExcludeNonBrowsable => throw new NotImplementedException();
+
             public bool CompareRecordsByValue => throw new NotImplementedException();
 
             public ITraceWriter TraceWriter => throw new NotImplementedException();

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -1632,6 +1632,23 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
+        public void When_non_browsable_property_on_subject_is_ignored_but_is_present_on_expectation_it_should_fail()
+        {
+            // Arrange
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable() { PropertyThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable() { PropertyThatMightBeNonBrowsable = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.IgnoringNonBrowsableMembersOnSubject());
+
+            // Assert
+            action.Should().Throw<XunitException>().WithMessage(
+                $"Expectation has * subject.*ThatMightBeNonBrowsable that is non-browsable in the other object, and non-browsable " +
+                $"members on the subject are ignored with the current configuration*");
+        }
+
+        [Fact]
         public void When_property_is_non_browsable_only_in_expectation_excluding_non_browsable_members_should_make_it_succeed()
         {
             // Arrange

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -1723,29 +1723,318 @@ namespace FluentAssertions.Equivalency.Specs
             subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
         }
 
+        [Fact]
+        public void When_property_is_non_browsable_only_in_subject_excluding_non_browsable_members_should_not_make_it_succeed()
+        {
+            // Arrange
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable() { PropertyThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable() { PropertyThatMightBeNonBrowsable = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>().WithMessage("Expected property subject.PropertyThatMightBeNonBrowsable to be 1, but found 0.*");
+        }
+
+        [Fact]
+        public void When_property_is_non_browsable_only_in_subject_ignoring_non_browsable_members_on_subject_should_make_it_succeed()
+        {
+            // Arrange
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable() { PropertyThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable() { PropertyThatMightBeNonBrowsable = 1 };
+
+            // Act & Assert
+            subject.Should().BeEquivalentTo(expectation, config => config.IgnoringNonBrowsableMembersOnSubject());
+        }
+
+        [Fact]
+        public void When_property_is_non_browsable_only_in_expectation_excluding_non_browsable_members_should_make_it_succeed()
+        {
+            // Arrange
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable() { PropertyThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable() { PropertyThatMightBeNonBrowsable = 1 };
+
+            // Act & Assert
+            subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
+        }
+
+        [Fact]
+        public void When_field_is_non_browsable_only_in_subject_excluding_non_browsable_members_should_not_make_it_succeed()
+        {
+            // Arrange
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable() { FieldThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable() { FieldThatMightBeNonBrowsable = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>().WithMessage("Expected field subject.FieldThatMightBeNonBrowsable to be 1, but found 0.*");
+        }
+
+        [Fact]
+        public void When_field_is_non_browsable_only_in_subject_ignoring_non_browsable_members_on_subject_should_make_it_succeed()
+        {
+            // Arrange
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable() { FieldThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable() { FieldThatMightBeNonBrowsable = 1 };
+
+            // Act & Assert
+            subject.Should().BeEquivalentTo(expectation, config => config.IgnoringNonBrowsableMembersOnSubject());
+        }
+
+        [Fact]
+        public void When_field_is_non_browsable_only_in_expectation_excluding_non_browsable_members_should_make_it_succeed()
+        {
+            // Arrange
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable() { FieldThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable() { FieldThatMightBeNonBrowsable = 1 };
+
+            // Act & Assert
+            subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
+        }
+
+        public class NonBrowsableOnOneButMissingFromTheOther
+        {
+            [Fact]
+            public void When_property_is_missing_from_subject_excluding_non_browsable_members_should_make_it_succeed()
+            {
+                // Arrange
+                var subject =
+                    new
+                    {
+                        BrowsableField = 1,
+                        BrowsableProperty = 1,
+                        ExplicitlyBrowsableField = 1,
+                        ExplicitlyBrowsableProperty = 1,
+                        AdvancedBrowsableField = 1,
+                        AdvancedBrowsableProperty = 1,
+                        NonBrowsableField = 2,
+                        /* NonBrowsableProperty missing */
+                    };
+
+                var expected =
+                        new ClassWithNonBrowsableMembers
+                        {
+                            BrowsableField = 1,
+                            BrowsableProperty = 1,
+                            ExplicitlyBrowsableField = 1,
+                            ExplicitlyBrowsableProperty = 1,
+                            AdvancedBrowsableField = 1,
+                            AdvancedBrowsableProperty = 1,
+                            NonBrowsableField = 2,
+                            NonBrowsableProperty = 2,
+                        };
+
+                // Act & Assert
+                subject.Should().BeEquivalentTo(expected, opt => opt.ExcludingNonBrowsableMembers());
+            }
+
+            [Fact]
+            public void When_field_is_missing_from_subject_excluding_non_browsable_members_should_make_it_succeed()
+            {
+                // Arrange
+                var subject =
+                    new
+                    {
+                        BrowsableField = 1,
+                        BrowsableProperty = 1,
+                        ExplicitlyBrowsableField = 1,
+                        ExplicitlyBrowsableProperty = 1,
+                        AdvancedBrowsableField = 1,
+                        AdvancedBrowsableProperty = 1,
+                        /* NonBrowsableField missing */
+                        NonBrowsableProperty = 2,
+                    };
+
+                var expected =
+                        new ClassWithNonBrowsableMembers
+                        {
+                            BrowsableField = 1,
+                            BrowsableProperty = 1,
+                            ExplicitlyBrowsableField = 1,
+                            ExplicitlyBrowsableProperty = 1,
+                            AdvancedBrowsableField = 1,
+                            AdvancedBrowsableProperty = 1,
+                            NonBrowsableField = 2,
+                            NonBrowsableProperty = 2,
+                        };
+
+                // Act & Assert
+                subject.Should().BeEquivalentTo(expected, opt => opt.ExcludingNonBrowsableMembers());
+            }
+
+            [Fact]
+            public void When_property_is_missing_from_expectation_excluding_non_browsable_members_should_make_it_succeed()
+            {
+                // Arrange
+                var subject =
+                        new ClassWithNonBrowsableMembers
+                        {
+                            BrowsableField = 1,
+                            BrowsableProperty = 1,
+                            ExplicitlyBrowsableField = 1,
+                            ExplicitlyBrowsableProperty = 1,
+                            AdvancedBrowsableField = 1,
+                            AdvancedBrowsableProperty = 1,
+                            NonBrowsableField = 2,
+                            NonBrowsableProperty = 2,
+                        };
+
+                var expected =
+                    new
+                    {
+                        BrowsableField = 1,
+                        BrowsableProperty = 1,
+                        ExplicitlyBrowsableField = 1,
+                        ExplicitlyBrowsableProperty = 1,
+                        AdvancedBrowsableField = 1,
+                        AdvancedBrowsableProperty = 1,
+                        NonBrowsableField = 2,
+                        /* NonBrowsableProperty missing */
+                    };
+
+                // Act & Assert
+                subject.Should().BeEquivalentTo(expected, opt => opt.ExcludingNonBrowsableMembers());
+            }
+
+            [Fact]
+            public void When_field_is_missing_from_expectation_excluding_non_browsable_members_should_make_it_succeed()
+            {
+                // Arrange
+                var subject =
+                        new ClassWithNonBrowsableMembers
+                        {
+                            BrowsableField = 1,
+                            BrowsableProperty = 1,
+                            ExplicitlyBrowsableField = 1,
+                            ExplicitlyBrowsableProperty = 1,
+                            AdvancedBrowsableField = 1,
+                            AdvancedBrowsableProperty = 1,
+                            NonBrowsableField = 2,
+                            NonBrowsableProperty = 2,
+                        };
+
+                var expected =
+                    new
+                    {
+                        BrowsableField = 1,
+                        BrowsableProperty = 1,
+                        ExplicitlyBrowsableField = 1,
+                        ExplicitlyBrowsableProperty = 1,
+                        AdvancedBrowsableField = 1,
+                        AdvancedBrowsableProperty = 1,
+                        /* NonBrowsableField missing */
+                        NonBrowsableProperty = 2,
+                    };
+
+                // Act & Assert
+                subject.Should().BeEquivalentTo(expected, opt => opt.ExcludingNonBrowsableMembers());
+            }
+
+            [Fact]
+            public void When_non_browsable_members_are_excluded_it_should_still_be_possible_to_explicitly_include_non_browsable_field()
+            {
+                // Arrange
+                var subject =
+                    new ClassWithNonBrowsableMembers()
+                    {
+                        NonBrowsableField = 1,
+                    };
+
+                var expectation =
+                    new ClassWithNonBrowsableMembers()
+                    {
+                        NonBrowsableField = 2,
+                    };
+
+                // Act
+                Action action =
+                    () => subject.Should().BeEquivalentTo(
+                        expectation,
+                        opt => opt.IncludingFields().ExcludingNonBrowsableMembers().Including(e => e.NonBrowsableField));
+
+                // Assert
+                action.Should().Throw<XunitException>().WithMessage("Expected field subject.NonBrowsableField to be 2, but found 1.*");
+            }
+
+            [Fact]
+            public void When_non_browsable_members_are_excluded_it_should_still_be_possible_to_explicitly_include_non_browsable_property()
+            {
+                // Arrange
+                var subject =
+                    new ClassWithNonBrowsableMembers()
+                    {
+                        NonBrowsableProperty = 1,
+                    };
+
+                var expectation =
+                    new ClassWithNonBrowsableMembers()
+                    {
+                        NonBrowsableProperty = 2,
+                    };
+
+                // Act
+                Action action =
+                    () => subject.Should().BeEquivalentTo(
+                        expectation,
+                        opt => opt.IncludingProperties().ExcludingNonBrowsableMembers().Including(e => e.NonBrowsableProperty));
+
+                // Assert
+                action.Should().Throw<XunitException>().WithMessage("Expected property subject.NonBrowsableProperty to be 2, but found 1.*");
+            }
+        }
+
         private class ClassWithNonBrowsableMembers
         {
-            public int BrowsableField;
+            public int BrowsableField = -1;
 
             public int BrowsableProperty { get; set; }
 
             [EditorBrowsable(EditorBrowsableState.Always)]
-            public int ExplicitlyBrowsableField;
+            public int ExplicitlyBrowsableField = -1;
 
             [EditorBrowsable(EditorBrowsableState.Always)]
             public int ExplicitlyBrowsableProperty { get; set; }
 
             [EditorBrowsable(EditorBrowsableState.Advanced)]
-            public int AdvancedBrowsableField;
+            public int AdvancedBrowsableField = -1;
 
             [EditorBrowsable(EditorBrowsableState.Advanced)]
             public int AdvancedBrowsableProperty { get; set; }
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public int NonBrowsableField;
+            public int NonBrowsableField = -1;
 
             [EditorBrowsable(EditorBrowsableState.Never)]
             public int NonBrowsableProperty { get; set; }
+        }
+
+        private class ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable
+        {
+            public int BrowsableField = -1;
+
+            public int BrowsableProperty { get; set; }
+
+            public int FieldThatMightBeNonBrowsable = -1;
+
+            public int PropertyThatMightBeNonBrowsable { get; set; }
+        }
+
+        private class ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable
+        {
+            public int BrowsableField = -1;
+
+            public int BrowsableProperty { get; set; }
+
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public int FieldThatMightBeNonBrowsable = -1;
+
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public int PropertyThatMightBeNonBrowsable { get; set; }
         }
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -1488,6 +1489,263 @@ namespace FluentAssertions.Equivalency.Specs
             actual.Should().BeEquivalentTo(expected, options => options
                 .Including(a => a.Value2)
                 .RespectingRuntimeTypes());
+        }
+
+        [Fact]
+        public void When_browsable_field_differs_including_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { BrowsableField = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { BrowsableField = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_browsable_property_differs_including_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { BrowsableProperty = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { BrowsableProperty = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_advanced_browsable_field_differs_including_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { AdvancedBrowsableField = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { AdvancedBrowsableField = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_advanced_browsable_property_differs_including_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { AdvancedBrowsableProperty = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { AdvancedBrowsableProperty = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_explicitly_browsable_field_differs_including_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableField = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableField = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_explicitly_browsable_property_differs_including_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableProperty = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableProperty = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_non_browsable_field_differs_including_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { NonBrowsableField = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { NonBrowsableField = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_non_browsable_property_differs_including_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { NonBrowsableProperty = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { NonBrowsableProperty = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_browsable_field_differs_excluding_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { BrowsableField = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { BrowsableField = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_browsable_property_differs_excluding_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { BrowsableProperty = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { BrowsableProperty = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_advanced_browsable_field_differs_excluding_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { AdvancedBrowsableField = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { AdvancedBrowsableField = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_advanced_browsable_property_differs_excluding_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { AdvancedBrowsableProperty = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { AdvancedBrowsableProperty = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_explicilty_browsable_field_differs_excluding_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableField = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableField = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_explicilty_browsable_property_differs_excluding_non_browsable_members_should_not_affect_result()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableProperty = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableProperty = 1 };
+
+            // Act
+            Action action =
+                () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_non_browsable_field_differs_excluding_non_browsable_members_should_make_it_succeed()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { NonBrowsableField = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { NonBrowsableField = 1 };
+
+            // Act & Assert
+            subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
+        }
+
+        [Fact]
+        public void When_non_browsable_property_differs_excluding_non_browsable_members_should_make_it_succeed()
+        {
+            // Arrange
+            var subject = new ClassWithNonBrowsableMembers() { NonBrowsableProperty = 0 };
+            var expectation = new ClassWithNonBrowsableMembers() { NonBrowsableProperty = 1 };
+
+            // Act & Assert
+            subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
+        }
+
+        private class ClassWithNonBrowsableMembers
+        {
+            public int BrowsableField;
+
+            public int BrowsableProperty { get; set; }
+
+            [EditorBrowsable(EditorBrowsableState.Always)]
+            public int ExplicitlyBrowsableField;
+
+            [EditorBrowsable(EditorBrowsableState.Always)]
+            public int ExplicitlyBrowsableProperty { get; set; }
+
+            [EditorBrowsable(EditorBrowsableState.Advanced)]
+            public int AdvancedBrowsableField;
+
+            [EditorBrowsable(EditorBrowsableState.Advanced)]
+            public int AdvancedBrowsableProperty { get; set; }
+
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public int NonBrowsableField;
+
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public int NonBrowsableProperty { get; set; }
         }
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -1492,126 +1492,6 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_browsable_field_differs_including_non_browsable_members_should_not_affect_result()
-        {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers() { BrowsableField = 0 };
-            var expectation = new ClassWithNonBrowsableMembers() { BrowsableField = 1 };
-
-            // Act
-            Action action =
-                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
-
-            // Assert
-            action.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_browsable_property_differs_including_non_browsable_members_should_not_affect_result()
-        {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers() { BrowsableProperty = 0 };
-            var expectation = new ClassWithNonBrowsableMembers() { BrowsableProperty = 1 };
-
-            // Act
-            Action action =
-                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
-
-            // Assert
-            action.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_advanced_browsable_field_differs_including_non_browsable_members_should_not_affect_result()
-        {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers() { AdvancedBrowsableField = 0 };
-            var expectation = new ClassWithNonBrowsableMembers() { AdvancedBrowsableField = 1 };
-
-            // Act
-            Action action =
-                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
-
-            // Assert
-            action.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_advanced_browsable_property_differs_including_non_browsable_members_should_not_affect_result()
-        {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers() { AdvancedBrowsableProperty = 0 };
-            var expectation = new ClassWithNonBrowsableMembers() { AdvancedBrowsableProperty = 1 };
-
-            // Act
-            Action action =
-                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
-
-            // Assert
-            action.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_explicitly_browsable_field_differs_including_non_browsable_members_should_not_affect_result()
-        {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableField = 0 };
-            var expectation = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableField = 1 };
-
-            // Act
-            Action action =
-                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
-
-            // Assert
-            action.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_explicitly_browsable_property_differs_including_non_browsable_members_should_not_affect_result()
-        {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableProperty = 0 };
-            var expectation = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableProperty = 1 };
-
-            // Act
-            Action action =
-                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
-
-            // Assert
-            action.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_non_browsable_field_differs_including_non_browsable_members_should_not_affect_result()
-        {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers() { NonBrowsableField = 0 };
-            var expectation = new ClassWithNonBrowsableMembers() { NonBrowsableField = 1 };
-
-            // Act
-            Action action =
-                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
-
-            // Assert
-            action.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_non_browsable_property_differs_including_non_browsable_members_should_not_affect_result()
-        {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers() { NonBrowsableProperty = 0 };
-            var expectation = new ClassWithNonBrowsableMembers() { NonBrowsableProperty = 1 };
-
-            // Act
-            Action action =
-                () => subject.Should().BeEquivalentTo(expectation, config => config.IncludingNonBrowsableMembers());
-
-            // Assert
-            action.Should().Throw<XunitException>();
-        }
-
-        [Fact]
         public void When_browsable_field_differs_excluding_non_browsable_members_should_not_affect_result()
         {
             // Arrange
@@ -1672,7 +1552,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_explicilty_browsable_field_differs_excluding_non_browsable_members_should_not_affect_result()
+        public void When_explicitly_browsable_field_differs_excluding_non_browsable_members_should_not_affect_result()
         {
             // Arrange
             var subject = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableField = 0 };
@@ -1687,7 +1567,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_explicilty_browsable_property_differs_excluding_non_browsable_members_should_not_affect_result()
+        public void When_explicitly_browsable_property_differs_excluding_non_browsable_members_should_not_affect_result()
         {
             // Arrange
             var subject = new ClassWithNonBrowsableMembers() { ExplicitlyBrowsableProperty = 0 };
@@ -1746,7 +1626,9 @@ namespace FluentAssertions.Equivalency.Specs
             var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable() { PropertyThatMightBeNonBrowsable = 1 };
 
             // Act & Assert
-            subject.Should().BeEquivalentTo(expectation, config => config.IgnoringNonBrowsableMembersOnSubject());
+            subject.Should().BeEquivalentTo(
+                expectation,
+                config => config.IgnoringNonBrowsableMembersOnSubject().ExcludingMissingMembers());
         }
 
         [Fact]
@@ -1783,7 +1665,9 @@ namespace FluentAssertions.Equivalency.Specs
             var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable() { FieldThatMightBeNonBrowsable = 1 };
 
             // Act & Assert
-            subject.Should().BeEquivalentTo(expectation, config => config.IgnoringNonBrowsableMembersOnSubject());
+            subject.Should().BeEquivalentTo(
+                expectation,
+                config => config.IgnoringNonBrowsableMembersOnSubject().ExcludingMissingMembers());
         }
 
         [Fact]

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -216,6 +216,27 @@ orderDto.Should().BeEquivalentTo(order, options => options
 
 Notice that you can also map properties to fields and vice-versa.
 
+### Hidden Members
+
+Sometimes types have members out of necessity, to satisfy a contract, but they aren't logically a part of the type. In this case, they are often marked with the attribute `[EditorBrowsable(EditorBrowsableState.Never)]`, so that the object can satisfy the contract but the members don't show up in IntelliSense when writing code that uses the type.
+
+If you want to compare objects that have such fields, but you want to exclude the non-browsable "hidden" members (for instance, their implementations often simply throw `NotImplementedException`), you can call `ExcludingNonBrowsableMembers` on the options object:
+
+```csharp
+class DataType
+{
+    public int X { get; }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public int Y => throw new NotImplementedException();
+}
+
+DataType original, derived;
+
+derived.Should().BeEquivalentTo(original, options => options
+    .ExcludingNonBrowsableMembers());
+```
+
 ### Equivalency Comparison Behavior
 
 In addition to influencing the members that are including in the comparison, you can also override the actual assertion operation that is executed on a particular member.

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -21,6 +21,7 @@ sidebar:
 * Added `NotBe` for nullable boolean values - [#1865](https://github.com/fluentassertions/fluentassertions/pull/1865)
 * Added a new overload to `MatchRegex()` to assert on the number of regex matches - [#1869](https://github.com/fluentassertions/fluentassertions/pull/1869)
 * Added difference to numeric assertion failure messages - [#1859](https://github.com/fluentassertions/fluentassertions/pull/1859)
+* Added the ability to exclude fields & properties marked as non-browsable in the code editor from structural equality equivalency comparisons - [#1807](https://github.com/fluentassertions/fluentassertions/pull/1807) & [#1812](https://github.com/fluentassertions/fluentassertions/pull/1812)
 
 ### Fixes
 * `EnumAssertions.Be` did not determine the caller name - [#1835](https://github.com/fluentassertions/fluentassertions/pull/1835)
@@ -33,7 +34,7 @@ sidebar:
 ## 6.5.1
 
 ### Fixes
-* Fix regression introduced in 6.5.0 where `collection.Should().BeInAscendingOrder(x => x)` would fail - [#1802](https://github.com/fluentassertions/fluentassertions/pull/1802)
+* Fixed regression introduced in 6.5.0 where `collection.Should().BeInAscendingOrder(x => x)` would fail - [#1802](https://github.com/fluentassertions/fluentassertions/pull/1802)
 
 ## 6.5.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -21,7 +21,7 @@ sidebar:
 * Added `NotBe` for nullable boolean values - [#1865](https://github.com/fluentassertions/fluentassertions/pull/1865)
 * Added a new overload to `MatchRegex()` to assert on the number of regex matches - [#1869](https://github.com/fluentassertions/fluentassertions/pull/1869)
 * Added difference to numeric assertion failure messages - [#1859](https://github.com/fluentassertions/fluentassertions/pull/1859)
-* Added the ability to exclude fields & properties marked as non-browsable in the code editor from structural equality equivalency comparisons - [#1807](https://github.com/fluentassertions/fluentassertions/pull/1807) & [#1812](https://github.com/fluentassertions/fluentassertions/pull/1812)
+* Added the ability to exclude fields & properties marked as non-browsable in the code editor from structural equality comparisons - [#1807](https://github.com/fluentassertions/fluentassertions/pull/1807) & [#1812](https://github.com/fluentassertions/fluentassertions/pull/1812)
 
 ### Fixes
 * `EnumAssertions.Be` did not determine the caller name - [#1835](https://github.com/fluentassertions/fluentassertions/pull/1835)


### PR DESCRIPTION
In #1807, changes were made to allow non-browsable members to be excluded from equivalency tests. But, these changes ended up being reverted because they affected processing of both subject & expectation, but include/exclude functions are supposed to apply only to the expectation. In addition, the original changes only worked properly when the subject & expectation were of the same data type. In my actual usage, the subject and expectation are different data types and _only one of them_ marks the member as non-browsable. This wasn't factored in in the original implementation, for which the unit tests exclusively test the case where the subject and expectation are the same data type. The changes in #1807 got reverted since they were in an incomplete/uncertain state and were blocking a release.

This PR makes another attempt at adding this feature. In addition to the tests added in #1807, the PR adds unit tests that comprehensively cover the behaviour when the subject and expectation are different types and only one of them marks a member as non-browsable.

This PR then also provides an implementation that allows excluding non-browsable members from the expectation using an `Excluding` method, and from the subject using a separate `Ignore` method.