### PR TITLE
Add missing tests (according to coveralls) for Data* objects

### DIFF
--- a/Tests/FluentAssertions.Equivalency.Specs/DataColumnSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataColumnSpecs.cs
@@ -705,7 +705,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_object_of_type_unequal_to_DataColumn_is_asserted_with_a_DataColumn_it_fails()
+        public void Data_column_is_not_equivalent_to_another_type()
         {
             // Arrange
             var subject = new

--- a/Tests/FluentAssertions.Equivalency.Specs/DataColumnSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataColumnSpecs.cs
@@ -703,5 +703,27 @@ namespace FluentAssertions.Equivalency.Specs
             dataColumn1.Should().BeEquivalentTo(dataColumn2,
                 options => options.Excluding(dataColumn => dataColumn.ExtendedProperties));
         }
+
+        [Fact]
+        public void When_object_of_type_unequal_to_DataColumn_is_asserted_with_a_DataColumn_it_fails()
+        {
+            // Arrange
+            var subject = new
+            {
+                DataColumn = "foobar"
+            };
+
+            var expected = new
+            {
+                DataColumn = new DataColumn()
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*System.Data.DataColumn*found System.String*");
+        }
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRelationSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRelationSpecs.cs
@@ -320,7 +320,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_data_relation_is_expected_to_be_null_and_isnt_the_test_fails()
+        public void Data_relation_is_not_equivalent_to_null()
         {
             // Arrange
             var dataSet = new DataSet();

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRelationSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRelationSpecs.cs
@@ -288,7 +288,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_data_relation_is_null_and_isnt_expected_to_be_equivalence_test_fails()
+        public void Null_is_not_equivalent_to_a_corrent_initialized_object()
         {
             // Arrange
             var dataSet = new DataSet();

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRelationSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRelationSpecs.cs
@@ -288,7 +288,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void Null_is_not_equivalent_to_a_corrent_initialized_object()
+        public void Null_is_not_equivalent_to_a_data_relation()
         {
             // Arrange
             var dataSet = new DataSet();

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRelationSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRelationSpecs.cs
@@ -256,7 +256,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_object_of_type_unequal_to_DataRelation_is_asserted_with_a_DataRelation_it_fails()
+        public void Data_relation_is_not_equivalent_to_another_type()
         {
             // Arrange
             var dataSet = new DataSet();

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRelationSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRelationSpecs.cs
@@ -254,5 +254,101 @@ namespace FluentAssertions.Equivalency.Specs
                 .ExcludingRelated((DataRelation dataRelation) => dataRelation.ParentKeyConstraint)
                 .ExcludingRelated((DataRelation dataRelation) => dataRelation.ChildKeyConstraint));
         }
+
+        [Fact]
+        public void When_object_of_type_unequal_to_DataRelation_is_asserted_with_a_DataRelation_it_fails()
+        {
+            // Arrange
+            var dataSet = new DataSet();
+            var table = new DataTable();
+            var col1 = new DataColumn();
+            var col2 = new DataColumn();
+
+            table.Columns.Add(col1);
+            table.Columns.Add(col2);
+
+            dataSet.Tables.Add(table);
+
+            var subject = new
+            {
+                DataRelation = "foobar"
+            };
+
+            var expected = new
+            {
+                DataRelation = new DataRelation("bar", col1, col2)
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*System.Data.DataRelation*found System.String*");
+        }
+
+        [Fact]
+        public void When_data_relation_is_null_and_isnt_expected_to_be_equivalence_test_fails()
+        {
+            // Arrange
+            var dataSet = new DataSet();
+            var table = new DataTable();
+            var col1 = new DataColumn();
+            var col2 = new DataColumn();
+
+            table.Columns.Add(col1);
+            table.Columns.Add(col2);
+
+            dataSet.Tables.Add(table);
+
+            var subject = new
+            {
+                DataRelation = (DataRelation)null
+            };
+
+            var expected = new
+            {
+                DataRelation = new DataRelation("bar", col1, col2)
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected *value to be non-null, but found*");
+        }
+
+        [Fact]
+        public void When_data_relation_is_expected_to_be_null_and_isnt_the_test_fails()
+        {
+            // Arrange
+            var dataSet = new DataSet();
+            var table = new DataTable();
+            var col1 = new DataColumn();
+            var col2 = new DataColumn();
+
+            table.Columns.Add(col1);
+            table.Columns.Add(col2);
+
+            dataSet.Tables.Add(table);
+
+            var subject = new
+            {
+                DataRelation = new DataRelation("bar", col1, col2)
+            };
+
+            var expected = new
+            {
+                DataRelation = (DataRelation)null
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected *to be null, but found*");
+        }
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -360,7 +360,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_subject_of_type_DataRowCollection_is_expected_and_is_not_it_fails()
+        public void Any_type_is_not_equivalent_to_data_row_colletion()
         {
             // Arrange
             var subject = new

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -336,6 +336,47 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
+        public void When_object_of_type_unequal_to_DataRow_is_asserted_with_a_DataRow_it_fails()
+        {
+            // Arrange
+            var table = new DataTable();
+            var dataRow = table.NewRow();
+            var subject = new
+            {
+                DataRow = "foobar"
+            };
+
+            var expected = new
+            {
+                DataRow = dataRow
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*System.Data.DataRow*found System.String*");
+        }
+
+        [Fact]
+        public void When_subject_of_type_DataRowCollection_is_expected_and_is_not_it_fails()
+        {
+            // Arrange
+            var subject = new
+            {
+                DataRowCollection = "foo"
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo((DataRowCollection)null);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected* to be of type DataRowCollection, but found*");
+        }
+        
+        [Fact]
         public void When_data_row_has_column_then_asserting_that_it_has_that_column_should_succeed()
         {
             // Arrange

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -362,14 +362,11 @@ namespace FluentAssertions.Equivalency.Specs
         [Fact]
         public void Any_type_is_not_equivalent_to_data_row_colletion()
         {
-            // Arrange
-            var subject = new
-            {
-                DataRowCollection = "foo"
-            };
-
+            // Arrange 
+            var o = new object();
+            
             // Act
-            Action act = () => subject.Should().BeEquivalentTo((DataRowCollection)null);
+            Action act = () => o.Should().BeEquivalentTo((DataRowCollection)null);
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -336,7 +336,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_object_of_type_unequal_to_DataRow_is_asserted_with_a_DataRow_it_fails()
+        public void Data_row_is_not_equivalent_to_another_type()
         {
             // Arrange
             var table = new DataTable();
@@ -375,7 +375,7 @@ namespace FluentAssertions.Equivalency.Specs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected* to be of type DataRowCollection, but found*");
         }
-        
+
         [Fact]
         public void When_data_row_has_column_then_asserting_that_it_has_that_column_should_succeed()
         {

--- a/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
@@ -616,6 +616,28 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
+        public void When_object_of_type_unequal_to_DataSet_is_asserted_with_a_DataSet_it_fails()
+        {
+            // Arrange
+            var subject = new
+            {
+                DataSet = "foobar"
+            };
+
+            var expected = new
+            {
+                DataSet = new DataSet()
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*System.Data.DataSet*found System.String*");
+        }
+
+        [Fact]
         public void When_data_set_table_count_has_expected_value_equivalence_test_should_succeed()
         {
             // Arrange

--- a/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
@@ -616,7 +616,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_object_of_type_unequal_to_DataSet_is_asserted_with_a_DataSet_it_fails()
+        public void Data_set_is_not_equivalent_to_another_type()
         {
             // Arrange
             var subject = new

--- a/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
@@ -722,7 +722,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_object_of_type_unequal_to_DataTable_is_asserted_with_a_DataTable_it_fails()
+        public void Data_table_is_not_equivalent_to_another_type()
         {
             // Arrange
             var subject = new

--- a/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
@@ -722,6 +722,28 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
+        public void When_object_of_type_unequal_to_DataTable_is_asserted_with_a_DataTable_it_fails()
+        {
+            // Arrange
+            var subject = new
+            {
+                DataTable = "foobar"
+            };
+
+            var expected = new
+            {
+                DataTable = new DataTable()
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*System.Data.DataTable*found System.String*");
+        }
+
+        [Fact]
         public void When_data_table_has_expected_row_count_it_should_succeed()
         {
             // Arrange


### PR DESCRIPTION
This ref. #1823

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).