### PR TITLE
Add net6.0 target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         dotnet-version: |
           2.1.x
           3.1.x
-          5.0.x
+          6.0.x
 
     - name: Run NUKE
       run: ./build.ps1

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -42,7 +42,7 @@ class Build : NukeBuild
     [Solution(GenerateProjects = true)]
     readonly Solution Solution;
 
-    [GitVersion(Framework = "net5.0")]
+    [GitVersion(Framework = "net6.0")]
     readonly GitVersion GitVersion;
 
     [PackageExecutable("nspec", "NSpecRunner.exe", Version = "3.1.0")]
@@ -159,7 +159,7 @@ class Build : NukeBuild
         .Executes(() =>
         {
             ReportGenerator(s => s
-                .SetProcessToolPath(ToolPathResolver.GetPackageExecutable("ReportGenerator", "ReportGenerator.dll", framework: "net5.0"))
+                .SetProcessToolPath(ToolPathResolver.GetPackageExecutable("ReportGenerator", "ReportGenerator.dll", framework: "net6.0"))
                 .SetTargetDirectory(RootDirectory / "TestResults" / "reports")
                 .AddReports(RootDirectory / "TestResults/**/coverage.cobertura.xml")
                 .AddReportTypes("HtmlInline_AzurePipelines_Dark", "lcov")

--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..\</NukeRootDirectory>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/fluentassertions/fluentassertions/badge.svg?branch=develop)](https://coveralls.io/github/fluentassertions/fluentassertions?branch=develop)
 
 # About this project
-A very extensive set of extension methods that allow you to more naturally specify the expected outcome of a TDD or BDD-style unit tests. Targets .NET Framework 4.7, as well as .NET Core 2.1, .NET Core 3.0, .NET Standard 2.0 and 2.1.
+A very extensive set of extension methods that allow you to more naturally specify the expected outcome of a TDD or BDD-style unit tests. Targets .NET Framework 4.7, as well as .NET Core 2.1, .NET Core 3.0, .NET 6, .NET Standard 2.0 and 2.1.
 
 See https://www.fluentassertions.com for [background information](https://fluentassertions.com/about/), [usage documentation](https://fluentassertions.com/introduction), an [extensibility guide](https://fluentassertions.com/extensibility/), support information and more [tips & tricks](https://fluentassertions.com/tips/).
 
@@ -14,7 +14,7 @@ See https://www.fluentassertions.com for [background information](https://fluent
 Originally authored by Dennis Doomen with Jonas Nyrup as the productive side-kick. Notable contributions were provided by Artur Krajewski, Lukas Grützmacher and David Omid.
 
 # How do I build this?
-Install Visual Studio 2019 16.9+ or JetBrains Rider 2021.1.0 as well as the Build Tools 2019 (including the Universal Windows Platform build tools). You will also need to have .NET Framework 4.7 SDK and .NET 5.0 SDK installed. Check [global.json](global.json) for the current minimum required version.
+Install Visual Studio 2022 17.0+ or JetBrains Rider 2021.3 as well as the Build Tools 2022 (including the Universal Windows Platform build tools). You will also need to have .NET Framework 4.7 SDK and .NET 6.0 SDK installed. Check [global.json](global.json) for the current minimum required version.
 
 # What are these Approval.Tests?
 This is a special set of tests that use the [Verify](https://github.com/VerifyTests/Verify) project to verify whether you've introduced any breaking changes in the public API of the library.

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -23,6 +23,7 @@ namespace FluentAssertions.Execution
         private readonly FormattingOptions formattingOptions = AssertionOptions.FormattingOptions.Clone();
         private readonly IAssertionStrategy assertionStrategy;
         private readonly ContextDataItems contextData = new();
+        private readonly StringBuilder tracing = new();
 
         private Func<string> reason;
 
@@ -32,7 +33,6 @@ namespace FluentAssertions.Execution
         private Func<string> expectation;
         private string fallbackIdentifier = "object";
         private bool? succeeded;
-        private readonly StringBuilder tracing = new();
 
         private sealed class DeferredReportable
         {

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <!-- To reduce build times, we only enable analyzers for the newest TFM -->
   <PropertyGroup>
-    <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net47;net6.0;netcoreapp2.1;netcoreapp3.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -18,7 +18,7 @@
     <Authors>Dennis Doomen;Jonas Nyrup</Authors>
     <PackageDescription>
       A very extensive set of extension methods that allow you to more naturally specify the expected outcome of a TDD or
-      BDD-style unit tests. Targets .NET Framework 4.7, .NET Core 2.1 and 3.0, as well as .NET Standard 2.0 and 2.1.
+      BDD-style unit tests. Targets .NET Framework 4.7, .NET Core 2.1 and 3.0, .NET 6, as well as .NET Standard 2.0 and 2.1.
       Supports the unit test frameworks MSTest2, NUnit3, XUnit2, MSpec, and NSpec3.
     </PackageDescription>
     <PackageProjectUrl>https://www.fluentassertions.com</PackageProjectUrl>
@@ -31,7 +31,7 @@
     <Copyright>Copyright Dennis Doomen 2010-2020</Copyright>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
     <RunAnalyzers>false</RunAnalyzers>
@@ -65,10 +65,10 @@
   <ItemGroup Condition=" !('$(TargetFramework)' == 'net47' Or '$(TargetFramework)' == 'netstandard2.0') ">
     <Compile Remove="SystemExtensions.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0' Or '$(TargetFramework)' == 'net6.0' ">
     <Compile Remove="Common/NullConfigurationStore.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" !('$(TargetFramework)' == 'net47' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0') ">
+  <ItemGroup Condition=" !('$(TargetFramework)' == 'net47' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0' Or '$(TargetFramework)' == 'net6.0') ">
     <Compile Remove="Common/AppSettingsConfigurationStore.cs" />
     <Compile Remove="Common/ConfigurationStoreExceptionInterceptor.cs" />
   </ItemGroup>
@@ -83,6 +83,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
@@ -91,7 +94,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -147,9 +147,11 @@ namespace FluentAssertions
                 Binder = new SimpleBinder(subject.GetType())
             };
 
+#pragma warning disable SYSLIB0011 // BinaryFormatter is obsoleted, GH-issue 1779 tracks the upcoming removal in .NET 8.0
             binaryFormatter.Serialize(stream, subject);
             stream.Position = 0;
             return binaryFormatter.Deserialize(stream);
+#pragma warning restore SYSLIB0011
         }
 
         private class SimpleBinder : SerializationBinder

--- a/Src/FluentAssertions/StringSyntaxAttribute.cs
+++ b/Src/FluentAssertions/StringSyntaxAttribute.cs
@@ -2,7 +2,6 @@
 #if !NET7_0_OR_GREATER
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
 #nullable enable
 
 namespace System.Diagnostics.CodeAnalysis

--- a/Tests/Approval.Tests/ApiApproval.cs
+++ b/Tests/Approval.Tests/ApiApproval.cs
@@ -19,6 +19,7 @@ namespace Approval.Tests
     {
         [Theory]
         [InlineData("net47")]
+        [InlineData("net6.0")]
         [InlineData("netstandard2.0")]
         [InlineData("netstandard2.1")]
         [InlineData("netcoreapp2.1")]

--- a/Tests/Approval.Tests/Approval.Tests.csproj
+++ b/Tests/Approval.Tests/Approval.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1,0 +1,2692 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Equivalency.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
+namespace FluentAssertions
+{
+    public class AggregateExceptionExtractor : FluentAssertions.Specialized.IExtractExceptions
+    {
+        public AggregateExceptionExtractor() { }
+        public System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception { }
+    }
+    public class AndConstraint<T>
+    {
+        public AndConstraint(T parentConstraint) { }
+        public T And { get; }
+    }
+    public class AndWhichConstraint<TParentConstraint, TMatchedElement> : FluentAssertions.AndConstraint<TParentConstraint>
+    {
+        public AndWhichConstraint(TParentConstraint parentConstraint, System.Collections.Generic.IEnumerable<TMatchedElement> matchedConstraint) { }
+        public AndWhichConstraint(TParentConstraint parentConstraint, TMatchedElement matchedConstraint) { }
+        public TMatchedElement Subject { get; }
+        public TMatchedElement Which { get; }
+    }
+    public static class AssertionExtensions
+    {
+        public static TTo As<TTo>(this object subject) { }
+        public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
+        public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Enumerating<T, TResult>(this T subject, System.Func<T, System.Collections.Generic.IEnumerable<TResult>> enumerable) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action, FluentAssertions.Common.StartTimer createTimer = null) { }
+        public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action, FluentAssertions.Common.StartTimer createTimer = null) { }
+        public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
+        public static FluentAssertions.Events.IMonitor<T> Monitor<T>(this T eventSource, System.Func<System.DateTime> utcNow = null) { }
+        public static FluentAssertions.Specialized.ExecutionTimeAssertions Should(this FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should(this FluentAssertions.Specialized.ExecutionTimeAssertions _) { }
+        public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should(this FluentAssertions.Types.MethodInfoSelectorAssertions _) { }
+        public static FluentAssertions.Types.PropertyInfoSelectorAssertions Should(this FluentAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should(this FluentAssertions.Types.PropertyInfoSelectorAssertions _) { }
+        public static FluentAssertions.Types.TypeSelectorAssertions Should(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should(this FluentAssertions.Types.TypeSelectorAssertions _) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Data.DataColumnAssertions Should(this System.Data.DataColumn actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
+        public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
+        public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should(this System.Net.Http.HttpResponseMessage actualValue) { }
+        public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<byte> Should(this byte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<decimal> Should(this decimal? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<double> Should(this double? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<float> Should(this float? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ulong> Should(this ulong? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ushort> Should(this ushort? actualValue) { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.BooleanAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.GuidAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TSubject>(this FluentAssertions.Specialized.TaskCompletionSourceAssertions<TSubject> _) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TSubject, TAssertions>(this FluentAssertions.Numeric.NumericAssertions<TSubject, TAssertions> _)
+            where TSubject :  struct, System.IComparable<TSubject>
+            where TAssertions : FluentAssertions.Numeric.NumericAssertions<TSubject, TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TEnum, TAssertions>(this FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions> _)
+            where TEnum :  struct, System.Enum
+            where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TSubject, TAssertions>(this FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(this TCollection actualValue)
+            where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
+    }
+    public static class AssertionOptions
+    {
+        public static FluentAssertions.EquivalencyPlan EquivalencyPlan { get; }
+        public static FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
+        public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
+        public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+    }
+    public static class AsyncAssertionsExtensions
+    {
+        public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
+    }
+    public static class AtLeast
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class AtMost
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class CallerIdentifier
+    {
+        public static System.Action<string> Logger { get; set; }
+        public static string DetermineCallerIdentity() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    public class CustomAssertionAttribute : System.Attribute
+    {
+        public CustomAssertionAttribute() { }
+    }
+    public static class DataRowAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataRowAssertions<TDataRow> Should<TDataRow>(this TDataRow actualValue)
+            where TDataRow : System.Data.DataRow { }
+    }
+    public static class DataSetAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataSetAssertions<TDataSet> Should<TDataSet>(this TDataSet actualValue)
+            where TDataSet : System.Data.DataSet { }
+    }
+    public static class DataTableAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataTableAssertions<TDataTable> Should<TDataTable>(this TDataTable actualValue)
+            where TDataTable : System.Data.DataTable { }
+    }
+    public static class EnumAssertionsExtensions
+    {
+        public static FluentAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
+            where TEnum :  struct, System.Enum { }
+        public static FluentAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>(this TEnum? @enum)
+            where TEnum :  struct, System.Enum { }
+    }
+    public class EquivalencyPlan : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
+    {
+        public EquivalencyPlan() { }
+        public void Add<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void AddAfter<TPredecessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Clear() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IEquivalencyStep> GetEnumerator() { }
+        public void Insert<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void InsertBefore<TSuccessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Remove<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep { }
+        public void Reset() { }
+    }
+    public static class EventRaisingExtensions
+    {
+        public static FluentAssertions.Events.IEventRecording WithArgs<T>(this FluentAssertions.Events.IEventRecording eventRecording, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecording WithArgs<T>(this FluentAssertions.Events.IEventRecording eventRecording, params System.Linq.Expressions.Expression<System.Func<T, bool>>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecording WithSender(this FluentAssertions.Events.IEventRecording eventRecording, object expectedSender) { }
+    }
+    public static class Exactly
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class ExceptionAssertionsExtensions
+    {
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> Where<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> WithInnerException<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, System.Type innerException, string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerException<TException, TInnerException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
+            where TException : System.Exception
+            where TInnerException : System.Exception { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> WithInnerExceptionExactly<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, System.Type innerException, string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
+            where TException : System.Exception
+            where TInnerException : System.Exception { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public static FluentAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this FluentAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
+    }
+    public static class FluentActions
+    {
+        public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Invoking(System.Action action) { }
+        public static System.Func<T> Invoking<T>(System.Func<T> func) { }
+    }
+    public static class LessThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class MoreThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class NumericAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+    }
+    public static class ObjectAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class OccurrenceConstraint
+    {
+        protected OccurrenceConstraint(int expectedCount) { }
+    }
+    public static class TypeEnumerableExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreClasses(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreInNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotClasses(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotStatic(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreStatic(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreUnderNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatDeriveFrom<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatImplement<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatSatisfy(this System.Collections.Generic.IEnumerable<System.Type> types, System.Func<System.Type, bool> predicate) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> UnwrapEnumerableTypes(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> UnwrapTaskTypes(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+    }
+    public static class TypeExtensions
+    {
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this System.Type type) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this System.Type type) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Type type) { }
+    }
+    public static class XmlAssertionExtensions
+    {
+        public static FluentAssertions.Xml.XmlElementAssertions Should(this System.Xml.XmlElement actualValue) { }
+        public static FluentAssertions.Xml.XmlNodeAssertions Should(this System.Xml.XmlNode actualValue) { }
+    }
+}
+namespace FluentAssertions.Collections
+{
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.GenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    {
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+    }
+    public class GenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T>>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+    {
+        public GenericCollectionAssertions(TCollection actualValue) { }
+    }
+    public class GenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TCollection, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+        where TAssertions : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public GenericCollectionAssertions(TCollection actualValue) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, System.Collections.Generic.IEnumerable<TExpectation>> AllBeAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, System.Collections.Generic.IEnumerable<TExpectation>> AllBeOfType<TExpectation>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllSatisfy(System.Action<T> expected, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpectation>(System.Collections.Generic.IEnumerable<TActual> actual, System.Collections.Generic.ICollection<TExpectation> expected, System.Func<TActual, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpectation>(System.Collections.Generic.IEnumerable<TActual> actualItems, System.Collections.Generic.ICollection<TExpectation> expected, System.Func<TActual, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertSubjectEquality<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<T, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInAscendingOrder(System.Func<T, T, int> comparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder(System.Func<T, T, int> comparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.Generic.IEnumerable<T> expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainEquivalentOf<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainEquivalentOf<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params T[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainItemsAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(T element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<T, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params T[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<T, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThanOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThanOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> HaveElementAt(int index, T element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Func<T, T, int> comparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Func<T, T, int> comparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSubsetOf(System.Collections.Generic.IEnumerable<T> unexpectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params T[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Satisfy(params System.Linq.Expressions.Expression<System.Func<T, bool>>[] predicates) { }
+        public FluentAssertions.AndConstraint<TAssertions> Satisfy(System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression<System.Func<T, bool>>> predicates, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(params System.Action<T>[] elementInspectors) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(T element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<T, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected static System.Collections.Generic.IEnumerable<TExpectation> RepeatAsManyAs<TExpectation>(TExpectation value, System.Collections.Generic.IEnumerable<T> enumerable) { }
+    }
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue>>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
+    }
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, System.Collections.Generic.KeyValuePair<TKey, TValue>, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
+    {
+        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(params System.Collections.Generic.KeyValuePair<TKey, TValue>[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<T>(T expected, string because = "", params object[] becauseArgs)
+            where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(params System.Collections.Generic.KeyValuePair<TKey, TValue>[] items) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
+    }
+    public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
+    {
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+    }
+    public class StringCollectionAssertions<TCollection> : FluentAssertions.Collections.StringCollectionAssertions<TCollection, FluentAssertions.Collections.StringCollectionAssertions<TCollection>>
+        where TCollection : System.Collections.Generic.IEnumerable<string>
+    {
+        public StringCollectionAssertions(TCollection actualValue) { }
+    }
+    public class StringCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, string, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<string>
+        where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
+    {
+        public StringCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class SubsequentOrderingAssertions<T> : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.SubsequentOrderingAssertions<T>>
+    {
+        public SubsequentOrderingAssertions(System.Collections.Generic.IEnumerable<T> actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+    }
+    public class SubsequentOrderingGenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T>>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+    {
+        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+    }
+    public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+        where TAssertions : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
+    }
+    public class WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
+    {
+        public WhoseValueConstraint(TAssertions parentConstraint, TValue value) { }
+        public TValue WhoseValue { get; }
+    }
+}
+namespace FluentAssertions.Common
+{
+    public enum CSharpAccessModifier
+    {
+        Public = 0,
+        Private = 1,
+        Protected = 2,
+        Internal = 3,
+        ProtectedInternal = 4,
+        InvalidForCSharp = 5,
+        PrivateProtected = 6,
+    }
+    public class Configuration
+    {
+        public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
+        public string TestFrameworkName { get; set; }
+        public string ValueFormatterAssembly { get; set; }
+        public FluentAssertions.Common.ValueFormatterDetectionMode ValueFormatterDetectionMode { get; set; }
+        public static FluentAssertions.Common.Configuration Current { get; }
+    }
+    public static class DateTimeExtensions
+    {
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime) { }
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime, System.TimeSpan offset) { }
+    }
+    public interface IClock
+    {
+        void Delay(System.TimeSpan timeToDelay);
+        System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
+        FluentAssertions.Common.ITimer StartTimer();
+    }
+    public interface IConfigurationStore
+    {
+        string GetSetting(string name);
+    }
+    public interface IReflector
+    {
+        System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
+    }
+    public interface ITimer : System.IDisposable
+    {
+        System.TimeSpan Elapsed { get; }
+    }
+    public static class Services
+    {
+        public static FluentAssertions.Common.Configuration Configuration { get; }
+        public static FluentAssertions.Common.IConfigurationStore ConfigurationStore { get; set; }
+        public static FluentAssertions.Common.IReflector Reflector { get; set; }
+        public static System.Action<string> ThrowException { get; set; }
+        public static void ResetToDefaults() { }
+    }
+    public delegate FluentAssertions.Common.ITimer StartTimer();
+    public enum ValueFormatterDetectionMode
+    {
+        Disabled = 0,
+        Specific = 1,
+        Scan = 2,
+    }
+}
+namespace FluentAssertions.Data
+{
+    public class DataColumnAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataColumn, FluentAssertions.Data.DataColumnAssertions>
+    {
+        public DataColumnAssertions(System.Data.DataColumn dataColumn) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataColumnAssertions> BeEquivalentTo(System.Data.DataColumn expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataColumnAssertions> BeEquivalentTo(System.Data.DataColumn expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataColumn>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataColumn>> config, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataRowAssertions<TDataRow> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDataRow, FluentAssertions.Data.DataRowAssertions<TDataRow>>
+        where TDataRow : System.Data.DataRow
+    {
+        public DataRowAssertions(TDataRow dataRow) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> BeEquivalentTo(System.Data.DataRow expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> BeEquivalentTo(System.Data.DataRow expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataRow>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataRow>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>, System.Data.DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> HaveColumns(params string[] expectedColumnNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> HaveColumns(System.Collections.Generic.IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataSetAssertions<TDataSet> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataSet, FluentAssertions.Data.DataSetAssertions<TDataSet>>
+        where TDataSet : System.Data.DataSet
+    {
+        public DataSetAssertions(TDataSet dataSet) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> BeEquivalentTo(System.Data.DataSet expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> BeEquivalentTo(System.Data.DataSet expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataSet>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataSet>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>, System.Data.DataTable> HaveTable(string expectedTableName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTableCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTables(params string[] expectedTableNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTables(System.Collections.Generic.IEnumerable<string> expectedTableNames, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataTableAssertions<TDataTable> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataTable, FluentAssertions.Data.DataTableAssertions<TDataTable>>
+        where TDataTable : System.Data.DataTable
+    {
+        public DataTableAssertions(TDataTable dataTable) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> BeEquivalentTo(System.Data.DataTable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> BeEquivalentTo(System.Data.DataTable expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataTable>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataTable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>, System.Data.DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveColumns(params string[] expectedColumnNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveColumns(System.Collections.Generic.IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveRowCount(int expected, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IDataEquivalencyAssertionOptions<T> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+    {
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> AllowingMismatchedTypes();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> Excluding(System.Linq.Expressions.Expression<System.Func<T, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumn(System.Data.DataColumn column);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumn(string tableName, string columnName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnInAllTables(string columnName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(System.Collections.Generic.IEnumerable<System.Data.DataColumn> columns);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(params System.Data.DataColumn[] columns);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, System.Collections.Generic.IEnumerable<string> columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, params string[] columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(System.Collections.Generic.IEnumerable<string> columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(params string[] columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingOriginalData();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.Constraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataColumn, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataRelation, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataRow, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataTable, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.ForeignKeyConstraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.UniqueConstraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTable(string tableName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTables(System.Collections.Generic.IEnumerable<string> tableNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTables(params string[] tableNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> IgnoringUnmatchedColumns();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> UsingRowMatchMode(FluentAssertions.Data.RowMatchMode rowMatchMode);
+    }
+    public enum RowMatchMode
+    {
+        Index = 0,
+        PrimaryKey = 1,
+    }
+}
+namespace FluentAssertions.Equivalency
+{
+    public class Comparands
+    {
+        public Comparands() { }
+        public Comparands(object subject, object expectation, System.Type compileTimeType) { }
+        public System.Type CompileTimeType { get; set; }
+        public object Expectation { get; set; }
+        public System.Type RuntimeType { get; }
+        public object Subject { get; set; }
+        public System.Type GetExpectedType(FluentAssertions.Equivalency.IEquivalencyAssertionOptions options) { }
+        public override string ToString() { }
+    }
+    public class ConversionSelector
+    {
+        public ConversionSelector() { }
+        public FluentAssertions.Equivalency.ConversionSelector Clone() { }
+        public void Exclude(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
+        public void Include(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
+        public void IncludeAll() { }
+        public bool RequiresConversion(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.INode currentNode) { }
+        public override string ToString() { }
+    }
+    public enum CyclicReferenceHandling
+    {
+        Ignore = 0,
+        ThrowException = 1,
+    }
+    public enum EnumEquivalencyHandling
+    {
+        ByValue = 0,
+        ByName = 1,
+    }
+    public enum EqualityStrategy
+    {
+        Equals = 0,
+        Members = 1,
+        ForceEquals = 2,
+        ForceMembers = 3,
+    }
+    public class EquivalencyAssertionOptions : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions>
+    {
+        public EquivalencyAssertionOptions() { }
+    }
+    public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
+    {
+        public EquivalencyAssertionOptions() { }
+        public EquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping(string expectationMemberPath, string subjectMemberPath) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TSubject>(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expectationMemberPath, System.Linq.Expressions.Expression<System.Func<TSubject, object>> subjectMemberPath) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(System.Linq.Expressions.Expression<System.Func<TNestedExpectation, object>> expectationMember, System.Linq.Expressions.Expression<System.Func<TNestedSubject, object>> subjectMember) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(string expectationMemberName, string subjectMemberName) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+    }
+    public enum EquivalencyResult
+    {
+        ContinueWithNext = 0,
+        AssertionCompleted = 1,
+    }
+    public abstract class EquivalencyStep<T> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        protected EquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+        protected abstract FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator);
+    }
+    public class EquivalencyValidationContext : FluentAssertions.Equivalency.IEquivalencyValidationContext
+    {
+        public EquivalencyValidationContext(FluentAssertions.Equivalency.INode root, FluentAssertions.Equivalency.IEquivalencyAssertionOptions options) { }
+        public FluentAssertions.Equivalency.INode CurrentNode { get; }
+        public FluentAssertions.Equivalency.IEquivalencyAssertionOptions Options { get; }
+        public FluentAssertions.Execution.Reason Reason { get; set; }
+        public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; set; }
+        public FluentAssertions.Equivalency.Tracing.Tracer Tracer { get; }
+        public FluentAssertions.Equivalency.IEquivalencyValidationContext AsCollectionItem<TItem>(string index) { }
+        public FluentAssertions.Equivalency.IEquivalencyValidationContext AsDictionaryItem<TKey, TExpectation>(TKey key) { }
+        public FluentAssertions.Equivalency.IEquivalencyValidationContext AsNestedMember(FluentAssertions.Equivalency.IMember expectationMember) { }
+        public FluentAssertions.Equivalency.IEquivalencyValidationContext Clone() { }
+        public bool IsCyclicReference(object expectation) { }
+        public override string ToString() { }
+    }
+    public class EquivalencyValidator : FluentAssertions.Equivalency.IEquivalencyValidator
+    {
+        public EquivalencyValidator() { }
+        public void AssertEquality(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.EquivalencyValidationContext context) { }
+        public void RecursivelyAssertEquality(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context) { }
+    }
+    public class Field : FluentAssertions.Equivalency.Node, FluentAssertions.Equivalency.IMember, FluentAssertions.Equivalency.INode
+    {
+        public Field(System.Reflection.FieldInfo fieldInfo, FluentAssertions.Equivalency.INode parent) { }
+        public Field(System.Type reflectedType, System.Reflection.FieldInfo fieldInfo, FluentAssertions.Equivalency.INode parent) { }
+        public System.Type DeclaringType { get; set; }
+        public override string Description { get; }
+        public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
+        public System.Type ReflectedType { get; }
+        public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
+        public object GetValue(object obj) { }
+    }
+    public delegate string GetSubjectId();
+    public interface IAssertionContext<TSubject>
+    {
+        string Because { get; set; }
+        object[] BecauseArgs { get; set; }
+        TSubject Expectation { get; }
+        FluentAssertions.Equivalency.INode SelectedNode { get; }
+        TSubject Subject { get; }
+    }
+    public interface IEquivalencyAssertionOptions
+    {
+        bool AllowInfiniteRecursion { get; }
+        bool CompareRecordsByValue { get; }
+        FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
+        FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool ExcludeNonBrowsable { get; }
+        FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
+        FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
+        bool IsRecursive { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
+        FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
+        FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        bool UseRuntimeTyping { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> UserEquivalencySteps { get; }
+        FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
+    }
+    public interface IEquivalencyStep
+    {
+        FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator);
+    }
+    public interface IEquivalencyValidationContext
+    {
+        FluentAssertions.Equivalency.INode CurrentNode { get; }
+        FluentAssertions.Equivalency.IEquivalencyAssertionOptions Options { get; }
+        FluentAssertions.Execution.Reason Reason { get; }
+        FluentAssertions.Equivalency.Tracing.Tracer Tracer { get; }
+        FluentAssertions.Equivalency.IEquivalencyValidationContext AsCollectionItem<TItem>(string index);
+        FluentAssertions.Equivalency.IEquivalencyValidationContext AsDictionaryItem<TKey, TExpectation>(TKey key);
+        FluentAssertions.Equivalency.IEquivalencyValidationContext AsNestedMember(FluentAssertions.Equivalency.IMember expectationMember);
+        FluentAssertions.Equivalency.IEquivalencyValidationContext Clone();
+        bool IsCyclicReference(object expectation);
+    }
+    public interface IEquivalencyValidator
+    {
+        void RecursivelyAssertEquality(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IMember : FluentAssertions.Equivalency.INode
+    {
+        System.Type DeclaringType { get; }
+        FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        bool IsBrowsable { get; }
+        System.Type ReflectedType { get; }
+        FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
+        object GetValue(object obj);
+    }
+    public interface IMemberInfo
+    {
+        System.Type DeclaringType { get; }
+        FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        string Name { get; }
+        string Path { get; set; }
+        FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
+        System.Type Type { get; }
+    }
+    public interface IMemberMatchingRule
+    {
+        FluentAssertions.Equivalency.IMember Match(FluentAssertions.Equivalency.IMember expectedMember, object subject, FluentAssertions.Equivalency.INode parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions options);
+    }
+    public interface IMemberSelectionRule
+    {
+        bool IncludesMembers { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMember> SelectMembers(FluentAssertions.Equivalency.INode currentNode, System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMember> selectedMembers, FluentAssertions.Equivalency.MemberSelectionContext context);
+    }
+    public interface INode
+    {
+        int Depth { get; }
+        string Description { get; }
+        FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
+        bool IsRoot { get; }
+        string Name { get; set; }
+        string Path { get; }
+        string PathAndName { get; }
+        bool RootIsCollection { get; }
+        System.Type Type { get; }
+    }
+    public interface IObjectInfo
+    {
+        System.Type CompileTimeType { get; }
+        string Path { get; set; }
+        System.Type RuntimeType { get; }
+        System.Type Type { get; }
+    }
+    public interface IOrderingRule
+    {
+        FluentAssertions.Equivalency.OrderStrictness Evaluate(FluentAssertions.Equivalency.IObjectInfo objectInfo);
+    }
+    public static class MemberFactory
+    {
+        public static FluentAssertions.Equivalency.IMember Create(System.Reflection.MemberInfo memberInfo, FluentAssertions.Equivalency.INode parent) { }
+    }
+    public class MemberSelectionContext
+    {
+        public MemberSelectionContext(System.Type compileTimeType, System.Type runtimeType, FluentAssertions.Equivalency.IEquivalencyAssertionOptions options) { }
+        public FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
+        public FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
+        public System.Type Type { get; }
+    }
+    [System.Flags]
+    public enum MemberVisibility
+    {
+        None = 0,
+        Internal = 1,
+        Public = 2,
+    }
+    public class Node : FluentAssertions.Equivalency.INode
+    {
+        public Node() { }
+        public int Depth { get; }
+        public virtual string Description { get; }
+        public FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; set; }
+        public bool IsRoot { get; }
+        public string Name { get; set; }
+        public string Path { get; set; }
+        public string PathAndName { get; }
+        public bool RootIsCollection { get; set; }
+        public System.Type Type { get; set; }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+        public override string ToString() { }
+        public static FluentAssertions.Equivalency.INode From<T>(FluentAssertions.Equivalency.GetSubjectId getSubjectId) { }
+        public static FluentAssertions.Equivalency.INode FromCollectionItem<T>(string index, FluentAssertions.Equivalency.INode parent) { }
+        public static FluentAssertions.Equivalency.INode FromDictionaryItem<T>(object key, FluentAssertions.Equivalency.INode parent) { }
+    }
+    public enum OrderStrictness
+    {
+        Strict = 0,
+        NotStrict = 1,
+        Irrelevant = 2,
+    }
+    public class OrderingRuleCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule>, System.Collections.IEnumerable
+    {
+        public OrderingRuleCollection() { }
+        public OrderingRuleCollection(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule> orderingRules) { }
+        public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
+        public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IObjectInfo objectInfo) { }
+    }
+    public class Property : FluentAssertions.Equivalency.Node, FluentAssertions.Equivalency.IMember, FluentAssertions.Equivalency.INode
+    {
+        public Property(System.Reflection.PropertyInfo propertyInfo, FluentAssertions.Equivalency.INode parent) { }
+        public Property(System.Type reflectedType, System.Reflection.PropertyInfo propertyInfo, FluentAssertions.Equivalency.INode parent) { }
+        public System.Type DeclaringType { get; }
+        public override string Description { get; }
+        public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public bool IsBrowsable { get; }
+        public System.Type ReflectedType { get; }
+        public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
+        public object GetValue(object obj) { }
+    }
+    public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+        where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
+    {
+        protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public bool CompareRecordsByValue { get; }
+        public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
+        public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        protected TSelf AddMatchingRule(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
+        protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers(System.Type type) { }
+        public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue(System.Type type) { }
+        public TSelf ComparingByValue<T>() { }
+        public TSelf ComparingEnumsByName() { }
+        public TSelf ComparingEnumsByValue() { }
+        public TSelf ComparingRecordsByMembers() { }
+        public TSelf ComparingRecordsByValue() { }
+        public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingFields() { }
+        public TSelf ExcludingMissingMembers() { }
+        public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingNonBrowsableMembers() { }
+        public TSelf ExcludingProperties() { }
+        public TSelf IgnoringCyclicReferences() { }
+        public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf IncludingAllDeclaredProperties() { }
+        public TSelf IncludingAllRuntimeProperties() { }
+        public TSelf IncludingFields() { }
+        public TSelf IncludingInternalFields() { }
+        public TSelf IncludingInternalProperties() { }
+        public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingNonBrowsableMembers() { }
+        public TSelf IncludingProperties() { }
+        public TSelf RespectingDeclaredTypes() { }
+        public TSelf RespectingRuntimeTypes() { }
+        public TSelf ThrowingOnMissingMembers() { }
+        public override string ToString() { }
+        public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IOrderingRule orderingRule) { }
+        public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf Using<T>(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public TSelf Using<T, TEqualityComparer>()
+            where TEqualityComparer : System.Collections.Generic.IEqualityComparer<T>, new () { }
+        public TSelf WithAutoConversion() { }
+        public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
+        public TSelf WithStrictOrdering() { }
+        public TSelf WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
+        public TSelf WithTracing(FluentAssertions.Equivalency.Tracing.ITraceWriter writer = null) { }
+        public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
+        public void WithoutMatchingRules() { }
+        public void WithoutSelectionRules() { }
+        public TSelf WithoutStrictOrdering() { }
+        public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
+        public class Restriction<TMember>
+        {
+            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
+            public TSelf WhenTypeIs<TMemberType>()
+                where TMemberType : TMember { }
+        }
+    }
+    public static class SubjectInfoExtensions
+    {
+        public static bool WhichGetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+    }
+}
+namespace FluentAssertions.Equivalency.Steps
+{
+    public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> assertion) { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+        public override string ToString() { }
+    }
+    public class AutoConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AutoConversionStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+        public override string ToString() { }
+    }
+    public class ConstraintCollectionEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Data.ConstraintCollection>
+    {
+        public ConstraintCollectionEquivalencyStep() { }
+        protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class ConstraintEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Data.Constraint>
+    {
+        public ConstraintEquivalencyStep() { }
+        protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class DataColumnEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Data.DataColumn>
+    {
+        public DataColumnEquivalencyStep() { }
+        protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class DataRelationEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Data.DataRelation>
+    {
+        public DataRelationEquivalencyStep() { }
+        protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class DataRowCollectionEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Data.DataRowCollection>
+    {
+        public DataRowCollectionEquivalencyStep() { }
+        protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class DataRowEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Data.DataRow>
+    {
+        public DataRowEquivalencyStep() { }
+        protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class DataSetEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Data.DataSet>
+    {
+        public DataSetEquivalencyStep() { }
+        protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class DataTableEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Data.DataTable>
+    {
+        public DataTableEquivalencyStep() { }
+        protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Collections.IDictionary>
+    {
+        public DictionaryEquivalencyStep() { }
+        protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class EnumEqualityStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumEqualityStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class EnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumerableEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class EqualityComparerEquivalencyStep<T> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EqualityComparerEquivalencyStep(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+        public override string ToString() { }
+    }
+    public class GenericDictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericDictionaryEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class GenericEnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericEnumerableEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class ReferenceEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ReferenceEqualityEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class RunAllUserStepsEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public RunAllUserStepsEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public SimpleEqualityEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class StringEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StringEqualityEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class StructuralEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StructuralEqualityEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ValueTypeEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class XAttributeEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Xml.Linq.XAttribute>
+    {
+        public XAttributeEquivalencyStep() { }
+        protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class XDocumentEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Xml.Linq.XDocument>
+    {
+        public XDocumentEquivalencyStep() { }
+        protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class XElementEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Xml.Linq.XElement>
+    {
+        public XElementEquivalencyStep() { }
+        protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+}
+namespace FluentAssertions.Equivalency.Tracing
+{
+    public delegate string GetTraceMessage(FluentAssertions.Equivalency.INode node);
+    public interface ITraceWriter
+    {
+        System.IDisposable AddBlock(string trace);
+        void AddSingle(string trace);
+        string ToString();
+    }
+    public class StringBuilderTraceWriter : FluentAssertions.Equivalency.Tracing.ITraceWriter
+    {
+        public StringBuilderTraceWriter() { }
+        public System.IDisposable AddBlock(string trace) { }
+        public void AddSingle(string trace) { }
+        public override string ToString() { }
+    }
+    public class Tracer
+    {
+        public override string ToString() { }
+        public System.IDisposable WriteBlock(FluentAssertions.Equivalency.Tracing.GetTraceMessage getTraceMessage) { }
+        public void WriteLine(FluentAssertions.Equivalency.Tracing.GetTraceMessage getTraceMessage) { }
+    }
+}
+namespace FluentAssertions.Events
+{
+    public class EventAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<T, FluentAssertions.Events.EventAssertions<T>>
+    {
+        protected EventAssertions(FluentAssertions.Events.IMonitor<T> monitor) { }
+        protected override string Identifier { get; }
+        public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
+        public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecording RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+    }
+    public class EventMetadata
+    {
+        public EventMetadata(string eventName, System.Type handlerType) { }
+        public string EventName { get; }
+        public System.Type HandlerType { get; }
+    }
+    public interface IEventRecording : System.Collections.Generic.IEnumerable<FluentAssertions.Events.OccurredEvent>, System.Collections.IEnumerable
+    {
+        System.Type EventHandlerType { get; }
+        string EventName { get; }
+        object EventObject { get; }
+    }
+    public interface IMonitor<T> : System.IDisposable
+    {
+        FluentAssertions.Events.EventMetadata[] MonitoredEvents { get; }
+        FluentAssertions.Events.OccurredEvent[] OccurredEvents { get; }
+        T Subject { get; }
+        void Clear();
+        FluentAssertions.Events.IEventRecording GetRecordingFor(string eventName);
+        FluentAssertions.Events.EventAssertions<T> Should();
+    }
+    public class OccurredEvent
+    {
+        public OccurredEvent() { }
+        public string EventName { get; set; }
+        public object[] Parameters { get; set; }
+        public int Sequence { get; set; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+}
+namespace FluentAssertions.Execution
+{
+    [System.Serializable]
+    public class AssertionFailedException : System.Exception
+    {
+        public AssertionFailedException(string message) { }
+        protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public sealed class AssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public AssertionScope() { }
+        public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
+        public AssertionScope(System.Lazy<string> context) { }
+        public AssertionScope(string context) { }
+        public string CallerIdentity { get; }
+        public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
+        public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
+        public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddNonReportable(string key, object value) { }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, System.Func<string> valueFunc) { }
+        public void AddReportable(string key, string value) { }
+        public void AppendTracing(string tracingBlock) { }
+        public void AssumeSingleCaller() { }
+        public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
+        public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.AssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
+        public T Get<T>(string key) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public bool HasFailures() { }
+        public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Continuation
+    {
+        public FluentAssertions.Execution.IAssertionScope Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
+    }
+    public class ContinuationOfGiven<TSubject>
+    {
+        public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
+    }
+    public sealed class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public static class Execute
+    {
+        public static FluentAssertions.Execution.AssertionScope Assertion { get; }
+    }
+    public class FailReason
+    {
+        public FailReason(string message, params object[] args) { }
+        public object[] Args { get; }
+        public string Message { get; }
+    }
+    public class GivenSelector<T>
+    {
+        public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<T, object>[] args) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+    }
+    public interface IAssertionScope : System.IDisposable
+    {
+        FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
+        FluentAssertions.Execution.Continuation ClearExpectation();
+        string[] Discard();
+        FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc);
+        FluentAssertions.Execution.Continuation FailWith(string message);
+        FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders);
+        FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
+        FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
+        FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
+        FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);
+    }
+    public interface IAssertionStrategy
+    {
+        System.Collections.Generic.IEnumerable<string> FailureMessages { get; }
+        System.Collections.Generic.IEnumerable<string> DiscardFailures();
+        void HandleFailure(string message);
+        void ThrowIfAny(System.Collections.Generic.IDictionary<string, object> context);
+    }
+    public interface ICloneable2
+    {
+        object Clone();
+    }
+    public class Reason
+    {
+        public Reason(string formattedMessage, object[] arguments) { }
+        public object[] Arguments { get; set; }
+        public string FormattedMessage { get; set; }
+    }
+}
+namespace FluentAssertions.Extensions
+{
+    public static class FluentDateTimeExtensions
+    {
+        public static System.DateTime AddMicroseconds(this System.DateTime self, long microseconds) { }
+        public static System.DateTimeOffset AddMicroseconds(this System.DateTimeOffset self, long microseconds) { }
+        public static System.DateTime AddNanoseconds(this System.DateTime self, long nanoseconds) { }
+        public static System.DateTimeOffset AddNanoseconds(this System.DateTimeOffset self, long nanoseconds) { }
+        public static System.DateTime After(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime April(this int day, int year) { }
+        public static System.DateTime AsLocal(this System.DateTime dateTime) { }
+        public static System.DateTime AsUtc(this System.DateTime dateTime) { }
+        public static System.DateTime At(this System.DateTime date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTimeOffset At(this System.DateTimeOffset date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTime August(this int day, int year) { }
+        public static System.DateTime Before(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime December(this int day, int year) { }
+        public static System.DateTime February(this int day, int year) { }
+        public static System.DateTime January(this int day, int year) { }
+        public static System.DateTime July(this int day, int year) { }
+        public static System.DateTime June(this int day, int year) { }
+        public static System.DateTime March(this int day, int year) { }
+        public static System.DateTime May(this int day, int year) { }
+        public static int Microsecond(this System.DateTime self) { }
+        public static int Microsecond(this System.DateTimeOffset self) { }
+        public static int Nanosecond(this System.DateTime self) { }
+        public static int Nanosecond(this System.DateTimeOffset self) { }
+        public static System.DateTime November(this int day, int year) { }
+        public static System.DateTime October(this int day, int year) { }
+        public static System.DateTime September(this int day, int year) { }
+        public static System.DateTimeOffset WithOffset(this System.DateTime self, System.TimeSpan offset) { }
+    }
+    public static class FluentTimeSpanExtensions
+    {
+        public const long TicksPerMicrosecond = 10;
+        public const double TicksPerNanosecond = 0.01D;
+        public static System.TimeSpan And(this System.TimeSpan sourceTime, System.TimeSpan offset) { }
+        public static System.TimeSpan Days(this double days) { }
+        public static System.TimeSpan Days(this int days) { }
+        public static System.TimeSpan Days(this int days, System.TimeSpan offset) { }
+        public static System.TimeSpan Hours(this double hours) { }
+        public static System.TimeSpan Hours(this int hours) { }
+        public static System.TimeSpan Hours(this int hours, System.TimeSpan offset) { }
+        public static int Microseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Microseconds(this int microseconds) { }
+        public static System.TimeSpan Microseconds(this long microseconds) { }
+        public static System.TimeSpan Milliseconds(this double milliseconds) { }
+        public static System.TimeSpan Milliseconds(this int milliseconds) { }
+        public static System.TimeSpan Minutes(this double minutes) { }
+        public static System.TimeSpan Minutes(this int minutes) { }
+        public static System.TimeSpan Minutes(this int minutes, System.TimeSpan offset) { }
+        public static int Nanoseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Nanoseconds(this int nanoseconds) { }
+        public static System.TimeSpan Nanoseconds(this long nanoseconds) { }
+        public static System.TimeSpan Seconds(this double seconds) { }
+        public static System.TimeSpan Seconds(this int seconds) { }
+        public static System.TimeSpan Seconds(this int seconds, System.TimeSpan offset) { }
+        public static System.TimeSpan Ticks(this int ticks) { }
+        public static System.TimeSpan Ticks(this long ticks) { }
+        public static double TotalMicroseconds(this System.TimeSpan self) { }
+        public static double TotalNanoseconds(this System.TimeSpan self) { }
+    }
+}
+namespace FluentAssertions.Formatting
+{
+    public class AggregateExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AggregateExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AttributeBasedFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DateTimeOffsetValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DecimalValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DefaultValueFormatter() { }
+        protected virtual int SpacesPerIndentionLevel { get; }
+        public virtual bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }
+        protected virtual string TypeDisplayName(System.Type type) { }
+    }
+    public class DictionaryValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DictionaryValueFormatter() { }
+        protected virtual int MaxItems { get; }
+        public virtual bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DoubleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class EnumValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumValueFormatter() { }
+        public virtual bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumerableValueFormatter() { }
+        protected virtual int MaxItems { get; }
+        public virtual bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExpressionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public delegate void FormatChild(string childPath, object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph);
+    public class FormattedObjectGraph
+    {
+        public FormattedObjectGraph(int maxLines) { }
+        public int LineCount { get; }
+        public static int SpacesPerIndentation { get; }
+        public void AddFragment(string fragment) { }
+        public void AddFragmentOnNewLine(string fragment) { }
+        public void AddLine(string line) { }
+        public override string ToString() { }
+        public System.IDisposable WithIndentation() { }
+    }
+    public static class Formatter
+    {
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
+        public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static string ToString(object value, FluentAssertions.Formatting.FormattingOptions options = null) { }
+    }
+    public class FormattingContext
+    {
+        public FormattingContext() { }
+        public bool UseLineBreaks { get; set; }
+    }
+    public class FormattingOptions
+    {
+        public FormattingOptions() { }
+        public int MaxDepth { get; set; }
+        public int MaxLines { get; set; }
+        public bool UseLineBreaks { get; set; }
+    }
+    public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public GuidValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public interface IValueFormatter
+    {
+        bool CanHandle(object value);
+        void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+    }
+    public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MaxLinesExceededException : System.Exception
+    {
+        public MaxLinesExceededException() { }
+        public MaxLinesExceededException(string message) { }
+        public MaxLinesExceededException(string message, System.Exception innerException) { }
+    }
+    public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public MultidimensionalArrayFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public NullValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class PredicateLambdaExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public PredicateLambdaExpressionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public PropertyInfoFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SingleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public StringValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TaskFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TimeSpanValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    public class ValueFormatterAttribute : System.Attribute
+    {
+        public ValueFormatterAttribute() { }
+    }
+    public class XAttributeValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XAttributeValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XDocumentValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XElementValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XmlReaderValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlReaderValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}
+namespace FluentAssertions.Numeric
+{
+    public class ComparableTypeAssertions<T> : FluentAssertions.Numeric.ComparableTypeAssertions<T, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+    }
+    public class ComparableTypeAssertions<T, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Numeric.ComparableTypeAssertions<T, TAssertions>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
+        where T :  struct, System.IComparable<T>
+    {
+        public NullableNumericAssertions(T? value) { }
+    }
+    public class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+        where T :  struct, System.IComparable<T>
+        where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
+    {
+        public NullableNumericAssertions(T? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
+        where T :  struct, System.IComparable<T>
+    {
+        public NumericAssertions(T value) { }
+    }
+    public class NumericAssertions<T, TAssertions>
+        where T :  struct, System.IComparable<T>
+        where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+    {
+        public NumericAssertions(T value) { }
+        public T? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Primitives
+{
+    public class BooleanAssertions : FluentAssertions.Primitives.BooleanAssertions<FluentAssertions.Primitives.BooleanAssertions>
+    {
+        public BooleanAssertions(bool? value) { }
+    }
+    public class BooleanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
+    {
+        public BooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+    }
+    public class DateTimeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+        public System.DateTime? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<System.DateTime>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<FluentAssertions.Primitives.DateTimeOffsetAssertions>
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+    }
+    public class DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+        public System.DateTimeOffset? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<System.DateTimeOffset>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeExactly(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeExactly(System.DateTimeOffset? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetRangeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
+    {
+        protected DateTimeOffsetRangeAssertions(TAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+    }
+    public class DateTimeRangeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
+    {
+        protected DateTimeRangeAssertions(TAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+    }
+    public class EnumAssertions<TEnum> : FluentAssertions.Primitives.EnumAssertions<TEnum, FluentAssertions.Primitives.EnumAssertions<TEnum>>
+        where TEnum :  struct, System.Enum
+    {
+        public EnumAssertions(TEnum subject) { }
+    }
+    public class EnumAssertions<TEnum, TAssertions>
+        where TEnum :  struct, System.Enum
+        where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
+    {
+        public EnumAssertions(TEnum subject) { }
+        public TEnum? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params TEnum[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TEnum> validValues, string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameNameAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameValueAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(decimal expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<TEnum?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TEnum unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TEnum? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag(TEnum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameNameAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameValueAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(decimal unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
+    {
+        public GuidAssertions(System.Guid? value) { }
+    }
+    public class GuidAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
+    {
+        public GuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+    }
+    public class HttpResponseMessageAssertions : FluentAssertions.Primitives.HttpResponseMessageAssertions<FluentAssertions.Primitives.HttpResponseMessageAssertions>
+    {
+        public HttpResponseMessageAssertions(System.Net.Http.HttpResponseMessage value) { }
+    }
+    public class HttpResponseMessageAssertions<TAssertions> : FluentAssertions.Primitives.ObjectAssertions<System.Net.Http.HttpResponseMessage, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.HttpResponseMessageAssertions<TAssertions>
+    {
+        protected HttpResponseMessageAssertions(System.Net.Http.HttpResponseMessage value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeRedirection(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSuccessful(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveClientError(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveError(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveServerError(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveStatusCode(System.Net.HttpStatusCode expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveStatusCode(System.Net.HttpStatusCode unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>
+    {
+        public NullableBooleanAssertions(bool? value) { }
+    }
+    public class NullableBooleanAssertions<TAssertions> : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<TAssertions>
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+    }
+    public class NullableDateTimeAssertions<TAssertions> : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions>
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+    }
+    public class NullableDateTimeOffsetAssertions<TAssertions> : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableEnumAssertions<TEnum> : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, FluentAssertions.Primitives.NullableEnumAssertions<TEnum>>
+        where TEnum :  struct, System.Enum
+    {
+        public NullableEnumAssertions(TEnum? subject) { }
+    }
+    public class NullableEnumAssertions<TEnum, TAssertions> : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
+        where TEnum :  struct, System.Enum
+        where TAssertions : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, TAssertions>
+    {
+        public NullableEnumAssertions(TEnum? subject) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+    }
+    public class NullableGuidAssertions<TAssertions> : FluentAssertions.Primitives.GuidAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableGuidAssertions<TAssertions>
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions>
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+    }
+    public class NullableSimpleTimeSpanAssertions<TAssertions> : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<TAssertions>
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class ObjectAssertions : FluentAssertions.Primitives.ObjectAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
+    {
+        public ObjectAssertions(object value) { }
+    }
+    public class ObjectAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.ObjectAssertions<TSubject, TAssertions>
+    {
+        public ObjectAssertions(TSubject value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+    {
+        protected ReferenceTypeAssertions(TSubject subject) { }
+        protected abstract string Identifier { get; }
+        public TSubject Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameAs(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<TSubject, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
+            where T : TSubject { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+    }
+    public class SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringAssertions : FluentAssertions.Primitives.StringAssertions<FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+    }
+    public class StringAssertions<TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<string, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.StringAssertions<TAssertions>
+    {
+        public StringAssertions(string value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLowerCased(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeUpperCased(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeLowerCased(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeUpperCased(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+    }
+    public enum TimeSpanCondition
+    {
+        MoreThan = 0,
+        AtLeast = 1,
+        Exactly = 2,
+        Within = 3,
+        LessThan = 4,
+    }
+}
+namespace FluentAssertions.Reflection
+{
+    public class AssemblyAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.Assembly, FluentAssertions.Reflection.AssemblyAssertions>
+    {
+        public AssemblyAssertions(System.Reflection.Assembly assembly) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> NotReference(System.Reflection.Assembly assembly, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> Reference(System.Reflection.Assembly assembly, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Specialized
+{
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action, FluentAssertions.Specialized.ActionAssertions>
+    {
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        protected override void InvokeSubject() { }
+    }
+    public class AsyncFunctionAssertions<TTask, TAssertions> : FluentAssertions.Specialized.DelegateAssertionsBase<System.Func<TTask>, TAssertions>
+        where TTask : System.Threading.Tasks.Task
+        where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
+    {
+        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public abstract class DelegateAssertionsBase<TDelegate, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDelegate, FluentAssertions.Specialized.DelegateAssertionsBase<TDelegate, TAssertions>>
+        where TDelegate : System.Delegate
+        where TAssertions : FluentAssertions.Specialized.DelegateAssertionsBase<TDelegate, TAssertions>
+    {
+        protected FluentAssertions.AndConstraint<TAssertions> NotThrowInternal(System.Exception exception, string because, object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<TAssertions> NotThrowInternal<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        protected FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowInternal<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public abstract class DelegateAssertions<TDelegate, TAssertions> : FluentAssertions.Specialized.DelegateAssertionsBase<TDelegate, TAssertions>
+        where TDelegate : System.Delegate
+        where TAssertions : FluentAssertions.Specialized.DelegateAssertions<TDelegate, TAssertions>
+    {
+        protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        protected abstract void InvokeSubject();
+        public FluentAssertions.AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public FluentAssertions.AndConstraint<TAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public class ExceptionAssertions<TException> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, FluentAssertions.Specialized.ExceptionAssertions<TException>>
+        where TException : System.Exception
+    {
+        public ExceptionAssertions(System.Collections.Generic.IEnumerable<TException> exceptions) { }
+        public TException And { get; }
+        protected override string Identifier { get; }
+        public TException Which { get; }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Specialized.ExceptionAssertions<System.Exception> WithInnerException(System.Type innerException, string because = null, params object[] becauseArgs) { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerException<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<System.Exception> WithInnerExceptionExactly(System.Type innerException, string because = null, params object[] becauseArgs) { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class ExecutionTime
+    {
+        public ExecutionTime(System.Action action, FluentAssertions.Common.StartTimer createTimer) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action, FluentAssertions.Common.StartTimer createTimer) { }
+        protected ExecutionTime(System.Action action, string actionDescription, FluentAssertions.Common.StartTimer createTimer) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription, FluentAssertions.Common.StartTimer createTimer) { }
+    }
+    public class ExecutionTimeAssertions
+    {
+        public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThanOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThanOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+    }
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>, FluentAssertions.Specialized.FunctionAssertions<T>>
+    {
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        protected override void InvokeSubject() { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task<TResult>, FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>>
+    {
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
+    }
+    public interface IExtractExceptions
+    {
+        System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception;
+    }
+    public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
+    {
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action, FluentAssertions.Common.StartTimer createTimer) { }
+    }
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task, FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>
+    {
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+    }
+    public class TaskCompletionSourceAssertions<T>
+    {
+        public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
+        public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Streams
+{
+    public class BufferedStreamAssertions : FluentAssertions.Streams.BufferedStreamAssertions<FluentAssertions.Streams.BufferedStreamAssertions>
+    {
+        public BufferedStreamAssertions(System.IO.BufferedStream stream) { }
+    }
+    public class BufferedStreamAssertions<TAssertions> : FluentAssertions.Streams.StreamAssertions<System.IO.BufferedStream, TAssertions>
+        where TAssertions : FluentAssertions.Streams.BufferedStreamAssertions<TAssertions>
+    {
+        public BufferedStreamAssertions(System.IO.BufferedStream stream) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> HaveBufferSize(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveBufferSize(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class StreamAssertions : FluentAssertions.Streams.StreamAssertions<System.IO.Stream, FluentAssertions.Streams.StreamAssertions>
+    {
+        public StreamAssertions(System.IO.Stream stream) { }
+    }
+    public class StreamAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.IO.Stream
+        where TAssertions : FluentAssertions.Streams.StreamAssertions<TSubject, TAssertions>
+    {
+        public StreamAssertions(TSubject stream) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeReadOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(long expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HavePosition(long expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(long unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(long unexpected, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Types
+{
+    public static class AllTypes
+    {
+        public static FluentAssertions.Types.TypeSelector From(System.Reflection.Assembly assembly) { }
+    }
+    public class ConstructorInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.ConstructorInfo, FluentAssertions.Types.ConstructorInfoAssertions>
+    {
+        public ConstructorInfoAssertions(System.Reflection.ConstructorInfo constructorInfo) { }
+        protected override string Identifier { get; }
+    }
+    public abstract class MemberInfoAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MemberInfo
+        where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+    {
+        protected MemberInfoAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+    public abstract class MethodBaseAssertions<TSubject, TAssertions> : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MethodBase
+        where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
+    {
+        protected MethodBaseAssertions(TSubject subject) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
+    {
+        public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturnVoid(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, System.Collections.IEnumerable
+    {
+        public MethodInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public MethodInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.MethodInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturnVoid { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
+        public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreAsync() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotAsync() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotStatic() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreStatic() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public System.Reflection.MethodInfo[] ToArray() { }
+    }
+    public class MethodInfoSelectorAssertions
+    {
+        public MethodInfoSelectorAssertions(params System.Reflection.MethodInfo[] methods) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> SubjectMethods { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> Be(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBe(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoAssertions : FluentAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, FluentAssertions.Types.PropertyInfoAssertions>
+    {
+        public PropertyInfoAssertions(System.Reflection.PropertyInfo propertyInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo>, System.Collections.IEnumerable
+    {
+        public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
+        public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }
+        public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public System.Reflection.PropertyInfo[] ToArray() { }
+    }
+    public class PropertyInfoSelectorAssertions
+    {
+        public PropertyInfoSelectorAssertions(params System.Reflection.PropertyInfo[] properties) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> SubjectProperties { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+    }
+    public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
+    {
+        public TypeAssertions(System.Type type) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be(System.Type expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be<TExpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, TAttribute> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, TAttribute> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveIndexer(System.Type indexerType, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty(System.Type propertyType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe(System.Type unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe<TUnexpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveIndexer(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+    }
+    public class TypeSelector : System.Collections.Generic.IEnumerable<System.Type>, System.Collections.IEnumerable
+    {
+        public TypeSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public TypeSelector(System.Type type) { }
+        public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
+        public FluentAssertions.Types.TypeSelector ThatAreClasses() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotClasses() { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
+        public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatSatisfy(System.Func<System.Type, bool> predicate) { }
+        public System.Type[] ToArray() { }
+        public FluentAssertions.Types.TypeSelector UnwrapEnumerableTypes() { }
+        public FluentAssertions.Types.TypeSelector UnwrapTaskTypes() { }
+    }
+    public class TypeSelectorAssertions
+    {
+        public TypeSelectorAssertions(params System.Type[] types) { }
+        public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeInNamespace(string @namespace, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeUnderNamespace(string @namespace, string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeInNamespace(string @namespace, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeUnderNamespace(string @namespace, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Xml
+{
+    public class XAttributeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XAttribute, FluentAssertions.Xml.XAttributeAssertions>
+    {
+        public XAttributeAssertions(System.Xml.Linq.XAttribute attribute) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class XDocumentAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XDocument, FluentAssertions.Xml.XDocumentAssertions>
+    {
+        public XDocumentAssertions(System.Xml.Linq.XDocument document) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class XElementAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XElement, FluentAssertions.Xml.XElementAssertions>
+    {
+        public XElementAssertions(System.Xml.Linq.XElement xElement) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class XmlElementAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlElement, FluentAssertions.Xml.XmlElementAssertions>
+    {
+        public XmlElementAssertions(System.Xml.XmlElement xmlElement) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected, string because = "", params object[] becauseArgs) { }
+    }
+    public class XmlNodeAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlNode, FluentAssertions.Xml.XmlNodeAssertions>
+    {
+        public XmlNodeAssertions(System.Xml.XmlNode xmlNode) { }
+    }
+    public class XmlNodeAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Xml.XmlNode
+        where TAssertions : FluentAssertions.Xml.XmlNodeAssertions<TSubject, TAssertions>
+    {
+        public XmlNodeAssertions(TSubject xmlNode) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class XmlNodeFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlNodeFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}

--- a/Tests/Benchmarks/BeEquivalentToWithDeeplyNestedStructures.cs
+++ b/Tests/Benchmarks/BeEquivalentToWithDeeplyNestedStructures.cs
@@ -8,7 +8,7 @@ namespace Benchmarks
 {
     [MemoryDiagnoser]
     [SimpleJob(RuntimeMoniker.Net472)]
-    [SimpleJob(RuntimeMoniker.Net50)]
+    [SimpleJob(RuntimeMoniker.Net60)]
     public class BeEquivalentToWithDeeplyNestedStructures
     {
         public class ComplexType

--- a/Tests/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5;net472</TargetFrameworks>
+    <TargetFrameworks>net6;net472</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>

--- a/Tests/Benchmarks/CollectionEqual.cs
+++ b/Tests/Benchmarks/CollectionEqual.cs
@@ -8,7 +8,7 @@ namespace Benchmarks
 {
     [MemoryDiagnoser]
     [SimpleJob(RuntimeMoniker.Net472)]
-    [SimpleJob(RuntimeMoniker.Net50)]
+    [SimpleJob(RuntimeMoniker.Net60)]
     public class CollectionEqualBenchmarks
     {
         private IEnumerable<int> collection1;

--- a/Tests/Benchmarks/Issue1657.cs
+++ b/Tests/Benchmarks/Issue1657.cs
@@ -9,7 +9,7 @@ namespace Benchmarks
 {
     [MemoryDiagnoser]
     [SimpleJob(RuntimeMoniker.Net472)]
-    [SimpleJob(RuntimeMoniker.Net50)]
+    [SimpleJob(RuntimeMoniker.Net60)]
     public class Issue1657
     {
         private List<ExampleObject> list;

--- a/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
+++ b/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
@@ -2,7 +2,7 @@
 
   <!-- To reduce build times, we only enable analyzers for the newest TFM -->
   <PropertyGroup>
-    <TargetFrameworks>net47;net5.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net47;net6.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>
@@ -14,7 +14,7 @@
     <DebugType>full</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net5.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
     <RunAnalyzers>false</RunAnalyzers>
@@ -42,7 +42,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
@@ -61,7 +61,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/FluentAssertions.Specs/Common/TimeSpanExtensions.cs
+++ b/Tests/FluentAssertions.Specs/Common/TimeSpanExtensions.cs
@@ -3,7 +3,7 @@
 namespace FluentAssertions.Specs.Common
 {
     /// <summary>
-    /// Implements extensions to <see cref="TimeSpan"/> available in .NET Core 2, but not in .NET Framework.
+    /// Implements extensions to <see cref="TimeSpan"/> available in .NET Core 2+, but not in .NET Framework.
     /// </summary>
     public static class TimeSpanExtensions
     {

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -2,7 +2,7 @@
 
   <!-- To reduce build times, we only enable analyzers for the newest TFM -->
   <PropertyGroup>
-    <TargetFrameworks>net47;net5.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net47;net6.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>
@@ -14,7 +14,7 @@
     <DebugType>full</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net5.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
     <RunAnalyzers>false</RunAnalyzers>
@@ -46,7 +46,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
@@ -65,7 +65,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
+++ b/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>MSTestV2.Specs</RootNamespace>
     <AssemblyName>MSTestV2.Specs</AssemblyName>
     <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>

--- a/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
+++ b/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>MSpec.Specs</RootNamespace>
     <AssemblyName>MSpec.Specs</AssemblyName>
     <CodeAnalysisRuleSet>Rules.ruleset</CodeAnalysisRuleSet>

--- a/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
+++ b/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>NUnit3.Specs</RootNamespace>
     <AssemblyName>NUnit3.Specs</AssemblyName>
     <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>

--- a/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
+++ b/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net47;net5.0</TargetFrameworks>
+    <TargetFrameworks>net47;net6.0</TargetFrameworks>
     <RootNamespace>XUnit2.Specs</RootNamespace>
     <AssemblyName>XUnit2.Specs</AssemblyName>
     <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>

--- a/docs/_pages/about.md
+++ b/docs/_pages/about.md
@@ -39,7 +39,7 @@ will fail with:
 
 ## Supported Frameworks and Libraries
 
-Fluent Assertions cross-compiles to .NET Framework 4.7, as well as .NET Core 2.1 and 3.0, .NET Standard 2.0 and 2.1.
+Fluent Assertions cross-compiles to .NET Framework 4.7, as well as .NET Core 2.1 and 3.0, .NET 6, .NET Standard 2.0 and 2.1.
 
 Because of that Fluent Assertions supports the following minimum platforms.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@ intro:
      [<i class="fa fa-coffee"></i> Buy us a coffee](https://ko-fi.com/dennisdoomen){: .btn .btn--paypal}
      <br/>
      A very extensive set of extension methods that allow you to more naturally specify the expected outcome of a TDD or
-     BDD-style unit tests. Targets .NET Framework 4.7, as well as .NET Core 2.1, .NET Core 3.0, .NET Standard 2.0 and 2.1.'
+     BDD-style unit tests. Targets .NET Framework 4.7, as well as .NET Core 2.1, .NET Core 3.0, .NET 6, .NET Standard 2.0 and 2.1.'
 feature_row:
   - title: "Intention-Revealing Unit Tests"
     image_path: /assets/images/binoculars.svg
@@ -52,7 +52,7 @@ feature_row2:
   - title: "Feature Complete"
     image_path: /assets/images/checklist.svg
     excerpt: '
-Targets .NET 4.7, .NET Core 2.1, .Net Core  3.0, .NET Standard 2.0 and 2.1.
+Targets .NET 4.7, .NET Core 2.1, .Net Core  3.0, .NET 6, .NET Standard 2.0 and 2.1.
 Supports MSTest2, xUnit2, NUnit3, MSpec and NSpec3.
 '
   - title: "Great Support"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.200",
+        "version": "6.0.100",
         "rollForward": "latestMajor"
     }
 }


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

This PR adds a net6.0 which is a prerequisite to implement #1754.