### PR TITLE
WithMapping now works in equivalency assertions on collections

### DIFF
--- a/Src/FluentAssertions/Common/MemberPath.cs
+++ b/Src/FluentAssertions/Common/MemberPath.cs
@@ -96,6 +96,14 @@ namespace FluentAssertions.Common
         /// </summary>
         public bool GetContainsSpecificCollectionIndex() => dottedPath.ContainsSpecificCollectionIndex();
 
+        /// <summary>
+        /// Returns a copy of the current object as if it represented an un-indexed item in a collection.
+        /// </summary>
+        public MemberPath WithCollectionAsRoot()
+        {
+            return new MemberPath(reflectedType, declaringType, "[]." + dottedPath);
+        }
+
         private string[] Segments => segments ??= dottedPath.Split(new[] { '.', '[', ']' }, StringSplitOptions.RemoveEmptyEntries);
 
         /// <summary>

--- a/Src/FluentAssertions/Equivalency/Matching/MappedPathMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedPathMatchingRule.cs
@@ -35,7 +35,13 @@ namespace FluentAssertions.Equivalency.Matching
 
         public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions options)
         {
-            if (expectationPath.IsEquivalentTo(expectedMember.PathAndName))
+            MemberPath path = expectationPath;
+            if (expectedMember.RootIsCollection)
+            {
+                path = path.WithCollectionAsRoot();
+            }
+            
+            if (path.IsEquivalentTo(expectedMember.PathAndName))
             {
                 var member = MemberFactory.Find(subject, subjectPath.MemberName, expectedMember.Type, parent);
                 if (member is null)

--- a/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
@@ -475,6 +475,44 @@ namespace FluentAssertions.Equivalency.Specs
                 );
         }
 
+        [Fact]
+        public void Can_map_members_of_a_root_collection()
+        {
+            // Arrange
+            var entity = new Entity
+            {
+                EntityId = 1,
+                Name = "Test"
+            };
+            
+            var dto = new EntityDto
+            {
+                Id = 1,
+                Name = "Test"
+            };
+          
+            var entityCol = new[] { entity };
+            var dtoCol = new[] { dto };
+
+            // Act / Assert
+            dtoCol.Should().BeEquivalentTo(entityCol, c =>
+                c.WithMapping<EntityDto>(s => s.EntityId, d => d.Id));
+        }
+
+        private class Entity
+        {
+            public int EntityId { get; init; }
+
+            public string Name { get; init; }
+        }
+
+        private class EntityDto
+        {
+            public int Id { get; init; }
+
+            public string Name { get; init; }
+        }
+
         internal class ParentOfExpectationWithProperty2
         {
             public ExpectationWithProperty2[] Parent { get; }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,6 +18,7 @@ sidebar:
 * `EnumAssertions.Be` did not determine the caller name - [#1835](https://github.com/fluentassertions/fluentassertions/pull/1835)
 * Ensure `ExcludingMissingMembers` doesn't undo usage of `WithMapping` in `BeEquivalentTo` - [#1838](https://github.com/fluentassertions/fluentassertions/pull/1838)
 * Better handling of NaN in various numeric assertions - [#1822](https://github.com/fluentassertions/fluentassertions/pull/1822)
+* `WithMapping` in `BeEquivalentTo` now also works when the root is a collection - [#1858](https://github.com/fluentassertions/fluentassertions/pull/1858)
 
 ### Fixes (Extensibility)
 


### PR DESCRIPTION
`WithMapping` did not take into account that when you compare two collections using `Should().BeEquivalentTo`, a slightly different path in the code-base is taken. 

This fixes #1840 

