### PR TITLE
Add missing tests for matching `null` with a wildcard

### DIFF
--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
@@ -49,11 +49,6 @@ namespace FluentAssertions.Primitives
 
         private string CleanNewLines(string input)
         {
-            if (input is null)
-            {
-                return null;
-            }
-
             return IgnoreNewLineDifferences ? input.RemoveNewLines() : input;
         }
 

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Match.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Match.cs
@@ -82,6 +82,20 @@ namespace FluentAssertions.Specs.Primitives
         }
 
         [Fact]
+        public void Null_does_not_match_to_any_string()
+        {
+            // Arrange
+            string subject = null;
+
+            // Act
+            Action act = () => subject.Should().Match("*");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected subject to match *, but found <null>.");
+        }
+
+        [Fact]
         public void When_a_string_is_matched_against_an_empty_string_it_should_throw_with_a_clear_explanation()
         {
             // Arrange


### PR DESCRIPTION
This refs #1823 

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).