### PR TITLE
Add missing `null` check tests in Data*Specs

### DIFF
--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -364,7 +364,7 @@ namespace FluentAssertions.Equivalency.Specs
         {
             // Arrange 
             var o = new object();
-            
+
             // Act
             Action act = () => o.Should().BeEquivalentTo((DataRowCollection)null);
 
@@ -404,6 +404,20 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
+        public void Null_data_row_does_not_have_column()
+        {
+            // Arrange
+            var dataRow = (DataRow)null;
+
+            // Act
+            Action action =
+                () => dataRow.Should().HaveColumn("Does not matter");
+
+            // Assert
+            action.Should().Throw<XunitException>().WithMessage("Expected dataRow to contain a column named *Does not matter*, but found <null>*");
+        }
+
+        [Fact]
         public void When_data_row_data_has_all_columns_being_asserted_then_it_should_succeed()
         {
             // Arrange
@@ -417,6 +431,46 @@ namespace FluentAssertions.Equivalency.Specs
 
             // Act & Assert
             dataRow.Should().HaveColumns(subsetOfColumnNames);
+        }
+
+        [Fact]
+        public void Data_row_with_all_colums_asserted_and_using_the_array_overload_passes()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataRow = dataSet.TypedDataTable1[0];
+
+            string[] subsetOfColumnNames = dataRow.Table.Columns.Cast<DataColumn>()
+                .Take(dataRow.Table.Columns.Count - 2)
+                .Select(column => column.ColumnName)
+                .ToArray();
+
+            // Act & Assert
+            dataRow.Should().HaveColumns(subsetOfColumnNames);
+        }
+
+        [Fact]
+        public void Null_data_row_and_using_the_array_overload_fails()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+            var dataRow = dataSet.TypedDataTable1[0];
+
+            var actual = (DataRow)null;
+
+            string[] subsetOfColumnNames = dataRow.Table.Columns.Cast<DataColumn>()
+                .Take(dataRow.Table.Columns.Count - 2)
+                .Select(column => column.ColumnName)
+                .ToArray();
+
+            // Act
+            Action act = () => actual.Should().HaveColumns(subsetOfColumnNames);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected actual to be in a table containing *column*, but found <null>*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
@@ -648,6 +648,22 @@ namespace FluentAssertions.Equivalency.Specs
             // Act & Assert
             dataSet.Should().HaveTableCount(correctTableCount);
         }
+        
+        [Fact]
+        public void Null_data_set_fails()
+        {
+            // Arrange
+            var dataSet = (DataSet)null;
+
+            var correctTableCount = -1;
+
+            // Act
+            Action act = () => dataSet.Should().HaveTableCount(correctTableCount);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected dataSet to contain exactly*, but found <null>*");
+        }
 
         [Fact]
         public void When_data_set_table_count_has_unexpected_value_equivalence_test_should_fail()
@@ -680,6 +696,22 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
+        public void Null_data_set_does_not_contain_expected_table()
+        {
+            // Arrange
+            var dataSet = (DataSet)null;
+
+            var existingTableName = "Does not matter";
+
+            // Act
+            Action act = () => dataSet.Should().HaveTable(existingTableName);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected dataSet to contain a table named*, but found <nulL>*");
+        }
+
+        [Fact]
         public void When_data_set_does_not_contain_expected_table_asserting_that_it_has_that_table_should_fail()
         {
             // Arrange
@@ -706,6 +738,24 @@ namespace FluentAssertions.Equivalency.Specs
 
             // Act & Assert
             dataSet.Should().HaveTables(existingTableNames);
+        }
+
+        [Fact]
+        public void Null_data_set_has_no_tables_and_fails()
+        {
+            // Arrange
+            var dataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+            var actual = (DataSet)null;
+
+            var existingTableNames = dataSet.Tables.Cast<DataTable>()
+                .Select(table => table.TableName);
+
+            // Act
+            Action act = () => actual.Should().HaveTables(existingTableNames);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected actual to contain*table*with specific name*, but found <null>*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
@@ -758,6 +758,22 @@ namespace FluentAssertions.Equivalency.Specs
         }
 
         [Fact]
+        public void Null_data_table_no_rows_and_fails_test()
+        {
+            // Arrange
+            var dataTable = (DataTable)null;
+
+            int correctRowCount = -1;
+
+            // Act
+            Action act = () => dataTable.Should().HaveRowCount(correctRowCount);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected dataTable to contain exactly*row*, but found <nulL>*");
+        }
+
+        [Fact]
         public void When_empty_data_table_has_expected_row_count_of_zero_it_should_succeed()
         {
             // Arrange
@@ -805,6 +821,22 @@ namespace FluentAssertions.Equivalency.Specs
             // Act & Assert
             dataTable.Should().HaveColumn(expectedColumnName);
         }
+        
+        [Fact]
+        public void Null_data_table_has_no_columns_and_fail_the_test()
+        {
+            // Arrange
+            var dataTable = (DataTable)null;
+
+            var expectedColumnName = "Does not matter";
+
+            // Act
+            Action act = () => dataTable.Should().HaveColumn(expectedColumnName);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected dataTable to contain a column named*, but found <null>*");
+        }
 
         [Fact]
         public void When_data_table_does_not_have_expected_column_it_should_fail()
@@ -835,6 +867,22 @@ namespace FluentAssertions.Equivalency.Specs
 
             // Act & Assert
             dataTable.Should().HaveColumns(existingColumnNames);
+        }
+
+        [Fact]
+        public void Null_data_table_has_no_columns_and_fails_the_test()
+        {
+            // Arrange
+            var actual = (DataTable)null;
+
+            var existingColumnName = "Does not matter";
+
+            // Act
+            Action act = () => actual.Should().HaveColumns(existingColumnName);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected actual to contain*column*with specific name*, but found <null>*");
         }
 
         [Fact]


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

ref. #1823 