### PR TITLE
Determine caller name for `EnumAssertions.Be`

### DIFF
--- a/Src/FluentAssertions/Primitives/EnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/EnumAssertions.cs
@@ -57,7 +57,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject?.Equals(expected) == true)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected the enum to be {0}{reason}, but found {1}.",
+                .FailWith("Expected {context:the enum} to be {0}{reason}, but found {1}.",
                     expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Primitives/NullableEnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableEnumAssertions.cs
@@ -42,7 +42,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:nullable date and time} to have a value{reason}, but found {0}.", Subject);
+                .FailWith("Expected {context:nullable enum} to have a value{reason}, but found {0}.", Subject);
 
             return new AndWhichConstraint<TAssertions, TEnum>((TAssertions)this, Subject.GetValueOrDefault());
         }
@@ -77,7 +77,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:nullable date and time} to have a value{reason}, but found {0}.", Subject);
+                .FailWith("Did not expect {context:nullable enum} to have a value{reason}, but found {0}.", Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Tests/FluentAssertions.Specs/Primitives/EnumAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/EnumAssertionSpecs.cs
@@ -169,7 +169,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*because we want to test the failure message*");
+                .WithMessage("*subject*because we want to test the failure message*");
         }
 
         [Theory]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,6 +14,7 @@ sidebar:
 * Added the ability to exclude fields & properties marked as non-browsable in the code editor from structural equality equivalency comparisons - [#1807](https://github.com/fluentassertions/fluentassertions/pull/1807)
 
 ### Fixes
+* `EnumAssertions.Be` did not determine the caller name - [#1835](https://github.com/fluentassertions/fluentassertions/pull/1835)
 
 ### Fixes (Extensibility)
 


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

Fixes #1832 