### PR TITLE
Improve the formatting of descriptions of Types

### DIFF
--- a/Src/FluentAssertions/Common/TypeDescriptionUtility.cs
+++ b/Src/FluentAssertions/Common/TypeDescriptionUtility.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace FluentAssertions.Common
+{
+    internal static class TypeDescriptionUtility
+    {
+        public static string GetDescriptionOfObjectType(object obj)
+        {
+            return (obj is null) ? "<null>" : GetTypeDescription(obj.GetType(), describeValue: true);
+        }
+
+        public static string GetTypeDescription(Type type)
+            => GetTypeDescription(type, describeValue: false);
+
+        private static string GetTypeDescription(Type type, bool describeValue)
+        {
+            if ((type.Namespace == "System.Linq") && type.IsGenericType)
+            {
+                return "an anonymous iterator from a LINQ expression with element type " + type.GetGenericArguments()[0].FullName;
+            }
+            else
+            {
+                return
+                    describeValue
+                    ? (type.IsValueType ? "a value of type " : "an instance of ") + type.FullName
+                    : type.FullName;
+            }
+        }
+    }
+}

--- a/Src/FluentAssertions/DataColumnCollectionAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataColumnCollectionAssertionExtensions.cs
@@ -48,8 +48,8 @@ namespace FluentAssertions
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
                         "Invalid expectation: Expected {context:column collection} to refer to an instance of " +
-                        "DataColumnCollection{reason}, but found {0}.",
-                        assertion.Subject);
+                        "DataColumnCollection{reason}, but found " +
+                        TypeDescriptionUtility.GetDescriptionOfObjectType(assertion.Subject) + ".");
             }
 
             return new AndConstraint<GenericCollectionAssertions<DataColumn>>(assertion);
@@ -89,8 +89,8 @@ namespace FluentAssertions
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
                         "Invalid expectation: Expected {context:column collection} to refer to a different instance of " +
-                        "DataColumnCollection{reason}, but found {0}.",
-                        assertion.Subject);
+                        "DataColumnCollection{reason}, but found " +
+                        TypeDescriptionUtility.GetDescriptionOfObjectType(assertion.Subject) + ".");
             }
 
             return new AndConstraint<GenericCollectionAssertions<DataColumn>>(assertion);

--- a/Src/FluentAssertions/DataRowCollectionAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataRowCollectionAssertionExtensions.cs
@@ -46,8 +46,8 @@ namespace FluentAssertions
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
                         "Invalid expectation: Expected {context:column collection} to refer to an instance of " +
-                        "DataRowCollection{reason}, but found {0}.",
-                        assertion.Subject);
+                        "DataRowCollection{reason}, but found " +
+                        TypeDescriptionUtility.GetDescriptionOfObjectType(assertion.Subject) + ".");
             }
 
             return new AndConstraint<GenericCollectionAssertions<DataRow>>(assertion);
@@ -84,8 +84,8 @@ namespace FluentAssertions
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
                         "Invalid expectation: Expected {context:column collection} to refer to a different instance of " +
-                        "DataRowCollection{reason}, but found {0}.",
-                        assertion.Subject);
+                        "DataRowCollection{reason}, but found " +
+                        TypeDescriptionUtility.GetDescriptionOfObjectType(assertion.Subject) + ".");
             }
 
             return new AndConstraint<GenericCollectionAssertions<DataRow>>(assertion);

--- a/Src/FluentAssertions/DataTableCollectionAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataTableCollectionAssertionExtensions.cs
@@ -43,8 +43,8 @@ namespace FluentAssertions
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
                         "Invalid expectation: Expected {context:column collection} to refer to an instance of " +
-                        "DataTableCollection{reason}, but found {0}.",
-                        assertion.Subject);
+                        "DataTableCollection{reason}, but found " +
+                        TypeDescriptionUtility.GetDescriptionOfObjectType(assertion.Subject) + ".");
             }
 
             return new AndConstraint<GenericCollectionAssertions<DataTable>>(assertion);
@@ -81,8 +81,8 @@ namespace FluentAssertions
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
                         "Invalid expectation: Expected {context:column collection} to refer to a different instance of " +
-                        "DataTableCollection{reason}, but found {0}.",
-                        assertion.Subject);
+                        "DataTableCollection{reason}, but found " +
+                        TypeDescriptionUtility.GetDescriptionOfObjectType(assertion.Subject) + ".");
             }
 
             return new AndConstraint<GenericCollectionAssertions<DataTable>>(assertion);

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -466,13 +466,8 @@ namespace FluentAssertions.Types
 
         private static string GetDescriptionsFor(IEnumerable<Type> types)
         {
-            IEnumerable<string> descriptions = types.Select(type => GetDescriptionFor(type));
+            IEnumerable<string> descriptions = types.Select(type => TypeDescriptionUtility.GetTypeDescription(type));
             return string.Join(Environment.NewLine, descriptions);
-        }
-
-        private static string GetDescriptionFor(Type type)
-        {
-            return type.ToString();
         }
 
         /// <inheritdoc/>

--- a/Tests/FluentAssertions.Specs/Common/TypeDescriptionUtilitySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Common/TypeDescriptionUtilitySpecs.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using FluentAssertions.Common;
+
+using Xunit;
+
+namespace FluentAssertions.Specs
+{
+    public class TypeDescriptionUtilitySpecs
+    {
+        [Fact]
+        public void When_object_is_null_it_should_work()
+        {
+            // Act & Assert
+            TypeDescriptionUtility.GetDescriptionOfObjectType(null).Should().Be("<null>");
+        }
+
+        [Fact]
+        public void When_object_is_value_type_it_should_work()
+        {
+            // Act & Assert
+            TypeDescriptionUtility.GetDescriptionOfObjectType(37).Should().Be("a value of type System.Int32");
+        }
+
+        [Fact]
+        public void When_object_is_reference_type_it_should_work()
+        {
+            // Act & Assert
+            TypeDescriptionUtility.GetDescriptionOfObjectType(new object()).Should().Be("an instance of System.Object");
+        }
+
+        [Fact]
+        public void When_object_is_generic_value_type_it_should_work()
+        {
+            // Arrange
+            var box = new Box<int>() { Value = 37 };
+
+            // Act & Assert
+            TypeDescriptionUtility.GetDescriptionOfObjectType(box).Should()
+                .Match("a value of type *+Box`1[[System.Int32*]]");
+        }
+
+        [Fact]
+        public void When_object_is_generic_reference_type_it_should_work()
+        {
+            // Act & Assert
+            TypeDescriptionUtility.GetDescriptionOfObjectType(new List<int>()).Should()
+                .Match("an instance of System.Collections.Generic.List`1[[System.Int32*]]");
+        }
+
+        [Fact]
+        public void When_object_is_LINQ_anonymous_iterator_type_it_should_work()
+        {
+            // Arrange
+            var value = new[] { 1, 2, 3 }.Select(x => 2 * x);
+
+            TypeDescriptionUtility.GetDescriptionOfObjectType(value).Should().Be(
+                "an anonymous iterator from a LINQ expression with element type System.Int32");
+        }
+
+        private struct Box<T>
+        {
+            public T Value { get; set; }
+        }
+    }
+}

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -23,6 +23,7 @@ sidebar:
 * Added `NotBe` for nullable boolean values - [#1865](https://github.com/fluentassertions/fluentassertions/pull/1865)
 * Added a new overload to `MatchRegex()` to assert on the number of regex matches - [#1869](https://github.com/fluentassertions/fluentassertions/pull/1869)
 * Added difference to numeric assertion failure messages - [#1859](https://github.com/fluentassertions/fluentassertions/pull/1859)
+* Improved the formatting of data type names, especially with regard to LINQ results - [#1895](https://github.com/fluentassertions/fluentassertions/1895)
 
 ### Fixes
 * `EnumAssertions.Be` did not determine the caller name - [#1835](https://github.com/fluentassertions/fluentassertions/pull/1835)


### PR DESCRIPTION
This PR adds a new type `TypeDescriptionUtility` that includes some logic to improve the readability where type names are being included in test output. In particular, LINQ result sets are identified and made human-readable. This functionality was originally written for #1812 but was extracted to its own independent PR -- as such this functionality is initially used directly in `DataTableCollection`, `DataColumnCollection` and `DataRowCollection` assertions. It has also been applied to formatting of the type name in `TypeSelectorAssertions`. The new functionality is unit-tested, and `releases.md` has been updated to describe the change.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).