### PR TITLE
More testing of guarding methods

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -1028,6 +1028,22 @@ namespace FluentAssertions
             InvalidShouldCall();
         }
 
+        /// <inheritdoc cref="Should(ExecutionTimeAssertions)" />
+        [Obsolete("You are asserting the 'AndConstraint' itself. Remove the 'Should()' method directly following 'And'", error: true)]
+        public static void Should<TAssertions>(this DateTimeRangeAssertions<TAssertions> _)
+            where TAssertions : DateTimeAssertions<TAssertions>
+        {
+            InvalidShouldCall();
+        }
+
+        /// <inheritdoc cref="Should(ExecutionTimeAssertions)" />
+        [Obsolete("You are asserting the 'AndConstraint' itself. Remove the 'Should()' method directly following 'And'", error: true)]
+        public static void Should<TAssertions>(this DateTimeOffsetRangeAssertions<TAssertions> _)
+            where TAssertions : DateTimeOffsetAssertions<TAssertions>
+        {
+            InvalidShouldCall();
+        }
+
         [DoesNotReturn]
         private static void InvalidShouldCall()
         {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -118,6 +118,14 @@ namespace FluentAssertions
             where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.GuidAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -126,6 +126,14 @@ namespace FluentAssertions
             where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.GuidAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -118,6 +118,14 @@ namespace FluentAssertions
             where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.GuidAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -118,6 +118,14 @@ namespace FluentAssertions
             where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.GuidAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -117,6 +117,14 @@ namespace FluentAssertions
             where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.GuidAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -118,6 +118,14 @@ namespace FluentAssertions
             where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should<TAssertions>(this FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> _)
+            where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions> { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.GuidAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions> { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +

--- a/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
@@ -503,7 +503,7 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
-        public void When_a_nullable_property_is_overriden_with_a_custom_assertion_it_should_use_it()
+        public void When_a_nullable_property_is_overridden_with_a_custom_assertion_it_should_use_it()
         {
             // Arrange
             var actual = new SimpleWithNullable

--- a/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using FluentAssertions.Common;
 using FluentAssertions.Numeric;
 using FluentAssertions.Primitives;
 using FluentAssertions.Specialized;
@@ -13,7 +14,7 @@ namespace FluentAssertions.Specs
     public class AssertionExtensionsSpecs
     {
         [Fact]
-        public void Assertions_classes_have_overriden_equals()
+        public void Assertions_classes_override_equals()
         {
             // Arrange / Act
             var equalsOverloads = AllTypes.From(typeof(FluentAssertions.AssertionExtensions).Assembly)
@@ -33,6 +34,40 @@ namespace FluentAssertions.Specs
             MethodInfo equals = t.GetMethod("Equals", BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public,
                 null, new[] { typeof(object) }, null);
             return equals is not null;
+        }
+
+        public static object[][] ClassesWithGuardEquals() => new object[][]
+        {
+            new object[] { new ObjectAssertions<object, ObjectAssertions>(default) },
+            new object[] { new BooleanAssertions<BooleanAssertions>(default) },
+            new object[] { new DateTimeAssertions<DateTimeAssertions>(default) },
+            new object[] { new DateTimeRangeAssertions<DateTimeAssertions>(default, default, default, default) },
+            new object[] { new DateTimeOffsetAssertions<DateTimeOffsetAssertions>(default) },
+            new object[] { new DateTimeOffsetRangeAssertions<DateTimeOffsetAssertions>(default, default, default, default) },
+#if NET6_0_OR_GREATER
+            new object[] { new DateOnlyAssertions<DateOnlyAssertions>(default) },
+            new object[] { new TimeOnlyAssertions<TimeOnlyAssertions>(default) },
+#endif
+            new object[] { new ExecutionTimeAssertions(new ExecutionTime(() => { }, () => new StopwatchTimer())) },
+            new object[] { new GuidAssertions<GuidAssertions>(default) },
+            new object[] { new MethodInfoSelectorAssertions() },
+            new object[] { new NumericAssertions<int, NumericAssertions<int>>(default) },
+            new object[] { new PropertyInfoSelectorAssertions() },
+            new object[] { new SimpleTimeSpanAssertions<SimpleTimeSpanAssertions>(default) },
+            new object[] { new TaskCompletionSourceAssertions<int>(default) },
+            new object[] { new TypeSelectorAssertions() },
+            new object[] { new EnumAssertions<StringComparison, EnumAssertions<StringComparison>>(default) }
+        };
+
+        [Theory]
+        [MemberData(nameof(ClassesWithGuardEquals))]
+        public void Guarding_equals_throws(object obj)
+        {
+            // Act
+            Action act = () => obj.Equals(null);
+
+            // Assert
+            act.Should().ThrowExactly<NotSupportedException>();
         }
 
         [Theory]

--- a/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
@@ -39,7 +39,9 @@ namespace FluentAssertions.Specs
         [InlineData(typeof(ReferenceTypeAssertions<object, ObjectAssertions>))]
         [InlineData(typeof(BooleanAssertions<BooleanAssertions>))]
         [InlineData(typeof(DateTimeAssertions<DateTimeAssertions>))]
+        [InlineData(typeof(DateTimeRangeAssertions<DateTimeAssertions>))]
         [InlineData(typeof(DateTimeOffsetAssertions<DateTimeOffsetAssertions>))]
+        [InlineData(typeof(DateTimeOffsetRangeAssertions<DateTimeOffsetAssertions>))]
 #if NET6_0_OR_GREATER
         [InlineData(typeof(DateOnlyAssertions<DateOnlyAssertions>))]
         [InlineData(typeof(TimeOnlyAssertions<TimeOnlyAssertions>))]
@@ -95,6 +97,11 @@ namespace FluentAssertions.Specs
                 .Where(m => !IsGuardOverload(m))
                 .Select(t => GetMostParentType(t.ReturnType))
                 .Distinct()
+                .Concat(new[]
+                {
+                    typeof(DateTimeRangeAssertions<>),
+                    typeof(DateTimeOffsetRangeAssertions<>)
+                })
                 .ToList();
 
             List<Type> fakeOverloads = shouldOverloads


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

Found that we didn't have fake `Should` overloads for `DateTime[Offset]RangeAssertions` since they don't have real `Should` overloads, but are always constructed from `DateTime[Offset]Assertions`.

I've also added code-coverage tests of guarding `Equals` methods right below `Assertions_classes_override_equals` which tests that `bool Equals(object obj)` is overridden.