### PR TITLE
Fix A_NaN_is_never_in_range_of_two_doubles

### DIFF
--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -189,7 +189,7 @@ namespace FluentAssertions.Numeric
             {
                 throw new ArgumentException("A value can never be less than NaN", nameof(expected));
             }
-           
+
             Execute.Assertion
                 .ForCondition(Subject.HasValue && !IsNaN(Subject.Value) && Subject.Value.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
@@ -216,7 +216,7 @@ namespace FluentAssertions.Numeric
             {
                 throw new ArgumentException("A value can never be less than or equal to NaN", nameof(expected));
             }
-            
+
             Execute.Assertion
                 .ForCondition(Subject.HasValue && !IsNaN(Subject.Value) && Subject.Value.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
@@ -273,7 +273,7 @@ namespace FluentAssertions.Numeric
             {
                 throw new ArgumentException("A value can never be greater than or equal to a NaN", nameof(expected));
             }
-            
+
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)
@@ -309,9 +309,9 @@ namespace FluentAssertions.Numeric
         {
             if (IsNaN(minimumValue) || IsNaN(maximumValue))
             {
-                throw new ArgumentException("A range cannot begin or end with NaN");  
+                throw new ArgumentException("A range cannot begin or end with NaN");
             }
-            
+
             Execute.Assertion
                 .ForCondition(Subject.HasValue && (Subject.Value.CompareTo(minimumValue) >= 0) && (Subject.Value.CompareTo(maximumValue) <= 0))
                 .BecauseOf(because, becauseArgs)
@@ -347,7 +347,7 @@ namespace FluentAssertions.Numeric
             {
                 throw new ArgumentException("A range cannot begin or end with NaN");
             }
-            
+
             Execute.Assertion
                 .ForCondition(Subject.HasValue && !((Subject.Value.CompareTo(minimumValue) >= 0) && (Subject.Value.CompareTo(maximumValue) <= 0)))
                 .BecauseOf(because, becauseArgs)
@@ -480,6 +480,6 @@ namespace FluentAssertions.Numeric
         public override bool Equals(object obj) =>
             throw new NotSupportedException("Calling Equals on Assertion classes is not supported.");
 
-        private protected virtual bool IsNaN(T value) => false; 
+        private protected virtual bool IsNaN(T value) => false;
     }
 }

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -678,7 +678,7 @@ namespace FluentAssertions.Specs.Numeric
                     .Should().Throw<XunitException>()
                     .WithMessage("Expected value to be greater than 3 because we want to test the failure message, but found 2.");
             }
-            
+
             [Fact]
             public void NaN_is_never_greater_than_another_float()
             {
@@ -1198,7 +1198,7 @@ namespace FluentAssertions.Specs.Numeric
             public void A_NaN_is_never_in_range_of_two_doubles()
             {
                 // Arrange
-                float value = float.NaN;
+                double value = double.NaN;
 
                 // Act
                 Action act = () => value.Should().BeInRange(4, 5);


### PR DESCRIPTION
This wasn't caught be code coverage as `BeInRange` is generic and the paths were already covered by `float`.