### PR TITLE
[WIP] Add WithStrictTyping options

### DIFF
--- a/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
@@ -161,6 +161,11 @@ namespace FluentAssertions.Equivalency
 
             return this;
         }
+
+        public EquivalencyAssertionOptions<TExpectation> WithStrictTyping()
+        {
+            return this;
+        }
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/Steps/TypeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/TypeEquivalencyStep.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency.Steps
+{
+    /// <summary>
+    /// A equivalency step for Fluent Assertions that asserts an object must be the same type to be equivalent.
+    /// This differs from Fluent Assertions default equivalency assertion that states 2 objects are equivalent if the have the same properties and values, reguardless of type.
+    /// Useful when working with polymorphic models that may or may not have inner properties. - https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/object-oriented/polymorphism
+    /// </summary>
+    public class TypeEquivalencyStep : IEquivalencyStep
+    {
+        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+        {
+            // When comparing using a collection we want to compare the children of the collection not the collection itself (the root object)
+            // Value Types should be directly compared otherwise `GetSelectedMembers(comparands, context).Any()` will return false and skip actual value checking
+            if (comparands.Subject is IEnumerable || comparands.RuntimeType.IsValueType)
+            {
+                return EquivalencyResult.ContinueWithNext;
+            }
+
+            // If both are null or same reference or are comparable, no need to have this step check anything
+            if (comparands.Subject == comparands.Expectation)
+            {
+                return EquivalencyResult.ContinueWithNext;
+            }
+
+            // The above checked if both were null, if only 1 is null then no need to have this step check anything
+            if (comparands.Subject == null || comparands.Expectation == null)
+            {
+                return EquivalencyResult.ContinueWithNext;
+            }
+
+            Type expectedType = comparands.GetExpectedType(context.Options);
+            
+            Execute.Assertion
+                .ForCondition(comparands.Subject.GetType() == expectedType)
+                .FailWith("Expected {context:subject} to be of type {0}, but found {1}", expectedType, comparands.Subject.GetType());
+
+            return EquivalencyResult.ContinueWithNext;
+        }
+
+        /// <summary>
+        /// The members (fields and properties) on the context subject that is used to compare structural equivalency.
+        /// </summary>
+        private static IEnumerable<IMember> GetSelectedMembers(Comparands comparands, IEquivalencyValidationContext context)
+        {
+            IEnumerable<IMember> members = Enumerable.Empty<IMember>();
+
+            foreach (IMemberSelectionRule selectionRule in context.Options.SelectionRules)
+            {
+                members = selectionRule.SelectMembers(context.CurrentNode, members, new MemberSelectionContext(comparands.CompileTimeType, comparands.RuntimeType, context.Options));
+            }
+
+            return members;
+        }
+    }
+}

--- a/Src/FluentAssertions/EquivalencyPlan.cs
+++ b/Src/FluentAssertions/EquivalencyPlan.cs
@@ -115,6 +115,7 @@ namespace FluentAssertions
             {
                 new RunAllUserStepsEquivalencyStep(),
                 new AutoConversionStep(),
+                new TypeEquivalencyStep(),
                 new ReferenceEqualityEquivalencyStep(),
                 new GenericDictionaryEquivalencyStep(),
                 new DataSetEquivalencyStep(),

--- a/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
+++ b/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
@@ -3,7 +3,7 @@
   <!-- To reduce build times, we only enable analyzers for the newest TFM -->
   <PropertyGroup>
     <TargetFrameworks>net47;net6.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>

--- a/Tests/FluentAssertions.Equivalency.Specs/TypeEqualitySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TypeEqualitySpecs.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Equivalency.Specs;
+
+[SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1512:Single-line comments should not be followed by blank line")]
+public class TypeEqualitySpecs
+{
+    // TODO: nested run-time type doesn't match
+    // TODO: nested compile-time type doesn't match
+    // TODO: top-level doesn't match, but strict typing is only enabled for a nested type that doesn't match
+    // TODO: top-level doesn't match, but strict typing is only enabled for a nested type that does match
+    // TODO: strict typing for top-level type, but not for the rest and the run-time type of a nested type mismatches
+    // TODO: global strict typing is enabled, but disabled for a particular test case
+    // TODO: global strict typing is enabled for a particular type, but disabled for a particular test case
+
+    [Fact]
+    public void Throws_when_top_level_types_are_expected_to_match()
+    {
+        // Arrange
+        var subject = new FooWithNestedClass();
+        
+        var expectation = new BarWithNested();
+
+        // Act 
+        Action act = () => subject.Should().BeEquivalentTo(expectation, x => x.WithStrictTyping());
+        
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expect subject to be of type BarWithNested, but found FooWithNestedClass");
+    }
+
+    [Fact]
+    public void Throws_when_nested_runtime_types_are_expected_to_match()
+    {
+        // Arrange
+        var subject = new FooWithNestedClass();
+        
+        var expectation = new BarWithNested();
+
+        // Act 
+        Action act = () => subject.Should().BeEquivalentTo(expectation, x => x.WithStrictTypingFor(x => x.Nested));
+        
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expect subject to be of type BarWithNested, but found FooWithNestedClass");
+    }
+
+    
+    private class FooWithNestedClass
+    {
+        public Nested Nested { get; set; }
+    }
+
+    private class BarWithNested
+    {
+        public Nested Nested { get; set; }
+    }
+
+    private class Nested
+    {
+    }
+    
+    private class NestedSubtype
+    {
+        
+    }
+}

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -234,6 +234,31 @@ orderDto.Should().BeEquivalentTo(order, options => options
     .WhenTypeIs<DateTime>());
 ```
 
+If working with polymorphic models where equality is often not needed by default but asserting the correct type is needed you can use the `TypeEquivalencyStep`.
+
+```csharp
+abstract class OrderStatus
+{
+    class OrderPlaced : Status {}
+    class OrderProcessing : Status {}
+    class Error : Status 
+    {
+        Exception Exception { get; }
+    }
+    class Success : Status 
+    {
+        string ConfirmationCode { get; }
+    }
+}
+
+orderStatusUpdates // new List<Status>{}
+    .Should()
+    .BeInOrderSameTypeEquivalentTo(
+        new Status.Placed(), 
+        new Status.OrderProcessing(), 
+        new Status.Success(confirmationCode: "Aj-78"));
+```
+
 ### Enums
 
 By default, `Should().BeEquivalentTo()` compares `Enum` members by the enum's underlying numeric value.

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,7 @@ sidebar:
 * Annotated `[Not]MatchRegex(string)` with `[StringSyntax("Regex")]` which IDEs can use to colorize the regular expression argument - [#1816](https://github.com/fluentassertions/fluentassertions/pull/1816)
 * Added support for .NET6 `DateOnly` struct - [#1844](https://github.com/fluentassertions/fluentassertions/pull/1844)
 * Added support for .NET6 `TimeOnly` struct - [#1848](https://github.com/fluentassertions/fluentassertions/pull/1848)
+* Added `TypeEquivalencyStep` for asserting types are equal when asserting equivalency. Useful when working with polymorphic models that do not implement equality. - [#1704](https://github.com/fluentassertions/fluentassertions/pull/1704)
 
 ### Fixes
 * `EnumAssertions.Be` did not determine the caller name - [#1835](https://github.com/fluentassertions/fluentassertions/pull/1835)


### PR DESCRIPTION
Closes #798

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

Copilot:all