### PR TITLE
Ensure ExcludingMissingMembers doesn't undo usage of WithMapping

### DIFF
--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -376,12 +376,12 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Tries to match the members of the subject with equally named members on the expectation. Ignores those
-        /// members that don't exist on the expectation and previously registered matching rules.
+        /// Tries to match the members of the expectation with equally named members on the subject. Ignores those
+        /// members that don't exist on the subject and previously registered matching rules.
         /// </summary>
         public TSelf ExcludingMissingMembers()
         {
-            ClearMatchingRules();
+            matchingRules.RemoveAll(x => x is MustMatchByNameRule);
             matchingRules.Add(new TryMatchByNameRule());
             return (TSelf)this;
         }
@@ -391,7 +391,7 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         public TSelf ThrowingOnMissingMembers()
         {
-            ClearMatchingRules();
+            matchingRules.RemoveAll(x => x is TryMatchByNameRule);
             matchingRules.Add(new MustMatchByNameRule());
             return (TSelf)this;
         }
@@ -463,7 +463,7 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         public void WithoutMatchingRules()
         {
-            ClearMatchingRules();
+            matchingRules.Clear();
         }
 
         /// <summary>
@@ -844,12 +844,7 @@ namespace FluentAssertions.Equivalency
         {
             selectionRules.RemoveAll(selectionRule => selectionRule is T);
         }
-
-        private void ClearMatchingRules()
-        {
-            matchingRules.Clear();
-        }
-
+        
         protected TSelf AddSelectionRule(IMemberSelectionRule selectionRule)
         {
             selectionRules.Add(selectionRule);

--- a/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
@@ -429,6 +429,52 @@ namespace FluentAssertions.Equivalency.Specs
                 .WithMessage("*does not have member NonExistingProperty*");
         }
 
+        [Fact]
+        public void Exclusion_of_missing_members_works_with_mapping()
+        {
+            // Arrange
+            var subject = new
+            {
+                Property1 = 1
+            };
+
+            var expectation = new
+            {
+                Property2 = 2, 
+                Ignore = 3
+            };
+
+            // Act / Assert
+            subject.Should()
+                .NotBeEquivalentTo(expectation, opt => opt
+                    .WithMapping("Property2", "Property1")
+                    .ExcludingMissingMembers()
+                );
+        }
+
+        [Fact]
+        public void Mapping_works_with_exclusion_of_missing_members()
+        {
+            // Arrange
+            var subject = new
+            {
+                Property1 = 1
+            };
+
+            var expectation = new
+            {
+                Property2 = 2, 
+                Ignore = 3
+            };
+
+            // Act / Assert
+            subject.Should()
+                .NotBeEquivalentTo(expectation, opt => opt
+                    .ExcludingMissingMembers()
+                    .WithMapping("Property2", "Property1")
+                );
+        }
+
         internal class ParentOfExpectationWithProperty2
         {
             public ExpectationWithProperty2[] Parent { get; }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -15,6 +15,7 @@ sidebar:
 
 ### Fixes
 * `EnumAssertions.Be` did not determine the caller name - [#1835](https://github.com/fluentassertions/fluentassertions/pull/1835)
+* Ensure `ExcludingMissingMembers` doesn't undo usage of `WithMapping` in `BeEquivalentTo` - [#1838](https://github.com/fluentassertions/fluentassertions/pull/1838)
 
 ### Fixes (Extensibility)
 


### PR DESCRIPTION
The option `ExcludingMissingMembers` tries to undo what `ThrowingOnMissingMembers` does and vice-versa by clearing out all matching rules. However, by doing that, it would also remove any `MappedPathMatchingRule` instances that were added by using the `WithMapping` method. This has been fixed.

Fixes #1828 

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).