### PR TITLE
Update documentation: Add missing tip for `ContainItemsAssignableTo<T>()`

### DIFF
--- a/docs/_data/mstest-migration/collectionAssert.yml
+++ b/docs/_data/mstest-migration/collectionAssert.yml
@@ -128,6 +128,6 @@
     CollectionAssert.AllItemsAreInstancesOfType failed. Element at index 0 is not of expected type. Expected type:<UnitTests2.MyIdenticalClass>. Actual type:<UnitTests2.MyClass>.
 
   new-message: |
-    Expected collection to contain only items of type UnitTests2.MyIdenticalClass, but item SomeProperty: 1, OtherProperty: item at index 0 is of type UnitTests2.MyClass.
+    Expected collection to contain at least one element assignable to type "T", but found {System.Int32}.
 
 

--- a/docs/_data/mstest-migration/collectionAssert.yml
+++ b/docs/_data/mstest-migration/collectionAssert.yml
@@ -122,12 +122,12 @@
     CollectionAssert.AllItemsAreInstancesOfType(actual, typeof(T));
 
   new: |
-    actual.Should().ContainItemsAssignableTo<T>();
+    actual.Should().AllBeAssignableTo<T>();
 
   old-message: |
     CollectionAssert.AllItemsAreInstancesOfType failed. Element at index 0 is not of expected type. Expected type:<UnitTests2.MyIdenticalClass>. Actual type:<UnitTests2.MyClass>.
 
   new-message: |
-    Expected collection to contain at least one element assignable to type "T", but found {System.Int32}.
+    Expected type to be "T", but found [System.String],
 
 

--- a/docs/_data/tips/collections.yml
+++ b/docs/_data/tips/collections.yml
@@ -180,6 +180,18 @@
     Expected collection to contain a single item, but found {"", "", ""}.
 
 - old: |
+    actual.Any(item => typeof(string).IsAssignableFrom(item.GetType())).Should().BeTrue();
+
+  new: |
+    actual.Should().ContainItemsAssignableTo<string>();
+  
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected collection to contain at least one element assignable to type "System.String", but found {System.Int32}.
+    
+- old: |
     actual.Should().HaveCount(0);
 
   new: |

--- a/docs/_data/tips/collections.yml
+++ b/docs/_data/tips/collections.yml
@@ -180,18 +180,6 @@
     Expected collection to contain a single item, but found {"", "", ""}.
 
 - old: |
-    actual.Any(item => typeof(string).IsAssignableFrom(item.GetType())).Should().BeTrue();
-
-  new: |
-    actual.Should().ContainItemsAssignableTo<string>();
-  
-  old-message: |
-    Expected True, but found False.
-
-  new-message: |
-    Expected collection to contain at least one element assignable to type "System.String", but found {System.Int32}.
-    
-- old: |
     actual.Should().HaveCount(0);
 
   new: |


### PR DESCRIPTION
This refs and closes #1841

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).