### PR TITLE
Improve code coverage of fake should overloads

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq.Expressions;
 using System.Net.Http;
@@ -999,6 +1000,7 @@ namespace FluentAssertions
             InvalidShouldCall();
         }
 
+        [DoesNotReturn]
         private static void InvalidShouldCall()
         {
             throw new InvalidOperationException("You are asserting the 'AndConstraint' itself. Remove the 'Should()' method directly following 'And'.");

--- a/Src/FluentAssertions/DoesNotReturnAttribute.cs
+++ b/Src/FluentAssertions/DoesNotReturnAttribute.cs
@@ -1,0 +1,18 @@
+﻿// copied from https://source.dot.net/#System.Private.CoreLib/NullableAttributes.cs
+#if !(NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER)
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DoesNotReturnAttribute : Attribute
+    {
+    }
+}
+#endif

--- a/Src/FluentAssertions/Execution/FallbackTestFramework.cs
+++ b/Src/FluentAssertions/Execution/FallbackTestFramework.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace FluentAssertions.Execution
 {
     /// <summary>
@@ -13,6 +15,7 @@ namespace FluentAssertions.Execution
         /// <summary>
         /// Throws a framework-specific exception to indicate a failing unit test.
         /// </summary>
+        [DoesNotReturn]
         public void Throw(string message)
         {
             throw new AssertionFailedException(message);

--- a/Src/FluentAssertions/Execution/ITestFramework.cs
+++ b/Src/FluentAssertions/Execution/ITestFramework.cs
@@ -1,4 +1,6 @@
-﻿namespace FluentAssertions.Execution
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace FluentAssertions.Execution
 {
     /// <summary>
     /// Represents an abstraction of a particular test framework such as MSTest, nUnit, etc.
@@ -13,6 +15,7 @@
         /// <summary>
         /// Throws a framework-specific exception to indicate a failing unit test.
         /// </summary>
+        [DoesNotReturn]
         void Throw(string message);
     }
 }

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -8,6 +9,7 @@ namespace FluentAssertions.Execution
     {
         private Assembly assembly;
 
+        [DoesNotReturn]
         public void Throw(string message)
         {
             Type exceptionType = assembly.GetType(ExceptionFullName);

--- a/Src/FluentAssertions/Execution/NSpecFramework.cs
+++ b/Src/FluentAssertions/Execution/NSpecFramework.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -27,6 +28,7 @@ namespace FluentAssertions.Execution
             }
         }
 
+        [DoesNotReturn]
         public void Throw(string message)
         {
             Type exceptionType = assembly.GetType("NSpec.Domain.AssertionException");

--- a/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
+++ b/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using FluentAssertions.Common;
 
@@ -22,6 +23,7 @@ namespace FluentAssertions.Execution
 
         #endregion
 
+        [DoesNotReturn]
         public static void Throw(string message)
         {
             if (testFramework is null)

--- a/Src/FluentAssertions/Execution/XUnit2TestFramework.cs
+++ b/Src/FluentAssertions/Execution/XUnit2TestFramework.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace FluentAssertions.Execution
@@ -25,6 +26,7 @@ namespace FluentAssertions.Execution
             }
         }
 
+        [DoesNotReturn]
         public void Throw(string message)
         {
             Type exceptionType = assembly.GetType("Xunit.Sdk.XunitException");

--- a/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using FluentAssertions.Numeric;
+using FluentAssertions.Primitives;
+using FluentAssertions.Specialized;
 using FluentAssertions.Types;
 using Xunit;
 
@@ -32,6 +35,49 @@ namespace FluentAssertions.Specs
             return equals is not null;
         }
 
+        [Theory]
+        [InlineData(typeof(ReferenceTypeAssertions<object, ObjectAssertions>))]
+        [InlineData(typeof(BooleanAssertions<BooleanAssertions>))]
+        [InlineData(typeof(DateTimeAssertions<DateTimeAssertions>))]
+        [InlineData(typeof(DateTimeOffsetAssertions<DateTimeOffsetAssertions>))]
+#if NET6_0_OR_GREATER
+        [InlineData(typeof(DateOnlyAssertions<DateOnlyAssertions>))]
+#endif
+        [InlineData(typeof(ExecutionTimeAssertions))]
+        [InlineData(typeof(GuidAssertions<GuidAssertions>))]
+        [InlineData(typeof(MethodInfoSelectorAssertions))]
+        [InlineData(typeof(NumericAssertions<int, NumericAssertions<int>>))]
+        [InlineData(typeof(PropertyInfoSelectorAssertions))]
+        [InlineData(typeof(SimpleTimeSpanAssertions<SimpleTimeSpanAssertions>))]
+        [InlineData(typeof(TaskCompletionSourceAssertions<int>))]
+        [InlineData(typeof(TypeSelectorAssertions))]
+        [InlineData(typeof(EnumAssertions<StringComparison, EnumAssertions<StringComparison>>))]
+        public void Fake_should_method_throws(Type type)
+        {
+            // Arrange
+            MethodInfo fakeOverload = AllTypes.From(typeof(FluentAssertions.AssertionExtensions).Assembly)
+                .ThatAreClasses()
+                .ThatAreStatic()
+                .Where(t => t.IsPublic)
+                .SelectMany(t => t.GetMethods(BindingFlags.Static | BindingFlags.Public))
+                .Single(m => m.Name == "Should" && IsGuardOverload(m)
+                    && m.GetParameters().Single().ParameterType.Name == type.Name);
+
+            if (type.IsConstructedGenericType)
+            {
+                fakeOverload = fakeOverload.MakeGenericMethod(type.GenericTypeArguments);
+            }
+
+            // Act
+            Action act = () => fakeOverload.Invoke(null, new object[] { null });
+
+            // Assert
+            act.Should()
+                .ThrowExactly<TargetInvocationException>()
+                .WithInnerExceptionExactly<InvalidOperationException>()
+                .WithMessage("You are asserting the 'AndConstraint' itself. Remove the 'Should()' method directly following 'And'.");
+        }
+
         [Fact]
         public void Should_methods_have_a_matching_overload_to_guard_against_chaining_and_constraints()
         {
@@ -58,7 +104,8 @@ namespace FluentAssertions.Specs
             // Assert
             fakeOverloads.Should().BeEquivalentTo(realOverloads, opt => opt
                 .Using<Type>(ctx => ctx.Subject.Name.Should().Be(ctx.Expectation.Name))
-                .WhenTypeIs<Type>());
+                .WhenTypeIs<Type>(),
+                "AssertionExtensions.cs should have a guard overload of Should calling InvalidShouldCall()");
         }
 
         private static bool IsGuardOverload(MethodInfo m) =>


### PR DESCRIPTION
This PR adds tests covering the fake `Should` overloads.

I first aimed for test that would find all the relevant types itself, but even before reaching that goal the test became quite unreadable.
So went with a `Theory`, which should be manageable for contributors, as `Should_methods_have_a_matching_overload_to_guard_against_chaining_and_constraints` will complain about missing `Should` overloads.

Thanks to @eNeRGy164 for the inspiration.