### PR TITLE
Added a new overload to `MatchRegex()` to assert on the number of regex matches

### DIFF
--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -387,14 +387,40 @@ namespace FluentAssertions.Primitives
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
+        /// <summary>
+        /// Asserts that a string matches a regular expression with expected occurrence
+        /// </summary>
+        /// <param name="regularExpression">
+        /// The regular expression with which the subject is matched.
+        /// </param>
+        /// <param name="occurrenceConstraint">
+        /// The excpected occurences of regex matches
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
         public AndConstraint<TAssertions> MatchRegex([RegexPattern][StringSyntax("Regex")] string regularExpression,
             OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
         {
-            MatchRegex(regularExpression, because, becauseArgs);
+            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
 
-            MatchRegex(new Regex(regularExpression), occurrenceConstraint, because, becauseArgs);
+            Regex regex;
+            try
+            {
+                regex = new Regex(regularExpression);
+            }
+            catch (ArgumentException)
+            {
+                Execute.Assertion.FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.",
+                    regularExpression);
+                return new AndConstraint<TAssertions>((TAssertions)this);
+            }
 
-            return new AndConstraint<TAssertions>((TAssertions)this);
+            return MatchRegex(regex, occurrenceConstraint, because, becauseArgs);
         }
 
         /// <summary>
@@ -430,17 +456,53 @@ namespace FluentAssertions.Primitives
             return MatchRegex(regex, because, becauseArgs);
         }
 
+        /// <summary>
+        /// Asserts that a string matches a regular expression with expected occurrence
+        /// </summary>
+        /// <param name="regularExpression">
+        /// The regular expression with which the subject is matched.
+        /// </param>
+        /// <param name="occurrenceConstraint">
+        /// The excpected occurences of regex matches
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
         public AndConstraint<TAssertions> MatchRegex(Regex regularExpression,
             OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
         {
-            int actual = regularExpression.Matches(Subject).Count;
+            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression),
+                    "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
 
-            Execute.Assertion
-                .ForConstraint(occurrenceConstraint, actual)
+            var regexStr = regularExpression.ToString();
+            if (regexStr.Length == 0)
+            {
+                throw new ArgumentException(
+                    "Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.",
+                    nameof(regularExpression));
+            }
+
+            bool success = Execute.Assertion
+                .ForCondition(Subject is not null)
                 .UsingLineBreaks
                 .BecauseOf(because, becauseArgs)
-                .FailWith($"Expected {{context:string}} to match regex {{0}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
-                    regularExpression.ToString());
+                .FailWith("Expected {context:string} to match regex {0}{reason}, but it was <null>.", regexStr);
+
+            if (success)
+            {
+                int actual = regularExpression.Matches(Subject).Count;
+
+                Execute.Assertion
+                    .ForConstraint(occurrenceConstraint, actual)
+                    .UsingLineBreaks
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith($"Expected {{context:string}} to match regex {{0}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
+                        regularExpression.ToString());
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -387,6 +387,16 @@ namespace FluentAssertions.Primitives
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
+        public AndConstraint<TAssertions> MatchRegex([RegexPattern][StringSyntax("Regex")] string regularExpression,
+            OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
+        {
+            MatchRegex(regularExpression, because, becauseArgs);
+
+            MatchRegex(new Regex(regularExpression), occurrenceConstraint, because, becauseArgs);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
         /// <summary>
         /// Asserts that a string matches a regular expression.
         /// </summary>
@@ -420,6 +430,21 @@ namespace FluentAssertions.Primitives
             return MatchRegex(regex, because, becauseArgs);
         }
 
+        public AndConstraint<TAssertions> MatchRegex(Regex regularExpression,
+            OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
+        {
+            int actual = regularExpression.Matches(Subject).Count;
+
+            Execute.Assertion
+                .ForConstraint(occurrenceConstraint, actual)
+                .UsingLineBreaks
+                .BecauseOf(because, becauseArgs)
+                .FailWith($"Expected {{context:string}} to match regex {{0}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
+                    regularExpression.ToString());
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
         /// <summary>
         /// Asserts that a string matches a regular expression.
         /// </summary>
@@ -433,7 +458,8 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> MatchRegex(Regex regularExpression, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> MatchRegex(Regex regularExpression,
+            string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression),
                 "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -394,7 +394,10 @@ namespace FluentAssertions.Primitives
         /// The regular expression with which the subject is matched.
         /// </param>
         /// <param name="occurrenceConstraint">
-        /// The excpected occurences of regex matches
+        /// A constraint specifying the expected amount of times a regex should match a string.
+        /// It can be created by invoking static methods Once, Twice, Thrice, or Times(int)
+        /// on the classes <see cref="Exactly"/>, <see cref="AtLeast"/>, <see cref="MoreThan"/>, <see cref="AtMost"/>, and <see cref="LessThan"/>.
+        /// For example, <see cref="Exactly.Times(int)"/> or <see cref="LessThan.Twice()"/>.
         /// </param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -406,7 +409,8 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> MatchRegex([RegexPattern][StringSyntax("Regex")] string regularExpression,
             OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
         {
-            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
+            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression),
+                "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
 
             Regex regex;
             try
@@ -463,7 +467,10 @@ namespace FluentAssertions.Primitives
         /// The regular expression with which the subject is matched.
         /// </param>
         /// <param name="occurrenceConstraint">
-        /// The excpected occurences of regex matches
+        /// A constraint specifying the expected amount of times a regex should match a string.
+        /// It can be created by invoking static methods Once, Twice, Thrice, or Times(int)
+        /// on the classes <see cref="Exactly"/>, <see cref="AtLeast"/>, <see cref="MoreThan"/>, <see cref="AtMost"/>, and <see cref="LessThan"/>.
+        /// For example, <see cref="Exactly.Times(int)"/> or <see cref="LessThan.Twice()"/>.
         /// </param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -476,7 +483,7 @@ namespace FluentAssertions.Primitives
             OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression),
-                    "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
+                "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
 
             var regexStr = regularExpression.ToString();
             if (regexStr.Length == 0)
@@ -501,7 +508,7 @@ namespace FluentAssertions.Primitives
                     .UsingLineBreaks
                     .BecauseOf(because, becauseArgs)
                     .FailWith($"Expected {{context:string}} to match regex {{0}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
-                        regularExpression.ToString());
+                        regexStr);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2120,6 +2120,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -58,8 +58,6 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
         public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
         public static FluentAssertions.Data.DataColumnAssertions Should(this System.Data.DataColumn actualValue) { }
-        public static FluentAssertions.Primitives.DateOnlyAssertions Should(this System.DateOnly actualValue) { }
-        public static FluentAssertions.Primitives.NullableDateOnlyAssertions Should(this System.DateOnly? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
@@ -74,8 +72,6 @@ namespace FluentAssertions
         public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
         public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
-        public static FluentAssertions.Primitives.TimeOnlyAssertions Should(this System.TimeOnly actualValue) { }
-        public static FluentAssertions.Primitives.NullableTimeOnlyAssertions Should(this System.TimeOnly? actualValue) { }
         public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
         public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
         public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
@@ -114,10 +110,6 @@ namespace FluentAssertions
             where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
-        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateOnlyAssertions<TAssertions> _)
-            where TAssertions : FluentAssertions.Primitives.DateOnlyAssertions<TAssertions> { }
-        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
-            "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -132,10 +124,6 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
-        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
-            "ly following \'And\'", true)]
-        public static void Should<TAssertions>(this FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions> _)
-            where TAssertions : FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should<TSubject>(this FluentAssertions.Specialized.TaskCompletionSourceAssertions<TSubject> _) { }
@@ -1448,12 +1436,6 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    public class DateOnlyValueFormatter : FluentAssertions.Formatting.IValueFormatter
-    {
-        public DateOnlyValueFormatter() { }
-        public bool CanHandle(object value) { }
-        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
-    }
     public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DateTimeOffsetValueFormatter() { }
@@ -1627,12 +1609,6 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    public class TimeOnlyValueFormatter : FluentAssertions.Formatting.IValueFormatter
-    {
-        public TimeOnlyValueFormatter() { }
-        public bool CanHandle(object value) { }
-        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
-    }
     public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public TimeSpanValueFormatter() { }
@@ -1778,39 +1754,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
-    }
-    public class DateOnlyAssertions : FluentAssertions.Primitives.DateOnlyAssertions<FluentAssertions.Primitives.DateOnlyAssertions>
-    {
-        public DateOnlyAssertions(System.DateOnly? value) { }
-    }
-    public class DateOnlyAssertions<TAssertions>
-        where TAssertions : FluentAssertions.Primitives.DateOnlyAssertions<TAssertions>
-    {
-        public DateOnlyAssertions(System.DateOnly? value) { }
-        public System.DateOnly? Subject { get; }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateOnly expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateOnly? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateOnly expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateOnly expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateOnly expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateOnly expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateOnly[] validValues) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<System.DateOnly>[] validValues) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateOnly> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateOnly?> validValues, string because = "", params object[] becauseArgs) { }
-        public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateOnly unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateOnly? unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateOnly unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateOnly unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateOnly unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateOnly unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
     {
@@ -2013,19 +1956,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableDateOnlyAssertions : FluentAssertions.Primitives.NullableDateOnlyAssertions<FluentAssertions.Primitives.NullableDateOnlyAssertions>
-    {
-        public NullableDateOnlyAssertions(System.DateOnly? value) { }
-    }
-    public class NullableDateOnlyAssertions<TAssertions> : FluentAssertions.Primitives.DateOnlyAssertions<TAssertions>
-        where TAssertions : FluentAssertions.Primitives.NullableDateOnlyAssertions<TAssertions>
-    {
-        public NullableDateOnlyAssertions(System.DateOnly? value) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
-    }
     public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
@@ -2090,19 +2020,6 @@ namespace FluentAssertions.Primitives
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
-    }
-    public class NullableTimeOnlyAssertions : FluentAssertions.Primitives.NullableTimeOnlyAssertions<FluentAssertions.Primitives.NullableTimeOnlyAssertions>
-    {
-        public NullableTimeOnlyAssertions(System.TimeOnly? value) { }
-    }
-    public class NullableTimeOnlyAssertions<TAssertions> : FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions>
-        where TAssertions : FluentAssertions.Primitives.NullableTimeOnlyAssertions<TAssertions>
-    {
-        public NullableTimeOnlyAssertions(System.TimeOnly? value) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -2203,6 +2120,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
@@ -2226,41 +2145,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
-    }
-    public class TimeOnlyAssertions : FluentAssertions.Primitives.TimeOnlyAssertions<FluentAssertions.Primitives.TimeOnlyAssertions>
-    {
-        public TimeOnlyAssertions(System.TimeOnly? value) { }
-    }
-    public class TimeOnlyAssertions<TAssertions>
-        where TAssertions : FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions>
-    {
-        public TimeOnlyAssertions(System.TimeOnly? value) { }
-        public System.TimeOnly? Subject { get; }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeOnly expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeOnly? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.TimeOnly expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.TimeOnly expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.TimeOnly expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.TimeOnly expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<System.TimeOnly>[] validValues) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.TimeOnly[] validValues) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.TimeOnly> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.TimeOnly?> validValues, string because = "", params object[] becauseArgs) { }
-        public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveHours(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveMilliseconds(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveMinutes(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveSeconds(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeOnly unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeOnly? unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.TimeOnly unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.TimeOnly unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.TimeOnly unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.TimeOnly unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveHours(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveMilliseconds(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinutes(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveSeconds(int unexpected, string because = "", params object[] becauseArgs) { }
     }
     public enum TimeSpanCondition
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -58,6 +58,8 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
         public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
         public static FluentAssertions.Data.DataColumnAssertions Should(this System.Data.DataColumn actualValue) { }
+        public static FluentAssertions.Primitives.DateOnlyAssertions Should(this System.DateOnly actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateOnlyAssertions Should(this System.DateOnly? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
@@ -72,6 +74,8 @@ namespace FluentAssertions
         public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
         public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.TimeOnlyAssertions Should(this System.TimeOnly actualValue) { }
+        public static FluentAssertions.Primitives.NullableTimeOnlyAssertions Should(this System.TimeOnly? actualValue) { }
         public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
         public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
         public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
@@ -110,6 +114,10 @@ namespace FluentAssertions
             where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateOnlyAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateOnlyAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -124,6 +132,10 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should<TSubject>(this FluentAssertions.Specialized.TaskCompletionSourceAssertions<TSubject> _) { }
@@ -1436,6 +1448,12 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    public class DateOnlyValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DateOnlyValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
     public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DateTimeOffsetValueFormatter() { }
@@ -1609,6 +1627,12 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    public class TimeOnlyValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TimeOnlyValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
     public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public TimeSpanValueFormatter() { }
@@ -1754,6 +1778,39 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateOnlyAssertions : FluentAssertions.Primitives.DateOnlyAssertions<FluentAssertions.Primitives.DateOnlyAssertions>
+    {
+        public DateOnlyAssertions(System.DateOnly? value) { }
+    }
+    public class DateOnlyAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateOnlyAssertions<TAssertions>
+    {
+        public DateOnlyAssertions(System.DateOnly? value) { }
+        public System.DateOnly? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateOnly expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateOnly? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateOnly expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateOnly expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateOnly expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateOnly expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateOnly[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<System.DateOnly>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateOnly> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateOnly?> validValues, string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateOnly unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateOnly? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateOnly unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateOnly unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateOnly unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateOnly unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
     {
@@ -1957,6 +2014,19 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
+    public class NullableDateOnlyAssertions : FluentAssertions.Primitives.NullableDateOnlyAssertions<FluentAssertions.Primitives.NullableDateOnlyAssertions>
+    {
+        public NullableDateOnlyAssertions(System.DateOnly? value) { }
+    }
+    public class NullableDateOnlyAssertions<TAssertions> : FluentAssertions.Primitives.DateOnlyAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateOnlyAssertions<TAssertions>
+    {
+        public NullableDateOnlyAssertions(System.DateOnly? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
     public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
@@ -2021,6 +2091,19 @@ namespace FluentAssertions.Primitives
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableTimeOnlyAssertions : FluentAssertions.Primitives.NullableTimeOnlyAssertions<FluentAssertions.Primitives.NullableTimeOnlyAssertions>
+    {
+        public NullableTimeOnlyAssertions(System.TimeOnly? value) { }
+    }
+    public class NullableTimeOnlyAssertions<TAssertions> : FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableTimeOnlyAssertions<TAssertions>
+    {
+        public NullableTimeOnlyAssertions(System.TimeOnly? value) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -2146,6 +2229,41 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+    }
+    public class TimeOnlyAssertions : FluentAssertions.Primitives.TimeOnlyAssertions<FluentAssertions.Primitives.TimeOnlyAssertions>
+    {
+        public TimeOnlyAssertions(System.TimeOnly? value) { }
+    }
+    public class TimeOnlyAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions>
+    {
+        public TimeOnlyAssertions(System.TimeOnly? value) { }
+        public System.TimeOnly? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeOnly expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeOnly? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.TimeOnly expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.TimeOnly expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.TimeOnly expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.TimeOnly expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<System.TimeOnly>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.TimeOnly[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.TimeOnly> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.TimeOnly?> validValues, string because = "", params object[] becauseArgs) { }
+        public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHours(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMilliseconds(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinutes(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSeconds(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeOnly unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeOnly? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.TimeOnly unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.TimeOnly unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.TimeOnly unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.TimeOnly unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHours(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMilliseconds(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinutes(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSeconds(int unexpected, string because = "", params object[] becauseArgs) { }
     }
     public enum TimeSpanCondition
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -2120,6 +2120,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -2120,6 +2120,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2072,6 +2072,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2120,6 +2120,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
@@ -225,7 +225,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"Expected string to match regex*\"Lorem.*\" exactly 2 times, but found it 1 time.");
+                .WithMessage($"Expected subject to match regex*\"Lorem.*\" exactly 2 times, but found it 1 time.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
@@ -228,6 +228,33 @@ namespace FluentAssertions.Specs.Primitives
                 .WithMessage($"Expected subject to match regex*\"Lorem.*\" exactly 2 times, but found it 1 time.");
         }
 
+        [Fact]
+        public void When_a_string_is_matched_against_a_regex_and_the_expected_count_is_zero_and_string_not_matches_it_passes()
+        {
+            // Arrange
+            string subject = "a";
+
+            // Act
+            Action act = () => subject.Should().MatchRegex("b", Exactly.Times(0));
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_a_string_is_matched_against_a_regex_and_the_expected_count_is_zero_and_string_matches_it_fails()
+        {
+            // Arrange
+            string subject = "a";
+
+            // Act
+            Action act = () => subject.Should().MatchRegex("a", Exactly.Times(0));
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage($"Expected subject to match regex*\"a\" exactly 0 times, but found it 1 time.");
+        }
+
         #endregion
 
         #region Not Match Regex

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
@@ -200,7 +200,7 @@ namespace FluentAssertions.Specs.Primitives
         }
 
         [Fact]
-        public void When_a_string_is_matched_against_a_regex_and_the_count_of_matches_fits_into_the_expected_it_passes()
+        public void When_a_string_is_matched_and_the_count_of_matches_fits_into_the_expected_it_passes()
         {
             // Arrange
             string subject = "hello world";
@@ -213,7 +213,7 @@ namespace FluentAssertions.Specs.Primitives
         }
 
         [Fact]
-        public void When_a_string_is_matched_against_a_regex_and_the_count_of_matches_do_not_fit_the_expected_it_fails()
+        public void When_a_string_is_matched_and_the_count_of_matches_do_not_fit_the_expected_it_fails()
         {
             // Arrange
             string subject = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt " +
@@ -229,7 +229,7 @@ namespace FluentAssertions.Specs.Primitives
         }
 
         [Fact]
-        public void When_a_string_is_matched_against_a_regex_and_the_expected_count_is_zero_and_string_not_matches_it_passes()
+        public void When_a_string_is_matched_and_the_expected_count_is_zero_and_string_not_matches_it_passes()
         {
             // Arrange
             string subject = "a";
@@ -242,7 +242,7 @@ namespace FluentAssertions.Specs.Primitives
         }
 
         [Fact]
-        public void When_a_string_is_matched_against_a_regex_and_the_expected_count_is_zero_and_string_matches_it_fails()
+        public void When_a_string_is_matched_and_the_expected_count_is_zero_and_string_matches_it_fails()
         {
             // Arrange
             string subject = "a";

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
@@ -199,6 +199,35 @@ namespace FluentAssertions.Specs.Primitives
                 .WithParameterName("regularExpression");
         }
 
+        [Fact]
+        public void When_a_string_is_matched_against_a_regex_and_the_count_of_matches_are_exactly_the_expected_it_passes()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().MatchRegex(new Regex("hello.*"), Exactly.Once());
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_a_string_is_matched_against_a_regex_and_the_count_of_matches_are_not_the_expected_it_fails()
+        {
+            // Arrange
+            string subject = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt " +
+                "ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et " +
+                "ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.";
+
+            // Act
+            Action act = () => subject.Should().MatchRegex("Lorem.*", Exactly.Twice());
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage($"Expected string to match regex*\"Lorem.*\" exactly 2 times, but found it 1 time.");
+        }
+
         #endregion
 
         #region Not Match Regex

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
@@ -200,20 +200,20 @@ namespace FluentAssertions.Specs.Primitives
         }
 
         [Fact]
-        public void When_a_string_is_matched_against_a_regex_and_the_count_of_matches_are_exactly_the_expected_it_passes()
+        public void When_a_string_is_matched_against_a_regex_and_the_count_of_matches_fits_into_the_expected_it_passes()
         {
             // Arrange
             string subject = "hello world";
 
             // Act
-            Action act = () => subject.Should().MatchRegex(new Regex("hello.*"), Exactly.Once());
+            Action act = () => subject.Should().MatchRegex(new Regex("hello.*"), AtLeast.Once());
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_a_string_is_matched_against_a_regex_and_the_count_of_matches_are_not_the_expected_it_fails()
+        public void When_a_string_is_matched_against_a_regex_and_the_count_of_matches_do_not_fit_the_expected_it_fails()
         {
             // Arrange
             string subject = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt " +
@@ -253,6 +253,103 @@ namespace FluentAssertions.Specs.Primitives
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage($"Expected subject to match regex*\"a\" exactly 0 times, but found it 1 time.");
+        }
+
+        [Fact]
+        public void When_the_subject_is_null_it_fails()
+        {
+            // Arrange
+            string subject = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                subject.Should().MatchRegex(".*", Exactly.Times(0), "because it should be a string");
+            };
+
+            // Assert
+            act.Should().ThrowExactly<XunitException>()
+                .WithMessage("Expected subject to match regex*\".*\" because it should be a string, but it was <null>.");
+        }
+
+        [Fact]
+        public void When_the_subject_is_empty_and_expected_count_is_zero_and_the_regex_matches_it_passes()
+        {
+            // Arrange
+            string subject = string.Empty;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                subject.Should().MatchRegex(".+", Exactly.Times(0));
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_the_subject_is_empty_and_expected_count_is_more_than_zero_it_fails()
+        {
+            // Arrange
+            string subject = string.Empty;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                subject.Should().MatchRegex(".+", AtLeast.Once());
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage($"Expected subject to match regex* at least 1 time, but found it 0 times.*");
+        }
+
+        [Fact]
+        public void When_regex_is_null_it_fails_and_ignores_occurrences()
+        {
+            // Arrange
+            string subject = "a";
+
+            // Act
+            Action act = () => subject.Should().MatchRegex((Regex)null, Exactly.Times(0));
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the BeNull method.*")
+                .WithParameterName("regularExpression");
+        }
+
+        [Fact]
+        public void When_regex_is_empty_it_fails_and_ignores_occurrences()
+        {
+            // Arrange
+            string subject = "a";
+
+            // Act
+            Action act = () => subject.Should().MatchRegex(string.Empty, Exactly.Times(0));
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentException>()
+                .WithMessage("Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.*")
+                .WithParameterName("regularExpression");
+        }
+
+        [Fact]
+        public void When_regex_is_invalid_it_fails_and_ignores_occurrences()
+        {
+            // Arrange
+            string subject = "a";
+
+            // Act
+            Action act = () => subject.Should().MatchRegex(".**", Exactly.Times(0));
+
+            // Assert
+            act.Should().ThrowExactly<XunitException>()
+                .WithMessage("Cannot match subject against \".**\" because it is not a valid regular expression.*");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
@@ -274,7 +274,7 @@ namespace FluentAssertions.Specs.Primitives
         }
 
         [Fact]
-        public void When_the_subject_is_empty_and_expected_count_is_zero_and_the_regex_matches_it_passes()
+        public void When_the_subject_is_empty_and_expected_count_is_zero_it_passes()
         {
             // Arrange
             string subject = string.Empty;
@@ -283,7 +283,7 @@ namespace FluentAssertions.Specs.Primitives
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                subject.Should().MatchRegex(".+", Exactly.Times(0));
+                subject.Should().MatchRegex("a", Exactly.Times(0));
             };
 
             // Assert

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,7 +14,7 @@ sidebar:
 * Added support for .NET6 `DateOnly` struct - [#1844](https://github.com/fluentassertions/fluentassertions/pull/1844)
 * Added support for .NET6 `TimeOnly` struct - [#1848](https://github.com/fluentassertions/fluentassertions/pull/1848)
 * Added `NotBe` for nullable boolean values - [#1865](https://github.com/fluentassertions/fluentassertions/pull/1865)
-* Added ability to count regex matches - [#1869](https://github.com/fluentassertions/fluentassertions/pull/1869)
+* Added a new overload to `MatchRegex()` to be able to assert on ount of regex matches  - [#1869](https://github.com/fluentassertions/fluentassertions/pull/1869)
 
 
 ### Fixes

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,7 @@ sidebar:
 * Annotated `[Not]MatchRegex(string)` with `[StringSyntax("Regex")]` which IDEs can use to colorize the regular expression argument - [#1816](https://github.com/fluentassertions/fluentassertions/pull/1816)
 * Added support for .NET6 `DateOnly` struct - [#1844](https://github.com/fluentassertions/fluentassertions/pull/1844)
 * Added support for .NET6 `TimeOnly` struct - [#1848](https://github.com/fluentassertions/fluentassertions/pull/1848)
+* Added ability to count regex matches
 
 ### Fixes
 * `EnumAssertions.Be` did not determine the caller name - [#1835](https://github.com/fluentassertions/fluentassertions/pull/1835)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,7 +14,7 @@ sidebar:
 * Added support for .NET6 `DateOnly` struct - [#1844](https://github.com/fluentassertions/fluentassertions/pull/1844)
 * Added support for .NET6 `TimeOnly` struct - [#1848](https://github.com/fluentassertions/fluentassertions/pull/1848)
 * Added `NotBe` for nullable boolean values - [#1865](https://github.com/fluentassertions/fluentassertions/pull/1865)
-* Added a new overload to `MatchRegex()` to be able to assert on ount of regex matches  - [#1869](https://github.com/fluentassertions/fluentassertions/pull/1869)
+* Added a new overload to `MatchRegex()` to be able to assert on count of regex matches  - [#1869](https://github.com/fluentassertions/fluentassertions/pull/1869)
 
 
 ### Fixes

--- a/docs/_pages/strings.md
+++ b/docs/_pages/strings.md
@@ -113,5 +113,5 @@ And if that's not enough, you can assert on the number of matches of a regular e
 
 ```csharp
 someString.Should().MatchRegex("h.*\\sworld.$", Exactly.Once());
-someString.Should().MatchRegex(new System.Text.RegularExpressions.Regex("h.*\\sworld.$"), AtLeast.Twice());
+someString.Should().MatchRegex(new Regex("h.*\\sworld.$"), AtLeast.Twice());
 ```

--- a/docs/_pages/strings.md
+++ b/docs/_pages/strings.md
@@ -109,7 +109,7 @@ subject.Should().NotMatchRegex(new System.Text.RegularExpressions.Regex(".*earth
 subject.Should().NotMatchRegex(".*earth.*");
 ```
 
-And if that's not enough, you can count the occurrence of a regular expression:
+And if that's not enough, you can assert on the number of matches of a regular expression:
 
 ```csharp
 someString.Should().MatchRegex("h.*\\sworld.$", Exactly.Once());

--- a/docs/_pages/strings.md
+++ b/docs/_pages/strings.md
@@ -104,8 +104,8 @@ And if wildcards aren't enough for you, you can always use some regular expressi
 
 ```csharp
 someString.Should().MatchRegex("h.*\\sworld.$");
-someString.Should().MatchRegex(new System.Text.RegularExpressions.Regex("h.*\\sworld.$"));
-subject.Should().NotMatchRegex(new System.Text.RegularExpressions.Regex(".*earth.*"));
+someString.Should().MatchRegex(new Regex("h.*\\sworld.$"));
+subject.Should().NotMatchRegex(new Regex(".*earth.*"));
 subject.Should().NotMatchRegex(".*earth.*");
 ```
 

--- a/docs/_pages/strings.md
+++ b/docs/_pages/strings.md
@@ -108,3 +108,10 @@ someString.Should().MatchRegex(new System.Text.RegularExpressions.Regex("h.*\\sw
 subject.Should().NotMatchRegex(new System.Text.RegularExpressions.Regex(".*earth.*"));
 subject.Should().NotMatchRegex(".*earth.*");
 ```
+
+And if that's not enough, you can count the occurrence of a regular expression:
+
+```csharp
+someString.Should().MatchRegex("h.*\\sworld.$", Exactly.Once());
+someString.Should().MatchRegex(new System.Text.RegularExpressions.Regex("h.*\\sworld.$"), AtLeast.Twice());
+```


### PR DESCRIPTION

Ref. #1868 

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).