### PR TITLE
Structure assertions with nested classes instead of regions (Part 2)

### DIFF
--- a/Tests/FluentAssertions.Specs/Primitives/GuidAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/GuidAssertionSpecs.cs
@@ -6,201 +6,208 @@ namespace FluentAssertions.Specs.Primitives
 {
     public class GuidAssertionSpecs
     {
-        #region BeEmpty / NotBeEmpty
-
-        [Fact]
-        public void Should_succeed_when_asserting_empty_guid_is_empty()
+        public class BeEmpty
         {
-            // Arrange
-            Guid guid = Guid.Empty;
+            [Fact]
+            public void Should_succeed_when_asserting_empty_guid_is_empty()
+            {
+                // Arrange
+                Guid guid = Guid.Empty;
 
-            // Act / Assert
-            guid.Should().BeEmpty();
+                // Act / Assert
+                guid.Should().BeEmpty();
+            }
+
+            [Fact]
+            public void Should_fail_when_asserting_non_empty_guid_is_empty()
+            {
+                // Arrange
+                var guid = new Guid("12345678-1234-1234-1234-123456789012");
+
+                // Act
+                Action act = () => guid.Should().BeEmpty("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected Guid to be empty because we want to test the failure message, but found {12345678-1234-1234-1234-123456789012}.");
+            }
         }
 
-        [Fact]
-        public void Should_fail_when_asserting_non_empty_guid_is_empty()
+        public class NotBeEmpty
         {
-            // Arrange
-            var guid = new Guid("12345678-1234-1234-1234-123456789012");
+            [Fact]
+            public void Should_succeed_when_asserting_non_empty_guid_is_not_empty()
+            {
+                // Arrange
+                var guid = new Guid("12345678-1234-1234-1234-123456789012");
 
-            // Act
-            Action act = () => guid.Should().BeEmpty("because we want to test the failure {0}", "message");
+                // Act
+                Action act = () => guid.Should().NotBeEmpty();
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected Guid to be empty because we want to test the failure message, but found {12345678-1234-1234-1234-123456789012}.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void Should_fail_when_asserting_empty_guid_is_not_empty()
+            {
+                // Act
+                Action act = () => Guid.Empty.Should().NotBeEmpty("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect Guid.Empty to be empty because we want to test the failure message.");
+            }
         }
 
-        [Fact]
-        public void Should_succeed_when_asserting_non_empty_guid_is_not_empty()
+        public class Be
         {
-            // Arrange
-            var guid = new Guid("12345678-1234-1234-1234-123456789012");
+            [Fact]
+            public void Should_succeed_when_asserting_guid_equals_the_same_guid()
+            {
+                // Arrange
+                var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+                var sameGuid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
 
-            // Act
-            Action act = () => guid.Should().NotBeEmpty();
+                // Act
+                Action act = () => guid.Should().Be(sameGuid);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void Should_succeed_when_asserting_guid_equals_the_same_guid_in_string_format()
+            {
+                // Arrange
+                var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+
+                // Act
+                Action act = () => guid.Should().Be("11111111-aaaa-bbbb-cccc-999999999999");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void Should_fail_when_asserting_guid_equals_a_different_guid()
+            {
+                // Arrange
+                var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+                var differentGuid = new Guid("55555555-ffff-eeee-dddd-444444444444");
+
+                // Act
+                Action act = () => guid.Should().Be(differentGuid, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected Guid to be {55555555-ffff-eeee-dddd-444444444444} because we want to test the failure message, but found {11111111-aaaa-bbbb-cccc-999999999999}.");
+            }
+
+            [Fact]
+            public void Should_throw_when_asserting_guid_equals_a_string_that_is_not_a_valid_guid()
+            {
+                // Arrange
+                var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+
+                // Act
+                Action act = () => guid.Should().Be(string.Empty, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<ArgumentException>()
+                    .WithParameterName("expected");
+            }
         }
 
-        [Fact]
-        public void Should_fail_when_asserting_empty_guid_is_not_empty()
+        public class NotBe
         {
-            // Act
-            Action act = () => Guid.Empty.Should().NotBeEmpty("because we want to test the failure {0}", "message");
+            [Fact]
+            public void Should_succeed_when_asserting_guid_does_not_equal_a_different_guid()
+            {
+                // Arrange
+                var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+                var differentGuid = new Guid("55555555-ffff-eeee-dddd-444444444444");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect Guid.Empty to be empty because we want to test the failure message.");
+                // Act
+                Action act = () =>
+                    guid.Should().NotBe(differentGuid);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void Should_succeed_when_asserting_guid_does_not_equal_the_same_guid()
+            {
+                // Arrange
+                var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+                var sameGuid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+
+                // Act
+                Action act = () => guid.Should().NotBe(sameGuid, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect Guid to be {11111111-aaaa-bbbb-cccc-999999999999} because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void Should_throw_when_asserting_guid_does_not_equal_a_string_that_is_not_a_valid_guid()
+            {
+                // Arrange
+                var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+
+                // Act
+                Action act = () => guid.Should().NotBe(string.Empty, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<ArgumentException>()
+                    .WithParameterName("unexpected");
+            }
+
+            [Fact]
+            public void Should_succeed_when_asserting_guid_does_not_equal_a_different_guid_in_string_format()
+            {
+                // Arrange
+                var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+
+                // Act
+                Action act = () =>
+                    guid.Should().NotBe("55555555-ffff-eeee-dddd-444444444444");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void Should_succeed_when_asserting_guid_does_not_equal_the_same_guid_in_string_format()
+            {
+                // Arrange
+                var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+
+                // Act
+                Action act = () =>
+                    guid.Should().NotBe("11111111-aaaa-bbbb-cccc-999999999999", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect Guid to be {11111111-aaaa-bbbb-cccc-999999999999} *failure message*.");
+            }
         }
 
-        #endregion
-
-        #region Be / NotBe
-
-        [Fact]
-        public void Should_succeed_when_asserting_guid_equals_the_same_guid()
+        public class ChainingConstraint
         {
-            // Arrange
-            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
-            var sameGuid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+            [Fact]
+            public void Should_support_chaining_constraints_with_and()
+            {
+                // Arrange
+                Guid guid = Guid.NewGuid();
 
-            // Act
-            Action act = () => guid.Should().Be(sameGuid);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_guid_equals_the_same_guid_in_string_format()
-        {
-            // Arrange
-            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
-
-            // Act
-            Action act = () => guid.Should().Be("11111111-aaaa-bbbb-cccc-999999999999");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void Should_fail_when_asserting_guid_equals_a_different_guid()
-        {
-            // Arrange
-            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
-            var differentGuid = new Guid("55555555-ffff-eeee-dddd-444444444444");
-
-            // Act
-            Action act = () => guid.Should().Be(differentGuid, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected Guid to be {55555555-ffff-eeee-dddd-444444444444} because we want to test the failure message, but found {11111111-aaaa-bbbb-cccc-999999999999}.");
-        }
-
-        [Fact]
-        public void Should_throw_when_asserting_guid_equals_a_string_that_is_not_a_valid_guid()
-        {
-            // Arrange
-            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
-
-            // Act
-            Action act = () => guid.Should().Be(string.Empty, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<ArgumentException>()
-                .WithParameterName("expected");
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_guid_does_not_equal_a_different_guid()
-        {
-            // Arrange
-            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
-            var differentGuid = new Guid("55555555-ffff-eeee-dddd-444444444444");
-
-            // Act
-            Action act = () =>
-                guid.Should().NotBe(differentGuid);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_guid_does_not_equal_the_same_guid()
-        {
-            // Arrange
-            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
-            var sameGuid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
-
-            // Act
-            Action act = () => guid.Should().NotBe(sameGuid, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect Guid to be {11111111-aaaa-bbbb-cccc-999999999999} because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void Should_throw_when_asserting_guid_does_not_equal_a_string_that_is_not_a_valid_guid()
-        {
-            // Arrange
-            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
-
-            // Act
-            Action act = () => guid.Should().NotBe(string.Empty, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<ArgumentException>()
-                .WithParameterName("unexpected");
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_guid_does_not_equal_a_different_guid_in_string_format()
-        {
-            // Arrange
-            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
-
-            // Act
-            Action act = () =>
-                guid.Should().NotBe("55555555-ffff-eeee-dddd-444444444444");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_guid_does_not_equal_the_same_guid_in_string_format()
-        {
-            // Arrange
-            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
-
-            // Act
-            Action act = () =>
-                guid.Should().NotBe("11111111-aaaa-bbbb-cccc-999999999999", "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect Guid to be {11111111-aaaa-bbbb-cccc-999999999999} *failure message*.");
-        }
-
-        #endregion
-
-        [Fact]
-        public void Should_support_chaining_constraints_with_and()
-        {
-            // Arrange
-            Guid guid = Guid.NewGuid();
-
-            // Act / Assert
-            guid.Should()
-                .NotBeEmpty()
-                .And.Be(guid);
+                // Act / Assert
+                guid.Should()
+                    .NotBeEmpty()
+                    .And.Be(guid);
+            }
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -14,132 +14,136 @@ namespace FluentAssertions.Specs.Primitives
 {
     public class ObjectAssertionSpecs
     {
-        #region Be / NotBe
-
-        [Fact]
-        public void When_two_equal_object_are_expected_to_be_equal_it_should_not_fail()
+        public class Be
         {
-            // Arrange
-            var someObject = new ClassWithCustomEqualMethod(1);
-            var equalObject = new ClassWithCustomEqualMethod(1);
+            [Fact]
+            public void When_two_equal_object_are_expected_to_be_equal_it_should_not_fail()
+            {
+                // Arrange
+                var someObject = new ClassWithCustomEqualMethod(1);
+                var equalObject = new ClassWithCustomEqualMethod(1);
 
-            // Act / Assert
-            someObject.Should().Be(equalObject);
+                // Act / Assert
+                someObject.Should().Be(equalObject);
+            }
+
+            [Fact]
+            public void When_two_different_objects_are_expected_to_be_equal_it_should_fail_with_a_clear_explanation()
+            {
+                // Arrange
+                var someObject = new ClassWithCustomEqualMethod(1);
+                var nonEqualObject = new ClassWithCustomEqualMethod(2);
+
+                // Act
+                Action act = () => someObject.Should().Be(nonEqualObject);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected someObject to be ClassWithCustomEqualMethod(2), but found ClassWithCustomEqualMethod(1).");
+            }
+
+            [Fact]
+            public void When_both_subject_and_expected_are_null_it_should_succeed()
+            {
+                // Arrange
+                object someObject = null;
+                object expectedObject = null;
+
+                // Act / Assert
+                someObject.Should().Be(expectedObject);
+            }
+
+            [Fact]
+            public void When_the_subject_is_null_it_should_fail()
+            {
+                // Arrange
+                object someObject = null;
+                var nonEqualObject = new ClassWithCustomEqualMethod(2);
+
+                // Act
+                Action act = () => someObject.Should().Be(nonEqualObject);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected someObject to be ClassWithCustomEqualMethod(2), but found <null>.");
+            }
+
+            [Fact]
+            public void When_two_different_objects_are_expected_to_be_equal_it_should_fail_and_use_the_reason()
+            {
+                // Arrange
+                var someObject = new ClassWithCustomEqualMethod(1);
+                var nonEqualObject = new ClassWithCustomEqualMethod(2);
+
+                // Act
+                Action act = () => someObject.Should().Be(nonEqualObject, "because it should use the {0}", "reason");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected someObject to be ClassWithCustomEqualMethod(2) because it should use the reason, but found ClassWithCustomEqualMethod(1).");
+            }
+
+            [Fact]
+            public void When_comparing_a_numeric_and_an_enum_for_equality_it_should_throw()
+            {
+                // Arrange
+                object subject = 1;
+                MyEnum expected = MyEnum.One;
+
+                // Act
+                Action act = () => subject.Should().Be(expected);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
         }
 
-        [Fact]
-        public void When_two_different_objects_are_expected_to_be_equal_it_should_fail_with_a_clear_explanation()
+        public class NotBe
         {
-            // Arrange
-            var someObject = new ClassWithCustomEqualMethod(1);
-            var nonEqualObject = new ClassWithCustomEqualMethod(2);
+            [Fact]
+            public void When_non_equal_objects_are_expected_to_be_not_equal_it_should_not_fail()
+            {
+                // Arrange
+                var someObject = new ClassWithCustomEqualMethod(1);
+                var nonEqualObject = new ClassWithCustomEqualMethod(2);
 
-            // Act
-            Action act = () => someObject.Should().Be(nonEqualObject);
+                // Act / Assert
+                someObject.Should().NotBe(nonEqualObject);
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected someObject to be ClassWithCustomEqualMethod(2), but found ClassWithCustomEqualMethod(1).");
-        }
+            [Fact]
+            public void When_two_equal_objects_are_expected_not_to_be_equal_it_should_fail_with_a_clear_explanation()
+            {
+                // Arrange
+                var someObject = new ClassWithCustomEqualMethod(1);
+                var equalObject = new ClassWithCustomEqualMethod(1);
 
-        [Fact]
-        public void When_both_subject_and_expected_are_null_it_should_succeed()
-        {
-            // Arrange
-            object someObject = null;
-            object expectedObject = null;
+                // Act
+                Action act = () =>
+                    someObject.Should().NotBe(equalObject);
 
-            // Act / Assert
-            someObject.Should().Be(expectedObject);
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect someObject to be equal to ClassWithCustomEqualMethod(1).");
+            }
 
-        [Fact]
-        public void When_the_subject_is_null_it_should_fail()
-        {
-            // Arrange
-            object someObject = null;
-            var nonEqualObject = new ClassWithCustomEqualMethod(2);
+            [Fact]
+            public void When_two_equal_objects_are_expected_not_to_be_equal_it_should_fail_and_use_the_reason()
+            {
+                // Arrange
+                var someObject = new ClassWithCustomEqualMethod(1);
+                var equalObject = new ClassWithCustomEqualMethod(1);
 
-            // Act
-            Action act = () => someObject.Should().Be(nonEqualObject);
+                // Act
+                Action act = () =>
+                    someObject.Should().NotBe(equalObject, "because we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected someObject to be ClassWithCustomEqualMethod(2), but found <null>.");
-        }
-
-        [Fact]
-        public void When_two_different_objects_are_expected_to_be_equal_it_should_fail_and_use_the_reason()
-        {
-            // Arrange
-            var someObject = new ClassWithCustomEqualMethod(1);
-            var nonEqualObject = new ClassWithCustomEqualMethod(2);
-
-            // Act
-            Action act = () => someObject.Should().Be(nonEqualObject, "because it should use the {0}", "reason");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected someObject to be ClassWithCustomEqualMethod(2) because it should use the reason, but found ClassWithCustomEqualMethod(1).");
-        }
-
-        [Fact]
-        public void When_non_equal_objects_are_expected_to_be_not_equal_it_should_not_fail()
-        {
-            // Arrange
-            var someObject = new ClassWithCustomEqualMethod(1);
-            var nonEqualObject = new ClassWithCustomEqualMethod(2);
-
-            // Act / Assert
-            someObject.Should().NotBe(nonEqualObject);
-        }
-
-        [Fact]
-        public void When_two_equal_objects_are_expected_not_to_be_equal_it_should_fail_with_a_clear_explanation()
-        {
-            // Arrange
-            var someObject = new ClassWithCustomEqualMethod(1);
-            var equalObject = new ClassWithCustomEqualMethod(1);
-
-            // Act
-            Action act = () =>
-                someObject.Should().NotBe(equalObject);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect someObject to be equal to ClassWithCustomEqualMethod(1).");
-        }
-
-        [Fact]
-        public void When_two_equal_objects_are_expected_not_to_be_equal_it_should_fail_and_use_the_reason()
-        {
-            // Arrange
-            var someObject = new ClassWithCustomEqualMethod(1);
-            var equalObject = new ClassWithCustomEqualMethod(1);
-
-            // Act
-            Action act = () =>
-                someObject.Should().NotBe(equalObject, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect someObject to be equal to ClassWithCustomEqualMethod(1) " +
-                "because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void When_comparing_a_numeric_and_an_enum_for_equality_it_should_throw()
-        {
-            // Arrange
-            object subject = 1;
-            MyEnum expected = MyEnum.One;
-
-            // Act
-            Action act = () => subject.Should().Be(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>();
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect someObject to be equal to ClassWithCustomEqualMethod(1) " +
+                    "because we want to test the failure message.");
+            }
         }
 
         private enum MyEnum
@@ -148,810 +152,810 @@ namespace FluentAssertions.Specs.Primitives
             Two = 2
         }
 
-        #endregion
-
-        #region BeNull / BeNotNull
-
-        [Fact]
-        public void Should_succeed_when_asserting_null_object_to_be_null()
+        public class BeNull
         {
-            // Arrange
-            object someObject = null;
+            [Fact]
+            public void Should_succeed_when_asserting_null_object_to_be_null()
+            {
+                // Arrange
+                object someObject = null;
 
-            // Act / Assert
-            someObject.Should().BeNull();
+                // Act / Assert
+                someObject.Should().BeNull();
+            }
+
+            [Fact]
+            public void Should_fail_when_asserting_non_null_object_to_be_null()
+            {
+                // Arrange
+                var someObject = new object();
+
+                // Act
+                Action act = () => someObject.Should().BeNull();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_a_non_null_object_is_expected_to_be_null_it_should_fail()
+            {
+                // Arrange
+                var someObject = new object();
+
+                // Act
+                Action act = () => someObject.Should().BeNull("because we want to test the failure {0}", "message");
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .Where(e => e.Message.StartsWith(
+                        "Expected someObject to be <null> because we want to test the failure message, but found System.Object",
+                        StringComparison.Ordinal));
+            }
         }
 
-        [Fact]
-        public void Should_fail_when_asserting_non_null_object_to_be_null()
+        public class BeNotNull
         {
-            // Arrange
-            var someObject = new object();
+            [Fact]
+            public void Should_succeed_when_asserting_non_null_object_not_to_be_null()
+            {
+                // Arrange
+                var someObject = new object();
 
-            // Act
-            Action act = () => someObject.Should().BeNull();
+                // Act / Assert
+                someObject.Should().NotBeNull();
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>();
+            [Fact]
+            public void Should_fail_when_asserting_null_object_not_to_be_null()
+            {
+                // Arrange
+                object someObject = null;
+
+                // Act
+                Action act = () => someObject.Should().NotBeNull();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void Should_fail_with_descriptive_message_when_asserting_null_object_not_to_be_null()
+            {
+                // Arrange
+                object someObject = null;
+
+                // Act
+                Action act = () => someObject.Should().NotBeNull("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected someObject not to be <null> because we want to test the failure message.");
+            }
         }
 
-        [Fact]
-        public void When_a_non_null_object_is_expected_to_be_null_it_should_fail()
+        public class BeOfType
         {
-            // Arrange
-            var someObject = new object();
+            [Fact]
+            public void When_object_type_is_matched_against_null_type_exactly_it_should_throw()
+            {
+                // Arrange
+                var someObject = new object();
 
-            // Act
-            Action act = () => someObject.Should().BeNull("because we want to test the failure {0}", "message");
+                // Act
+                Action act = () => someObject.Should().BeOfType(null);
 
-            // Assert
-            act
-                .Should().Throw<XunitException>()
-                .Where(e => e.Message.StartsWith(
-                    "Expected someObject to be <null> because we want to test the failure message, but found System.Object",
-                    StringComparison.Ordinal));
-        }
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithParameterName("expectedType");
+            }
 
-        [Fact]
-        public void Should_succeed_when_asserting_non_null_object_not_to_be_null()
-        {
-            // Arrange
-            var someObject = new object();
+            [Fact]
+            public void When_object_type_is_exactly_equal_to_the_specified_type_it_should_not_fail()
+            {
+                // Arrange
+                var someObject = new Exception();
 
-            // Act / Assert
-            someObject.Should().NotBeNull();
-        }
+                // Act
+                Action act = () => someObject.Should().BeOfType<Exception>();
 
-        [Fact]
-        public void Should_fail_when_asserting_null_object_not_to_be_null()
-        {
-            // Arrange
-            object someObject = null;
+                // Assert
+                act.Should().NotThrow();
+            }
 
-            // Act
-            Action act = () => someObject.Should().NotBeNull();
+            [Fact]
+            public void When_object_type_is_value_type_and_matches_received_type_should_not_fail_and_assert_correctly()
+            {
+                // Arrange
+                int valueTypeObject = 42;
 
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
+                // Act
+                Action act = () => valueTypeObject.Should().BeOfType(typeof(int));
 
-        [Fact]
-        public void Should_fail_with_descriptive_message_when_asserting_null_object_not_to_be_null()
-        {
-            // Arrange
-            object someObject = null;
+                // Assert
+                act.Should().NotThrow();
+            }
 
-            // Act
-            Action act = () => someObject.Should().NotBeNull("because we want to test the failure {0}", "message");
+            [Fact]
+            public void When_object_is_matched_against_a_null_type_it_should_throw()
+            {
+                // Arrange
+                int valueTypeObject = 42;
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected someObject not to be <null> because we want to test the failure message.");
-        }
+                // Act
+                Action act = () => valueTypeObject.Should().BeOfType(null);
 
-        #endregion
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithParameterName("expectedType");
+            }
 
-        #region BeOfType / NotBeOfType
+            [Fact]
+            public void When_null_object_is_matched_against_a_type_it_should_throw()
+            {
+                // Arrange
+                int? valueTypeObject = null;
 
-        [Fact]
-        public void When_object_type_is_matched_against_null_type_exactly_it_should_throw()
-        {
-            // Arrange
-            var someObject = new object();
+                // Act
+                Action act = () => valueTypeObject.Should().BeOfType(typeof(int), "because we want to test the failure {0}", "message");
 
-            // Act
-            Action act = () => someObject.Should().BeOfType(null);
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*type to be System.Int32*because we want to test the failure message*");
+            }
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithParameterName("expectedType");
-        }
+            [Fact]
+            public void When_object_type_is_value_type_and_doesnt_match_received_type_should_fail()
+            {
+                // Arrange
+                int valueTypeObject = 42;
+                var doubleType = typeof(double);
 
-        [Fact]
-        public void When_object_type_is_matched_negatively_against_null_type_exactly_it_should_throw()
-        {
-            // Arrange
-            var someObject = new object();
+                // Act
+                Action act = () => valueTypeObject.Should().BeOfType(doubleType);
 
-            // Act
-            Action act = () => someObject.Should().NotBeOfType(null);
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage($"Expected type to be {doubleType}, but found {valueTypeObject.GetType()}.");
+            }
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithParameterName("unexpectedType");
-        }
+            [Fact]
+            public void When_object_is_of_the_expected_type_it_should_cast_the_returned_object_for_chaining()
+            {
+                // Arrange
+                var someObject = new Exception("Actual Message");
 
-        [Fact]
-        public void When_object_type_is_exactly_equal_to_the_specified_type_it_should_not_fail()
-        {
-            // Arrange
-            var someObject = new Exception();
+                // Act
+                Action act = () => someObject.Should().BeOfType<Exception>().Which.Message.Should().Be("Other Message");
 
-            // Act
-            Action act = () => someObject.Should().BeOfType<Exception>();
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*Expected*Other*Actual*");
+            }
 
-            // Assert
-            act.Should().NotThrow();
-        }
+            [Fact]
+            public void When_object_type_is_different_than_expected_type_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var someObject = new object();
 
-        [Fact]
-        public void When_object_type_is_value_type_and_matches_received_type_should_not_fail_and_assert_correctly()
-        {
-            // Arrange
-            int valueTypeObject = 42;
+                // Act
+                Action act = () => someObject.Should().BeOfType<int>("because they are {0} {1}", "of different", "type");
 
-            // Act
-            Action act = () => valueTypeObject.Should().BeOfType(typeof(int));
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected type to be System.Int32 because they are of different type, but found System.Object.");
+            }
 
-            // Assert
-            act.Should().NotThrow();
-        }
+            [Fact]
+            public void When_asserting_the_type_of_a_null_object_it_should_throw()
+            {
+                // Arrange
+                object someObject = null;
 
-        [Fact]
-        public void When_object_is_matched_against_a_null_type_it_should_throw()
-        {
-            // Arrange
-            int valueTypeObject = 42;
+                // Act
+                Action act = () => someObject.Should().BeOfType<int>();
 
-            // Act
-            Action act = () => valueTypeObject.Should().BeOfType(null);
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected someObject to be System.Int32, but found <null>.");
+            }
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithParameterName("expectedType");
-        }
+            [Fact]
+            public void When_object_type_is_same_as_expected_type_but_in_different_assembly_it_should_fail_with_assembly_qualified_name()
+            {
+                // Arrange
+                var typeFromOtherAssembly =
+                    new AssemblyA.ClassA().ReturnClassC();
 
-        [Fact]
-        public void When_null_object_is_matched_against_a_type_it_should_throw()
-        {
-            // Arrange
-            int? valueTypeObject = null;
-
-            // Act
-            Action act = () => valueTypeObject.Should().BeOfType(typeof(int), "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*type to be System.Int32*because we want to test the failure message*");
-        }
-
-        [Fact]
-        public void When_object_is_matched_negatively_against_a_null_type_it_should_throw()
-        {
-            // Arrange
-            int valueTypeObject = 42;
-
-            // Act
-            Action act = () => valueTypeObject.Should().NotBeOfType(null);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithParameterName("unexpectedType");
-        }
-
-        [Fact]
-        public void When_object_type_is_value_type_and_doesnt_match_received_type_as_expected_should_not_fail_and_assert_correctly()
-        {
-            // Arrange
-            int valueTypeObject = 42;
-
-            // Act
-            Action act = () => valueTypeObject.Should().NotBeOfType(typeof(double));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_null_object_is_matched_negatively_against_a_type_it_should_throw()
-        {
-            // Arrange
-            int? valueTypeObject = null;
-
-            // Act
-            Action act = () => valueTypeObject.Should().NotBeOfType(typeof(int), "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*type not to be System.Int32*because we want to test the failure message*");
-        }
-
-        [Fact]
-        public void When_object_type_is_value_type_and_matches_received_type_not_as_expected_should_fail()
-        {
-            // Arrange
-            int valueTypeObject = 42;
-            var expectedType = typeof(int);
-
-            // Act
-            Action act = () => valueTypeObject.Should().NotBeOfType(expectedType);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage($"Expected type not to be [{expectedType.AssemblyQualifiedName}], but it is.");
-        }
-
-        [Fact]
-        public void When_object_type_is_value_type_and_doesnt_match_received_type_should_fail()
-        {
-            // Arrange
-            int valueTypeObject = 42;
-            var doubleType = typeof(double);
-
-            // Act
-            Action act = () => valueTypeObject.Should().BeOfType(doubleType);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage($"Expected type to be {doubleType}, but found {valueTypeObject.GetType()}.");
-        }
-
-        [Fact]
-        public void When_object_is_of_the_expected_type_it_should_cast_the_returned_object_for_chaining()
-        {
-            // Arrange
-            var someObject = new Exception("Actual Message");
-
-            // Act
-            Action act = () => someObject.Should().BeOfType<Exception>().Which.Message.Should().Be("Other Message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*Expected*Other*Actual*");
-        }
-
-        [Fact]
-        public void When_object_type_is_different_than_expected_type_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var someObject = new object();
-
-            // Act
-            Action act = () => someObject.Should().BeOfType<int>("because they are {0} {1}", "of different", "type");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be System.Int32 because they are of different type, but found System.Object.");
-        }
-
-        [Fact]
-        public void When_asserting_the_type_of_a_null_object_it_should_throw()
-        {
-            // Arrange
-            object someObject = null;
-
-            // Act
-            Action act = () => someObject.Should().BeOfType<int>();
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected someObject to be System.Int32, but found <null>.");
-        }
-
-        [Fact]
-        public void When_object_type_is_same_as_expected_type_but_in_different_assembly_it_should_fail_with_assembly_qualified_name()
-        {
-            // Arrange
-            var typeFromOtherAssembly =
-                new AssemblyA.ClassA().ReturnClassC();
-
-            // Act
+                // Act
 #pragma warning disable 436 // disable the warning on conflicting types, as this is the intention for the spec
 
-            Action act = () =>
-                typeFromOtherAssembly.Should().BeOfType<AssemblyB.ClassC>();
+                Action act = () =>
+                    typeFromOtherAssembly.Should().BeOfType<AssemblyB.ClassC>();
 
 #pragma warning restore 436
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be [AssemblyB.ClassC, FluentAssertions.Specs*], but found [AssemblyB.ClassC, AssemblyB*].");
-        }
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be [AssemblyB.ClassC, FluentAssertions.Specs*], but found [AssemblyB.ClassC, AssemblyB*].");
+            }
 
-        [Fact]
-        public void When_object_type_is_a_subclass_of_the_expected_type_it_should_fail()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-
-            // Act
-            Action act = () => someObject.Should().BeOfType<DummyBaseClass>();
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be FluentAssertions*DummyBaseClass, but found FluentAssertions*DummyImplementingClass.");
-        }
-
-        #endregion
-
-        #region BeAssignableTo
-
-        [Fact]
-        public void When_object_type_is_matched_against_null_type_it_should_throw()
-        {
-            // Arrange
-            var someObject = new object();
-
-            // Act
-            Action act = () => someObject.Should().BeAssignableTo(null);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithParameterName("type");
-        }
-
-        [Fact]
-        public void When_its_own_type_it_should_succeed()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-
-            // Act / Assert
-            someObject.Should().BeAssignableTo<DummyImplementingClass>();
-        }
-
-        [Fact]
-        public void When_its_base_type_it_should_succeed()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-
-            // Act / Assert
-            someObject.Should().BeAssignableTo<DummyBaseClass>();
-        }
-
-        [Fact]
-        public void When_an_implemented_interface_type_it_should_succeed()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-
-            // Act / Assert
-            someObject.Should().BeAssignableTo<IDisposable>();
-        }
-
-        [Fact]
-        public void When_an_unrelated_type_it_should_fail_with_a_descriptive_message()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message");
-
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*assignable to {typeof(DateTime)}*failure message*{typeof(DummyImplementingClass)} is not*");
-        }
-
-        [Fact]
-        public void When_to_the_expected_type_it_should_cast_the_returned_object_for_chaining()
-        {
-            // Arrange
-            var someObject = new Exception("Actual Message");
-
-            // Act
-            Action act = () => someObject.Should().BeAssignableTo<Exception>().Which.Message.Should().Be("Other Message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*Expected*Other*Actual*");
-        }
-
-        [Fact]
-        public void When_a_null_instance_is_asserted_to_be_assignableOfT_it_should_fail()
-        {
-            // Arrange
-            object someObject = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_object_type_is_a_subclass_of_the_expected_type_it_should_fail()
             {
-                using var _ = new AssertionScope();
-                someObject.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var someObject = new DummyImplementingClass();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*assignable to {typeof(DateTime)}*failure message*found <null>*");
+                // Act
+                Action act = () => someObject.Should().BeOfType<DummyBaseClass>();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected type to be FluentAssertions*DummyBaseClass, but found FluentAssertions*DummyImplementingClass.");
+            }
         }
 
-        [Fact]
-        public void When_its_own_type_instance_it_should_succeed()
+        public class NotBeOfType
         {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-
-            // Act / Assert
-            someObject.Should().BeAssignableTo(typeof(DummyImplementingClass));
-        }
-
-        [Fact]
-        public void When_its_base_type_instance_it_should_succeed()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-
-            // Act / Assert
-            someObject.Should().BeAssignableTo(typeof(DummyBaseClass));
-        }
-
-        [Fact]
-        public void When_an_implemented_interface_type_instance_it_should_succeed()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-
-            // Act / Assert
-            someObject.Should().BeAssignableTo(typeof(IDisposable));
-        }
-
-        [Fact]
-        public void When_an_implemented_open_generic_interface_type_instance_it_should_succeed()
-        {
-            // Arrange
-            var someObject = new System.Collections.Generic.List<string>();
-
-            // Act / Assert
-            someObject.Should().BeAssignableTo(typeof(System.Collections.Generic.IList<>));
-        }
-
-        [Fact]
-        public void When_a_null_instance_is_asserted_to_be_assignable_it_should_fail_with_a_descriptive_message()
-        {
-            // Arrange
-            object someObject = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_object_type_is_matched_negatively_against_null_type_exactly_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                someObject.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var someObject = new object();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*assignable to {typeof(DateTime)}*failure message*found <null>*");
-        }
+                // Act
+                Action act = () => someObject.Should().NotBeOfType(null);
 
-        [Fact]
-        public void When_an_unrelated_type_instance_it_should_fail_with_a_descriptive_message()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithParameterName("unexpectedType");
+            }
 
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*assignable to {typeof(DateTime)}*failure message*{typeof(DummyImplementingClass)} is not*");
-        }
-
-        [Fact]
-        public void When_unrelated_to_open_generic_type_it_should_fail_with_a_descriptive_message()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().BeAssignableTo(typeof(System.Collections.Generic.IList<>), "because we want to test the failure {0}", "message");
-
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*assignable to {typeof(System.Collections.Generic.IList<>)}*failure message*{typeof(DummyImplementingClass)} is not*");
-        }
-
-        [Fact]
-        public void When_an_assertion_fails_on_BeAssignableTo_succeeding_message_should_be_included()
-        {
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_object_is_matched_negatively_against_a_null_type_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                var item = string.Empty;
-                item.Should().BeAssignableTo<int>();
-                item.Should().BeAssignableTo<long>();
-            };
+                // Arrange
+                int valueTypeObject = 42;
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                "Expected * to be assignable to System.Int32, but System.String is not.*" +
-                "Expected * to be assignable to System.Int64, but System.String is not.");
-        }
+                // Act
+                Action act = () => valueTypeObject.Should().NotBeOfType(null);
 
-        #endregion
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithParameterName("unexpectedType");
+            }
 
-        #region NotBeAssignableTo
-
-        [Fact]
-        public void When_object_type_is_matched_negatively_against_null_type_it_should_throw()
-        {
-            // Arrange
-            var someObject = new object();
-
-            // Act
-            Action act = () => someObject.Should().NotBeAssignableTo(null);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithParameterName("type");
-        }
-
-        [Fact]
-        public void When_its_own_type_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().NotBeAssignableTo<DummyImplementingClass>("because we want to test the failure {0}", "message");
-
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(DummyImplementingClass)}*failure message*{typeof(DummyImplementingClass)} is*");
-        }
-
-        [Fact]
-        public void When_its_base_type_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().NotBeAssignableTo<DummyBaseClass>("because we want to test the failure {0}", "message");
-
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(DummyBaseClass)}*failure message*{typeof(DummyImplementingClass)} is*");
-        }
-
-        [Fact]
-        public void When_an_implemented_interface_type_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().NotBeAssignableTo<IDisposable>("because we want to test the failure {0}", "message");
-
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(IDisposable)}*failure message*{typeof(DummyImplementingClass)} is*");
-        }
-
-        [Fact]
-        public void When_an_unrelated_type_and_asserting_not_assignable_it_should_succeed()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-
-            // Act / Assert
-            someObject.Should().NotBeAssignableTo<DateTime>();
-        }
-
-        [Fact]
-        public void When_not_to_the_unexpected_type_and_asserting_not_assignable_it_should_not_cast_the_returned_object_for_chaining()
-        {
-            // Arrange
-            var someObject = new Exception("Actual Message");
-
-            // Act
-            Action act = () => someObject.Should().NotBeAssignableTo<DummyImplementingClass>()
-                .And.Subject.Should().BeOfType<Exception>()
-                .Which.Message.Should().Be("Other Message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*Expected*Other*Actual*");
-        }
-
-        [Fact]
-        public void When_its_own_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().NotBeAssignableTo(typeof(DummyImplementingClass), "because we want to test the failure {0}", "message");
-
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(DummyImplementingClass)}*failure message*{typeof(DummyImplementingClass)} is*");
-        }
-
-        [Fact]
-        public void When_its_base_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().NotBeAssignableTo(typeof(DummyBaseClass), "because we want to test the failure {0}", "message");
-
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(DummyBaseClass)}*failure message*{typeof(DummyImplementingClass)} is*");
-        }
-
-        [Fact]
-        public void When_an_implemented_interface_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().NotBeAssignableTo(typeof(IDisposable), "because we want to test the failure {0}", "message");
-
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(IDisposable)}*failure message*{typeof(DummyImplementingClass)} is*");
-        }
-
-        [Fact]
-        public void When_an_implemented_open_generic_interface_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
-        {
-            // Arrange
-            var someObject = new System.Collections.Generic.List<string>();
-            Action act = () => someObject.Should().NotBeAssignableTo(typeof(System.Collections.Generic.IList<>), "because we want to test the failure {0}", "message");
-
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(System.Collections.Generic.IList<>)}*failure message*{typeof(System.Collections.Generic.List<string>)} is*");
-        }
-
-        [Fact]
-        public void When_a_null_instance_is_asserted_to_not_be_assignable_it_should_fail_with_a_descriptive_message()
-        {
-            // Arrange
-            object someObject = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_object_type_is_value_type_and_doesnt_match_received_type_as_expected_should_not_fail_and_assert_correctly()
             {
-                using var _ = new AssertionScope();
+                // Arrange
+                int valueTypeObject = 42;
+
+                // Act
+                Action act = () => valueTypeObject.Should().NotBeOfType(typeof(double));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_null_object_is_matched_negatively_against_a_type_it_should_throw()
+            {
+                // Arrange
+                int? valueTypeObject = null;
+
+                // Act
+                Action act = () => valueTypeObject.Should().NotBeOfType(typeof(int), "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*type not to be System.Int32*because we want to test the failure message*");
+            }
+
+            [Fact]
+            public void When_object_type_is_value_type_and_matches_received_type_not_as_expected_should_fail()
+            {
+                // Arrange
+                int valueTypeObject = 42;
+                var expectedType = typeof(int);
+
+                // Act
+                Action act = () => valueTypeObject.Should().NotBeOfType(expectedType);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage($"Expected type not to be [{expectedType.AssemblyQualifiedName}], but it is.");
+            }
+        }
+
+        public class BeAssignableTo
+        {
+            [Fact]
+            public void When_object_type_is_matched_against_null_type_it_should_throw()
+            {
+                // Arrange
+                var someObject = new object();
+
+                // Act
+                Action act = () => someObject.Should().BeAssignableTo(null);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithParameterName("type");
+            }
+
+            [Fact]
+            public void When_its_own_type_it_should_succeed()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+
+                // Act / Assert
+                someObject.Should().BeAssignableTo<DummyImplementingClass>();
+            }
+
+            [Fact]
+            public void When_its_base_type_it_should_succeed()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+
+                // Act / Assert
+                someObject.Should().BeAssignableTo<DummyBaseClass>();
+            }
+
+            [Fact]
+            public void When_an_implemented_interface_type_it_should_succeed()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+
+                // Act / Assert
+                someObject.Should().BeAssignableTo<IDisposable>();
+            }
+
+            [Fact]
+            public void When_an_unrelated_type_it_should_fail_with_a_descriptive_message()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+                Action act = () => someObject.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*assignable to {typeof(DateTime)}*failure message*{typeof(DummyImplementingClass)} is not*");
+            }
+
+            [Fact]
+            public void When_to_the_expected_type_it_should_cast_the_returned_object_for_chaining()
+            {
+                // Arrange
+                var someObject = new Exception("Actual Message");
+
+                // Act
+                Action act = () => someObject.Should().BeAssignableTo<Exception>().Which.Message.Should().Be("Other Message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*Expected*Other*Actual*");
+            }
+
+            [Fact]
+            public void When_a_null_instance_is_asserted_to_be_assignableOfT_it_should_fail()
+            {
+                // Arrange
+                object someObject = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    someObject.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*assignable to {typeof(DateTime)}*failure message*found <null>*");
+            }
+
+            [Fact]
+            public void When_its_own_type_instance_it_should_succeed()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+
+                // Act / Assert
+                someObject.Should().BeAssignableTo(typeof(DummyImplementingClass));
+            }
+
+            [Fact]
+            public void When_its_base_type_instance_it_should_succeed()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+
+                // Act / Assert
+                someObject.Should().BeAssignableTo(typeof(DummyBaseClass));
+            }
+
+            [Fact]
+            public void When_an_implemented_interface_type_instance_it_should_succeed()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+
+                // Act / Assert
+                someObject.Should().BeAssignableTo(typeof(IDisposable));
+            }
+
+            [Fact]
+            public void When_an_implemented_open_generic_interface_type_instance_it_should_succeed()
+            {
+                // Arrange
+                var someObject = new System.Collections.Generic.List<string>();
+
+                // Act / Assert
+                someObject.Should().BeAssignableTo(typeof(System.Collections.Generic.IList<>));
+            }
+
+            [Fact]
+            public void When_a_null_instance_is_asserted_to_be_assignable_it_should_fail_with_a_descriptive_message()
+            {
+                // Arrange
+                object someObject = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    someObject.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*assignable to {typeof(DateTime)}*failure message*found <null>*");
+            }
+
+            [Fact]
+            public void When_an_unrelated_type_instance_it_should_fail_with_a_descriptive_message()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+                Action act = () => someObject.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*assignable to {typeof(DateTime)}*failure message*{typeof(DummyImplementingClass)} is not*");
+            }
+
+            [Fact]
+            public void When_unrelated_to_open_generic_type_it_should_fail_with_a_descriptive_message()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+                Action act = () => someObject.Should().BeAssignableTo(typeof(System.Collections.Generic.IList<>), "because we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*assignable to {typeof(System.Collections.Generic.IList<>)}*failure message*{typeof(DummyImplementingClass)} is not*");
+            }
+
+            [Fact]
+            public void When_an_assertion_fails_on_BeAssignableTo_succeeding_message_should_be_included()
+            {
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    var item = string.Empty;
+                    item.Should().BeAssignableTo<int>();
+                    item.Should().BeAssignableTo<long>();
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                    "Expected * to be assignable to System.Int32, but System.String is not.*" +
+                    "Expected * to be assignable to System.Int64, but System.String is not.");
+            }
+        }
+
+        public class NotBeAssignableTo
+        {
+            [Fact]
+            public void When_object_type_is_matched_negatively_against_null_type_it_should_throw()
+            {
+                // Arrange
+                var someObject = new object();
+
+                // Act
+                Action act = () => someObject.Should().NotBeAssignableTo(null);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithParameterName("type");
+            }
+
+            [Fact]
+            public void When_its_own_type_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+                Action act = () => someObject.Should().NotBeAssignableTo<DummyImplementingClass>("because we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*not be assignable to {typeof(DummyImplementingClass)}*failure message*{typeof(DummyImplementingClass)} is*");
+            }
+
+            [Fact]
+            public void When_its_base_type_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+                Action act = () => someObject.Should().NotBeAssignableTo<DummyBaseClass>("because we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*not be assignable to {typeof(DummyBaseClass)}*failure message*{typeof(DummyImplementingClass)} is*");
+            }
+
+            [Fact]
+            public void When_an_implemented_interface_type_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+                Action act = () => someObject.Should().NotBeAssignableTo<IDisposable>("because we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*not be assignable to {typeof(IDisposable)}*failure message*{typeof(DummyImplementingClass)} is*");
+            }
+
+            [Fact]
+            public void When_an_unrelated_type_and_asserting_not_assignable_it_should_succeed()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+
+                // Act / Assert
+                someObject.Should().NotBeAssignableTo<DateTime>();
+            }
+
+            [Fact]
+            public void When_not_to_the_unexpected_type_and_asserting_not_assignable_it_should_not_cast_the_returned_object_for_chaining()
+            {
+                // Arrange
+                var someObject = new Exception("Actual Message");
+
+                // Act
+                Action act = () => someObject.Should().NotBeAssignableTo<DummyImplementingClass>()
+                    .And.Subject.Should().BeOfType<Exception>()
+                    .Which.Message.Should().Be("Other Message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*Expected*Other*Actual*");
+            }
+
+            [Fact]
+            public void When_its_own_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+                Action act = () => someObject.Should().NotBeAssignableTo(typeof(DummyImplementingClass), "because we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*not be assignable to {typeof(DummyImplementingClass)}*failure message*{typeof(DummyImplementingClass)} is*");
+            }
+
+            [Fact]
+            public void When_its_base_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+                Action act = () => someObject.Should().NotBeAssignableTo(typeof(DummyBaseClass), "because we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*not be assignable to {typeof(DummyBaseClass)}*failure message*{typeof(DummyImplementingClass)} is*");
+            }
+
+            [Fact]
+            public void When_an_implemented_interface_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+                Action act = () => someObject.Should().NotBeAssignableTo(typeof(IDisposable), "because we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*not be assignable to {typeof(IDisposable)}*failure message*{typeof(DummyImplementingClass)} is*");
+            }
+
+            [Fact]
+            public void When_an_implemented_open_generic_interface_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+            {
+                // Arrange
+                var someObject = new System.Collections.Generic.List<string>();
+                Action act = () => someObject.Should().NotBeAssignableTo(typeof(System.Collections.Generic.IList<>), "because we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*not be assignable to {typeof(System.Collections.Generic.IList<>)}*failure message*{typeof(System.Collections.Generic.List<string>)} is*");
+            }
+
+            [Fact]
+            public void When_a_null_instance_is_asserted_to_not_be_assignable_it_should_fail_with_a_descriptive_message()
+            {
+                // Arrange
+                object someObject = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    someObject.Should().NotBeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"*not be assignable to {typeof(DateTime)}*failure message*found <null>*");
+            }
+
+            [Fact]
+            public void When_an_unrelated_type_instance_and_asserting_not_assignable_it_should_succeed()
+            {
+                // Arrange
+                var someObject = new DummyImplementingClass();
+
+                // Act / Assert
                 someObject.Should().NotBeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
-            };
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(DateTime)}*failure message*found <null>*");
-        }
-
-        [Fact]
-        public void When_an_unrelated_type_instance_and_asserting_not_assignable_it_should_succeed()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-
-            // Act / Assert
-            someObject.Should().NotBeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
-        }
-
-        [Fact]
-        public void When_unrelated_to_open_generic_type_and_asserting_not_assignable_it_should_succeed()
-        {
-            // Arrange
-            var someObject = new DummyImplementingClass();
-
-            // Act / Assert
-            someObject.Should().NotBeAssignableTo(typeof(System.Collections.Generic.IList<>), "because we want to test the failure {0}", "message");
-        }
-
-        #endregion
-
-        #region Miscellaneous
-
-        [Fact]
-        public void Should_support_chaining_constraints_with_and()
-        {
-            // Arrange
-            var someObject = new Exception();
-
-            // Act / Assert
-            someObject.Should()
-                .BeOfType<Exception>()
-                .And
-                .NotBeNull();
-        }
-
-        #endregion
-
-        #region BeBinarySerializable
-
-        [Fact]
-        public void When_an_object_is_binary_serializable_it_should_succeed()
-        {
-            // Arrange
-            var subject = new SerializableClass
+            [Fact]
+            public void When_unrelated_to_open_generic_type_and_asserting_not_assignable_it_should_succeed()
             {
-                Name = "John",
-                Id = 2
-            };
+                // Arrange
+                var someObject = new DummyImplementingClass();
 
-            // Act
-            Action act = () => subject.Should().BeBinarySerializable();
-
-            // Assert
-            act.Should().NotThrow();
+                // Act / Assert
+                someObject.Should().NotBeAssignableTo(typeof(System.Collections.Generic.IList<>), "because we want to test the failure {0}", "message");
+            }
         }
 
-        [Fact]
-        public void When_an_object_is_binary_serializable_with_non_serializable_members_it_should_succeed()
+        public class Miscellaneous
         {
-            // Arrange
-            var subject = new SerializableClassWithNonSerializableMember()
+            [Fact]
+            public void Should_support_chaining_constraints_with_and()
             {
-                Name = "John",
-                NonSerializable = "Nonserializable value"
-            };
+                // Arrange
+                var someObject = new Exception();
 
-            // Act
-            Action act = () => subject.Should().BeBinarySerializable<SerializableClassWithNonSerializableMember>(options =>
-                options.Excluding(s => s.NonSerializable));
-
-            // Assert
-            act.Should().NotThrow();
+                // Act / Assert
+                someObject.Should()
+                    .BeOfType<Exception>()
+                    .And
+                    .NotBeNull();
+            }
         }
 
-        [Fact]
-        public void When_injecting_null_options_it_should_throw()
+        public class BeBinarySerializable
         {
-            // Arrange
-            var subject = new SerializableClassWithNonSerializableMember();
-
-            // Act
-            Action act = () => subject.Should().BeBinarySerializable<SerializableClassWithNonSerializableMember>(options: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("options");
-        }
-
-        [Fact]
-        public void When_an_object_is_not_binary_serializable_it_should_fail()
-        {
-            // Arrange
-            var subject = new UnserializableClass
+            [Fact]
+            public void When_an_object_is_binary_serializable_it_should_succeed()
             {
-                Name = "John"
-            };
+                // Arrange
+                var subject = new SerializableClass
+                {
+                    Name = "John",
+                    Id = 2
+                };
 
-            // Act
-            Action act = () => subject.Should().BeBinarySerializable("we need to store it on {0}", "disk");
+                // Act
+                Action act = () => subject.Should().BeBinarySerializable();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*to be serializable because we need to store it on disk, but serialization failed with:*UnserializableClass*");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_an_object_is_binary_serializable_but_not_deserializable_it_should_fail()
-        {
-            // Arrange
-            var subject = new BinarySerializableClassMissingDeserializationConstructor
+            [Fact]
+            public void When_an_object_is_binary_serializable_with_non_serializable_members_it_should_succeed()
             {
-                Name = "John",
-                BirthDay = 20.September(1973)
-            };
+                // Arrange
+                var subject = new SerializableClassWithNonSerializableMember()
+                {
+                    Name = "John",
+                    NonSerializable = "Nonserializable value"
+                };
 
-            // Act
-            Action act = () => subject.Should().BeBinarySerializable();
+                // Act
+                Action act = () => subject.Should().BeBinarySerializable<SerializableClassWithNonSerializableMember>(options =>
+                    options.Excluding(s => s.NonSerializable));
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*to be serializable, but serialization failed with:*BinarySerializableClassMissingDeserializationConstructor*");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_an_object_is_binary_serializable_but_doesnt_restore_all_properties_it_should_fail()
-        {
-            // Arrange
-            var subject = new BinarySerializableClassNotRestoringAllProperties
+            [Fact]
+            public void When_injecting_null_options_it_should_throw()
             {
-                Name = "John",
-                BirthDay = 20.September(1973)
-            };
+                // Arrange
+                var subject = new SerializableClassWithNonSerializableMember();
 
-            // Act
-            Action act = () => subject.Should().BeBinarySerializable();
+                // Act
+                Action act = () => subject.Should().BeBinarySerializable<SerializableClassWithNonSerializableMember>(options: null);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*to be serializable, but serialization failed with:*subject.Name*to be*");
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("options");
+            }
+
+            [Fact]
+            public void When_an_object_is_not_binary_serializable_it_should_fail()
+            {
+                // Arrange
+                var subject = new UnserializableClass
+                {
+                    Name = "John"
+                };
+
+                // Act
+                Action act = () => subject.Should().BeBinarySerializable("we need to store it on {0}", "disk");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*to be serializable because we need to store it on disk, but serialization failed with:*UnserializableClass*");
+            }
+
+            [Fact]
+            public void When_an_object_is_binary_serializable_but_not_deserializable_it_should_fail()
+            {
+                // Arrange
+                var subject = new BinarySerializableClassMissingDeserializationConstructor
+                {
+                    Name = "John",
+                    BirthDay = 20.September(1973)
+                };
+
+                // Act
+                Action act = () => subject.Should().BeBinarySerializable();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*to be serializable, but serialization failed with:*BinarySerializableClassMissingDeserializationConstructor*");
+            }
+
+            [Fact]
+            public void When_an_object_is_binary_serializable_but_doesnt_restore_all_properties_it_should_fail()
+            {
+                // Arrange
+                var subject = new BinarySerializableClassNotRestoringAllProperties
+                {
+                    Name = "John",
+                    BirthDay = 20.September(1973)
+                };
+
+                // Act
+                Action act = () => subject.Should().BeBinarySerializable();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*to be serializable, but serialization failed with:*subject.Name*to be*");
+            }
+
+            [Fact]
+            public void When_a_system_exception_is_asserted_to_be_serializable_it_should_compare_its_fields_and_properties()
+            {
+                // Arrange
+                var subject = new Exception("some error");
+
+                // Act
+                Action act = () => subject.Should().BeBinarySerializable();
+
+                // Assert
+                act.Should().NotThrow();
+            }
         }
-
-        [Fact]
-        public void When_a_system_exception_is_asserted_to_be_serializable_it_should_compare_its_fields_and_properties()
-        {
-            // Arrange
-            var subject = new Exception("some error");
-
-            // Act
-            Action act = () => subject.Should().BeBinarySerializable();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
+        
         internal class UnserializableClass
         {
             public string Name { get; set; }
@@ -1013,61 +1017,60 @@ namespace FluentAssertions.Specs.Primitives
                 info.AddValue("BirthDay", BirthDay);
             }
         }
-
-        #endregion
-
-        #region BeXmlSerializable
-
-        [Fact]
-        public void When_an_object_is_xml_serializable_it_should_succeed()
+        
+        public class BeXmlSerializable
         {
-            // Arrange
-            var subject = new XmlSerializableClass
+            [Fact]
+            public void When_an_object_is_xml_serializable_it_should_succeed()
             {
-                Name = "John",
-                Id = 1
-            };
+                // Arrange
+                var subject = new XmlSerializableClass
+                {
+                    Name = "John",
+                    Id = 1
+                };
 
-            // Act
-            Action act = () => subject.Should().BeXmlSerializable();
+                // Act
+                Action act = () => subject.Should().BeXmlSerializable();
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_an_object_is_not_xml_serializable_it_should_fail()
-        {
-            // Arrange
-            var subject = new NonPublicClass
+            [Fact]
+            public void When_an_object_is_not_xml_serializable_it_should_fail()
             {
-                Name = "John"
-            };
+                // Arrange
+                var subject = new NonPublicClass
+                {
+                    Name = "John"
+                };
 
-            // Act
-            Action act = () => subject.Should().BeXmlSerializable("we need to store it on {0}", "disk");
+                // Act
+                Action act = () => subject.Should().BeXmlSerializable("we need to store it on {0}", "disk");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*to be serializable because we need to store it on disk, but serialization failed with:*NonPublicClass*");
-        }
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*to be serializable because we need to store it on disk, but serialization failed with:*NonPublicClass*");
+            }
 
-        [Fact]
-        public void When_an_object_is_xml_serializable_but_doesnt_restore_all_properties_it_should_fail()
-        {
-            // Arrange
-            var subject = new XmlSerializableClassNotRestoringAllProperties
+            [Fact]
+            public void When_an_object_is_xml_serializable_but_doesnt_restore_all_properties_it_should_fail()
             {
-                Name = "John",
-                BirthDay = 20.September(1973)
-            };
+                // Arrange
+                var subject = new XmlSerializableClassNotRestoringAllProperties
+                {
+                    Name = "John",
+                    BirthDay = 20.September(1973)
+                };
 
-            // Act
-            Action act = () => subject.Should().BeXmlSerializable();
+                // Act
+                Action act = () => subject.Should().BeXmlSerializable();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*to be serializable, but serialization failed with:*Name*to be*");
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*to be serializable, but serialization failed with:*Name*to be*");
+            }
         }
 
         internal class NonPublicClass
@@ -1104,91 +1107,90 @@ namespace FluentAssertions.Specs.Primitives
             }
         }
 
-        #endregion
-
-        #region BeDataContractSerializable
-
-        [Fact]
-        public void When_an_object_is_data_contract_serializable_it_should_succeed()
+        public class BeDataContractSerializable
         {
-            // Arrange
-            var subject = new DataContractSerializableClass
+            [Fact]
+            public void When_an_object_is_data_contract_serializable_it_should_succeed()
             {
-                Name = "John",
-                Id = 1
-            };
+                // Arrange
+                var subject = new DataContractSerializableClass
+                {
+                    Name = "John",
+                    Id = 1
+                };
 
-            // Act
-            Action act = () => subject.Should().BeDataContractSerializable();
+                // Act
+                Action act = () => subject.Should().BeDataContractSerializable();
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_an_object_is_not_data_contract_serializable_it_should_fail()
-        {
-            // Arrange
-            var subject = new NonDataContractSerializableClass();
-
-            // Act
-            Action act = () => subject.Should().BeDataContractSerializable("we need to store it on {0}", "disk");
-
-            // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage("*we need to store it on disk*EnumMemberAttribute*");
-        }
-
-        [Fact]
-        public void When_an_object_is_data_contract_serializable_but_doesnt_restore_all_properties_it_should_fail()
-        {
-            // Arrange
-            var subject = new DataContractSerializableClassNotRestoringAllProperties
+            [Fact]
+            public void When_an_object_is_not_data_contract_serializable_it_should_fail()
             {
-                Name = "John",
-                BirthDay = 20.September(1973)
-            };
+                // Arrange
+                var subject = new NonDataContractSerializableClass();
 
-            // Act
-            Action act = () => subject.Should().BeDataContractSerializable();
+                // Act
+                Action act = () => subject.Should().BeDataContractSerializable("we need to store it on {0}", "disk");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*to be serializable, but serialization failed with:*property subject.Name*to be*");
-        }
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*we need to store it on disk*EnumMemberAttribute*");
+            }
 
-        [Fact]
-        public void When_a_data_contract_serializable_object_doesnt_restore_an_ignored_property_it_should_succeed()
-        {
-            // Arrange
-            var subject = new DataContractSerializableClassNotRestoringAllProperties
+            [Fact]
+            public void When_an_object_is_data_contract_serializable_but_doesnt_restore_all_properties_it_should_fail()
             {
-                Name = "John",
-                BirthDay = 20.September(1973)
-            };
+                // Arrange
+                var subject = new DataContractSerializableClassNotRestoringAllProperties
+                {
+                    Name = "John",
+                    BirthDay = 20.September(1973)
+                };
 
-            // Act
-            Action act = () => subject.Should().BeDataContractSerializable<DataContractSerializableClassNotRestoringAllProperties>(
-                options => options.Excluding(x => x.Name));
+                // Act
+                Action act = () => subject.Should().BeDataContractSerializable();
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*to be serializable, but serialization failed with:*property subject.Name*to be*");
+            }
 
-        [Fact]
-        public void When_injecting_null_options_to_BeDataContractSerializable_it_should_throw()
-        {
-            // Arrange
-            var subject = new DataContractSerializableClassNotRestoringAllProperties();
+            [Fact]
+            public void When_a_data_contract_serializable_object_doesnt_restore_an_ignored_property_it_should_succeed()
+            {
+                // Arrange
+                var subject = new DataContractSerializableClassNotRestoringAllProperties
+                {
+                    Name = "John",
+                    BirthDay = 20.September(1973)
+                };
 
-            // Act
-            Action act = () => subject.Should().BeDataContractSerializable<DataContractSerializableClassNotRestoringAllProperties>(
-                options: null);
+                // Act
+                Action act = () => subject.Should().BeDataContractSerializable<DataContractSerializableClassNotRestoringAllProperties>(
+                    options => options.Excluding(x => x.Name));
 
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("options");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_injecting_null_options_to_BeDataContractSerializable_it_should_throw()
+            {
+                // Arrange
+                var subject = new DataContractSerializableClassNotRestoringAllProperties();
+
+                // Act
+                Action act = () => subject.Should().BeDataContractSerializable<DataContractSerializableClassNotRestoringAllProperties>(
+                    options: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("options");
+            }
         }
 
         public enum Color
@@ -1217,9 +1219,6 @@ namespace FluentAssertions.Specs.Primitives
             [DataMember]
             public DateTime BirthDay { get; set; }
         }
-
-        #endregion
-
     }
 
     internal class DummyBaseClass


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).