### PR TITLE
Better handling of NaN in nullable numeric assertions

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -686,7 +686,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<float> Should(this float? actualValue)
         {
-            return new NullableNumericAssertions<float>(actualValue);
+            return new NullableFloatAssertions(actualValue);
         }
 
         /// <summary>
@@ -706,7 +706,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<double> Should(this double? actualValue)
         {
-            return new NullableNumericAssertions<double>(actualValue);
+            return new NullableDoubleAssertions(actualValue);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Numeric/NullableDoubleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableDoubleAssertions.cs
@@ -1,0 +1,12 @@
+﻿namespace FluentAssertions.Numeric
+{
+    internal class NullableDoubleAssertions : NullableNumericAssertions<double>
+    {
+        public NullableDoubleAssertions(double? value)
+            : base(value)
+        {
+        }
+
+        private protected override bool IsNaN(double value) => double.IsNaN(value);
+    }
+}

--- a/Src/FluentAssertions/Numeric/NullableFloatAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableFloatAssertions.cs
@@ -1,0 +1,12 @@
+﻿namespace FluentAssertions.Numeric
+{
+    internal class NullableFloatAssertions : NullableNumericAssertions<float>
+    {
+        public NullableFloatAssertions(float? value)
+            : base(value)
+        {
+        }
+
+        private protected override bool IsNaN(float value) => float.IsNaN(value);
+    }
+}

--- a/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.cs
@@ -6,6 +6,444 @@ namespace FluentAssertions.Specs.Numeric
 {
     public class NullableNumericAssertionSpecs
     {
+        public class BePositive
+        {
+            [Fact]
+            public void NaN_is_never_a_positive_float()
+            {
+                // Arrange
+                float? value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().BePositive();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*but found NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_a_positive_double()
+            {
+                // Arrange
+                double? value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().BePositive();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*but found NaN*");
+            }
+        }
+
+        public class BeNegative
+        {
+            [Fact]
+            public void NaN_is_never_a_negative_float()
+            {
+                // Arrange
+                float? value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().BeNegative();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*but found NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_a_negative_double()
+            {
+                // Arrange
+                double? value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().BeNegative();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*but found NaN*");
+            }
+        }
+
+        public class BeLessThan
+        {
+            [Fact]
+            public void A_float_can_never_be_less_than_NaN()
+            {
+                // Arrange
+                float? value = 3.4F;
+
+                // Act
+                Action act = () => value.Should().BeLessThan(float.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_less_than_another_float()
+            {
+                // Arrange
+                float? value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().BeLessThan(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_double_can_never_be_less_than_NaN()
+            {
+                // Arrange
+                double? value = 3.4F;
+
+                // Act
+                Action act = () => value.Should().BeLessThan(double.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_less_than_another_double()
+            {
+                // Arrange
+                double? value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().BeLessThan(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+        }
+
+        public class BeGreaterThan
+        {
+            [Fact]
+            public void A_float_can_never_be_greater_than_NaN()
+            {
+                // Arrange
+                float? value = 3.4F;
+
+                // Act
+                Action act = () => value.Should().BeGreaterThan(float.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_greater_than_another_float()
+            {
+                // Arrange
+                float? value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().BeGreaterThan(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_double_can_never_be_greater_than_NaN()
+            {
+                // Arrange
+                double? value = 3.4F;
+
+                // Act
+                Action act = () => value.Should().BeGreaterThan(double.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_greater_than_another_double()
+            {
+                // Arrange
+                double? value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().BeGreaterThan(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+        }
+
+        public class BeLessThanOrEqualTo
+        {
+            [Fact]
+            public void A_float_can_never_be_less_than_or_equal_to_NaN()
+            {
+                // Arrange
+                float? value = 3.4F;
+
+                // Act
+                Action act = () => value.Should().BeLessThanOrEqualTo(float.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_less_than_or_equal_to_another_float()
+            {
+                // Arrange
+                float? value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().BeLessThanOrEqualTo(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_double_can_never_be_less_than_or_equal_to_NaN()
+            {
+                // Arrange
+                double? value = 3.4;
+
+                // Act
+                Action act = () => value.Should().BeLessThanOrEqualTo(double.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_less_than_or_equal_to_another_double()
+            {
+                // Arrange
+                double? value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().BeLessThanOrEqualTo(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+        }
+
+        public class BeGreaterThanOrEqualTo
+        {
+            [Fact]
+            public void A_float_can_never_be_greater_than_or_equal_to_NaN()
+            {
+                // Arrange
+                float? value = 3.4F;
+
+                // Act
+                Action act = () => value.Should().BeGreaterThanOrEqualTo(float.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_greater_than_or_equal_to_another_float()
+            {
+                // Arrange
+                float? value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().BeGreaterThanOrEqualTo(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void A_double_can_never_be_greater_than_or_equal_to_NaN()
+            {
+                // Arrange
+                double? value = 3.4;
+
+                // Act
+                Action act = () => value.Should().BeGreaterThanOrEqualTo(double.NaN);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_greater_than_or_equal_to_another_double()
+            {
+                // Arrange
+                double? value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().BeGreaterThanOrEqualTo(0);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*NaN*");
+            }
+        }
+
+        public class BeInRange
+        {
+            [Theory]
+            [InlineData(float.NaN, 5F)]
+            [InlineData(5F, float.NaN)]
+            public void A_float_can_never_be_in_a_range_containing_NaN(float minimumValue, float maximumValue)
+            {
+                // Arrange
+                float? value = 4.5F;
+
+                // Act
+                Action act = () => value.Should().BeInRange(minimumValue, maximumValue);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage(
+                        "*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_in_range_of_two_floats()
+            {
+                // Arrange
+                float? value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().BeInRange(4, 5);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected value to be between*4* and*5*, but found*NaN*");
+            }
+
+            [Theory]
+            [InlineData(double.NaN, 5)]
+            [InlineData(5, double.NaN)]
+            public void A_double_can_never_be_in_a_range_containing_NaN(double minimumValue, double maximumValue)
+            {
+                // Arrange
+                double? value = 4.5;
+
+                // Act
+                Action act = () => value.Should().BeInRange(minimumValue, maximumValue);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage(
+                        "*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_in_range_of_two_doubles()
+            {
+                // Arrange
+                double? value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().BeInRange(4, 5);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected value to be between*4* and*5*, but found*NaN*");
+            }
+        }
+
+        public class NotBeInRange
+        {
+            [Theory]
+            [InlineData(float.NaN, 1F)]
+            [InlineData(1F, float.NaN)]
+            public void Cannot_use_NaN_in_a_range_of_floats(float minimumValue, float maximumValue)
+            {
+                // Arrange
+                float? value = 4.5F;
+
+                // Act
+                Action act = () => value.Should().NotBeInRange(minimumValue, maximumValue);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_inside_any_range_of_floats()
+            {
+                // Arrange
+                float? value = float.NaN;
+
+                // Act / Assert
+                value.Should().NotBeInRange(4, 5);
+            }
+
+            [Theory]
+            [InlineData(double.NaN, 1D)]
+            [InlineData(1D, double.NaN)]
+            public void Cannot_use_NaN_in_a_range_of_doubles(double minimumValue, double maximumValue)
+            {
+                // Arrange
+                double? value = 4.5D;
+
+                // Act
+                Action act = () => value.Should().NotBeInRange(minimumValue, maximumValue);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("*NaN*");
+            }
+
+            [Fact]
+            public void NaN_is_never_inside_any_range_of_doubles()
+            {
+                // Arrange
+                double? value = double.NaN;
+
+                // Act / Assert
+                value.Should().NotBeInRange(4, 5);
+            }
+        }
+
         public class HaveValue
         {
             [Fact]
@@ -221,6 +659,57 @@ namespace FluentAssertions.Specs.Numeric
                 // Assert
                 act.Should().Throw<XunitException>()
                     .WithMessage("Expected*2 because we want to test the failure message, but found 1.");
+            }
+
+            [Fact]
+            public void Nan_is_never_equal_to_a_normal_float()
+            {
+                // Arrange
+                float? value = float.NaN;
+
+                // Act
+                Action act = () => value.Should().Be(3.4F);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected value to be *3.4F, but found NaN*");
+            }
+
+            [Fact]
+            public void NaN_can_be_compared_to_NaN_when_its_a_float()
+            {
+                // Arrange
+                float? value = float.NaN;
+
+                // Act
+                value.Should().Be(float.NaN);
+            }
+
+            [Fact]
+            public void Nan_is_never_equal_to_a_normal_double()
+            {
+                // Arrange
+                double? value = double.NaN;
+
+                // Act
+                Action act = () => value.Should().Be(3.4D);
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected value to be *3.4, but found NaN*");
+            }
+
+            [Fact]
+            public void NaN_can_be_compared_to_NaN_when_its_a_double()
+            {
+                // Arrange
+                double? value = double.NaN;
+
+                // Act
+                value.Should().Be(double.NaN);
             }
         }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,7 +17,7 @@ sidebar:
 ### Fixes
 * `EnumAssertions.Be` did not determine the caller name - [#1835](https://github.com/fluentassertions/fluentassertions/pull/1835)
 * Ensure `ExcludingMissingMembers` doesn't undo usage of `WithMapping` in `BeEquivalentTo` - [#1838](https://github.com/fluentassertions/fluentassertions/pull/1838)
-* Better handling of NaN in various numeric assertions - [#1822](https://github.com/fluentassertions/fluentassertions/pull/1822)
+* Better handling of NaN in various numeric assertions - [#1822](https://github.com/fluentassertions/fluentassertions/pull/1822) & [#1867](https://github.com/fluentassertions/fluentassertions/pull/1867)
 * `WithMapping` in `BeEquivalentTo` now also works when the root is a collection - [#1858](https://github.com/fluentassertions/fluentassertions/pull/1858)
 
 ### Fixes (Extensibility)


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

I noticed that #1859 had to add `NullableFloatAssertions`/`NullableDoubleAssertions`, so I suspected that #1822 might not cover all cases for `float?` and `double?`.

This PR ensures that `NumericAssertions.IsNaN` is overridden for `float?` and `double?`.

The tests are copied from #1822 