### PR TITLE
Remove constructor parameter for NullableDateOnlyAssertions

### DIFF
--- a/Src/FluentAssertions/Primitives/NullableDateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateOnlyAssertions.cs
@@ -12,8 +12,8 @@ namespace FluentAssertions.Primitives
     [DebuggerNonUserCode]
     public class NullableDateOnlyAssertions : NullableDateOnlyAssertions<NullableDateOnlyAssertions>
     {
-        public NullableDateOnlyAssertions(DateOnly? expected)
-            : base(expected)
+        public NullableDateOnlyAssertions(DateOnly? value)
+            : base(value)
         {
         }
     }
@@ -25,8 +25,8 @@ namespace FluentAssertions.Primitives
     public class NullableDateOnlyAssertions<TAssertions> : DateOnlyAssertions<TAssertions>
         where TAssertions : NullableDateOnlyAssertions<TAssertions>
     {
-        public NullableDateOnlyAssertions(DateOnly? expected)
-            : base(expected)
+        public NullableDateOnlyAssertions(DateOnly? value)
+            : base(value)
         {
         }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2003,12 +2003,12 @@ namespace FluentAssertions.Primitives
     }
     public class NullableDateOnlyAssertions : FluentAssertions.Primitives.NullableDateOnlyAssertions<FluentAssertions.Primitives.NullableDateOnlyAssertions>
     {
-        public NullableDateOnlyAssertions(System.DateOnly? expected) { }
+        public NullableDateOnlyAssertions(System.DateOnly? value) { }
     }
     public class NullableDateOnlyAssertions<TAssertions> : FluentAssertions.Primitives.DateOnlyAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.NullableDateOnlyAssertions<TAssertions>
     {
-        public NullableDateOnlyAssertions(System.DateOnly? expected) { }
+        public NullableDateOnlyAssertions(System.DateOnly? value) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }


### PR DESCRIPTION
Unreleased, so not yet a breaking change to rename constructor parameters.