### PR TITLE
Improve difference calculation of overflowing integrals

### DIFF
--- a/Src/FluentAssertions/Numeric/ByteAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ByteAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -13,10 +14,10 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override byte? CalculateDifferenceForFailureMessage(byte expected)
+        private protected override string CalculateDifferenceForFailureMessage(byte subject, byte expected)
         {
-            var difference = (byte?)(Subject - expected);
-            return difference != 0 ? difference : null;
+            int difference = subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/DecimalAssertions.cs
+++ b/Src/FluentAssertions/Numeric/DecimalAssertions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -14,12 +15,12 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override decimal? CalculateDifferenceForFailureMessage(decimal expected)
+        private protected override string CalculateDifferenceForFailureMessage(decimal subject, decimal expected)
         {
             try
             {
-                var difference = checked(Subject - expected);
-                return difference != 0 ? difference : null;
+                decimal difference = checked(subject - expected);
+                return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
             }
             catch (OverflowException)
             {

--- a/Src/FluentAssertions/Numeric/DoubleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/DoubleAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -15,10 +16,10 @@ namespace FluentAssertions.Numeric
 
         private protected override bool IsNaN(double value) => double.IsNaN(value);
 
-        private protected override double? CalculateDifferenceForFailureMessage(double expected)
+        private protected override string CalculateDifferenceForFailureMessage(double subject, double expected)
         {
-            var difference = Subject - expected;
-            return difference != 0 ? difference : null;
+            var difference = subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/DoubleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/DoubleAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Numeric
         private protected override string CalculateDifferenceForFailureMessage(double subject, double expected)
         {
             var difference = subject - expected;
-            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
+            return difference != 0 ? difference.ToString("R", CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/Int16Assertions.cs
+++ b/Src/FluentAssertions/Numeric/Int16Assertions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -13,15 +14,15 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override short? CalculateDifferenceForFailureMessage(short expected)
+        private protected override string CalculateDifferenceForFailureMessage(short subject, short expected)
         {
-            if (Subject < 10 && expected < 10)
+            if (subject < 10 && expected < 10)
             {
                 return null;
             }
 
-            var difference = (short?)(Subject - expected);
-            return difference != 0 ? difference : null;
+            int difference = subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/Int32Assertions.cs
+++ b/Src/FluentAssertions/Numeric/Int32Assertions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -14,22 +14,15 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override int? CalculateDifferenceForFailureMessage(int expected)
+        private protected override string CalculateDifferenceForFailureMessage(int subject, int expected)
         {
-            if (Subject is > 0 and < 10 && expected is > 0 and < 10)
+            if (subject is > 0 and < 10 && expected is > 0 and < 10)
             {
                 return null;
             }
 
-            try
-            {
-                var difference = checked(Subject - expected);
-                return difference != 0 ? difference : null;
-            }
-            catch (OverflowException)
-            {
-                return null;
-            }
+            long difference = (long)subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/Int64Assertions.cs
+++ b/Src/FluentAssertions/Numeric/Int64Assertions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -14,22 +14,15 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override long? CalculateDifferenceForFailureMessage(long expected)
+        private protected override string CalculateDifferenceForFailureMessage(long subject, long expected)
         {
-            if (Subject is > 0 and < 10 && expected is > 0 and < 10)
+            if (subject is > 0 and < 10 && expected is > 0 and < 10)
             {
                 return null;
             }
 
-            try
-            {
-                var difference = checked(Subject - expected);
-                return difference != 0 ? difference : null;
-            }
-            catch (OverflowException)
-            {
-                return null;
-            }
+            decimal difference = (decimal)subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NullableByteAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableByteAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -13,10 +14,10 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override byte? CalculateDifferenceForFailureMessage(byte expected)
+        private protected override string CalculateDifferenceForFailureMessage(byte subject, byte expected)
         {
-            var difference = (byte?)(Subject - expected);
-            return difference != 0 ? difference : null;
+            int difference = subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NullableDecimalAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableDecimalAssertions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -14,12 +15,12 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override decimal? CalculateDifferenceForFailureMessage(decimal expected)
+        private protected override string CalculateDifferenceForFailureMessage(decimal subject, decimal expected)
         {
             try
             {
-                var difference = checked(Subject - expected);
-                return difference != 0 ? difference : null;
+                decimal difference = checked(subject - expected);
+                return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
             }
             catch (OverflowException)
             {

--- a/Src/FluentAssertions/Numeric/NullableDoubleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableDoubleAssertions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -15,10 +16,10 @@ namespace FluentAssertions.Numeric
 
         private protected override bool IsNaN(double value) => double.IsNaN(value);
 
-        private protected override double? CalculateDifferenceForFailureMessage(double expected)
+        private protected override string CalculateDifferenceForFailureMessage(double subject, double expected)
         {
-            var difference = Subject - expected;
-            return difference != 0 ? difference : null;
+            double difference = subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NullableDoubleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableDoubleAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Numeric
         private protected override string CalculateDifferenceForFailureMessage(double subject, double expected)
         {
             double difference = subject - expected;
-            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
+            return difference != 0 ? difference.ToString("R", CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NullableInt16Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableInt16Assertions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -13,15 +14,15 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override short? CalculateDifferenceForFailureMessage(short expected)
+        private protected override string CalculateDifferenceForFailureMessage(short subject, short expected)
         {
-            if (Subject < 10 && expected < 10)
+            if (subject < 10 && expected < 10)
             {
                 return null;
             }
 
-            var difference = (short?)(Subject - expected);
-            return difference != 0 ? difference : null;
+            int difference = subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NullableInt32Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableInt32Assertions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -14,22 +14,15 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override int? CalculateDifferenceForFailureMessage(int expected)
+        private protected override string CalculateDifferenceForFailureMessage(int subject, int expected)
         {
-            if (Subject is > 0 and < 10 && expected is > 0 and < 10)
+            if (subject is > 0 and < 10 && expected is > 0 and < 10)
             {
                 return null;
             }
 
-            try
-            {
-                var difference = checked(Subject - expected);
-                return difference != 0 ? difference : null;
-            }
-            catch (OverflowException)
-            {
-                return null;
-            }
+            long difference = (long)subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NullableInt64Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableInt64Assertions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -14,22 +14,15 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override long? CalculateDifferenceForFailureMessage(long expected)
+        private protected override string CalculateDifferenceForFailureMessage(long subject, long expected)
         {
-            if (Subject is > 0 and < 10 && expected is > 0 and < 10)
+            if (subject is > 0 and < 10 && expected is > 0 and < 10)
             {
                 return null;
             }
 
-            try
-            {
-                var difference = checked(Subject - expected);
-                return difference != 0 ? difference : null;
-            }
-            catch (OverflowException)
-            {
-                return null;
-            }
+            decimal difference = (decimal)subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NullableSByteAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableSByteAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -13,10 +14,10 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override sbyte? CalculateDifferenceForFailureMessage(sbyte expected)
+        private protected override string CalculateDifferenceForFailureMessage(sbyte subject, sbyte expected)
         {
-            var difference = (sbyte?)(Subject - expected);
-            return difference != 0 ? difference : null;
+            int difference = subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NullableSingleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableSingleAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Numeric
         private protected override string CalculateDifferenceForFailureMessage(float subject, float expected)
         {
             float difference = subject - expected;
-            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
+            return difference != 0 ? difference.ToString("R", CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NullableSingleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableSingleAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -15,10 +16,10 @@ namespace FluentAssertions.Numeric
 
         private protected override bool IsNaN(float value) => float.IsNaN(value);
 
-        private protected override float? CalculateDifferenceForFailureMessage(float expected)
+        private protected override string CalculateDifferenceForFailureMessage(float subject, float expected)
         {
-            var difference = Subject - expected;
-            return difference != 0 ? difference : null;
+            float difference = subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NullableUInt16Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableUInt16Assertions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -13,15 +14,15 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override ushort? CalculateDifferenceForFailureMessage(ushort expected)
+        private protected override string CalculateDifferenceForFailureMessage(ushort subject, ushort expected)
         {
-            if (Subject < 10 && expected < 10)
+            if (subject < 10 && expected < 10)
             {
                 return null;
             }
 
-            var difference = (ushort?)(Subject - expected);
-            return difference != 0 ? difference : null;
+            int difference = subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NullableUInt32Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableUInt32Assertions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -14,22 +14,15 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override uint? CalculateDifferenceForFailureMessage(uint expected)
+        private protected override string CalculateDifferenceForFailureMessage(uint subject, uint expected)
         {
-            if (Subject < 10 && expected < 10)
+            if (subject < 10 && expected < 10)
             {
                 return null;
             }
 
-            try
-            {
-                var difference = checked(Subject - expected);
-                return difference != 0 ? difference : null;
-            }
-            catch (OverflowException)
-            {
-                return null;
-            }
+            long difference = (long)subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NullableUInt64Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableUInt64Assertions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -14,22 +14,15 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override ulong? CalculateDifferenceForFailureMessage(ulong expected)
+        private protected override string CalculateDifferenceForFailureMessage(ulong subject, ulong expected)
         {
-            if (Subject < 10 && expected < 10)
+            if (subject < 10 && expected < 10)
             {
                 return null;
             }
 
-            try
-            {
-                var difference = checked(Subject - expected);
-                return difference != 0 ? difference : null;
-            }
-            catch (OverflowException)
-            {
-                return null;
-            }
+            decimal difference = (decimal)subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
-using static System.FormattableString;
 
 namespace FluentAssertions.Numeric
 {
@@ -486,23 +485,24 @@ namespace FluentAssertions.Numeric
         /// <summary>
         /// A method to generate additional information upon comparison failures.
         /// </summary>
+        /// <param name="subject">The current numeric value verified to be non-null.</param>
         /// <param name="expected">The value to compare the current numeric value with.</param>
         /// <returns>
         /// Returns the difference between a number value and the <paramref name="expected" /> value.
         /// Returns `null` if the compared numbers are small enough that a difference message is irrelevant.
         /// </returns>
-        private protected virtual T? CalculateDifferenceForFailureMessage(T expected) => null;
+        private protected virtual string CalculateDifferenceForFailureMessage(T subject, T expected) => null;
 
         private string GenerateDifferenceMessage(T? expected)
         {
             const string noDifferenceMessage = ".";
-            if (!Subject.HasValue || !expected.HasValue)
+            if (Subject is not T subject || expected is not T expectedValue)
             {
                 return noDifferenceMessage;
             }
 
-            var difference = CalculateDifferenceForFailureMessage(expected.Value);
-            return difference is null ? noDifferenceMessage : Invariant($" (difference of {difference}).");
+            var difference = CalculateDifferenceForFailureMessage(subject, expectedValue);
+            return difference is null ? noDifferenceMessage : $" (difference of {difference}).";
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/SByteAssertions.cs
+++ b/Src/FluentAssertions/Numeric/SByteAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -13,10 +14,10 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override sbyte? CalculateDifferenceForFailureMessage(sbyte expected)
+        private protected override string CalculateDifferenceForFailureMessage(sbyte subject, sbyte expected)
         {
-            var difference = (sbyte?)(Subject - expected);
-            return difference != 0 ? difference : null;
+            int difference = subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/SingleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/SingleAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Numeric
         private protected override string CalculateDifferenceForFailureMessage(float subject, float expected)
         {
             float difference = subject - expected;
-            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
+            return difference != 0 ? difference.ToString("R", CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/SingleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/SingleAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -15,10 +16,10 @@ namespace FluentAssertions.Numeric
 
         private protected override bool IsNaN(float value) => float.IsNaN(value);
 
-        private protected override float? CalculateDifferenceForFailureMessage(float expected)
+        private protected override string CalculateDifferenceForFailureMessage(float subject, float expected)
         {
-            var difference = Subject - expected;
-            return difference != 0 ? difference : null;
+            float difference = subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/UInt16Assertions.cs
+++ b/Src/FluentAssertions/Numeric/UInt16Assertions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -13,15 +14,15 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override ushort? CalculateDifferenceForFailureMessage(ushort expected)
+        private protected override string CalculateDifferenceForFailureMessage(ushort subject, ushort expected)
         {
-            if (Subject < 10 && expected < 10)
+            if (subject < 10 && expected < 10)
             {
                 return null;
             }
 
-            var difference = (ushort?)(Subject - expected);
-            return difference != 0 ? difference : null;
+            int difference = subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/UInt32Assertions.cs
+++ b/Src/FluentAssertions/Numeric/UInt32Assertions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -14,22 +14,15 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override uint? CalculateDifferenceForFailureMessage(uint expected)
+        private protected override string CalculateDifferenceForFailureMessage(uint subject, uint expected)
         {
-            if (Subject < 10 && expected < 10)
+            if (subject < 10 && expected < 10)
             {
                 return null;
             }
 
-            try
-            {
-                var difference = checked(Subject - expected);
-                return difference != 0 ? difference : null;
-            }
-            catch (OverflowException)
-            {
-                return null;
-            }
+            long difference = (long)subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/UInt64Assertions.cs
+++ b/Src/FluentAssertions/Numeric/UInt64Assertions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using System.Globalization;
 
 namespace FluentAssertions.Numeric
 {
@@ -14,22 +14,15 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        private protected override ulong? CalculateDifferenceForFailureMessage(ulong expected)
+        private protected override string CalculateDifferenceForFailureMessage(ulong subject, ulong expected)
         {
-            if (Subject < 10 && expected < 10)
+            if (subject < 10 && expected < 10)
             {
                 return null;
             }
 
-            try
-            {
-                var difference = checked(Subject - expected);
-                return difference != 0 ? difference : null;
-            }
-            catch (OverflowException)
-            {
-                return null;
-            }
+            decimal difference = (decimal)subject - expected;
+            return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Numeric/NumericDifferenceAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericDifferenceAssertionsSpecs.cs
@@ -756,119 +756,119 @@ namespace FluentAssertions.Specs.Numeric
         public class Overflow
         {
             [Fact]
-            public void The_difference_between_overflowed_ints_is_not_included_in_the_message()
+            public void The_difference_between_overflowed_ints_is_included_in_the_message()
             {
                 // Act
                 Action act = () =>
-                    int.MinValue.Should().Be(int.MaxValue, "because we want to test the failure {0}", "message");
+                    int.MinValue.Should().Be(int.MaxValue);
 
                 // Assert
                 act
                     .Should().Throw<XunitException>()
-                    .WithMessage("Expected int.MinValue to be 2147483647 because we want to test the failure message, but found -2147483648.");
+                    .WithMessage("Expected int.MinValue to be 2147483647*found -2147483648 (difference of -4294967295).");
             }
 
             [Fact]
-            public void The_difference_between_overflowed_nullable_ints_is_not_included_in_the_message()
+            public void The_difference_between_overflowed_nullable_ints_is_included_in_the_message()
             {
                 // Arrange
                 int? minValue = int.MinValue;
 
                 // Act
                 Action act = () =>
-                    minValue.Should().Be(int.MaxValue, "because we want to test the failure {0}", "message");
+                    minValue.Should().Be(int.MaxValue);
 
                 // Assert
                 act
                     .Should().Throw<XunitException>()
-                    .WithMessage("Expected minValue to be 2147483647 because we want to test the failure message, but found -2147483648.");
+                    .WithMessage("Expected minValue to be 2147483647*found -2147483648 (difference of -4294967295).");
             }
 
             [Fact]
-            public void The_difference_between_overflowed_uints_is_not_included_in_the_message()
+            public void The_difference_between_overflowed_uints_is_included_in_the_message()
             {
                 // Act
                 Action act = () =>
-                    uint.MinValue.Should().Be(uint.MaxValue, "because we want to test the failure {0}", "message");
+                    uint.MinValue.Should().Be(uint.MaxValue);
 
                 // Assert
                 act
                     .Should().Throw<XunitException>()
-                    .WithMessage("Expected uint.MinValue to be 4294967295u because we want to test the failure message, but found 0u.");
+                    .WithMessage("Expected uint.MinValue to be 4294967295u*found 0u (difference of -4294967295).");
             }
 
             [Fact]
-            public void The_difference_between_overflowed_nullable_uints_is_not_included_in_the_message()
+            public void The_difference_between_overflowed_nullable_uints_is_included_in_the_message()
             {
                 // Arrange
                 uint? minValue = uint.MinValue;
 
                 // Act
                 Action act = () =>
-                    minValue.Should().Be(uint.MaxValue, "because we want to test the failure {0}", "message");
+                    minValue.Should().Be(uint.MaxValue);
 
                 // Assert
                 act
                     .Should().Throw<XunitException>()
-                    .WithMessage("Expected minValue to be 4294967295u because we want to test the failure message, but found 0u.");
+                    .WithMessage("Expected minValue to be 4294967295u*found 0u (difference of -4294967295).");
             }
 
             [Fact]
-            public void The_difference_between_overflowed_longs_is_not_included_in_the_message()
+            public void The_difference_between_overflowed_longs_is_included_in_the_message()
             {
                 // Act
                 Action act = () =>
-                    long.MinValue.Should().Be(long.MaxValue, "because we want to test the failure {0}", "message");
+                    long.MinValue.Should().Be(long.MaxValue);
 
                 // Assert
                 act
                     .Should().Throw<XunitException>()
-                    .WithMessage("Expected long.MinValue to be 9223372036854775807L because we want to test the failure message, but found -9223372036854775808L.");
+                    .WithMessage("Expected long.MinValue to be 9223372036854775807L*found -9223372036854775808L (difference of -18446744073709551615).");
             }
 
             [Fact]
-            public void The_difference_between_overflowed_nullable_longs_is_not_included_in_the_message()
+            public void The_difference_between_overflowed_nullable_longs_is_included_in_the_message()
             {
                 // Arrange
                 long? minValue = long.MinValue;
 
                 // Act
                 Action act = () =>
-                    minValue.Should().Be(long.MaxValue, "because we want to test the failure {0}", "message");
+                    minValue.Should().Be(long.MaxValue);
 
                 // Assert
                 act
                     .Should().Throw<XunitException>()
-                    .WithMessage("Expected minValue to be 9223372036854775807L because we want to test the failure message, but found -9223372036854775808L.");
+                    .WithMessage("Expected minValue to be 9223372036854775807L*found -9223372036854775808L (difference of -18446744073709551615).");
             }
 
             [Fact]
-            public void The_difference_between_overflowed_ulongs_is_not_included_in_the_message()
+            public void The_difference_between_overflowed_ulongs_is_included_in_the_message()
             {
                 // Act
                 Action act = () =>
-                    ulong.MinValue.Should().Be(ulong.MaxValue, "because we want to test the failure {0}", "message");
+                    ulong.MinValue.Should().Be(ulong.MaxValue);
 
                 // Assert
                 act
                     .Should().Throw<XunitException>()
-                    .WithMessage("Expected ulong.MinValue to be 18446744073709551615UL because we want to test the failure message, but found 0UL.");
+                    .WithMessage("Expected ulong.MinValue to be 18446744073709551615UL*found 0UL (difference of -18446744073709551615).");
             }
 
             [Fact]
-            public void The_difference_between_overflowed_nullable_ulongs_is_not_included_in_the_message()
+            public void The_difference_between_overflowed_nullable_ulongs_is_included_in_the_message()
             {
                 // Arrange
                 ulong? minValue = ulong.MinValue;
 
                 // Act
                 Action act = () =>
-                    minValue.Should().Be(ulong.MaxValue, "because we want to test the failure {0}", "message");
+                    minValue.Should().Be(ulong.MaxValue);
 
                 // Assert
                 act
                     .Should().Throw<XunitException>()
-                    .WithMessage("Expected minValue to be 18446744073709551615UL because we want to test the failure message, but found 0UL.");
+                    .WithMessage("Expected minValue to be 18446744073709551615UL*found 0UL (difference of -18446744073709551615).");
             }
 
             [Fact]
@@ -876,12 +876,12 @@ namespace FluentAssertions.Specs.Numeric
             {
                 // Act
                 Action act = () =>
-                    decimal.MinValue.Should().Be(decimal.MaxValue, "because we want to test the failure {0}", "message");
+                    decimal.MinValue.Should().Be(decimal.MaxValue);
 
                 // Assert
                 act
                     .Should().Throw<XunitException>()
-                    .WithMessage("Expected decimal.MinValue to be 79228162514264337593543950335M because we want to test the failure message, but found -79228162514264337593543950335M.");
+                    .WithMessage("Expected decimal.MinValue to be 79228162514264337593543950335M*found -79228162514264337593543950335M.");
             }
 
             [Fact]
@@ -892,12 +892,12 @@ namespace FluentAssertions.Specs.Numeric
 
                 // Act
                 Action act = () =>
-                    minValue.Should().Be(decimal.MaxValue, "because we want to test the failure {0}", "message");
+                    minValue.Should().Be(decimal.MaxValue);
 
                 // Assert
                 act
                     .Should().Throw<XunitException>()
-                    .WithMessage("Expected minValue to be 79228162514264337593543950335M because we want to test the failure message, but found -79228162514264337593543950335M.");
+                    .WithMessage("Expected minValue to be 79228162514264337593543950335M*found -79228162514264337593543950335M.");
             }
         }
     }


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

Currently we avoid reporting incorrect differences for 32 and 64 bit integrals by doing a `checked` subtraction, catch any `OverflowException` and omit the difference in the failure message.

Instead we can do a widening conversion of `subject` and `expected` and _then_ perform a regular subtraction.
This removes the need for `checked` and try/catch and returns the difference.