### PR TITLE
Adds test for string collection equivalency

### DIFF
--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1459,6 +1459,17 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
+        public void When_two_arrays_contain_the_same_elements_it_should_treat_them_as_equivalent()
+        {
+            // Arrange
+            string[] array1 = new[] { "one", "two", "three" };
+            string[] array2 = new[] { "three", "two", "one" };
+
+            // Act / Assert
+            array1.Should().BeEquivalentTo(array2);
+        }
+
+        [Fact]
         public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_throw_with_a_clear_explanation()
         {
             // Act


### PR DESCRIPTION
Adds a test for string collection. Arrays were not tested.
Related to #1823

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).