### PR TITLE
Update docxml comments on BeInRange

### DIFF
--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -292,10 +292,10 @@ namespace FluentAssertions.Numeric
         /// Where the range is continuous or incremental depends on the actual type of the value.
         /// </remarks>
         /// <param name="minimumValue">
-        /// The minimum valid value of the range.
+        /// The minimum valid value of the range (inclusive).
         /// </param>
         /// <param name="maximumValue">
-        /// The maximum valid value of the range.
+        /// The maximum valid value of the range (inclusive).
         /// </param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion


### PR DESCRIPTION
It wasn't clear whether the values where inclusive or exclusive

I don't think any of the following apply, but happy to update it if required! 🙂 

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).