### PR TITLE
Try to stabilize UIFact tests by running them sequentially

### DIFF
--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -84,17 +84,21 @@ namespace FluentAssertions.Specs.Exceptions
             await act2.Should().ThrowAsync<XunitException>();
         }
 
-        [UIFact]
-        public async Task When_async_method_throws_an_empty_AggregateException_on_UI_thread_it_should_fail()
+        [Collection("UIFacts")]
+        public partial class UIFacts
         {
-            // Arrange
-            Func<Task> act = () => throw new AggregateException();
+            [UIFact]
+            public async Task When_async_method_throws_an_empty_AggregateException_on_UI_thread_it_should_fail()
+            {
+                // Arrange
+                Func<Task> act = () => throw new AggregateException();
 
-            // Act
-            Func<Task> act2 = () => act.Should().NotThrowAsync();
+                // Act
+                Func<Task> act2 = () => act.Should().NotThrowAsync();
 
-            // Assert
-            await act2.Should().ThrowAsync<XunitException>();
+                // Assert
+                await act2.Should().ThrowAsync<XunitException>();
+            }
         }
 
         [Fact]
@@ -107,14 +111,17 @@ namespace FluentAssertions.Specs.Exceptions
             await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
         }
 
-        [UIFact]
-        public async Task When_async_method_throws_a_nested_AggregateException_on_UI_thread_it_should_provide_the_message()
+        public partial class UIFacts
         {
-            // Arrange
-            Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
+            [UIFact]
+            public async Task When_async_method_throws_a_nested_AggregateException_on_UI_thread_it_should_provide_the_message()
+            {
+                // Arrange
+                Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
 
-            // Act & Assert
-            await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
+                // Act & Assert
+                await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
+            }
         }
 
         [Fact]
@@ -499,17 +506,20 @@ namespace FluentAssertions.Specs.Exceptions
             await action.Should().NotThrowAsync();
         }
 
-        [UIFact]
-        public async Task When_async_method_does_not_throw_async_exception_on_UI_thread_and_that_was_expected_it_should_succeed()
+        public partial class UIFacts
         {
-            // Arrange
-            var asyncObject = new AsyncClass();
+            [UIFact]
+            public async Task When_async_method_does_not_throw_async_exception_on_UI_thread_and_that_was_expected_it_should_succeed()
+            {
+                // Arrange
+                var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject.SucceedAsync();
+                // Act
+                Func<Task> action = () => asyncObject.SucceedAsync();
 
-            // Assert
-            await action.Should().NotThrowAsync();
+                // Assert
+                await action.Should().NotThrowAsync();
+            }
         }
 
         [Fact]
@@ -605,17 +615,20 @@ namespace FluentAssertions.Specs.Exceptions
             await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
         }
 
-        [UIFact]
-        public async Task When_subject_throws_on_UI_thread_expected_async_exact_exception_it_should_succeed()
+        public partial class UIFacts
         {
-            // Arrange
-            var asyncObject = new AsyncClass();
+            [UIFact]
+            public async Task When_subject_throws_on_UI_thread_expected_async_exact_exception_it_should_succeed()
+            {
+                // Arrange
+                var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
+                // Act
+                Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
 
-            // Assert
-            await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+                // Assert
+                await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+            }
         }
 
         [Fact]
@@ -1205,34 +1218,37 @@ namespace FluentAssertions.Specs.Exceptions
                 .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
         }
 
-        [UIFact]
-        public async Task When_no_exception_should_be_thrown_on_UI_thread_for_async_func_after_wait_time_but_it_was_it_should_throw()
+        public partial class UIFacts
         {
-            // Arrange
-            var waitTime = 2.Seconds();
-            var pollInterval = 10.Milliseconds();
-
-            var clock = new FakeClock();
-            var timer = clock.StartTimer();
-            clock.CompleteAfter(waitTime);
-
-            Func<Task> throwLongerThanWaitTime = async () =>
+            [UIFact]
+            public async Task When_no_exception_should_be_thrown_on_UI_thread_for_async_func_after_wait_time_but_it_was_it_should_throw()
             {
-                if (timer.Elapsed <= waitTime.Multiply(1.5))
+                // Arrange
+                var waitTime = 2.Seconds();
+                var pollInterval = 10.Milliseconds();
+
+                var clock = new FakeClock();
+                var timer = clock.StartTimer();
+                clock.CompleteAfter(waitTime);
+
+                Func<Task> throwLongerThanWaitTime = async () =>
                 {
-                    throw new ArgumentException("An exception was forced");
-                }
+                    if (timer.Elapsed <= waitTime.Multiply(1.5))
+                    {
+                        throw new ArgumentException("An exception was forced");
+                    }
 
-                await Task.Yield();
-            };
+                    await Task.Yield();
+                };
 
-            // Act
-            Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+                // Act
+                Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
+                    .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+                // Assert
+                await action.Should().ThrowAsync<XunitException>()
+                    .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+            }
         }
 
         [Fact]
@@ -1263,32 +1279,35 @@ namespace FluentAssertions.Specs.Exceptions
             await act.Should().NotThrowAsync();
         }
 
-        [UIFact]
-        public async Task When_no_exception_should_be_thrown_on_UI_thread_for_async_func_after_wait_time_and_none_was_it_should_not_throw()
+        public partial class UIFacts
         {
-            // Arrange
-            var waitTime = 6.Seconds();
-            var pollInterval = 10.Milliseconds();
-
-            var clock = new FakeClock();
-            var timer = clock.StartTimer();
-            clock.Delay(waitTime);
-
-            Func<Task> throwShorterThanWaitTime = async () =>
+            [UIFact]
+            public async Task When_no_exception_should_be_thrown_on_UI_thread_for_async_func_after_wait_time_and_none_was_it_should_not_throw()
             {
-                if (timer.Elapsed <= waitTime.Divide(12))
+                // Arrange
+                var waitTime = 6.Seconds();
+                var pollInterval = 10.Milliseconds();
+
+                var clock = new FakeClock();
+                var timer = clock.StartTimer();
+                clock.Delay(waitTime);
+
+                Func<Task> throwShorterThanWaitTime = async () =>
                 {
-                    throw new ArgumentException("An exception was forced");
-                }
+                    if (timer.Elapsed <= waitTime.Divide(12))
+                    {
+                        throw new ArgumentException("An exception was forced");
+                    }
 
-                await Task.Yield();
-            };
+                    await Task.Yield();
+                };
 
-            // Act
-            Func<Task> act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
+                // Act
+                Func<Task> act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
 
-            // Assert
-            await act.Should().NotThrowAsync();
+                // Assert
+                await act.Should().NotThrowAsync();
+            }
         }
         #endregion
     }

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -455,20 +455,24 @@ namespace FluentAssertions.Specs.Execution
                 .WithMessage("Expected foo.ShouldReturnSomeBool() to be false*");
         }
 
-        [UIFact]
-        public async Task Caller_identification_should_also_work_for_statements_following_async_code()
+        [Collection("UIFacts")]
+        public partial class UIFacts
         {
-            // Arrange
-            const string someText = "Hello";
-            Func<Task> task = async () => await Task.Yield();
+            [UIFact]
+            public async Task Caller_identification_should_also_work_for_statements_following_async_code()
+            {
+                // Arrange
+                const string someText = "Hello";
+                Func<Task> task = async () => await Task.Yield();
 
-            // Act
-            await task.Should().NotThrowAsync();
-            Action act = () => someText.Should().Be("Hi");
+                // Act
+                await task.Should().NotThrowAsync();
+                Action act = () => someText.Should().Be("Hi");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*someText*", "it should capture the variable name");
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*someText*", "it should capture the variable name");
+            }
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -79,20 +79,24 @@ namespace FluentAssertions.Specs.Specialized
             await action.Should().ThrowAsync<XunitException>();
         }
 
-        [UIFact]
-        public async Task When_task_completes_on_UI_thread_fast_async_it_should_succeed()
+        [Collection("UIFacts")]
+        public partial class UIFacts
         {
-            // Arrange
-            var timer = new FakeClock();
-            var taskFactory = new TaskCompletionSource<bool>();
+            [UIFact]
+            public async Task When_task_completes_on_UI_thread_fast_async_it_should_succeed()
+            {
+                // Arrange
+                var timer = new FakeClock();
+                var taskFactory = new TaskCompletionSource<bool>();
 
-            // Act
-            Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
-            taskFactory.SetResult(true);
-            timer.Complete();
+                // Act
+                Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+                taskFactory.SetResult(true);
+                timer.Complete();
 
-            // Assert
-            await action.Should().NotThrowAsync();
+                // Assert
+                await action.Should().NotThrowAsync();
+            }
         }
 
         [Fact]
@@ -110,37 +114,40 @@ namespace FluentAssertions.Specs.Specialized
             await action.Should().ThrowAsync<XunitException>();
         }
 
-        [UIFact]
-        public async Task When_task_completes_on_UI_thread_slow_async_it_should_fail()
+        public partial class UIFacts
         {
-            // Arrange
-            var timer = new FakeClock();
-            var taskFactory = new TaskCompletionSource<bool>();
-
-            // Act
-            Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
-            timer.Complete();
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>();
-        }
-
-        [UIFact]
-        public async Task When_task_is_checking_synchronization_context_on_UI_thread_it_should_succeed()
-        {
-            // Arrange
-            Func<Task> task = CheckContextAsync;
-
-            // Act
-            Func<Task> action = () => this.Awaiting(x => task()).Should().CompleteWithinAsync(1.Seconds());
-
-            // Assert
-            await action.Should().NotThrowAsync();
-
-            async Task CheckContextAsync()
+            [UIFact]
+            public async Task When_task_completes_on_UI_thread_slow_async_it_should_fail()
             {
-                await Task.Delay(1);
-                SynchronizationContext.Current.Should().NotBeNull();
+                // Arrange
+                var timer = new FakeClock();
+                var taskFactory = new TaskCompletionSource<bool>();
+
+                // Act
+                Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+                timer.Complete();
+
+                // Assert
+                await action.Should().ThrowAsync<XunitException>();
+            }
+
+            [UIFact]
+            public async Task When_task_is_checking_synchronization_context_on_UI_thread_it_should_succeed()
+            {
+                // Arrange
+                Func<Task> task = CheckContextAsync;
+
+                // Act
+                Func<Task> action = () => this.Awaiting(x => task()).Should().CompleteWithinAsync(1.Seconds());
+
+                // Assert
+                await action.Should().NotThrowAsync();
+
+                async Task CheckContextAsync()
+                {
+                    await Task.Delay(1);
+                    SynchronizationContext.Current.Should().NotBeNull();
+                }
             }
         }
     }

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -190,27 +190,31 @@ namespace FluentAssertions.Specs.Specialized
             await action.Should().NotThrowAsync();
         }
 
-        [UIFact]
-        public async Task When_task_does_not_throw_async_on_UI_thread_it_should_succeed()
+        [Collection("UIFacts")]
+        public partial class UIFacts
         {
-            // Arrange
-            var timer = new FakeClock();
-            var taskFactory = new TaskCompletionSource<int>();
-
-            // Act
-            Func<Task> action = async () =>
+            [UIFact]
+            public async Task When_task_does_not_throw_async_on_UI_thread_it_should_succeed()
             {
-                Func<Task<int>> func = () => taskFactory.Task;
+                // Arrange
+                var timer = new FakeClock();
+                var taskFactory = new TaskCompletionSource<int>();
 
-                (await func.Should(timer).NotThrowAsync())
-                    .Which.Should().Be(42);
-            };
+                // Act
+                Func<Task> action = async () =>
+                {
+                    Func<Task<int>> func = () => taskFactory.Task;
 
-            taskFactory.SetResult(42);
-            timer.Complete();
+                    (await func.Should(timer).NotThrowAsync())
+                        .Which.Should().Be(42);
+                };
 
-            // Assert
-            await action.Should().NotThrowAsync();
+                taskFactory.SetResult(42);
+                timer.Complete();
+
+                // Assert
+                await action.Should().NotThrowAsync();
+            }
         }
 
         [Fact]
@@ -231,22 +235,25 @@ namespace FluentAssertions.Specs.Specialized
             await action.Should().ThrowAsync<XunitException>();
         }
 
-        [UIFact]
-        public async Task When_task_throws_async_on_UI_thread_it_should_fail()
+        public partial class UIFacts
         {
-            // Arrange
-            var timer = new FakeClock();
-
-            // Act
-            Func<Task> action = () =>
+            [UIFact]
+            public async Task When_task_throws_async_on_UI_thread_it_should_fail()
             {
-                Func<Task<int>> func = () => throw new AggregateException();
+                // Arrange
+                var timer = new FakeClock();
 
-                return func.Should(timer).NotThrowAsync();
-            };
+                // Act
+                Func<Task> action = () =>
+                {
+                    Func<Task<int>> func = () => throw new AggregateException();
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>();
+                    return func.Should(timer).NotThrowAsync();
+                };
+
+                // Assert
+                await action.Should().ThrowAsync<XunitException>();
+            }
         }
 
         [Fact]
@@ -351,35 +358,38 @@ namespace FluentAssertions.Specs.Specialized
                 .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
         }
 
-        [UIFact]
-        public async Task When_no_exception_should_be_thrown_async_on_UI_thread_after_wait_time_but_it_was_it_should_throw()
+        public partial class UIFacts
         {
-            // Arrange
-            var waitTime = 2.Seconds();
-            var pollInterval = 10.Milliseconds();
-
-            var clock = new FakeClock();
-            var timer = clock.StartTimer();
-            clock.CompleteAfter(waitTime);
-
-            Func<Task<int>> throwLongerThanWaitTime = async () =>
+            [UIFact]
+            public async Task When_no_exception_should_be_thrown_async_on_UI_thread_after_wait_time_but_it_was_it_should_throw()
             {
-                if (timer.Elapsed <= waitTime.Multiply(1.5))
+                // Arrange
+                var waitTime = 2.Seconds();
+                var pollInterval = 10.Milliseconds();
+
+                var clock = new FakeClock();
+                var timer = clock.StartTimer();
+                clock.CompleteAfter(waitTime);
+
+                Func<Task<int>> throwLongerThanWaitTime = async () =>
                 {
-                    throw new ArgumentException("An exception was forced");
-                }
+                    if (timer.Elapsed <= waitTime.Multiply(1.5))
+                    {
+                        throw new ArgumentException("An exception was forced");
+                    }
 
-                await Task.Yield();
-                return 42;
-            };
+                    await Task.Yield();
+                    return 42;
+                };
 
-            // Act
-            Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+                // Act
+                Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
+                    .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+                // Assert
+                await action.Should().ThrowAsync<XunitException>()
+                    .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+            }
         }
 
         [Fact]
@@ -415,37 +425,40 @@ namespace FluentAssertions.Specs.Specialized
             await act.Should().NotThrowAsync();
         }
 
-        [UIFact]
-        public async Task When_no_exception_should_be_thrown_async_on_UI_thread_after_wait_time_and_none_was_it_should_not_throw()
+        public partial class UIFacts
         {
-            // Arrange
-            var waitTime = 6.Seconds();
-            var pollInterval = 10.Milliseconds();
-
-            var clock = new FakeClock();
-            var timer = clock.StartTimer();
-            clock.Delay(waitTime);
-
-            Func<Task<int>> throwShorterThanWaitTime = async () =>
+            [UIFact]
+            public async Task When_no_exception_should_be_thrown_async_on_UI_thread_after_wait_time_and_none_was_it_should_not_throw()
             {
-                if (timer.Elapsed <= waitTime.Divide(12))
+                // Arrange
+                var waitTime = 6.Seconds();
+                var pollInterval = 10.Milliseconds();
+
+                var clock = new FakeClock();
+                var timer = clock.StartTimer();
+                clock.Delay(waitTime);
+
+                Func<Task<int>> throwShorterThanWaitTime = async () =>
                 {
-                    throw new ArgumentException("An exception was forced");
-                }
+                    if (timer.Elapsed <= waitTime.Divide(12))
+                    {
+                        throw new ArgumentException("An exception was forced");
+                    }
 
-                await Task.Yield();
-                return 42;
-            };
+                    await Task.Yield();
+                    return 42;
+                };
 
-            // Act
-            Func<Task> act = async () =>
-            {
-                (await throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval))
-                    .Which.Should().Be(42);
-            };
+                // Act
+                Func<Task> act = async () =>
+                {
+                    (await throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval))
+                        .Which.Should().Be(42);
+                };
 
-            // Assert
-            await act.Should().NotThrowAsync();
+                // Assert
+                await act.Should().NotThrowAsync();
+            }
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/UIFactsDefinition.cs
+++ b/Tests/FluentAssertions.Specs/UIFactsDefinition.cs
@@ -1,0 +1,8 @@
+﻿using Xunit;
+
+namespace FluentAssertions.Specs
+{
+    // Try to stabilize UIFact tests
+    [CollectionDefinition("UIFacts", DisableParallelization = true)]
+    public class UIFactsDefinition { }
+}


### PR DESCRIPTION
Everyone's tired of `[UIFact]` tests (semi-)randomly failing and I don't have a clue what's causing the issue.
I initially wanted to use https://github.com/JoshKeegan/xRetry to simply retry them, but it doesn't seem combinable with `UIFact`.

So instead I went with running the `[UIFact]` tests sequentially and crossing fingers it'll improve things.

Disable whitespace while reviewing.