### PR TITLE
Structure assertions with nested classes instead of regions (Part 4)

### DIFF
--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeAssignableTo.cs
@@ -11,161 +11,160 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region All Be Assignable To
-
-        [Fact]
-        public void When_the_types_in_a_collection_is_matched_against_a_null_type_it_should_throw()
+        public class AllBeAssignableTo
         {
-            // Arrange
-            var collection = new int[0];
-
-            // Act
-            Action act = () => collection.Should().AllBeAssignableTo(null);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithParameterName("expectedType");
-        }
-
-        [Fact]
-        public void When_collection_is_null_then_all_be_assignable_to_should_fail()
-        {
-            // Arrange
-            IEnumerable<object> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_the_types_in_a_collection_is_matched_against_a_null_type_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().AllBeAssignableTo(typeof(object), "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new int[0];
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
-        }
+                // Act
+                Action act = () => collection.Should().AllBeAssignableTo(null);
 
-        [Fact]
-        public void When_all_of_the_types_in_a_collection_match_expected_type_it_should_succeed()
-        {
-            // Arrange
-            var collection = new int[] { 1, 2, 3 };
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithParameterName("expectedType");
+            }
 
-            // Act / Assert
-            collection.Should().AllBeAssignableTo<int>();
-        }
-
-        [Fact]
-        public void When_matching_a_collection_against_a_type_it_should_return_the_casted_items()
-        {
-            // Arrange
-            var collection = new int[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().AllBeAssignableTo<int>()
-                .Which.Should().Equal(1, 2, 3);
-        }
-
-        [Fact]
-        public void When_all_of_the_types_in_a_collection_match_the_type_or_subtype_it_should_succeed()
-        {
-            // Arrange
-            var collection = new object[] { new Exception(), new ArgumentException() };
-
-            // Act / Assert
-            collection.Should().AllBeAssignableTo<Exception>();
-        }
-
-        [Fact]
-        public void When_one_of_the_types_does_not_match_it_should_throw_with_a_clear_explanation()
-        {
-            // Arrange
-            var collection = new object[] { 1, "2", 3 };
-
-            // Act
-            Action act = () => collection.Should().AllBeAssignableTo<int>("because they are of different type");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be \"System.Int32\" because they are of different type, but found \"[System.Int32, System.String, System.Int32]\".");
-        }
-
-        [Fact]
-        public void When_one_of_the_elements_is_null_it_should_throw_with_a_clear_explanation()
-        {
-            // Arrange
-            var collection = new object[] { 1, null, 3 };
-
-            // Act
-            Action act = () => collection.Should().AllBeAssignableTo<int>("because they are of different type");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be \"System.Int32\" because they are of different type, but found a null element.");
-        }
-
-        [Fact]
-        public void When_collection_is_of_matching_types_it_should_succeed()
-        {
-            // Arrange
-            var collection = new Type[] { typeof(Exception), typeof(ArgumentException) };
-
-            // Act / Assert
-            collection.Should().AllBeAssignableTo<Exception>();
-        }
-
-        [Fact]
-        public void When_collection_of_types_contains_one_type_that_does_not_match_it_should_throw_with_a_clear_explanation()
-        {
-            // Arrange
-            var collection = new Type[] { typeof(int), typeof(string), typeof(int) };
-
-            // Act
-            Action act = () => collection.Should().AllBeAssignableTo<int>("because they are of different type");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be \"System.Int32\" because they are of different type, but found \"[System.Int32, System.String, System.Int32]\".");
-        }
-
-        [Fact]
-        public void When_collection_of_types_and_objects_are_all_of_matching_types_it_should_succeed()
-        {
-            // Arrange
-            var collection = new object[] { typeof(int), 2, typeof(int) };
-
-            // Act / Assert
-            collection.Should().AllBeAssignableTo<int>();
-        }
-
-        [Fact]
-        public void When_collection_of_different_types_and_objects_are_all_assignable_to_type_it_should_succeed()
-        {
-            // Arrange
-            var collection = new object[] { typeof(Exception), new ArgumentException() };
-
-            // Act / Assert
-            collection.Should().AllBeAssignableTo<Exception>();
-        }
-
-        [Fact]
-        public void When_collection_is_null_then_all_be_assignable_toOfT_should_fail()
-        {
-            // Arrange
-            IEnumerable<object> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_is_null_then_all_be_assignable_to_should_fail()
             {
-                using var _ = new AssertionScope();
-                collection.Should().AllBeAssignableTo<object>("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                IEnumerable<object> collection = null;
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().AllBeAssignableTo(typeof(object), "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
+            }
+
+            [Fact]
+            public void When_all_of_the_types_in_a_collection_match_expected_type_it_should_succeed()
+            {
+                // Arrange
+                var collection = new int[] { 1, 2, 3 };
+
+                // Act / Assert
+                collection.Should().AllBeAssignableTo<int>();
+            }
+
+            [Fact]
+            public void When_matching_a_collection_against_a_type_it_should_return_the_casted_items()
+            {
+                // Arrange
+                var collection = new int[] { 1, 2, 3 };
+
+                // Act / Assert
+                collection.Should().AllBeAssignableTo<int>()
+                    .Which.Should().Equal(1, 2, 3);
+            }
+
+            [Fact]
+            public void When_all_of_the_types_in_a_collection_match_the_type_or_subtype_it_should_succeed()
+            {
+                // Arrange
+                var collection = new object[] { new Exception(), new ArgumentException() };
+
+                // Act / Assert
+                collection.Should().AllBeAssignableTo<Exception>();
+            }
+
+            [Fact]
+            public void When_one_of_the_types_does_not_match_it_should_throw_with_a_clear_explanation()
+            {
+                // Arrange
+                var collection = new object[] { 1, "2", 3 };
+
+                // Act
+                Action act = () => collection.Should().AllBeAssignableTo<int>("because they are of different type");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected type to be \"System.Int32\" because they are of different type, but found \"[System.Int32, System.String, System.Int32]\".");
+            }
+
+            [Fact]
+            public void When_one_of_the_elements_is_null_it_should_throw_with_a_clear_explanation()
+            {
+                // Arrange
+                var collection = new object[] { 1, null, 3 };
+
+                // Act
+                Action act = () => collection.Should().AllBeAssignableTo<int>("because they are of different type");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected type to be \"System.Int32\" because they are of different type, but found a null element.");
+            }
+
+            [Fact]
+            public void When_collection_is_of_matching_types_it_should_succeed()
+            {
+                // Arrange
+                var collection = new Type[] { typeof(Exception), typeof(ArgumentException) };
+
+                // Act / Assert
+                collection.Should().AllBeAssignableTo<Exception>();
+            }
+
+            [Fact]
+            public void When_collection_of_types_contains_one_type_that_does_not_match_it_should_throw_with_a_clear_explanation()
+            {
+                // Arrange
+                var collection = new Type[] { typeof(int), typeof(string), typeof(int) };
+
+                // Act
+                Action act = () => collection.Should().AllBeAssignableTo<int>("because they are of different type");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected type to be \"System.Int32\" because they are of different type, but found \"[System.Int32, System.String, System.Int32]\".");
+            }
+
+            [Fact]
+            public void When_collection_of_types_and_objects_are_all_of_matching_types_it_should_succeed()
+            {
+                // Arrange
+                var collection = new object[] { typeof(int), 2, typeof(int) };
+
+                // Act / Assert
+                collection.Should().AllBeAssignableTo<int>();
+            }
+
+            [Fact]
+            public void When_collection_of_different_types_and_objects_are_all_assignable_to_type_it_should_succeed()
+            {
+                // Arrange
+                var collection = new object[] { typeof(Exception), new ArgumentException() };
+
+                // Act / Assert
+                collection.Should().AllBeAssignableTo<Exception>();
+            }
+
+            [Fact]
+            public void When_collection_is_null_then_all_be_assignable_toOfT_should_fail()
+            {
+                // Arrange
+                IEnumerable<object> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().AllBeAssignableTo<object>("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeOfType.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeOfType.cs
@@ -11,141 +11,140 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region All Be Of Type
-
-        [Fact]
-        public void When_the_types_in_a_collection_is_matched_against_a_null_type_exactly_it_should_throw()
+        public class AllBeOfType
         {
-            // Arrange
-            var collection = new int[0];
-
-            // Act
-            Action act = () => collection.Should().AllBeOfType(null);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithParameterName("expectedType");
-        }
-
-        [Fact]
-        public void When_collection_is_null_then_all_be_of_type_should_fail()
-        {
-            // Arrange
-            IEnumerable<object> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_the_types_in_a_collection_is_matched_against_a_null_type_exactly_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().AllBeOfType(typeof(object), "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new int[0];
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
-        }
+                // Act
+                Action act = () => collection.Should().AllBeOfType(null);
 
-        [Fact]
-        public void When_all_of_the_types_in_a_collection_match_expected_type_exactly_it_should_succeed()
-        {
-            // Arrange
-            var collection = new int[] { 1, 2, 3 };
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithParameterName("expectedType");
+            }
 
-            // Act / Assert
-            collection.Should().AllBeOfType<int>();
-        }
-
-        [Fact]
-        public void When_matching_a_collection_against_an_exact_type_it_should_return_the_casted_items()
-        {
-            // Arrange
-            var collection = new int[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().AllBeOfType<int>()
-                .Which.Should().Equal(1, 2, 3);
-        }
-
-        [Fact]
-        public void When_one_of_the_types_does_not_match_exactly_it_should_throw_with_a_clear_explanation()
-        {
-            // Arrange
-            var collection = new object[] { new Exception(), new ArgumentException() };
-
-            // Act
-            Action act = () => collection.Should().AllBeOfType<Exception>("because they are of different type");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be \"System.Exception\" because they are of different type, but found \"[System.Exception, System.ArgumentException]\".");
-        }
-
-        [Fact]
-        public void When_one_of_the_elements_is_null_for_an_exact_match_it_should_throw_with_a_clear_explanation()
-        {
-            // Arrange
-            var collection = new object[] { 1, null, 3 };
-
-            // Act
-            Action act = () => collection.Should().AllBeOfType<int>("because they are of different type");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be \"System.Int32\" because they are of different type, but found a null element.");
-        }
-
-        [Fact]
-        public void When_collection_of_types_match_expected_type_exactly_it_should_succeed()
-        {
-            // Arrange
-            var collection = new Type[] { typeof(int), typeof(int), typeof(int) };
-
-            // Act / Assert
-            collection.Should().AllBeOfType<int>();
-        }
-
-        [Fact]
-        public void When_collection_of_types_and_objects_match_type_exactly_it_should_succeed()
-        {
-            // Arrange
-            var collection = new object[] { typeof(ArgumentException), new ArgumentException() };
-
-            // Act / Assert
-            collection.Should().AllBeOfType<ArgumentException>();
-        }
-
-        [Fact]
-        public void When_collection_of_types_and_objects_do_not_match_type_exactly_it_should_throw()
-        {
-            // Arrange
-            var collection = new object[] { typeof(Exception), new ArgumentException() };
-
-            // Act
-            Action act = () => collection.Should().AllBeOfType<ArgumentException>();
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be \"System.ArgumentException\", but found \"[System.Exception, System.ArgumentException]\".");
-        }
-
-        [Fact]
-        public void When_collection_is_null_then_all_be_of_typeOfT_should_fail()
-        {
-            // Arrange
-            IEnumerable<object> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_is_null_then_all_be_of_type_should_fail()
             {
-                using var _ = new AssertionScope();
-                collection.Should().AllBeOfType<object>("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                IEnumerable<object> collection = null;
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().AllBeOfType(typeof(object), "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
+            }
+
+            [Fact]
+            public void When_all_of_the_types_in_a_collection_match_expected_type_exactly_it_should_succeed()
+            {
+                // Arrange
+                var collection = new int[] { 1, 2, 3 };
+
+                // Act / Assert
+                collection.Should().AllBeOfType<int>();
+            }
+
+            [Fact]
+            public void When_matching_a_collection_against_an_exact_type_it_should_return_the_casted_items()
+            {
+                // Arrange
+                var collection = new int[] { 1, 2, 3 };
+
+                // Act / Assert
+                collection.Should().AllBeOfType<int>()
+                    .Which.Should().Equal(1, 2, 3);
+            }
+
+            [Fact]
+            public void When_one_of_the_types_does_not_match_exactly_it_should_throw_with_a_clear_explanation()
+            {
+                // Arrange
+                var collection = new object[] { new Exception(), new ArgumentException() };
+
+                // Act
+                Action act = () => collection.Should().AllBeOfType<Exception>("because they are of different type");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected type to be \"System.Exception\" because they are of different type, but found \"[System.Exception, System.ArgumentException]\".");
+            }
+
+            [Fact]
+            public void When_one_of_the_elements_is_null_for_an_exact_match_it_should_throw_with_a_clear_explanation()
+            {
+                // Arrange
+                var collection = new object[] { 1, null, 3 };
+
+                // Act
+                Action act = () => collection.Should().AllBeOfType<int>("because they are of different type");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected type to be \"System.Int32\" because they are of different type, but found a null element.");
+            }
+
+            [Fact]
+            public void When_collection_of_types_match_expected_type_exactly_it_should_succeed()
+            {
+                // Arrange
+                var collection = new Type[] { typeof(int), typeof(int), typeof(int) };
+
+                // Act / Assert
+                collection.Should().AllBeOfType<int>();
+            }
+
+            [Fact]
+            public void When_collection_of_types_and_objects_match_type_exactly_it_should_succeed()
+            {
+                // Arrange
+                var collection = new object[] { typeof(ArgumentException), new ArgumentException() };
+
+                // Act / Assert
+                collection.Should().AllBeOfType<ArgumentException>();
+            }
+
+            [Fact]
+            public void When_collection_of_types_and_objects_do_not_match_type_exactly_it_should_throw()
+            {
+                // Arrange
+                var collection = new object[] { typeof(Exception), new ArgumentException() };
+
+                // Act
+                Action act = () => collection.Should().AllBeOfType<ArgumentException>();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected type to be \"System.ArgumentException\", but found \"[System.Exception, System.ArgumentException]\".");
+            }
+
+            [Fact]
+            public void When_collection_is_null_then_all_be_of_typeOfT_should_fail()
+            {
+                // Arrange
+                IEnumerable<object> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().AllBeOfType<object>("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -12,176 +12,174 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Be Empty
-
-        [Fact]
-        public void When_collection_is_empty_as_expected_it_should_not_throw()
+        public class BeEmpty
         {
-            // Arrange
-            var collection = new int[0];
-
-            // Act / Assert
-            collection.Should().BeEmpty();
-        }
-
-        [Fact]
-        public void When_collection_is_not_empty_unexpectedly_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().BeEmpty("that's what we expect");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty because that's what we expect, but found*1*2*3*");
-        }
-
-        [Fact]
-        public void When_asserting_collection_with_items_is_not_empty_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().NotBeEmpty();
-        }
-
-        [Fact]
-        public void When_asserting_collection_with_items_is_not_empty_it_should_enumerate_the_collection_only_once()
-        {
-            // Arrange
-            var trackingEnumerable = new TrackingTestEnumerable(1, 2, 3);
-
-            // Act
-            trackingEnumerable.Should().NotBeEmpty();
-
-            // Assert
-            trackingEnumerable.Enumerator.LoopCount.Should().Be(1);
-        }
-
-        [Fact]
-        public void When_asserting_collection_without_items_is_not_empty_it_should_fail()
-        {
-            // Arrange
-            var collection = new int[0];
-
-            // Act
-            Action act = () => collection.Should().NotBeEmpty();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_asserting_collection_without_items_is_not_empty_it_should_fail_with_descriptive_message_()
-        {
-            // Arrange
-            var collection = new int[0];
-
-            // Act
-            Action act = () => collection.Should().NotBeEmpty("because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection not to be empty because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_be_empty_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<object> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_is_empty_as_expected_it_should_not_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().BeEmpty("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new int[0];
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to be empty *failure message*, but found <null>.");
-        }
+                // Act / Assert
+                collection.Should().BeEmpty();
+            }
 
-        [Fact]
-        public void When_asserting_collection_to_be_empty_it_should_enumerate_only_once()
-        {
-            // Arrange
-            var collection = new CountingGenericEnumerable<int>(new int[0]);
-
-            // Act
-            collection.Should().BeEmpty();
-
-            // Assert
-            collection.GetEnumeratorCallCount.Should().Be(1);
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_not_be_empty_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<object> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_is_not_empty_unexpectedly_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotBeEmpty("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection not to be empty *failure message*, but found <null>.");
+                // Act
+                Action act = () => collection.Should().BeEmpty("that's what we expect");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*to be empty because that's what we expect, but found*1*2*3*");
+            }
+
+            [Fact]
+            public void When_asserting_collection_with_items_is_not_empty_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act / Assert
+                collection.Should().NotBeEmpty();
+            }
+
+            [Fact]
+            public void When_asserting_collection_with_items_is_not_empty_it_should_enumerate_the_collection_only_once()
+            {
+                // Arrange
+                var trackingEnumerable = new TrackingTestEnumerable(1, 2, 3);
+
+                // Act
+                trackingEnumerable.Should().NotBeEmpty();
+
+                // Assert
+                trackingEnumerable.Enumerator.LoopCount.Should().Be(1);
+            }
+
+            [Fact]
+            public void When_asserting_collection_without_items_is_not_empty_it_should_fail()
+            {
+                // Arrange
+                var collection = new int[0];
+
+                // Act
+                Action act = () => collection.Should().NotBeEmpty();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_collection_without_items_is_not_empty_it_should_fail_with_descriptive_message_()
+            {
+                // Arrange
+                var collection = new int[0];
+
+                // Act
+                Action act = () => collection.Should().NotBeEmpty("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection not to be empty because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_be_empty_but_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<object> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().BeEmpty("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to be empty *failure message*, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_be_empty_it_should_enumerate_only_once()
+            {
+                // Arrange
+                var collection = new CountingGenericEnumerable<int>(new int[0]);
+
+                // Act
+                collection.Should().BeEmpty();
+
+                // Assert
+                collection.GetEnumeratorCallCount.Should().Be(1);
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_not_be_empty_but_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<object> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotBeEmpty("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection not to be empty *failure message*, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_an_infinite_collection_to_be_empty_it_should_throw_correctly()
+            {
+                // Arrange
+                var collection = new InfiniteEnumerable();
+
+                // Act
+                Action act = () => collection.Should().BeEmpty();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
         }
 
-        [Fact]
-        public void When_asserting_an_infinite_collection_to_be_empty_it_should_throw_correctly()
+        public class NotBeEmpty
         {
-            // Arrange
-            var collection = new InfiniteEnumerable();
+            [Fact]
+            public void When_asserting_collection_to_be_not_empty_but_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
 
-            // Act
-            Action act = () => collection.Should().BeEmpty();
+                // Act
+                Action act = () => collection.Should().NotBeEmpty("because we want to test the behaviour with a null subject");
 
-            // Assert
-            act.Should().Throw<XunitException>();
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection not to be empty because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_be_not_empty_it_should_enumerate_only_once()
+            {
+                // Arrange
+                var collection = new CountingGenericEnumerable<int>(new[] { 42 });
+
+                // Act
+                collection.Should().NotBeEmpty();
+
+                // Assert
+                collection.GetEnumeratorCallCount.Should().Be(1);
+            }
         }
-
-        #endregion
-
-        #region Not Be Empty
-
-        [Fact]
-        public void When_asserting_collection_to_be_not_empty_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () => collection.Should().NotBeEmpty("because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to be empty because we want to test the behaviour with a null subject, but found <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_be_not_empty_it_should_enumerate_only_once()
-        {
-            // Arrange
-            var collection = new CountingGenericEnumerable<int>(new[] { 42 });
-
-            // Act
-            collection.Should().NotBeEmpty();
-
-            // Assert
-            collection.GetEnumeratorCallCount.Should().Be(1);
-        }
-
-        #endregion
 
         private class InfiniteEnumerable : IEnumerable<object>
         {

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
@@ -12,330 +12,328 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Be Equivalent To
-
-        [Fact]
-        public void When_two_collections_contain_the_same_elements_it_should_treat_them_as_equivalent()
+        public class BeEquivalentTo
         {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 3, 1, 2 };
-
-            // Act / Assert
-            collection1.Should().BeEquivalentTo(collection2);
-        }
-
-        [Fact]
-        public void When_a_collection_contains_same_elements_it_should_treat_it_as_equivalent()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().BeEquivalentTo(new[] { 3, 1, 2 });
-        }
-
-        [Fact]
-        public void When_character_collections_are_equivalent_it_should_not_throw()
-        {
-            // Arrange
-            char[] list1 = "abc123ab".ToCharArray();
-            char[] list2 = "abc123ab".ToCharArray();
-
-            // Act / Assert
-            list1.Should().BeEquivalentTo(list2);
-        }
-
-        [Fact]
-        public void When_collections_are_not_equivalent_it_should_throw()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2 };
-
-            // Act
-            Action act = () => collection1.Should().BeEquivalentTo(collection2, "we treat {0} alike", "all");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*collection*2 item(s)*we treat all alike, but *1 item(s) more than*");
-        }
-
-        [Fact]
-        public void When_collections_with_duplicates_are_not_equivalent_it_should_throw()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3, 1 };
-            var collection2 = new[] { 1, 2, 3, 3 };
-
-            // Act
-            Action act = () => collection1.Should().BeEquivalentTo(collection2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1[3]*to be 3, but found 1*");
-        }
-
-        [Fact]
-        public void When_testing_for_equivalence_against_empty_collection_it_should_throw()
-        {
-            // Arrange
-            var subject = new[] { 1, 2, 3 };
-            var otherCollection = new int[0];
-
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(otherCollection);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be a collection with 0 item(s), but*contains 3 item(s)*");
-        }
-
-        [Fact]
-        public void When_two_collections_are_both_empty_it_should_treat_them_as_equivalent()
-        {
-            // Arrange
-            var subject = new int[0];
-            var otherCollection = new int[0];
-
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(otherCollection);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_testing_for_equivalence_against_null_collection_it_should_throw()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            int[] collection2 = null;
-
-            // Act
-            Action act = () => collection1.Should().BeEquivalentTo(collection2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*<null>*but found {1, 2, 3}*");
-        }
-
-        [Fact]
-        public void When_asserting_collections_to_be_equivalent_but_subject_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-            var collection1 = new[] { 1, 2, 3 };
-
-            // Act
-            Action act =
-                () => collection.Should().BeEquivalentTo(collection1, "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to be <null>*");
-        }
-
-        [Fact]
-        public void Default_immutable_arrays_should_be_equivalent()
-        {
-            // Arrange
-            ImmutableArray<string> collection = default;
-            ImmutableArray<string> collection1 = default;
-
-            // Act / Assert
-            collection.Should().BeEquivalentTo(collection1);
-        }
-
-        [Fact]
-        public void Default_immutable_lists_should_be_equivalent()
-        {
-            // Arrange
-            ImmutableList<string> collection = default;
-            ImmutableList<string> collection1 = default;
-
-            // Act / Assert
-            collection.Should().BeEquivalentTo(collection1);
-        }
-
-        #endregion
-
-        #region Not Be Equivalent To
-
-        [Fact]
-        public void When_collection_is_not_equivalent_to_another_smaller_collection_it_should_succeed()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 3, 1 };
-
-            // Act / Assert
-            collection1.Should().NotBeEquivalentTo(collection2);
-        }
-
-        [Fact]
-        public void When_large_collection_is_equivalent_to_another_equally_size_collection_it_should_throw()
-        {
-            // Arrange
-            var collection1 = Enumerable.Repeat(1, 10000);
-            var collection2 = Enumerable.Repeat(1, 10000);
-
-            // Act
-            Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_collection_is_not_equivalent_to_another_equally_sized_collection_it_should_succeed()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 3, 1, 4 };
-
-            // Act / Assert
-            collection1.Should().NotBeEquivalentTo(collection2);
-        }
-
-        [Fact]
-        public void When_collections_are_unexpectedly_equivalent_it_should_throw()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 3, 1, 2 };
-
-            // Act
-            Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 {1, 2, 3} not*equivalent*{3, 1, 2}.");
-        }
-
-        [Fact]
-        public void When_asserting_collections_not_to_be_equivalent_but_subject_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] actual = null;
-            var expectation = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_two_collections_contain_the_same_elements_it_should_treat_them_as_equivalent()
             {
-                using var _ = new AssertionScope();
-                actual.Should().NotBeEquivalentTo(expectation, "because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new[] { 3, 1, 2 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*be equivalent because we want to test the behaviour with a null subject, but found <null>*");
-        }
+                // Act / Assert
+                collection1.Should().BeEquivalentTo(collection2);
+            }
 
-        [Fact]
-        public void When_non_empty_collection_is_not_expected_to_be_equivalent_to_an_empty_collection_it_should_succeed()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new int[0];
-
-            // Act
-            Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_testing_collections_not_to_be_equivalent_against_null_collection_it_should_throw()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            int[] collection2 = null;
-
-            // Act
-            Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithMessage("Cannot verify inequivalence against a <null> collection.*")
-                .WithParameterName("unexpected");
-        }
-
-        [Fact]
-        public void When_testing_collections_not_to_be_equivalent_against_same_collection_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            var collection1 = collection;
-
-            // Act
-            Action act = () => collection.Should().NotBeEquivalentTo(collection1,
-                "because we want to test the behaviour with same objects");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*not to be equivalent*because we want to test the behaviour with same objects*but they both reference the same object.");
-        }
-
-        [Fact]
-        public void When_a_collections_is_equivalent_to_an_approximate_copy_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1.0, 2.0, 3.0 };
-            var collection1 = new[] { 1.5, 2.5, 3.5 };
-
-            // Act
-            Action act = () => collection.Should().NotBeEquivalentTo(collection1, opt => opt
-                .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.5))
-                .WhenTypeIs<double>(),
-                "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*not to be equivalent*because we want to test the failure message*");
-        }
-
-        [Fact]
-        public void When_asserting_collections_not_to_be_equivalent_with_options_but_subject_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] actual = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_a_collection_contains_same_elements_it_should_treat_it_as_equivalent()
             {
-                using var _ = new AssertionScope();
-                actual.Should().NotBeEquivalentTo(new[] { 1, 2, 3 }, opt => opt, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected actual not to be equivalent *failure message*, but found <null>.");
+                // Act / Assert
+                collection.Should().BeEquivalentTo(new[] { 3, 1, 2 });
+            }
+
+            [Fact]
+            public void When_character_collections_are_equivalent_it_should_not_throw()
+            {
+                // Arrange
+                char[] list1 = "abc123ab".ToCharArray();
+                char[] list2 = "abc123ab".ToCharArray();
+
+                // Act / Assert
+                list1.Should().BeEquivalentTo(list2);
+            }
+
+            [Fact]
+            public void When_collections_are_not_equivalent_it_should_throw()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new[] { 1, 2 };
+
+                // Act
+                Action act = () => collection1.Should().BeEquivalentTo(collection2, "we treat {0} alike", "all");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*collection*2 item(s)*we treat all alike, but *1 item(s) more than*");
+            }
+
+            [Fact]
+            public void When_collections_with_duplicates_are_not_equivalent_it_should_throw()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3, 1 };
+                var collection2 = new[] { 1, 2, 3, 3 };
+
+                // Act
+                Action act = () => collection1.Should().BeEquivalentTo(collection2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection1[3]*to be 3, but found 1*");
+            }
+
+            [Fact]
+            public void When_testing_for_equivalence_against_empty_collection_it_should_throw()
+            {
+                // Arrange
+                var subject = new[] { 1, 2, 3 };
+                var otherCollection = new int[0];
+
+                // Act
+                Action act = () => subject.Should().BeEquivalentTo(otherCollection);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected subject to be a collection with 0 item(s), but*contains 3 item(s)*");
+            }
+
+            [Fact]
+            public void When_two_collections_are_both_empty_it_should_treat_them_as_equivalent()
+            {
+                // Arrange
+                var subject = new int[0];
+                var otherCollection = new int[0];
+
+                // Act
+                Action act = () => subject.Should().BeEquivalentTo(otherCollection);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_testing_for_equivalence_against_null_collection_it_should_throw()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                int[] collection2 = null;
+
+                // Act
+                Action act = () => collection1.Should().BeEquivalentTo(collection2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*<null>*but found {1, 2, 3}*");
+            }
+
+            [Fact]
+            public void When_asserting_collections_to_be_equivalent_but_subject_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+                var collection1 = new[] { 1, 2, 3 };
+
+                // Act
+                Action act =
+                    () => collection.Should().BeEquivalentTo(collection1, "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection not to be <null>*");
+            }
+
+            [Fact]
+            public void Default_immutable_arrays_should_be_equivalent()
+            {
+                // Arrange
+                ImmutableArray<string> collection = default;
+                ImmutableArray<string> collection1 = default;
+
+                // Act / Assert
+                collection.Should().BeEquivalentTo(collection1);
+            }
+
+            [Fact]
+            public void Default_immutable_lists_should_be_equivalent()
+            {
+                // Arrange
+                ImmutableList<string> collection = default;
+                ImmutableList<string> collection1 = default;
+
+                // Act / Assert
+                collection.Should().BeEquivalentTo(collection1);
+            }
         }
 
-        [Fact]
-        public void Default_immutable_array_should_not_be_equivalent_to_initialized_immutable_array()
+        public class NotBeEquivalentTo
         {
-            // Arrange
-            ImmutableArray<string> collection = default;
-            ImmutableArray<string> collection1 = ImmutableArray.Create("a", "b", "c");
+            [Fact]
+            public void When_collection_is_not_equivalent_to_another_smaller_collection_it_should_succeed()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new[] { 3, 1 };
 
-            // Act / Assert
-            collection.Should().NotBeEquivalentTo(collection1);
+                // Act / Assert
+                collection1.Should().NotBeEquivalentTo(collection2);
+            }
+
+            [Fact]
+            public void When_large_collection_is_equivalent_to_another_equally_size_collection_it_should_throw()
+            {
+                // Arrange
+                var collection1 = Enumerable.Repeat(1, 10000);
+                var collection2 = Enumerable.Repeat(1, 10000);
+
+                // Act
+                Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_collection_is_not_equivalent_to_another_equally_sized_collection_it_should_succeed()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new[] { 3, 1, 4 };
+
+                // Act / Assert
+                collection1.Should().NotBeEquivalentTo(collection2);
+            }
+
+            [Fact]
+            public void When_collections_are_unexpectedly_equivalent_it_should_throw()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new[] { 3, 1, 2 };
+
+                // Act
+                Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection1 {1, 2, 3} not*equivalent*{3, 1, 2}.");
+            }
+
+            [Fact]
+            public void When_asserting_collections_not_to_be_equivalent_but_subject_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] actual = null;
+                var expectation = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    actual.Should().NotBeEquivalentTo(expectation, "because we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*be equivalent because we want to test the behaviour with a null subject, but found <null>*");
+            }
+
+            [Fact]
+            public void When_non_empty_collection_is_not_expected_to_be_equivalent_to_an_empty_collection_it_should_succeed()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new int[0];
+
+                // Act
+                Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_testing_collections_not_to_be_equivalent_against_null_collection_it_should_throw()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                int[] collection2 = null;
+
+                // Act
+                Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithMessage("Cannot verify inequivalence against a <null> collection.*")
+                    .WithParameterName("unexpected");
+            }
+
+            [Fact]
+            public void When_testing_collections_not_to_be_equivalent_against_same_collection_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                var collection1 = collection;
+
+                // Act
+                Action act = () => collection.Should().NotBeEquivalentTo(collection1,
+                    "because we want to test the behaviour with same objects");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*not to be equivalent*because we want to test the behaviour with same objects*but they both reference the same object.");
+            }
+
+            [Fact]
+            public void When_a_collections_is_equivalent_to_an_approximate_copy_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1.0, 2.0, 3.0 };
+                var collection1 = new[] { 1.5, 2.5, 3.5 };
+
+                // Act
+                Action act = () => collection.Should().NotBeEquivalentTo(collection1, opt => opt
+                    .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.5))
+                    .WhenTypeIs<double>(),
+                    "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*not to be equivalent*because we want to test the failure message*");
+            }
+
+            [Fact]
+            public void When_asserting_collections_not_to_be_equivalent_with_options_but_subject_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] actual = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    actual.Should().NotBeEquivalentTo(new[] { 1, 2, 3 }, opt => opt, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected actual not to be equivalent *failure message*, but found <null>.");
+            }
+
+            [Fact]
+            public void Default_immutable_array_should_not_be_equivalent_to_initialized_immutable_array()
+            {
+                // Arrange
+                ImmutableArray<string> collection = default;
+                ImmutableArray<string> collection1 = ImmutableArray.Create("a", "b", "c");
+
+                // Act / Assert
+                collection.Should().NotBeEquivalentTo(collection1);
+            }
+
+            [Fact]
+            public void Immutable_array_should_not_be_equivalent_to_default_immutable_array()
+            {
+                // Arrange
+                ImmutableArray<string> collection = ImmutableArray.Create("a", "b", "c");
+                ImmutableArray<string> collection1 = default;
+
+                // Act / Assert
+                collection.Should().NotBeEquivalentTo(collection1);
+            }
         }
-
-        [Fact]
-        public void Immutable_array_should_not_be_equivalent_to_default_immutable_array()
-        {
-            // Arrange
-            ImmutableArray<string> collection = ImmutableArray.Create("a", "b", "c");
-            ImmutableArray<string> collection1 = default;
-
-            // Act / Assert
-            collection.Should().NotBeEquivalentTo(collection1);
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
@@ -11,157 +11,155 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Be In AscendingOrder
-
-        [Fact]
-        public void When_asserting_a_null_collection_to_be_in_ascending_order_it_should_throw()
+        public class BeInAscendingOrder
         {
-            // Arrange
-            List<int> result = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_asserting_a_null_collection_to_be_in_ascending_order_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                result.Should().BeInAscendingOrder();
-            };
+                // Arrange
+                List<int> result = null;
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*but found <null>*");
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    result.Should().BeInAscendingOrder();
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*but found <null>*");
+            }
+
+            [Fact]
+            public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 2, 3 };
+
+                // Act / Assert
+                collection.Should().BeInAscendingOrder();
+            }
+
+            [Fact]
+            public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 2, 3 };
+
+                // Act / Assert
+                collection.Should().BeInAscendingOrder(Comparer<int>.Default);
+            }
+
+            [Fact]
+            public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 6, 12, 15, 12, 17, 26 };
+
+                // Act
+                Action action = () => collection.Should().BeInAscendingOrder("because numbers are ordered");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to be in ascending order because numbers are ordered," +
+                        " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
+            }
+
+            [Fact]
+            public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 6, 12, 15, 12, 17, 26 };
+
+                // Act
+                Action action = () => collection.Should().BeInAscendingOrder(Comparer<int>.Default, "because numbers are ordered");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to be in ascending order because numbers are ordered," +
+                        " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
+            }
+
+            [Fact]
+            public void Items_can_be_ordered_by_the_identity_function()
+            {
+                // Arrange
+                var collection = new[] { 1, 2 };
+
+                // Act
+                Action action = () => collection.Should().BeInAscendingOrder(x => x);
+
+                // Assert
+                action.Should().NotThrow();
+            }
         }
 
-        [Fact]
-        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_it_should_succeed()
+        public class NotBeInAscendingOrder
         {
-            // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
+            [Fact]
+            public void When_asserting_a_null_collection_to_not_be_in_ascending_order_it_should_throw()
+            {
+                // Arrange
+                List<int> result = null;
 
-            // Act / Assert
-            collection.Should().BeInAscendingOrder();
+                // Act
+                Action act = () => result.Should().NotBeInAscendingOrder();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*but found <null>*");
+            }
+
+            [Fact]
+            public void When_asserting_the_items_in_an_unordered_collection_are_not_in_ascending_order_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { 1, 5, 3 };
+
+                // Act / Assert
+                collection.Should().NotBeInAscendingOrder();
+            }
+
+            [Fact]
+            public void When_asserting_the_items_in_an_unordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { 1, 5, 3 };
+
+                // Act / Assert
+                collection.Should().NotBeInAscendingOrder(Comparer<int>.Default);
+            }
+
+            [Fact]
+            public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_not_in_ascending_order_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 2, 3 };
+
+                // Act
+                Action action = () => collection.Should().NotBeInAscendingOrder("because numbers are not ordered");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect collection to be in ascending order because numbers are not ordered," +
+                        " but found {1, 2, 2, 3}.");
+            }
+
+            [Fact]
+            public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 2, 3 };
+
+                // Act
+                Action action = () => collection.Should().NotBeInAscendingOrder(Comparer<int>.Default, "because numbers are not ordered");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect collection to be in ascending order because numbers are not ordered," +
+                        " but found {1, 2, 2, 3}.");
+            }
         }
-
-        [Fact]
-        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
-
-            // Act / Assert
-            collection.Should().BeInAscendingOrder(Comparer<int>.Default);
-        }
-
-        [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 6, 12, 15, 12, 17, 26 };
-
-            // Act
-            Action action = () => collection.Should().BeInAscendingOrder("because numbers are ordered");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to be in ascending order because numbers are ordered," +
-                    " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
-        }
-
-        [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 6, 12, 15, 12, 17, 26 };
-
-            // Act
-            Action action = () => collection.Should().BeInAscendingOrder(Comparer<int>.Default, "because numbers are ordered");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to be in ascending order because numbers are ordered," +
-                    " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
-        }
-
-        [Fact]
-        public void Items_can_be_ordered_by_the_identity_function()
-        {
-            // Arrange
-            var collection = new[] { 1, 2 };
-
-            // Act
-            Action action = () => collection.Should().BeInAscendingOrder(x => x);
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        #endregion
-
-        #region Not Be In Ascending Order
-
-        [Fact]
-        public void When_asserting_a_null_collection_to_not_be_in_ascending_order_it_should_throw()
-        {
-            // Arrange
-            List<int> result = null;
-
-            // Act
-            Action act = () => result.Should().NotBeInAscendingOrder();
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*but found <null>*");
-        }
-
-        [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_not_in_ascending_order_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { 1, 5, 3 };
-
-            // Act / Assert
-            collection.Should().NotBeInAscendingOrder();
-        }
-
-        [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { 1, 5, 3 };
-
-            // Act / Assert
-            collection.Should().NotBeInAscendingOrder(Comparer<int>.Default);
-        }
-
-        [Fact]
-        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_not_in_ascending_order_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
-
-            // Act
-            Action action = () => collection.Should().NotBeInAscendingOrder("because numbers are not ordered");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in ascending order because numbers are not ordered," +
-                    " but found {1, 2, 2, 3}.");
-        }
-
-        [Fact]
-        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
-
-            // Act
-            Action action = () => collection.Should().NotBeInAscendingOrder(Comparer<int>.Default, "because numbers are not ordered");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in ascending order because numbers are not ordered," +
-                    " but found {1, 2, 2, 3}.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInDescendingOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInDescendingOrder.cs
@@ -10,87 +10,85 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Be In Descending Order
-
-        [Fact]
-        public void When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_it_should_succeed()
+        public class BeInDescendingOrder
         {
-            // Arrange
-            var collection = new[] { "z", "y", "x" };
+            [Fact]
+            public void When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { "z", "y", "x" };
 
-            // Act / Assert
-            collection.Should().BeInDescendingOrder();
+                // Act / Assert
+                collection.Should().BeInDescendingOrder();
+            }
+
+            [Fact]
+            public void When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "z", "x", "y" };
+
+                // Act
+                Action action = () => collection.Should().BeInDescendingOrder("because letters are ordered");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to be in descending order because letters are ordered," +
+                        " but found {\"z\", \"x\", \"y\"} where item at index 1 is in wrong order.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_it_should_throw()
+        public class NotBeInDescendingOrder
         {
-            // Arrange
-            var collection = new[] { "z", "x", "y" };
+            [Fact]
+            public void When_asserting_the_items_in_an_unordered_collection_are_not_in_descending_order_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { "x", "y", "x" };
 
-            // Act
-            Action action = () => collection.Should().BeInDescendingOrder("because letters are ordered");
+                // Act / Assert
+                collection.Should().NotBeInDescendingOrder();
+            }
 
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to be in descending order because letters are ordered," +
-                    " but found {\"z\", \"x\", \"y\"} where item at index 1 is in wrong order.");
+            [Fact]
+            public void When_asserting_the_items_in_an_unordered_collection_are_not_in_descending_order_using_the_given_comparer_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { "x", "y", "x" };
+
+                // Act / Assert
+                collection.Should().NotBeInDescendingOrder(Comparer<object>.Default);
+            }
+
+            [Fact]
+            public void When_asserting_the_items_in_a_descending_ordered_collection_are_not_in_descending_order_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "c", "b", "a" };
+
+                // Act
+                Action action = () => collection.Should().NotBeInDescendingOrder("because numbers are not ordered");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect collection to be in descending order because numbers are not ordered," +
+                        " but found {\"c\", \"b\", \"a\"}.");
+            }
+
+            [Fact]
+            public void When_asserting_the_items_in_a_descending_ordered_collection_are_not_in_descending_order_using_the_given_comparer_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "c", "b", "a" };
+
+                // Act
+                Action action = () => collection.Should().NotBeInDescendingOrder(Comparer<object>.Default, "because numbers are not ordered");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect collection to be in descending order because numbers are not ordered," +
+                        " but found {\"c\", \"b\", \"a\"}.");
+            }
         }
-
-        #endregion
-
-        #region Not Be In Descending Order
-
-        [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_not_in_descending_order_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { "x", "y", "x" };
-
-            // Act / Assert
-            collection.Should().NotBeInDescendingOrder();
-        }
-
-        [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_not_in_descending_order_using_the_given_comparer_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { "x", "y", "x" };
-
-            // Act / Assert
-            collection.Should().NotBeInDescendingOrder(Comparer<object>.Default);
-        }
-
-        [Fact]
-        public void When_asserting_the_items_in_a_descending_ordered_collection_are_not_in_descending_order_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "c", "b", "a" };
-
-            // Act
-            Action action = () => collection.Should().NotBeInDescendingOrder("because numbers are not ordered");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in descending order because numbers are not ordered," +
-                    " but found {\"c\", \"b\", \"a\"}.");
-        }
-
-        [Fact]
-        public void When_asserting_the_items_in_a_descending_ordered_collection_are_not_in_descending_order_using_the_given_comparer_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "c", "b", "a" };
-
-            // Act
-            Action action = () => collection.Should().NotBeInDescendingOrder(Comparer<object>.Default, "because numbers are not ordered");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in descending order because numbers are not ordered," +
-                    " but found {\"c\", \"b\", \"a\"}.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNull.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNull.cs
@@ -10,60 +10,58 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Be Null
-
-        [Fact]
-        public void When_collection_is_expected_to_be_null_and_it_is_it_should_not_throw()
+        public class BeNull
         {
-            // Arrange
-            IEnumerable<string> someCollection = null;
+            [Fact]
+            public void When_collection_is_expected_to_be_null_and_it_is_it_should_not_throw()
+            {
+                // Arrange
+                IEnumerable<string> someCollection = null;
 
-            // Act / Assert
-            someCollection.Should().BeNull();
+                // Act / Assert
+                someCollection.Should().BeNull();
+            }
+
+            [Fact]
+            public void When_collection_is_expected_to_be_null_and_it_isnt_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<string> someCollection = new string[0];
+
+                // Act
+                Action act = () => someCollection.Should().BeNull("because {0} is valid", "null");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected someCollection to be <null> because null is valid, but found {empty}.");
+            }
         }
 
-        [Fact]
-        public void When_collection_is_expected_to_be_null_and_it_isnt_it_should_throw()
+        public class NotBeNull
         {
-            // Arrange
-            IEnumerable<string> someCollection = new string[0];
+            [Fact]
+            public void When_collection_is_not_expected_to_be_null_and_it_isnt_it_should_not_throw()
+            {
+                // Arrange
+                IEnumerable<string> someCollection = new string[0];
 
-            // Act
-            Action act = () => someCollection.Should().BeNull("because {0} is valid", "null");
+                // Act / Assert
+                someCollection.Should().NotBeNull();
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected someCollection to be <null> because null is valid, but found {empty}.");
+            [Fact]
+            public void When_collection_is_not_expected_to_be_null_and_it_is_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<string> someCollection = null;
+
+                // Act
+                Action act = () => someCollection.Should().NotBeNull("because {0} should not", "someCollection");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected someCollection not to be <null> because someCollection should not.");
+            }
         }
-
-        #endregion
-
-        #region Not Be Null
-
-        [Fact]
-        public void When_collection_is_not_expected_to_be_null_and_it_isnt_it_should_not_throw()
-        {
-            // Arrange
-            IEnumerable<string> someCollection = new string[0];
-
-            // Act / Assert
-            someCollection.Should().NotBeNull();
-        }
-
-        [Fact]
-        public void When_collection_is_not_expected_to_be_null_and_it_is_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<string> someCollection = null;
-
-            // Act
-            Action act = () => someCollection.Should().NotBeNull("because {0} should not", "someCollection");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected someCollection not to be <null> because someCollection should not.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
@@ -9,115 +9,113 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Be Null Or Empty
-
-        [Fact]
-        public void
-            When_asserting_a_null_collection_to_be_null_or_empty_it_should_succeed()
+        public class BeNullOrEmpty
         {
-            // Arrange
-            int[] collection = null;
+            [Fact]
+            public void
+                When_asserting_a_null_collection_to_be_null_or_empty_it_should_succeed()
+            {
+                // Arrange
+                int[] collection = null;
 
-            // Act / Assert
-            collection.Should().BeNullOrEmpty();
+                // Act / Assert
+                collection.Should().BeNullOrEmpty();
+            }
+
+            [Fact]
+            public void
+                When_asserting_an_empty_collection_to_be_null_or_empty_it_should_succeed()
+            {
+                // Arrange
+                var collection = new int[0];
+
+                // Act / Assert
+                collection.Should().BeNullOrEmpty();
+            }
+
+            [Fact]
+            public void
+                When_asserting_non_empty_collection_to_be_null_or_empty_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().BeNullOrEmpty("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected collection to be null or empty because we want to test the failure message, but found {1, 2, 3}.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_be_null_or_empty_it_should_enumerate_only_once()
+            {
+                // Arrange
+                var collection = new CountingGenericEnumerable<int>(new int[0]);
+
+                // Act
+                collection.Should().BeNullOrEmpty();
+
+                // Assert
+                collection.GetEnumeratorCallCount.Should().Be(1);
+            }
         }
 
-        [Fact]
-        public void
-            When_asserting_an_empty_collection_to_be_null_or_empty_it_should_succeed()
+        public class NotBeNullOrEmpty
         {
-            // Arrange
-            var collection = new int[0];
+            [Fact]
+            public void
+                When_asserting_non_empty_collection_to_not_be_null_or_empty_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { new object() };
 
-            // Act / Assert
-            collection.Should().BeNullOrEmpty();
+                // Act / Assert
+                collection.Should().NotBeNullOrEmpty();
+            }
+
+            [Fact]
+            public void
+                When_asserting_null_collection_to_not_be_null_or_empty_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () => collection.Should().NotBeNullOrEmpty();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void
+                When_asserting_empty_collection_to_not_be_null_or_empty_it_should_throw()
+            {
+                // Arrange
+                var collection = new int[0];
+
+                // Act
+                Action act = () => collection.Should().NotBeNullOrEmpty();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_not_be_null_or_empty_it_should_enumerate_only_once()
+            {
+                // Arrange
+                var collection = new CountingGenericEnumerable<int>(new[] { 42 });
+
+                // Act
+                collection.Should().NotBeNullOrEmpty();
+
+                // Assert
+                collection.GetEnumeratorCallCount.Should().Be(1);
+            }
         }
-
-        [Fact]
-        public void
-            When_asserting_non_empty_collection_to_be_null_or_empty_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().BeNullOrEmpty("because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected collection to be null or empty because we want to test the failure message, but found {1, 2, 3}.");
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_be_null_or_empty_it_should_enumerate_only_once()
-        {
-            // Arrange
-            var collection = new CountingGenericEnumerable<int>(new int[0]);
-
-            // Act
-            collection.Should().BeNullOrEmpty();
-
-            // Assert
-            collection.GetEnumeratorCallCount.Should().Be(1);
-        }
-
-        #endregion
-
-        #region Not Be Null Or Empty
-
-        [Fact]
-        public void
-            When_asserting_non_empty_collection_to_not_be_null_or_empty_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { new object() };
-
-            // Act / Assert
-            collection.Should().NotBeNullOrEmpty();
-        }
-
-        [Fact]
-        public void
-            When_asserting_null_collection_to_not_be_null_or_empty_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () => collection.Should().NotBeNullOrEmpty();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void
-            When_asserting_empty_collection_to_not_be_null_or_empty_it_should_throw()
-        {
-            // Arrange
-            var collection = new int[0];
-
-            // Act
-            Action act = () => collection.Should().NotBeNullOrEmpty();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_not_be_null_or_empty_it_should_enumerate_only_once()
-        {
-            // Arrange
-            var collection = new CountingGenericEnumerable<int>(new[] { 42 });
-
-            // Act
-            collection.Should().NotBeNullOrEmpty();
-
-            // Assert
-            collection.GetEnumeratorCallCount.Should().Be(1);
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeSubsetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeSubsetOf.cs
@@ -10,162 +10,160 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Be Subset Of
-
-        [Fact]
-        public void When_collection_is_subset_of_a_specified_collection_it_should_not_throw()
+        public class BeSubsetOf
         {
-            // Arrange
-            var subset = new[] { 1, 2 };
-            var superset = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            subset.Should().BeSubsetOf(superset);
-        }
-
-        [Fact]
-        public void When_collection_is_not_a_subset_of_another_it_should_throw_with_the_reason()
-        {
-            // Arrange
-            var subset = new[] { 1, 2, 3, 6 };
-            var superset = new[] { 1, 2, 4, 5 };
-
-            // Act
-            Action act = () => subset.Should().BeSubsetOf(superset, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected subset to be a subset of {1, 2, 4, 5} because we want to test the failure message, " +
-                    "but items {3, 6} are not part of the superset.");
-        }
-
-        [Fact]
-        public void When_an_empty_collection_is_tested_against_a_superset_it_should_succeed()
-        {
-            // Arrange
-            var subset = new int[0];
-            var superset = new[] { 1, 2, 4, 5 };
-
-            // Act
-            Action act = () => subset.Should().BeSubsetOf(superset);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_subset_is_tested_against_a_null_superset_it_should_throw_with_a_clear_explanation()
-        {
-            // Arrange
-            var subset = new[] { 1, 2, 3 };
-            int[] superset = null;
-
-            // Act
-            Action act = () => subset.Should().BeSubsetOf(superset);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot verify a subset against a <null> collection.*");
-        }
-
-        [Fact]
-        public void When_a_set_is_expected_to_be_not_a_subset_it_should_succeed()
-        {
-            // Arrange
-            var subject = new[] { 1, 2, 4 };
-            var otherSet = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            subject.Should().NotBeSubsetOf(otherSet);
-        }
-
-        #endregion
-
-        #region Not Be Subset Of
-
-        [Fact]
-        public void When_an_empty_set_is_not_supposed_to_be_a_subset_of_another_set_it_should_throw()
-        {
-            // Arrange
-            var subject = new int[] { };
-            var otherSet = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => subject.Should().NotBeSubsetOf(otherSet);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect subject {empty} to be a subset of {1, 2, 3}.");
-        }
-
-        [Fact]
-        public void Should_fail_when_asserting_collection_is_not_subset_of_a_superset_collection()
-        {
-            // Arrange
-            var subject = new[] { 1, 2 };
-            var otherSet = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => subject.Should().NotBeSubsetOf(otherSet, "because I'm {0}", "mistaken");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect subject {1, 2} to be a subset of {1, 2, 3} because I'm mistaken.");
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_be_subset_against_null_collection_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-            var collection1 = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_is_subset_of_a_specified_collection_it_should_not_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().BeSubsetOf(collection1, "because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var subset = new[] { 1, 2 };
+                var superset = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to be a subset of {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
-        }
+                // Act / Assert
+                subset.Should().BeSubsetOf(superset);
+            }
 
-        [Fact]
-        public void When_asserting_collection_to_not_be_subset_against_same_collection_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            var collection1 = collection;
-
-            // Act
-            Action act = () => collection.Should().NotBeSubsetOf(collection1,
-                "because we want to test the behaviour with same objects");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect*to be a subset of*because we want to test the behaviour with same objects*but they both reference the same object.");
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_not_be_subset_against_null_collection_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_is_not_a_subset_of_another_it_should_throw_with_the_reason()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotBeSubsetOf(new[] { 1, 2, 3 }, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var subset = new[] { 1, 2, 3, 6 };
+                var superset = new[] { 1, 2, 4, 5 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Cannot assert a <null> collection against a subset.");
+                // Act
+                Action act = () => subset.Should().BeSubsetOf(superset, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected subset to be a subset of {1, 2, 4, 5} because we want to test the failure message, " +
+                        "but items {3, 6} are not part of the superset.");
+            }
+
+            [Fact]
+            public void When_an_empty_collection_is_tested_against_a_superset_it_should_succeed()
+            {
+                // Arrange
+                var subset = new int[0];
+                var superset = new[] { 1, 2, 4, 5 };
+
+                // Act
+                Action act = () => subset.Should().BeSubsetOf(superset);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_subset_is_tested_against_a_null_superset_it_should_throw_with_a_clear_explanation()
+            {
+                // Arrange
+                var subset = new[] { 1, 2, 3 };
+                int[] superset = null;
+
+                // Act
+                Action act = () => subset.Should().BeSubsetOf(superset);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot verify a subset against a <null> collection.*");
+            }
+
+            [Fact]
+            public void When_a_set_is_expected_to_be_not_a_subset_it_should_succeed()
+            {
+                // Arrange
+                var subject = new[] { 1, 2, 4 };
+                var otherSet = new[] { 1, 2, 3 };
+
+                // Act / Assert
+                subject.Should().NotBeSubsetOf(otherSet);
+            }
         }
 
-        #endregion
+        public class NotBeSubsetOf
+        {
+            [Fact]
+            public void When_an_empty_set_is_not_supposed_to_be_a_subset_of_another_set_it_should_throw()
+            {
+                // Arrange
+                var subject = new int[] { };
+                var otherSet = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => subject.Should().NotBeSubsetOf(otherSet);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect subject {empty} to be a subset of {1, 2, 3}.");
+            }
+
+            [Fact]
+            public void Should_fail_when_asserting_collection_is_not_subset_of_a_superset_collection()
+            {
+                // Arrange
+                var subject = new[] { 1, 2 };
+                var otherSet = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => subject.Should().NotBeSubsetOf(otherSet, "because I'm {0}", "mistaken");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect subject {1, 2} to be a subset of {1, 2, 3} because I'm mistaken.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_be_subset_against_null_collection_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+                var collection1 = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().BeSubsetOf(collection1, "because we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to be a subset of {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_not_be_subset_against_same_collection_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                var collection1 = collection;
+
+                // Act
+                Action act = () => collection.Should().NotBeSubsetOf(collection1,
+                    "because we want to test the behaviour with same objects");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect*to be a subset of*because we want to test the behaviour with same objects*but they both reference the same object.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_not_be_subset_against_null_collection_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotBeSubsetOf(new[] { 1, 2, 3 }, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Cannot assert a <null> collection against a subset.");
+            }
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
@@ -11,421 +11,419 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Contain
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_contains_an_item_from_the_collection()
+        public class Contain
         {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().Contain(1);
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_contains_multiple_items_from_the_collection_in_any_order()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().Contain(new[] { 2, 1 });
-        }
-
-        [Fact]
-        public void When_a_collection_does_not_contain_single_item_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().Contain(4, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to contain 4 because we do.");
-        }
-
-        [Fact]
-        public void When_asserting_collection_does_contain_item_against_null_collection_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void Should_succeed_when_asserting_collection_contains_an_item_from_the_collection()
             {
-                using var _ = new AssertionScope();
-                collection.Should().Contain(1, "because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain 1 because we want to test the behaviour with a null subject, but found <null>.");
-        }
+                // Act / Assert
+                collection.Should().Contain(1);
+            }
 
-        [Fact]
-        public void When_a_collection_does_not_contain_another_collection_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().Contain(new[] { 3, 4, 5 }, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to contain {3, 4, 5} because we do, but could not find {4, 5}.");
-        }
-
-        [Fact]
-        public void When_the_contents_of_a_collection_are_checked_against_an_empty_collection_it_should_throw_clear_explanation()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().Contain(new int[0]);
-
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify containment against an empty collection*");
-        }
-
-        [Fact]
-        public void When_asserting_collection_does_contain_a_list_of_items_against_null_collection_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void Should_succeed_when_asserting_collection_contains_multiple_items_from_the_collection_in_any_order()
             {
-                using var _ = new AssertionScope();
-                collection.Should().Contain(new[] { 1, 2 }, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain {1, 2} *failure message*, but found <null>.");
-        }
+                // Act / Assert
+                collection.Should().Contain(new[] { 2, 1 });
+            }
 
-        [Fact]
-        public void When_injecting_a_null_predicate_into_Contain_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<int> collection = new int[] { };
-
-            // Act
-            Action act = () => collection.Should().Contain(predicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("predicate");
-        }
-
-        [Fact]
-        public void When_collection_does_not_contain_an_expected_item_matching_a_predicate_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<int> collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().Contain(item => item > 3, "at least {0} item should be larger than 3", 1);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to have an item matching (item > 3) because at least 1 item should be larger than 3.");
-        }
-
-        [Fact]
-        public void When_collection_does_contain_an_expected_item_matching_a_predicate_it_should_allow_chaining_it()
-        {
-            // Arrange
-            IEnumerable<int> collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().Contain(item => item == 2).Which.Should().BeGreaterThan(4);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*greater*4*2*");
-        }
-
-        [Fact]
-        public void When_collection_does_contain_an_expected_item_matching_a_predicate_it_should_not_throw()
-        {
-            // Arrange
-            IEnumerable<int> collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().Contain(item => item == 2);
-        }
-
-        [Fact]
-        public void When_a_collection_of_strings_contains_the_expected_string_it_should_not_throw()
-        {
-            // Arrange
-            IEnumerable<string> strings = new[] { "string1", "string2", "string3" };
-
-            // Act / Assert
-            strings.Should().Contain("string2");
-        }
-
-        [Fact]
-        public void When_a_collection_of_strings_does_not_contain_the_expected_string_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<string> strings = new[] { "string1", "string2", "string3" };
-
-            // Act
-            Action act = () => strings.Should().Contain("string4", "because {0} is required", "4");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected strings {\"string1\", \"string2\", \"string3\"} to contain \"string4\" because 4 is required.");
-        }
-
-        [Fact]
-        public void When_asserting_collection_contains_some_values_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            const IEnumerable<string> strings = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_a_collection_does_not_contain_single_item_it_should_throw_with_clear_explanation()
             {
-                using var _ = new AssertionScope();
-                strings.Should().Contain("string4", "because we're checking how it reacts to a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected strings to contain \"string4\" because we're checking how it reacts to a null subject, but found <null>.");
-        }
+                // Act
+                Action act = () => collection.Should().Contain(4, "because {0}", "we do");
 
-        [Fact]
-        public void When_the_multiple_matching_objects_exists_it_continuation_using_the_matched_value_should_fail()
-        {
-            // Arrange
-            DateTime now = DateTime.Now;
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, 2, 3} to contain 4 because we do.");
+            }
 
-            IEnumerable<DateTime> collection = new[] { now, DateTime.SpecifyKind(now, DateTimeKind.Unspecified) };
-
-            // Act
-            Action act = () => collection.Should().Contain(now).Which.Kind.Should().Be(DateTimeKind.Local);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_asserting_collection_contains_values_according_to_predicate_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            const IEnumerable<string> strings = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_asserting_collection_does_contain_item_against_null_collection_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                strings.Should().Contain(x => x == "xxx", "because we're checking how it reacts to a null subject");
-            };
+                // Arrange
+                int[] collection = null;
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected strings to contain (x == \"xxx\") because we're checking how it reacts to a null subject, but found <null>.");
-        }
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().Contain(1, "because we want to test the behaviour with a null subject");
+                };
 
-        #endregion
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to contain 1 because we want to test the behaviour with a null subject, but found <null>.");
+            }
 
-        #region Not Contain
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_does_not_contain_an_item_that_is_not_in_the_collection()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().NotContain(4);
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_does_not_contain_any_items_that_is_not_in_the_collection()
-        {
-            // Arrange
-            IEnumerable<int> collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().NotContain(new[] { 4, 5 });
-        }
-
-        [Fact]
-        public void When_collection_contains_an_unexpected_item_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().NotContain(1, "because we {0} like it, but found it anyhow", "don't");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to not contain 1 because we don't like it, but found it anyhow.");
-        }
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_NotContain_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<int> collection = new int[] { };
-
-            // Act
-            Action act = () => collection.Should().NotContain(predicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("predicate");
-        }
-
-        [Fact]
-        public void When_collection_does_contain_an_unexpected_item_matching_a_predicate_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<int> collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().NotContain(item => item == 2, "because {0}s are evil", 2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to not have any items matching (item == 2) because 2s are evil,*{2}*");
-        }
-
-        [Fact]
-        public void When_collection_does_not_contain_an_unexpected_item_matching_a_predicate_it_should_not_throw()
-        {
-            // Arrange
-            IEnumerable<int> collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().NotContain(item => item == 4);
-        }
-
-        [Fact]
-        public void When_asserting_collection_does_not_contain_item_against_null_collection_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_a_collection_does_not_contain_another_collection_it_should_throw_with_clear_explanation()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotContain(1, "because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to not contain 1 because we want to test the behaviour with a null subject, but found <null>.");
-        }
+                // Act
+                Action act = () => collection.Should().Contain(new[] { 3, 4, 5 }, "because {0}", "we do");
 
-        [Fact]
-        public void When_collection_contains_unexpected_items_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, 2, 3} to contain {3, 4, 5} because we do, but could not find {4, 5}.");
+            }
 
-            // Act
-            Action act = () => collection.Should()
-                .NotContain(new[] { 1, 2, 4 }, "because we {0} like them", "don't");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to not contain {1, 2, 4} because we don't like them, but found {1, 2}.");
-        }
-
-        [Fact]
-        public void When_asserting_collection_does_not_contain_predicate_item_against_null_collection_it_should_fail()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_the_contents_of_a_collection_are_checked_against_an_empty_collection_it_should_throw_clear_explanation()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotContain(item => item == 4, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection not to contain (item == 4) *failure message*, but found <null>.");
-        }
+                // Act
+                Action act = () => collection.Should().Contain(new int[0]);
 
-        [Fact]
-        public void When_asserting_collection_does_not_contain_a_list_of_items_against_null_collection_it_should_fail()
-        {
-            // Arrange
-            int[] collection = null;
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage(
+                    "Cannot verify containment against an empty collection*");
+            }
 
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_asserting_collection_does_contain_a_list_of_items_against_null_collection_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotContain(new[] { 1, 2, 4 }, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                int[] collection = null;
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to not contain {1, 2, 4} *failure message*, but found <null>.");
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().Contain(new[] { 1, 2 }, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to contain {1, 2} *failure message*, but found <null>.");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_predicate_into_Contain_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<int> collection = new int[] { };
+
+                // Act
+                Action act = () => collection.Should().Contain(predicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("predicate");
+            }
+
+            [Fact]
+            public void When_collection_does_not_contain_an_expected_item_matching_a_predicate_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<int> collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().Contain(item => item > 3, "at least {0} item should be larger than 3", 1);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, 2, 3} to have an item matching (item > 3) because at least 1 item should be larger than 3.");
+            }
+
+            [Fact]
+            public void When_collection_does_contain_an_expected_item_matching_a_predicate_it_should_allow_chaining_it()
+            {
+                // Arrange
+                IEnumerable<int> collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().Contain(item => item == 2).Which.Should().BeGreaterThan(4);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*greater*4*2*");
+            }
+
+            [Fact]
+            public void When_collection_does_contain_an_expected_item_matching_a_predicate_it_should_not_throw()
+            {
+                // Arrange
+                IEnumerable<int> collection = new[] { 1, 2, 3 };
+
+                // Act / Assert
+                collection.Should().Contain(item => item == 2);
+            }
+
+            [Fact]
+            public void When_a_collection_of_strings_contains_the_expected_string_it_should_not_throw()
+            {
+                // Arrange
+                IEnumerable<string> strings = new[] { "string1", "string2", "string3" };
+
+                // Act / Assert
+                strings.Should().Contain("string2");
+            }
+
+            [Fact]
+            public void When_a_collection_of_strings_does_not_contain_the_expected_string_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<string> strings = new[] { "string1", "string2", "string3" };
+
+                // Act
+                Action act = () => strings.Should().Contain("string4", "because {0} is required", "4");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected strings {\"string1\", \"string2\", \"string3\"} to contain \"string4\" because 4 is required.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_contains_some_values_but_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                const IEnumerable<string> strings = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    strings.Should().Contain("string4", "because we're checking how it reacts to a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected strings to contain \"string4\" because we're checking how it reacts to a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_the_multiple_matching_objects_exists_it_continuation_using_the_matched_value_should_fail()
+            {
+                // Arrange
+                DateTime now = DateTime.Now;
+
+                IEnumerable<DateTime> collection = new[] { now, DateTime.SpecifyKind(now, DateTimeKind.Unspecified) };
+
+                // Act
+                Action act = () => collection.Should().Contain(now).Which.Kind.Should().Be(DateTimeKind.Local);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_collection_contains_values_according_to_predicate_but_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                const IEnumerable<string> strings = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    strings.Should().Contain(x => x == "xxx", "because we're checking how it reacts to a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected strings to contain (x == \"xxx\") because we're checking how it reacts to a null subject, but found <null>.");
+            }
         }
-
-        [Fact]
-        public void When_asserting_collection_doesnt_contain_values_according_to_predicate_but_collection_is_null_it_should_throw()
+        
+        public class NotContain
         {
-            // Arrange
-            const IEnumerable<string> strings = null;
+            [Fact]
+            public void Should_succeed_when_asserting_collection_does_not_contain_an_item_that_is_not_in_the_collection()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Act
-            Action act =
-                () => strings.Should().NotContain(x => x == "xxx", "because we're checking how it reacts to a null subject");
+                // Act / Assert
+                collection.Should().NotContain(4);
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected strings not to contain (x == \"xxx\") because we're checking how it reacts to a null subject, but found <null>.");
+            [Fact]
+            public void Should_succeed_when_asserting_collection_does_not_contain_any_items_that_is_not_in_the_collection()
+            {
+                // Arrange
+                IEnumerable<int> collection = new[] { 1, 2, 3 };
+
+                // Act / Assert
+                collection.Should().NotContain(new[] { 4, 5 });
+            }
+
+            [Fact]
+            public void When_collection_contains_an_unexpected_item_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().NotContain(1, "because we {0} like it, but found it anyhow", "don't");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, 2, 3} to not contain 1 because we don't like it, but found it anyhow.");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_predicate_into_NotContain_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<int> collection = new int[] { };
+
+                // Act
+                Action act = () => collection.Should().NotContain(predicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("predicate");
+            }
+
+            [Fact]
+            public void When_collection_does_contain_an_unexpected_item_matching_a_predicate_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<int> collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().NotContain(item => item == 2, "because {0}s are evil", 2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, 2, 3} to not have any items matching (item == 2) because 2s are evil,*{2}*");
+            }
+
+            [Fact]
+            public void When_collection_does_not_contain_an_unexpected_item_matching_a_predicate_it_should_not_throw()
+            {
+                // Arrange
+                IEnumerable<int> collection = new[] { 1, 2, 3 };
+
+                // Act / Assert
+                collection.Should().NotContain(item => item == 4);
+            }
+
+            [Fact]
+            public void When_asserting_collection_does_not_contain_item_against_null_collection_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotContain(1, "because we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to not contain 1 because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_collection_contains_unexpected_items_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should()
+                    .NotContain(new[] { 1, 2, 4 }, "because we {0} like them", "don't");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, 2, 3} to not contain {1, 2, 4} because we don't like them, but found {1, 2}.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_does_not_contain_predicate_item_against_null_collection_it_should_fail()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotContain(item => item == 4, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection not to contain (item == 4) *failure message*, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_does_not_contain_a_list_of_items_against_null_collection_it_should_fail()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotContain(new[] { 1, 2, 4 }, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to not contain {1, 2, 4} *failure message*, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_doesnt_contain_values_according_to_predicate_but_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                const IEnumerable<string> strings = null;
+
+                // Act
+                Action act =
+                    () => strings.Should().NotContain(x => x == "xxx", "because we're checking how it reacts to a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected strings not to contain (x == \"xxx\") because we're checking how it reacts to a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_a_collection_does_not_contain_the_expected_item_it_should_not_be_enumerated_twice()
+            {
+                // Arrange
+                var collection = new OneTimeEnumerable<int>(1, 2, 3);
+
+                // Act
+                Action act = () => collection.Should().Contain(4);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection*to contain 4.");
+            }
+
+            [Fact]
+            public void When_a_collection_contains_the_unexpected_item_it_should_not_be_enumerated_twice()
+            {
+                // Arrange
+                var collection = new OneTimeEnumerable<int>(1, 2, 3);
+
+                // Act
+                Action act = () => collection.Should().NotContain(2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection*to not contain 2.");
+            }
         }
-
-        [Fact]
-        public void When_a_collection_does_not_contain_the_expected_item_it_should_not_be_enumerated_twice()
-        {
-            // Arrange
-            var collection = new OneTimeEnumerable<int>(1, 2, 3);
-
-            // Act
-            Action act = () => collection.Should().Contain(4);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection*to contain 4.");
-        }
-
-        [Fact]
-        public void When_a_collection_contains_the_unexpected_item_it_should_not_be_enumerated_twice()
-        {
-            // Arrange
-            var collection = new OneTimeEnumerable<int>(1, 2, 3);
-
-            // Act
-            Action act = () => collection.Should().NotContain(2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection*to not contain 2.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainEquivalentOf.cs
@@ -10,399 +10,397 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Contain Equivalent Of
-
-        [Fact]
-        public void When_collection_contains_object_equal_of_another_it_should_succeed()
+        public class ContainEquivalentOf
         {
-            // Arrange
-            var item = new Customer { Name = "John" };
-            var collection = new[] { new Customer { Name = "Jane" }, item };
-
-            // Act / Assert
-            collection.Should().ContainEquivalentOf(item);
-        }
-
-        [Fact]
-        public void When_collection_contains_object_equivalent_of_another_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { new Customer { Name = "Jane" }, new Customer { Name = "John" } };
-            var item = new Customer { Name = "John" };
-
-            // Act / Assert
-            collection.Should().ContainEquivalentOf(item);
-        }
-
-        [Fact]
-        public void When_character_collection_does_contain_equivalent_it_should_succeed()
-        {
-            // Arrange
-            char[] collection = "abc123ab".ToCharArray();
-            char item = 'c';
-
-            // Act / Assert
-            collection.Should().ContainEquivalentOf(item);
-        }
-
-        [Fact]
-        public void When_string_collection_does_contain_same_string_with_other_case_it_should_throw()
-        {
-            // Arrange
-            string[] collection = new[] { "a", "b", "c" };
-            string item = "C";
-
-            // Act
-            Action act = () => collection.Should().ContainEquivalentOf(item);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection {\"a\", \"b\", \"c\"} to contain equivalent of \"C\".*");
-        }
-
-        [Fact]
-        public void When_string_collection_does_contain_same_string_it_should_throw_with_a_useful_message()
-        {
-            // Arrange
-            string[] collection = new[] { "a" };
-            string item = "b";
-
-            // Act
-            Action act = () => collection.Should().ContainEquivalentOf(item, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*because we want to test the failure message*");
-        }
-
-        [Fact]
-        public void When_collection_does_not_contain_object_equivalent_of_another_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            int item = 4;
-
-            // Act
-            Action act = () => collection.Should().ContainEquivalentOf(item);
-
-            // Act / Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection {1, 2, 3} to contain equivalent of 4.*");
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_contain_equivalent_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-            int expectation = 1;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_contains_object_equal_of_another_it_should_succeed()
             {
-                using var _ = new AssertionScope();
-                collection.Should().ContainEquivalentOf(expectation, "because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var item = new Customer { Name = "John" };
+                var collection = new[] { new Customer { Name = "Jane" }, item };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain equivalent of 1 because we want to test the behaviour with a null subject, but found <null>.");
-        }
+                // Act / Assert
+                collection.Should().ContainEquivalentOf(item);
+            }
 
-        [Fact]
-        public void When_collection_contains_equivalent_null_object_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3, (int?)null };
-            int? item = null;
-
-            // Act
-            Action act = () => collection.Should().ContainEquivalentOf(item);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_does_not_contain_equivalent_null_object_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            int? item = null;
-
-            // Act
-            Action act = () => collection.Should().ContainEquivalentOf(item);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection {1, 2, 3} to contain equivalent of <null>.*");
-        }
-
-        [Fact]
-        public void When_empty_collection_does_not_contain_equivalent_it_should_throw()
-        {
-            // Arrange
-            var collection = new int[0];
-            int item = 1;
-
-            // Act
-            Action act = () => collection.Should().ContainEquivalentOf(item);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection {empty} to contain equivalent of 1.*");
-        }
-
-        [Fact]
-        public void When_collection_does_not_contain_equivalent_because_of_second_property_it_should_throw()
-        {
-            // Arrange
-            var subject = new[]
+            [Fact]
+            public void When_collection_contains_object_equivalent_of_another_it_should_succeed()
             {
-                new Customer
-                {
-                    Name = "John",
-                    Age = 18
-                },
-                new Customer
-                {
-                    Name = "Jane",
-                    Age = 18
-                }
-            };
-            var item = new Customer { Name = "John", Age = 20 };
+                // Arrange
+                var collection = new[] { new Customer { Name = "Jane" }, new Customer { Name = "John" } };
+                var item = new Customer { Name = "John" };
 
-            // Act
-            Action act = () => subject.Should().ContainEquivalentOf(item);
+                // Act / Assert
+                collection.Should().ContainEquivalentOf(item);
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_collection_does_contain_equivalent_by_including_single_property_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[]
+            [Fact]
+            public void When_character_collection_does_contain_equivalent_it_should_succeed()
             {
-                new Customer
-                {
-                    Name = "John",
-                    Age = 18
-                },
-                new Customer
-                {
-                    Name = "Jane",
-                    Age = 18
-                }
-            };
-            var item = new Customer { Name = "John", Age = 20 };
+                // Arrange
+                char[] collection = "abc123ab".ToCharArray();
+                char item = 'c';
 
-            // Act / Assert
-            collection.Should().ContainEquivalentOf(item, options => options.Including(x => x.Name));
-        }
+                // Act / Assert
+                collection.Should().ContainEquivalentOf(item);
+            }
 
-        [Fact]
-        public void Tracing_should_be_included_in_the_assertion_output()
-        {
-            // Arrange
-            var collection = new[]
+            [Fact]
+            public void When_string_collection_does_contain_same_string_with_other_case_it_should_throw()
             {
-                new Customer
-                {
-                    Name = "John",
-                    Age = 18
-                },
-                new Customer
-                {
-                    Name = "Jane",
-                    Age = 18
-                }
-            };
+                // Arrange
+                string[] collection = new[] { "a", "b", "c" };
+                string item = "C";
 
-            var item = new Customer { Name = "John", Age = 21 };
+                // Act
+                Action act = () => collection.Should().ContainEquivalentOf(item);
 
-            // Act
-            Action act = () => collection.Should().ContainEquivalentOf(item, options => options.WithTracing());
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected collection {\"a\", \"b\", \"c\"} to contain equivalent of \"C\".*");
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*Equivalency was proven*");
-        }
-
-        [Fact]
-        public void When_injecting_a_null_config_to_ContainEquivalentOf_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-            object item = null;
-
-            // Act
-            Action act = () => collection.Should().ContainEquivalentOf(item, config: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("config");
-        }
-
-        [Fact]
-        public void When_collection_contains_object_equivalent_of_boxed_object_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            object boxedValue = 2;
-
-            // Act / Assert
-            collection.Should().ContainEquivalentOf(boxedValue);
-        }
-
-        #endregion
-
-        #region Not Contain Equivalent Of
-
-        [Fact]
-        public void When_collection_contains_object_equal_to_another_it_should_throw()
-        {
-            // Arrange
-            var item = 1;
-            var collection = new[] { 0, 1 };
-
-            // Act
-            Action act = () => collection.Should().NotContainEquivalentOf(item, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection {0, 1} not to contain*because we want to test the failure message, " +
-                                                             "but found one at index 1.*With configuration*");
-        }
-
-        [Fact]
-        public void When_collection_contains_several_objects_equal_to_another_it_should_throw()
-        {
-            // Arrange
-            var item = 1;
-            var collection = new[] { 0, 1, 1 };
-
-            // Act
-            Action act = () => collection.Should().NotContainEquivalentOf(item, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection {0, 1, 1} not to contain*because we want to test the failure message, " +
-                                                             "but found several at indices {1, 2}.*With configuration*");
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_not_to_contain_equivalent_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            var item = 1;
-            int[] collection = null;
-
-            // Act
-            Action act = () => collection.Should().NotContainEquivalentOf(item);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection*not to contain*but collection is <null>.");
-        }
-
-        [Fact]
-        public void When_injecting_a_null_config_to_NotContainEquivalentOf_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-            object item = null;
-
-            // Act
-            Action act = () => collection.Should().NotContainEquivalentOf(item, config: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("config");
-        }
-
-        [Fact]
-        public void When_asserting_empty_collection_to_not_contain_equivalent_it_should_succeed()
-        {
-            // Arrange
-            var collection = new int[0];
-            int item = 4;
-
-            // Act / Assert
-            collection.Should().NotContainEquivalentOf(item);
-        }
-
-        [Fact]
-        public void When_asserting_a_null_collection_to_not_contain_equivalent_of__then_it_should_fail()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_string_collection_does_contain_same_string_it_should_throw_with_a_useful_message()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotContainEquivalentOf(1, config => config, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                string[] collection = new[] { "a" };
+                string item = "b";
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection not to contain *failure message*, but collection is <null>.");
-        }
+                // Act
+                Action act = () => collection.Should().ContainEquivalentOf(item, "because we want to test the failure {0}", "message");
 
-        [Fact]
-        public void When_collection_does_not_contain_object_equivalent_of_unexpected_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            int item = 4;
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*because we want to test the failure message*");
+            }
 
-            // Act / Assert
-            collection.Should().NotContainEquivalentOf(item);
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_not_contain_equivalent_it_should_respect_config()
-        {
-            // Arrange
-            var collection = new[]
+            [Fact]
+            public void When_collection_does_not_contain_object_equivalent_of_another_it_should_throw()
             {
-                new Customer
-                {
-                    Name = "John",
-                    Age = 18
-                },
-                new Customer
-                {
-                    Name = "Jane",
-                    Age = 18
-                }
-            };
-            var item = new Customer { Name = "John", Age = 20 };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                int item = 4;
 
-            // Act
-            Action act = () => collection.Should().NotContainEquivalentOf(item, options => options.Excluding(x => x.Age));
+                // Act
+                Action act = () => collection.Should().ContainEquivalentOf(item);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*Exclude*Age*");
-        }
+                // Act / Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected collection {1, 2, 3} to contain equivalent of 4.*");
+            }
 
-        [Fact]
-        public void When_asserting_collection_to_not_contain_equivalent_it_should_allow_combining_inside_assertion_scope()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            int another = 3;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_asserting_collection_to_contain_equivalent_but_collection_is_null_it_should_throw()
             {
-                using (new AssertionScope())
-                {
-                    collection.Should().NotContainEquivalentOf(another, "because we want to test {0}", "first message")
-                        .And
-                        .HaveCount(4, "because we want to test {0}", "second message");
-                }
-            };
+                // Arrange
+                int[] collection = null;
+                int expectation = 1;
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection*not to contain*first message*but*.\n" +
-                                                             "Expected*4 item(s)*because*second message*but*.");
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().ContainEquivalentOf(expectation, "because we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to contain equivalent of 1 because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_collection_contains_equivalent_null_object_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3, (int?)null };
+                int? item = null;
+
+                // Act
+                Action act = () => collection.Should().ContainEquivalentOf(item);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_does_not_contain_equivalent_null_object_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                int? item = null;
+
+                // Act
+                Action act = () => collection.Should().ContainEquivalentOf(item);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected collection {1, 2, 3} to contain equivalent of <null>.*");
+            }
+
+            [Fact]
+            public void When_empty_collection_does_not_contain_equivalent_it_should_throw()
+            {
+                // Arrange
+                var collection = new int[0];
+                int item = 1;
+
+                // Act
+                Action act = () => collection.Should().ContainEquivalentOf(item);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected collection {empty} to contain equivalent of 1.*");
+            }
+
+            [Fact]
+            public void When_collection_does_not_contain_equivalent_because_of_second_property_it_should_throw()
+            {
+                // Arrange
+                var subject = new[]
+                {
+                    new Customer
+                    {
+                        Name = "John",
+                        Age = 18
+                    },
+                    new Customer
+                    {
+                        Name = "Jane",
+                        Age = 18
+                    }
+                };
+                var item = new Customer { Name = "John", Age = 20 };
+
+                // Act
+                Action act = () => subject.Should().ContainEquivalentOf(item);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_collection_does_contain_equivalent_by_including_single_property_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[]
+                {
+                    new Customer
+                    {
+                        Name = "John",
+                        Age = 18
+                    },
+                    new Customer
+                    {
+                        Name = "Jane",
+                        Age = 18
+                    }
+                };
+                var item = new Customer { Name = "John", Age = 20 };
+
+                // Act / Assert
+                collection.Should().ContainEquivalentOf(item, options => options.Including(x => x.Name));
+            }
+
+            [Fact]
+            public void Tracing_should_be_included_in_the_assertion_output()
+            {
+                // Arrange
+                var collection = new[]
+                {
+                    new Customer
+                    {
+                        Name = "John",
+                        Age = 18
+                    },
+                    new Customer
+                    {
+                        Name = "Jane",
+                        Age = 18
+                    }
+                };
+
+                var item = new Customer { Name = "John", Age = 21 };
+
+                // Act
+                Action act = () => collection.Should().ContainEquivalentOf(item, options => options.WithTracing());
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*Equivalency was proven*");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_config_to_ContainEquivalentOf_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+                object item = null;
+
+                // Act
+                Action act = () => collection.Should().ContainEquivalentOf(item, config: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("config");
+            }
+
+            [Fact]
+            public void When_collection_contains_object_equivalent_of_boxed_object_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                object boxedValue = 2;
+
+                // Act / Assert
+                collection.Should().ContainEquivalentOf(boxedValue);
+            }
         }
 
-        #endregion
+        public class NotContainEquivalentOf
+        {
+            [Fact]
+            public void When_collection_contains_object_equal_to_another_it_should_throw()
+            {
+                // Arrange
+                var item = 1;
+                var collection = new[] { 0, 1 };
+
+                // Act
+                Action act = () => collection.Should().NotContainEquivalentOf(item, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected collection {0, 1} not to contain*because we want to test the failure message, " +
+                                                                 "but found one at index 1.*With configuration*");
+            }
+
+            [Fact]
+            public void When_collection_contains_several_objects_equal_to_another_it_should_throw()
+            {
+                // Arrange
+                var item = 1;
+                var collection = new[] { 0, 1, 1 };
+
+                // Act
+                Action act = () => collection.Should().NotContainEquivalentOf(item, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected collection {0, 1, 1} not to contain*because we want to test the failure message, " +
+                                                                 "but found several at indices {1, 2}.*With configuration*");
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_not_to_contain_equivalent_but_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                var item = 1;
+                int[] collection = null;
+
+                // Act
+                Action act = () => collection.Should().NotContainEquivalentOf(item);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected collection*not to contain*but collection is <null>.");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_config_to_NotContainEquivalentOf_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+                object item = null;
+
+                // Act
+                Action act = () => collection.Should().NotContainEquivalentOf(item, config: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("config");
+            }
+
+            [Fact]
+            public void When_asserting_empty_collection_to_not_contain_equivalent_it_should_succeed()
+            {
+                // Arrange
+                var collection = new int[0];
+                int item = 4;
+
+                // Act / Assert
+                collection.Should().NotContainEquivalentOf(item);
+            }
+
+            [Fact]
+            public void When_asserting_a_null_collection_to_not_contain_equivalent_of__then_it_should_fail()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotContainEquivalentOf(1, config => config, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection not to contain *failure message*, but collection is <null>.");
+            }
+
+            [Fact]
+            public void When_collection_does_not_contain_object_equivalent_of_unexpected_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                int item = 4;
+
+                // Act / Assert
+                collection.Should().NotContainEquivalentOf(item);
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_not_contain_equivalent_it_should_respect_config()
+            {
+                // Arrange
+                var collection = new[]
+                {
+                    new Customer
+                    {
+                        Name = "John",
+                        Age = 18
+                    },
+                    new Customer
+                    {
+                        Name = "Jane",
+                        Age = 18
+                    }
+                };
+                var item = new Customer { Name = "John", Age = 20 };
+
+                // Act
+                Action act = () => collection.Should().NotContainEquivalentOf(item, options => options.Excluding(x => x.Age));
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*Exclude*Age*");
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_not_contain_equivalent_it_should_allow_combining_inside_assertion_scope()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                int another = 3;
+
+                // Act
+                Action act = () =>
+                {
+                    using (new AssertionScope())
+                    {
+                        collection.Should().NotContainEquivalentOf(another, "because we want to test {0}", "first message")
+                            .And
+                            .HaveCount(4, "because we want to test {0}", "second message");
+                    }
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected collection*not to contain*first message*but*.\n" +
+                                                                 "Expected*4 item(s)*because*second message*but*.");
+            }
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInOrder.cs
@@ -10,263 +10,261 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Contain In Order
-
-        [Fact]
-        public void When_two_collections_contain_the_same_items_in_the_same_order_it_should_not_throw()
+        public class ContainInOrder
         {
-            // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
-
-            // Act / Assert
-            collection.Should().ContainInOrder(1, 2, 3);
-        }
-
-        [Fact]
-        public void When_collection_contains_null_value_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new object[] { 1, null, 2, "string" };
-
-            // Act / Assert
-            collection.Should().ContainInOrder(new object[] { 1, null, "string" });
-        }
-
-        [Fact]
-        public void When_the_first_collection_contains_a_duplicate_item_without_affecting_the_order_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3, 2 };
-
-            // Act / Assert
-            collection.Should().ContainInOrder(1, 2, 3);
-        }
-
-        [Fact]
-        public void When_two_collections_contain_the_same_duplicate_items_in_the_same_order_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 1, 2, 12, 2, 2 };
-
-            // Act / Assert
-            collection.Should().ContainInOrder(1, 2, 1, 2, 12, 2, 2);
-        }
-
-        [Fact]
-        public void When_a_collection_does_not_contain_a_range_twice_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 1, 3, 12, 2, 2 };
-
-            // Act
-            Action act = () => collection.Should().ContainInOrder(1, 2, 1, 1, 2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 1, 3, 12, 2, 2} to contain items {1, 2, 1, 1, 2} in order, but 1 (index 3) did not appear (in the right order).");
-        }
-
-        [Fact]
-        public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_throw_with_a_clear_explanation()
-        {
-            // Act
-            Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder(new[] { 3, 1 }, "because we said so");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to contain items {3, 1} in order because we said so, but 1 (index 1) did not appear (in the right order).");
-        }
-
-        [Fact]
-        public void When_a_collection_does_not_contain_an_ordered_item_it_should_throw_with_a_clear_explanation()
-        {
-            // Act
-            Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder(new[] { 4, 1 }, "we failed");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to contain items {4, 1} in order because we failed, " +
-                    "but 4 (index 0) did not appear (in the right order).");
-        }
-
-        [Fact]
-        public void When_passing_in_null_while_checking_for_ordered_containment_it_should_throw_with_a_clear_explanation()
-        {
-            // Act
-            Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder(null);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot verify ordered containment against a <null> collection.*");
-        }
-
-        [Fact]
-        public void When_asserting_collection_contains_some_values_in_order_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] ints = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_two_collections_contain_the_same_items_in_the_same_order_it_should_not_throw()
             {
-                using var _ = new AssertionScope();
-                ints.Should().ContainInOrder(new[] { 4 }, "because we're checking how it reacts to a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected ints to contain {4} in order because we're checking how it reacts to a null subject, but found <null>.");
-        }
+                // Act / Assert
+                collection.Should().ContainInOrder(1, 2, 3);
+            }
 
-        #endregion
-
-        #region Not Contain In Order
-
-        [Fact]
-        public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().NotContainInOrder(2, 1);
-        }
-
-        [Fact]
-        public void When_a_collection_does_not_contain_an_ordered_item_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().NotContainInOrder(4, 1);
-        }
-
-        [Fact]
-        public void When_a_collection_contains_less_items_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2 };
-
-            // Act / Assert
-            collection.Should().NotContainInOrder(1, 2, 3);
-        }
-
-        [Fact]
-        public void When_a_collection_does_not_contain_a_range_twice_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 1, 3, 12, 2, 2 };
-
-            // Act / Assert
-            collection.Should().NotContainInOrder(1, 2, 1, 1, 2);
-        }
-
-        [Fact]
-        public void When_asserting_collection_does_not_contain_some_values_in_order_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () => collection.Should().NotContainInOrder(4);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Cannot verify absence of ordered containment in a <null> collection.");
-        }
-
-        [Fact]
-        public void When_two_collections_contain_the_same_items_in_the_same_order_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().NotContainInOrder(new[] { 1, 2, 3 }, "that's what we expect");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 2, 3} to not contain items {1, 2, 3} in order because that's what we expect, " +
-                "but items appeared in order ending at index 3.");
-        }
-
-        [Fact]
-        public void When_collection_is_null_then_not_contain_in_order_should_fail()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_contains_null_value_it_should_not_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotContainInOrder(new[] { 1, 2, 3 }, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new object[] { 1, null, 2, "string" };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Cannot verify absence of ordered containment in a <null> collection.");
+                // Act / Assert
+                collection.Should().ContainInOrder(new object[] { 1, null, "string" });
+            }
+
+            [Fact]
+            public void When_the_first_collection_contains_a_duplicate_item_without_affecting_the_order_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3, 2 };
+
+                // Act / Assert
+                collection.Should().ContainInOrder(1, 2, 3);
+            }
+
+            [Fact]
+            public void When_two_collections_contain_the_same_duplicate_items_in_the_same_order_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 1, 2, 12, 2, 2 };
+
+                // Act / Assert
+                collection.Should().ContainInOrder(1, 2, 1, 2, 12, 2, 2);
+            }
+
+            [Fact]
+            public void When_a_collection_does_not_contain_a_range_twice_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 1, 3, 12, 2, 2 };
+
+                // Act
+                Action act = () => collection.Should().ContainInOrder(1, 2, 1, 1, 2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, 2, 1, 3, 12, 2, 2} to contain items {1, 2, 1, 1, 2} in order, but 1 (index 3) did not appear (in the right order).");
+            }
+
+            [Fact]
+            public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_throw_with_a_clear_explanation()
+            {
+                // Act
+                Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder(new[] { 3, 1 }, "because we said so");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, 2, 3} to contain items {3, 1} in order because we said so, but 1 (index 1) did not appear (in the right order).");
+            }
+
+            [Fact]
+            public void When_a_collection_does_not_contain_an_ordered_item_it_should_throw_with_a_clear_explanation()
+            {
+                // Act
+                Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder(new[] { 4, 1 }, "we failed");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, 2, 3} to contain items {4, 1} in order because we failed, " +
+                        "but 4 (index 0) did not appear (in the right order).");
+            }
+
+            [Fact]
+            public void When_passing_in_null_while_checking_for_ordered_containment_it_should_throw_with_a_clear_explanation()
+            {
+                // Act
+                Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder(null);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot verify ordered containment against a <null> collection.*");
+            }
+
+            [Fact]
+            public void When_asserting_collection_contains_some_values_in_order_but_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] ints = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    ints.Should().ContainInOrder(new[] { 4 }, "because we're checking how it reacts to a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected ints to contain {4} in order because we're checking how it reacts to a null subject, but found <null>.");
+            }
         }
 
-        [Fact]
-        public void When_collection_contains_contain_the_same_items_in_the_same_order_with_null_value_it_should_throw()
+        public class NotContainInOrder
         {
-            // Arrange
-            var collection = new object[] { 1, null, 2, "string" };
+            [Fact]
+            public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Act
-            Action act = () => collection.Should().NotContainInOrder(1, null, "string");
+                // Act / Assert
+                collection.Should().NotContainInOrder(2, 1);
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, <null>, 2, \"string\"} to not contain items {1, <null>, \"string\"} in order, " +
-                "but items appeared in order ending at index 3.");
+            [Fact]
+            public void When_a_collection_does_not_contain_an_ordered_item_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act / Assert
+                collection.Should().NotContainInOrder(4, 1);
+            }
+
+            [Fact]
+            public void When_a_collection_contains_less_items_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2 };
+
+                // Act / Assert
+                collection.Should().NotContainInOrder(1, 2, 3);
+            }
+
+            [Fact]
+            public void When_a_collection_does_not_contain_a_range_twice_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 1, 3, 12, 2, 2 };
+
+                // Act / Assert
+                collection.Should().NotContainInOrder(1, 2, 1, 1, 2);
+            }
+
+            [Fact]
+            public void When_asserting_collection_does_not_contain_some_values_in_order_but_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () => collection.Should().NotContainInOrder(4);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Cannot verify absence of ordered containment in a <null> collection.");
+            }
+
+            [Fact]
+            public void When_two_collections_contain_the_same_items_in_the_same_order_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().NotContainInOrder(new[] { 1, 2, 3 }, "that's what we expect");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, 2, 2, 3} to not contain items {1, 2, 3} in order because that's what we expect, " +
+                    "but items appeared in order ending at index 3.");
+            }
+
+            [Fact]
+            public void When_collection_is_null_then_not_contain_in_order_should_fail()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotContainInOrder(new[] { 1, 2, 3 }, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Cannot verify absence of ordered containment in a <null> collection.");
+            }
+
+            [Fact]
+            public void When_collection_contains_contain_the_same_items_in_the_same_order_with_null_value_it_should_throw()
+            {
+                // Arrange
+                var collection = new object[] { 1, null, 2, "string" };
+
+                // Act
+                Action act = () => collection.Should().NotContainInOrder(1, null, "string");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, <null>, 2, \"string\"} to not contain items {1, <null>, \"string\"} in order, " +
+                    "but items appeared in order ending at index 3.");
+            }
+
+            [Fact]
+            public void When_the_first_collection_contains_a_duplicate_item_without_affecting_the_order_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3, 2 };
+
+                // Act
+                Action act = () => collection.Should().NotContainInOrder(1, 2, 3);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, 2, 3, 2} to not contain items {1, 2, 3} in order, " +
+                    "but items appeared in order ending at index 2.");
+            }
+
+            [Fact]
+            public void When_two_collections_contain_the_same_duplicate_items_in_the_same_order_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 1, 2, 12, 2, 2 };
+
+                // Act
+                Action act = () => collection.Should().NotContainInOrder(1, 2, 1, 2, 12, 2, 2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection {1, 2, 1, 2, 12, 2, 2} to not contain items {1, 2, 1, 2, 12, 2, 2} in order, " +
+                    "but items appeared in order ending at index 6.");
+            }
+
+            [Fact]
+            public void When_passing_in_null_while_checking_for_absence_of_ordered_containment_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().NotContainInOrder(null);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot verify absence of ordered containment against a <null> collection.*");
+            }
         }
-
-        [Fact]
-        public void When_the_first_collection_contains_a_duplicate_item_without_affecting_the_order_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3, 2 };
-
-            // Act
-            Action act = () => collection.Should().NotContainInOrder(1, 2, 3);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3, 2} to not contain items {1, 2, 3} in order, " +
-                "but items appeared in order ending at index 2.");
-        }
-
-        [Fact]
-        public void When_two_collections_contain_the_same_duplicate_items_in_the_same_order_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 1, 2, 12, 2, 2 };
-
-            // Act
-            Action act = () => collection.Should().NotContainInOrder(1, 2, 1, 2, 12, 2, 2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 1, 2, 12, 2, 2} to not contain items {1, 2, 1, 2, 12, 2, 2} in order, " +
-                "but items appeared in order ending at index 6.");
-        }
-
-        [Fact]
-        public void When_passing_in_null_while_checking_for_absence_of_ordered_containment_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().NotContainInOrder(null);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot verify absence of ordered containment against a <null> collection.*");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
@@ -11,74 +11,73 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Contain Items Assignable To
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_with_all_items_of_same_type_only_contains_item_of_one_type()
+        public class ContainItemsAssignableTo
         {
-            // Arrange
-            var collection = new[] { "1", "2", "3" };
+            [Fact]
+            public void Should_succeed_when_asserting_collection_with_all_items_of_same_type_only_contains_item_of_one_type()
+            {
+                // Arrange
+                var collection = new[] { "1", "2", "3" };
 
-            // Act / Assert
-            collection.Should().ContainItemsAssignableTo<string>();
-        }
+                // Act / Assert
+                collection.Should().ContainItemsAssignableTo<string>();
+            }
 
-        [Fact]
-        public void Should_succeed_when_asserting_collection_with_items_of_different_types_contains_item_of_expected_type()
-        {
-            // Arrange
-            var collection = new List<object>
+            [Fact]
+            public void Should_succeed_when_asserting_collection_with_items_of_different_types_contains_item_of_expected_type()
+            {
+                // Arrange
+                var collection = new List<object>
             {
                 1,
                 "2"
             };
 
-            // Act / Assert
-            collection.Should().ContainItemsAssignableTo<string>();
-        }
+                // Act / Assert
+                collection.Should().ContainItemsAssignableTo<string>();
+            }
 
-        [Fact]
-        public void When_asserting_collection_contains_item_assignable_to_against_null_collection_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_asserting_collection_contains_item_assignable_to_against_null_collection_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().ContainItemsAssignableTo<string>("because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                int[] collection = null;
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain at least one element assignable to type \"System.String\" because we want to test the behaviour with a null subject, but found <null>.");
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().ContainItemsAssignableTo<string>("because we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to contain at least one element assignable to type \"System.String\" because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_a_collection_is_empty_an_exception_should_be_thrown()
+            {
+                // Arrange
+                int[] collection = Array.Empty<int>();
+
+                // Act
+                Action act = () => collection.Should().ContainItemsAssignableTo<int>();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected collection to contain at least one element assignable to type \"System.Int32\", but found {empty}.");
+            }
+
+            [Fact]
+            public void Should_throw_exception_when_asserting_collection_for_missing_item_type()
+            {
+                var collection = new object[] { "1", 1.0m };
+
+                Action act = () => collection.Should().ContainItemsAssignableTo<int>();
+
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to contain at least one element assignable to type \"System.Int32\", but found {System.String, System.Decimal}.");
+            }
         }
-
-        [Fact]
-        public void When_a_collection_is_empty_an_exception_should_be_thrown()
-        {
-            // Arrange
-            int[] collection = Array.Empty<int>();
-
-            // Act
-            Action act = () => collection.Should().ContainItemsAssignableTo<int>();
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection to contain at least one element assignable to type \"System.Int32\", but found {empty}.");
-        }
-
-        [Fact]
-        public void Should_throw_exception_when_asserting_collection_for_missing_item_type()
-        {
-            var collection = new object[] { "1", 1.0m };
-
-            Action act = () => collection.Should().ContainItemsAssignableTo<int>();
-
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain at least one element assignable to type \"System.Int32\", but found {System.String, System.Decimal}.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.EndWith.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.EndWith.cs
@@ -11,227 +11,226 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region End With
-
-        [Fact]
-        public void When_collection_does_not_end_with_a_specific_element_it_should_throw()
+        public class EndWith
         {
-            // Arrange
-            var collection = new[] { "john", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().EndWith("ryan", "of some reason");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*end*ryan*because of some reason*but*mike*");
-        }
-
-        [Fact]
-        public void When_collection_does_end_with_a_specific_element_and_because_format_is_incorrect_it_should_not_fail()
-        {
-            // Arrange
-            var collection = new[] { "john", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().EndWith("mike", "of some reason {0,abc}", 1, 2);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_does_not_end_with_a_specific_element_in_a_sequence_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().EndWith(new[] { "bill", "ryan", "mike" }, "of some reason");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*end*ryan*because of some reason*but*differs at index 2*");
-        }
-
-        [Fact]
-        public void When_collection_does_not_end_with_a_null_sequence_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "john" };
-
-            // Act
-            Action act = () => collection.Should().EndWith((IEnumerable<string>)null);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .Which.ParamName.Should().Be("expectation");
-        }
-
-        [Fact]
-        public void When_collection_does_not_end_with_a_null_sequence_using_a_comparer_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "john" };
-
-            // Act
-            Action act = () => collection.Should().EndWith((IEnumerable<string>)null, (_, _) => true);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .Which.ParamName.Should().Be("expectation");
-        }
-
-        [Fact]
-        public void When_collection_does_not_end_with_a_specific_element_in_a_sequence_using_custom_equality_comparison_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().EndWith(new[] { "bill", "ryan", "mike" }, (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "of some reason");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*end*ryan*because of some reason*but*differs at index 2*");
-        }
-
-        [Fact]
-        public void When_collection_ends_with_the_specific_element_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "john", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().EndWith("mike");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_ends_with_the_specific_sequence_of_elements_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().EndWith(new[] { "jane", "mike" });
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_ends_with_the_specific_sequence_of_elements_using_custom_equality_comparison_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().EndWith(new[] { "JaNe", "mIkE" }, (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_ends_with_the_specific_null_element_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "jane", "mike", null };
-
-            // Act
-            Action act = () => collection.Should().EndWith((string)null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_ends_with_the_specific_sequence_with_null_elements_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "john", "bill", "jane", null, "mike", null };
-
-            // Act
-            Action act = () => collection.Should().EndWith(new[] { "jane", null, "mike", null });
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_ends_with_the_specific_sequence_with_null_elements_using_custom_equality_comparison_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "john", "bill", "jane", null, "mike", null };
-
-            // Act
-            Action act = () => collection.Should().EndWith(new[] { "JaNe", null, "mIkE", null }, (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_ends_with_null_but_that_wasnt_expected_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "jane", "mike", null };
-
-            // Act
-            Action act = () => collection.Should().EndWith("john");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*end*john*but*null*");
-        }
-
-        [Fact]
-        public void When_null_collection_is_expected_to_end_with_an_element_it_should_throw()
-        {
-            // Arrange
-            string[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_does_not_end_with_a_specific_element_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().EndWith("john");
-            };
+                // Arrange
+                var collection = new[] { "john", "jane", "mike" };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*end*john*but*collection*null*");
+                // Act
+                Action act = () => collection.Should().EndWith("ryan", "of some reason");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*end*ryan*because of some reason*but*mike*");
+            }
+
+            [Fact]
+            public void When_collection_does_end_with_a_specific_element_and_because_format_is_incorrect_it_should_not_fail()
+            {
+                // Arrange
+                var collection = new[] { "john", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().EndWith("mike", "of some reason {0,abc}", 1, 2);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_does_not_end_with_a_specific_element_in_a_sequence_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "john", "bill", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().EndWith(new[] { "bill", "ryan", "mike" }, "of some reason");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*end*ryan*because of some reason*but*differs at index 2*");
+            }
+
+            [Fact]
+            public void When_collection_does_not_end_with_a_null_sequence_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "john" };
+
+                // Act
+                Action act = () => collection.Should().EndWith((IEnumerable<string>)null);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .Which.ParamName.Should().Be("expectation");
+            }
+
+            [Fact]
+            public void When_collection_does_not_end_with_a_null_sequence_using_a_comparer_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "john" };
+
+                // Act
+                Action act = () => collection.Should().EndWith((IEnumerable<string>)null, (_, _) => true);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .Which.ParamName.Should().Be("expectation");
+            }
+
+            [Fact]
+            public void When_collection_does_not_end_with_a_specific_element_in_a_sequence_using_custom_equality_comparison_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "john", "bill", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().EndWith(new[] { "bill", "ryan", "mike" }, (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "of some reason");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*end*ryan*because of some reason*but*differs at index 2*");
+            }
+
+            [Fact]
+            public void When_collection_ends_with_the_specific_element_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "john", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().EndWith("mike");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_ends_with_the_specific_sequence_of_elements_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "john", "bill", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().EndWith(new[] { "jane", "mike" });
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_ends_with_the_specific_sequence_of_elements_using_custom_equality_comparison_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "john", "bill", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().EndWith(new[] { "JaNe", "mIkE" }, (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_ends_with_the_specific_null_element_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "jane", "mike", null };
+
+                // Act
+                Action act = () => collection.Should().EndWith((string)null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_ends_with_the_specific_sequence_with_null_elements_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "john", "bill", "jane", null, "mike", null };
+
+                // Act
+                Action act = () => collection.Should().EndWith(new[] { "jane", null, "mike", null });
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_ends_with_the_specific_sequence_with_null_elements_using_custom_equality_comparison_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "john", "bill", "jane", null, "mike", null };
+
+                // Act
+                Action act = () => collection.Should().EndWith(new[] { "JaNe", null, "mIkE", null }, (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_ends_with_null_but_that_wasnt_expected_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "jane", "mike", null };
+
+                // Act
+                Action act = () => collection.Should().EndWith("john");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*end*john*but*null*");
+            }
+
+            [Fact]
+            public void When_null_collection_is_expected_to_end_with_an_element_it_should_throw()
+            {
+                // Arrange
+                string[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().EndWith("john");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*end*john*but*collection*null*");
+            }
+
+            [Fact]
+            public void When_non_empty_collection_ends_with_the_empty_sequence_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().EndWith(new string[] { });
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_empty_collection_ends_with_the_empty_sequence_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new string[] { };
+
+                // Act
+                Action act = () => collection.Should().EndWith(new string[] { });
+
+                // Assert
+                act.Should().NotThrow();
+            }
         }
-
-        [Fact]
-        public void When_non_empty_collection_ends_with_the_empty_sequence_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().EndWith(new string[] { });
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_empty_collection_ends_with_the_empty_sequence_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new string[] { };
-
-            // Act
-            Action act = () => collection.Should().EndWith(new string[] { });
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Equal.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Equal.cs
@@ -11,414 +11,412 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Equal
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_is_equal_to_the_same_collection()
+        public class Equal
         {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection1.Should().Equal(collection2);
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_is_equal_to_the_same_list_of_elements()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().Equal(1, 2, 3);
-        }
-
-        [Fact]
-        public void When_both_collections_are_null_it_should_succeed()
-        {
-            // Arrange
-            int[] nullColl = null;
-
-            // Act
-            Action act = () => nullColl.Should().Equal(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_two_collections_containing_nulls_are_equal_it_should_not_throw()
-        {
-            // Arrange
-            var subject = new List<string> { "aaa", null };
-            var expected = new List<string> { "aaa", null };
-
-            // Act
-            Action action = () => subject.Should().Equal(expected);
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_two_collections_are_not_equal_because_one_item_differs_it_should_throw_using_the_reason()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2, 5 };
-
-            // Act
-            Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 to be equal to {1, 2, 5} because we want to test the failure message, but {1, 2, 3} differs at index 2.");
-        }
-
-        [Fact]
-        public void When_two_collections_are_not_equal_because_the_actual_collection_contains_more_items_it_should_throw_using_the_reason()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2 };
-
-            // Act
-            Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 to be equal to {1, 2} because we want to test the failure message, but {1, 2, 3} contains 1 item(s) too many.");
-        }
-
-        [Fact]
-        public void When_two_collections_are_not_equal_because_the_actual_collection_contains_less_items_it_should_throw_using_the_reason()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2, 3, 4 };
-
-            // Act
-            Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 to be equal to {1, 2, 3, 4} because we want to test the failure message, but {1, 2, 3} contains 1 item(s) less.");
-        }
-
-        [Fact]
-        public void When_two_multidimensional_collections_are_not_equal_and_it_should_format_the_collections_properly()
-        {
-            // Arrange
-            var collection1 = new[] { new[] { 1, 2 }, new[] { 3, 4 } };
-            var collection2 = new[] { new[] { 5, 6 }, new[] { 7, 8 } };
-
-            // Act
-            Action act = () => collection1.Should().Equal(collection2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 to be equal to {{5, 6}, {7, 8}}, but {{1, 2}, {3, 4}} differs at index 0.");
-        }
-
-        [Fact]
-        public void When_asserting_collections_to_be_equal_but_subject_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-            var collection1 = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().Equal(collection1, "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to be equal to {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_collections_to_be_equal_but_expected_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            int[] collection1 = null;
-
-            // Act
-            Action act = () => collection.Should().Equal(collection1, "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithMessage("Cannot compare collection with <null>.*")
-                .WithParameterName("expectation");
-        }
-
-        [Fact]
-        public void When_an_empty_collection_is_compared_for_equality_to_a_non_empty_collection_it_should_throw()
-        {
-            // Arrange
-            var collection1 = new int[0];
-            var collection2 = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection1.Should().Equal(collection2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 to be equal to {1, 2, 3}, but found empty collection.");
-        }
-
-        [Fact]
-        public void When_a_non_empty_collection_is_compared_for_equality_to_an_empty_collection_it_should_throw()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new int[0];
-
-            // Act
-            Action act = () => collection1.Should().Equal(collection2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 to be equal to {empty}, but found {1, 2, 3}.");
-        }
-
-        [Fact]
-        public void When_all_items_match_according_to_a_predicate_it_should_succeed()
-        {
-            // Arrange
-            var actual = new List<string> { "ONE", "TWO", "THREE", "FOUR" };
-            var expected = new[]
+            [Fact]
+            public void Should_succeed_when_asserting_collection_is_equal_to_the_same_collection()
             {
-               new { Value = "One" },
-               new { Value = "Two" },
-               new { Value = "Three" },
-               new { Value = "Four" }
-            };
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new[] { 1, 2, 3 };
 
-            // Act
-            Action action = () => actual.Should().Equal(expected,
-                (a, e) => string.Equals(a, e.Value, StringComparison.OrdinalIgnoreCase));
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_any_item_does_not_match_according_to_a_predicate_it_should_throw()
-        {
-            // Arrange
-            var actual = new List<string> { "ONE", "TWO", "THREE", "FOUR" };
-            var expected = new[]
-            {
-               new { Value = "One" },
-               new { Value = "Two" },
-               new { Value = "Three" },
-               new { Value = "Five" }
-            };
-
-            // Act
-            Action action = () => actual.Should().Equal(expected,
-                (a, e) => string.Equals(a, e.Value, StringComparison.OrdinalIgnoreCase));
-
-            // Assert
-            action
-                .Should().Throw<XunitException>()
-                .WithMessage("*Expected*equal to*, but*differs at index 3.*");
-        }
-
-        [Fact]
-        public void When_both_collections_are_empty_it_should_them_as_equal()
-        {
-            // Arrange
-            var actual = new List<string>();
-            var expected = new List<string>();
-
-            // Act
-            Action act = () => actual.Should().Equal(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_identical_collections_to_be_equal_it_should_enumerate_the_subject_only_once()
-        {
-            // Arrange
-            var actual = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
-            var expected = new[] { 1, 2, 3 };
-
-            // Act
-            actual.Should().Equal(expected);
-
-            // Assert
-            actual.GetEnumeratorCallCount.Should().Be(1);
-        }
-
-        [Fact]
-        public void When_asserting_identical_collections_to_not_be_equal_it_should_enumerate_the_subject_only_once()
-        {
-            // Arrange
-            var actual = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
-            var expected = new[] { 1, 2, 3 };
-
-            // Act
-            try
-            {
-                actual.Should().NotEqual(expected);
-            }
-            catch
-            {
-                /* we don't care about the exception, we just need to check the enumeration count */
+                // Act / Assert
+                collection1.Should().Equal(collection2);
             }
 
-            // Assert
-            actual.GetEnumeratorCallCount.Should().Be(1);
-        }
-
-        [Fact]
-        public void When_asserting_different_collections_to_be_equal_it_should_enumerate_the_subject_once()
-        {
-            // Arrange
-            var actual = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
-            var expected = new[] { 1, 2, 4 };
-
-            // Act
-            try
+            [Fact]
+            public void Should_succeed_when_asserting_collection_is_equal_to_the_same_list_of_elements()
             {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act / Assert
+                collection.Should().Equal(1, 2, 3);
+            }
+
+            [Fact]
+            public void When_both_collections_are_null_it_should_succeed()
+            {
+                // Arrange
+                int[] nullColl = null;
+
+                // Act
+                Action act = () => nullColl.Should().Equal(null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_two_collections_containing_nulls_are_equal_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new List<string> { "aaa", null };
+                var expected = new List<string> { "aaa", null };
+
+                // Act
+                Action action = () => subject.Should().Equal(expected);
+
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_two_collections_are_not_equal_because_one_item_differs_it_should_throw_using_the_reason()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new[] { 1, 2, 5 };
+
+                // Act
+                Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection1 to be equal to {1, 2, 5} because we want to test the failure message, but {1, 2, 3} differs at index 2.");
+            }
+
+            [Fact]
+            public void When_two_collections_are_not_equal_because_the_actual_collection_contains_more_items_it_should_throw_using_the_reason()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new[] { 1, 2 };
+
+                // Act
+                Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection1 to be equal to {1, 2} because we want to test the failure message, but {1, 2, 3} contains 1 item(s) too many.");
+            }
+
+            [Fact]
+            public void When_two_collections_are_not_equal_because_the_actual_collection_contains_less_items_it_should_throw_using_the_reason()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new[] { 1, 2, 3, 4 };
+
+                // Act
+                Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection1 to be equal to {1, 2, 3, 4} because we want to test the failure message, but {1, 2, 3} contains 1 item(s) less.");
+            }
+
+            [Fact]
+            public void When_two_multidimensional_collections_are_not_equal_and_it_should_format_the_collections_properly()
+            {
+                // Arrange
+                var collection1 = new[] { new[] { 1, 2 }, new[] { 3, 4 } };
+                var collection2 = new[] { new[] { 5, 6 }, new[] { 7, 8 } };
+
+                // Act
+                Action act = () => collection1.Should().Equal(collection2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection1 to be equal to {{5, 6}, {7, 8}}, but {{1, 2}, {3, 4}} differs at index 0.");
+            }
+
+            [Fact]
+            public void When_asserting_collections_to_be_equal_but_subject_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+                var collection1 = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().Equal(collection1, "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to be equal to {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_collections_to_be_equal_but_expected_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                int[] collection1 = null;
+
+                // Act
+                Action act = () => collection.Should().Equal(collection1, "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithMessage("Cannot compare collection with <null>.*")
+                    .WithParameterName("expectation");
+            }
+
+            [Fact]
+            public void When_an_empty_collection_is_compared_for_equality_to_a_non_empty_collection_it_should_throw()
+            {
+                // Arrange
+                var collection1 = new int[0];
+                var collection2 = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection1.Should().Equal(collection2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection1 to be equal to {1, 2, 3}, but found empty collection.");
+            }
+
+            [Fact]
+            public void When_a_non_empty_collection_is_compared_for_equality_to_an_empty_collection_it_should_throw()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new int[0];
+
+                // Act
+                Action act = () => collection1.Should().Equal(collection2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection1 to be equal to {empty}, but found {1, 2, 3}.");
+            }
+
+            [Fact]
+            public void When_all_items_match_according_to_a_predicate_it_should_succeed()
+            {
+                // Arrange
+                var actual = new List<string> { "ONE", "TWO", "THREE", "FOUR" };
+                var expected = new[]
+                {
+                    new { Value = "One" },
+                    new { Value = "Two" },
+                    new { Value = "Three" },
+                    new { Value = "Four" }
+                };
+
+                // Act
+                Action action = () => actual.Should().Equal(expected,
+                    (a, e) => string.Equals(a, e.Value, StringComparison.OrdinalIgnoreCase));
+
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_any_item_does_not_match_according_to_a_predicate_it_should_throw()
+            {
+                // Arrange
+                var actual = new List<string> { "ONE", "TWO", "THREE", "FOUR" };
+                var expected = new[]
+                {
+                    new { Value = "One" },
+                    new { Value = "Two" },
+                    new { Value = "Three" },
+                    new { Value = "Five" }
+                };
+
+                // Act
+                Action action = () => actual.Should().Equal(expected,
+                    (a, e) => string.Equals(a, e.Value, StringComparison.OrdinalIgnoreCase));
+
+                // Assert
+                action
+                    .Should().Throw<XunitException>()
+                    .WithMessage("*Expected*equal to*, but*differs at index 3.*");
+            }
+
+            [Fact]
+            public void When_both_collections_are_empty_it_should_them_as_equal()
+            {
+                // Arrange
+                var actual = new List<string>();
+                var expected = new List<string>();
+
+                // Act
+                Action act = () => actual.Should().Equal(expected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_identical_collections_to_be_equal_it_should_enumerate_the_subject_only_once()
+            {
+                // Arrange
+                var actual = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
+                var expected = new[] { 1, 2, 3 };
+
+                // Act
                 actual.Should().Equal(expected);
+
+                // Assert
+                actual.GetEnumeratorCallCount.Should().Be(1);
             }
-            catch
+
+            [Fact]
+            public void When_asserting_identical_collections_to_not_be_equal_it_should_enumerate_the_subject_only_once()
             {
-                /* we don't care about the exception, we just need to check the enumeration count */
+                // Arrange
+                var actual = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
+                var expected = new[] { 1, 2, 3 };
+
+                // Act
+                try
+                {
+                    actual.Should().NotEqual(expected);
+                }
+                catch
+                {
+                    /* we don't care about the exception, we just need to check the enumeration count */
+                }
+
+                // Assert
+                actual.GetEnumeratorCallCount.Should().Be(1);
             }
 
-            // Assert
-            actual.GetEnumeratorCallCount.Should().Be(1);
-        }
-
-        [Fact]
-        public void When_asserting_different_collections_to_not_be_equal_it_should_enumerate_the_subject_only_once()
-        {
-            // Arrange
-            var actual = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
-            var expected = new[] { 1, 2, 4 };
-
-            // Act
-            actual.Should().NotEqual(expected);
-
-            // Assert
-            actual.GetEnumeratorCallCount.Should().Be(1);
-        }
-
-        [Fact]
-        public void When_asserting_equality_with_a_collection_built_from_params_arguments_that_are_assignable_to_the_subjects_type_parameter_it_should_succeed_by_treating_the_arguments_as_of_that_type()
-        {
-            // Arrange
-            byte[] byteArray = { 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10 };
-
-            // Act
-            Action act = () => byteArray.Should().Equal(0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        #endregion
-
-        #region Not Equal
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_is_not_equal_to_a_different_collection()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 3, 1, 2 };
-
-            // Act / Assert
-            collection1.Should()
-                .NotEqual(collection2);
-        }
-
-        [Fact]
-        public void When_two_equal_collections_are_not_expected_to_be_equal_it_should_throw()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection1.Should().NotEqual(collection2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect collections {1, 2, 3} and {1, 2, 3} to be equal.");
-        }
-
-        [Fact]
-        public void When_two_equal_collections_are_not_expected_to_be_equal_it_should_report_a_clear_explanation()
-        {
-            // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection1.Should().NotEqual(collection2, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect collections {1, 2, 3} and {1, 2, 3} to be equal because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void When_asserting_collections_not_to_be_equal_subject_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-            var collection1 = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_asserting_different_collections_to_be_equal_it_should_enumerate_the_subject_once()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotEqual(collection1, "because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var actual = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
+                var expected = new[] { 1, 2, 4 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collections not to be equal because we want to test the behaviour with a null subject, but found <null>.");
+                // Act
+                try
+                {
+                    actual.Should().Equal(expected);
+                }
+                catch
+                {
+                    /* we don't care about the exception, we just need to check the enumeration count */
+                }
+
+                // Assert
+                actual.GetEnumeratorCallCount.Should().Be(1);
+            }
+
+            [Fact]
+            public void When_asserting_different_collections_to_not_be_equal_it_should_enumerate_the_subject_only_once()
+            {
+                // Arrange
+                var actual = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
+                var expected = new[] { 1, 2, 4 };
+
+                // Act
+                actual.Should().NotEqual(expected);
+
+                // Assert
+                actual.GetEnumeratorCallCount.Should().Be(1);
+            }
+
+            [Fact]
+            public void When_asserting_equality_with_a_collection_built_from_params_arguments_that_are_assignable_to_the_subjects_type_parameter_it_should_succeed_by_treating_the_arguments_as_of_that_type()
+            {
+                // Arrange
+                byte[] byteArray = { 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10 };
+
+                // Act
+                Action act = () => byteArray.Should().Equal(0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10);
+
+                // Assert
+                act.Should().NotThrow();
+            }
         }
-
-        [Fact]
-        public void When_asserting_collections_not_to_be_equal_but_expected_collection_is_null_it_should_throw()
+        
+        public class NotEqual
         {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            int[] collection1 = null;
+            [Fact]
+            public void Should_succeed_when_asserting_collection_is_not_equal_to_a_different_collection()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new[] { 3, 1, 2 };
 
-            // Act
-            Action act =
-                () => collection.Should().NotEqual(collection1, "because we want to test the behaviour with a null subject");
+                // Act / Assert
+                collection1.Should()
+                    .NotEqual(collection2);
+            }
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithMessage("Cannot compare collection with <null>.*")
-                .WithParameterName("unexpected");
+            [Fact]
+            public void When_two_equal_collections_are_not_expected_to_be_equal_it_should_throw()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection1.Should().NotEqual(collection2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect collections {1, 2, 3} and {1, 2, 3} to be equal.");
+            }
+
+            [Fact]
+            public void When_two_equal_collections_are_not_expected_to_be_equal_it_should_report_a_clear_explanation()
+            {
+                // Arrange
+                var collection1 = new[] { 1, 2, 3 };
+                var collection2 = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection1.Should().NotEqual(collection2, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect collections {1, 2, 3} and {1, 2, 3} to be equal because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void When_asserting_collections_not_to_be_equal_subject_but_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+                var collection1 = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotEqual(collection1, "because we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collections not to be equal because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_collections_not_to_be_equal_but_expected_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                int[] collection1 = null;
+
+                // Act
+                Action act =
+                    () => collection.Should().NotEqual(collection1, "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithMessage("Cannot compare collection with <null>.*")
+                    .WithParameterName("unexpected");
+            }
+
+            [Fact]
+            public void When_asserting_collections_not_to_be_equal_but_both_collections_reference_the_same_object_it_should_throw()
+            {
+                var collection1 = new[] { "one", "two", "three" };
+                var collection2 = collection1;
+
+                // Act
+                Action act = () => collection1.Should().NotEqual(collection2, "because we want to test the behaviour with same objects");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collections not to be equal because we want to test the behaviour with same objects, but they both reference the same object.");
+            }
         }
-
-        [Fact]
-        public void When_asserting_collections_not_to_be_equal_but_both_collections_reference_the_same_object_it_should_throw()
-        {
-            var collection1 = new[] { "one", "two", "three" };
-            var collection2 = collection1;
-
-            // Act
-            Action act = () => collection1.Should().NotEqual(collection2, "because we want to test the behaviour with same objects");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collections not to be equal because we want to test the behaviour with same objects, but they both reference the same object.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCount.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCount.cs
@@ -10,230 +10,228 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Have Count
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_has_a_count_that_equals_the_number_of_items()
+        public class HaveCount
         {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().HaveCount(3);
-        }
-
-        [Fact]
-        public void Should_fail_when_asserting_collection_has_a_count_that_is_different_from_the_number_of_items()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().HaveCount(4);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_collection_has_a_count_that_is_different_from_the_number_of_items_it_should_fail_with_descriptive_message_()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action action = () => collection.Should().HaveCount(4, "because we want to test the failure {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain 4 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
-        }
-
-        [Fact]
-        public void When_collection_has_a_count_larger_than_the_minimum_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().HaveCount(c => c >= 3);
-        }
-
-        [Fact]
-        public void When_collection_has_a_count_that_not_matches_the_predicate_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().HaveCount(c => c >= 4, "a minimum of 4 is required");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to have a count (c >= 4) because a minimum of 4 is required, but count is 3: {1, 2, 3}.");
-        }
-
-        [Fact]
-        public void When_collection_count_is_matched_against_a_null_predicate_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().HaveCount(null);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare collection count against a <null> predicate.*");
-        }
-
-        [Fact]
-        public void When_collection_count_is_matched_and_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void Should_succeed_when_asserting_collection_has_a_count_that_equals_the_number_of_items()
             {
-                using var _ = new AssertionScope();
-                collection.Should().HaveCount(1, "we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain 1 item(s) because we want to test the behaviour with a null subject, but found <null>.");
-        }
+                // Act / Assert
+                collection.Should().HaveCount(3);
+            }
 
-        [Fact]
-        public void When_collection_count_is_matched_against_a_predicate_and_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void Should_fail_when_asserting_collection_has_a_count_that_is_different_from_the_number_of_items()
             {
-                using var _ = new AssertionScope();
-                collection.Should().HaveCount(c => c < 3, "we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain (c < 3) items because we want to test the behaviour with a null subject, but found <null>.");
-        }
+                // Act
+                Action act = () => collection.Should().HaveCount(4);
 
-        [Fact]
-        public void When_collection_count_is_matched_against_a_predicate_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
 
-            // Act
-            Action act = () => collection.Should().HaveCount(c => c % 2 == 1);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_count_is_matched_against_a_predicate_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().HaveCount(c => c % 2 == 0);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_counting_generic_enumerable_it_should_enumerate()
-        {
-            // Arrange
-            var enumerable = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
-
-            // Act
-            enumerable.Should().HaveCount(3);
-
-            // Assert
-            enumerable.GetEnumeratorCallCount.Should().Be(1);
-        }
-
-        [Fact]
-        public void When_counting_generic_collection_it_should_not_enumerate()
-        {
-            // Arrange
-            var collection = new CountingGenericCollection<int>(new[] { 1, 2, 3 });
-
-            // Act
-            collection.Should().HaveCount(3);
-
-            // Assert
-            collection.GetCountCallCount.Should().Be(1);
-            collection.GetEnumeratorCallCount.Should().Be(0);
-        }
-
-        #endregion
-
-        #region Not Have Count
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_has_a_count_different_from_the_number_of_items()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().NotHaveCount(2);
-        }
-
-        [Fact]
-        public void Should_fail_when_asserting_collection_has_a_count_that_equals_the_number_of_items()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().NotHaveCount(3);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_collection_has_a_count_that_equals_than_the_number_of_items_it_should_fail_with_descriptive_message_()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action action = () => collection.Should().NotHaveCount(3, "because we want to test the failure {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("*not contain*3*because we want to test the failure message*3*");
-        }
-
-        [Fact]
-        public void When_collection_count_is_same_than_and_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_has_a_count_that_is_different_from_the_number_of_items_it_should_fail_with_descriptive_message_()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotHaveCount(1, "we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
+                // Act
+                Action action = () => collection.Should().HaveCount(4, "because we want to test the failure {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to contain 4 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+            }
+
+            [Fact]
+            public void When_collection_has_a_count_larger_than_the_minimum_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act / Assert
+                collection.Should().HaveCount(c => c >= 3);
+            }
+
+            [Fact]
+            public void When_collection_has_a_count_that_not_matches_the_predicate_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().HaveCount(c => c >= 4, "a minimum of 4 is required");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to have a count (c >= 4) because a minimum of 4 is required, but count is 3: {1, 2, 3}.");
+            }
+
+            [Fact]
+            public void When_collection_count_is_matched_against_a_null_predicate_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().HaveCount(null);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot compare collection count against a <null> predicate.*");
+            }
+
+            [Fact]
+            public void When_collection_count_is_matched_and_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().HaveCount(1, "we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to contain 1 item(s) because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_collection_count_is_matched_against_a_predicate_and_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().HaveCount(c => c < 3, "we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to contain (c < 3) items because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_collection_count_is_matched_against_a_predicate_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().HaveCount(c => c % 2 == 1);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_count_is_matched_against_a_predicate_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().HaveCount(c => c % 2 == 0);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_counting_generic_enumerable_it_should_enumerate()
+            {
+                // Arrange
+                var enumerable = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
+
+                // Act
+                enumerable.Should().HaveCount(3);
+
+                // Assert
+                enumerable.GetEnumeratorCallCount.Should().Be(1);
+            }
+
+            [Fact]
+            public void When_counting_generic_collection_it_should_not_enumerate()
+            {
+                // Arrange
+                var collection = new CountingGenericCollection<int>(new[] { 1, 2, 3 });
+
+                // Act
+                collection.Should().HaveCount(3);
+
+                // Assert
+                collection.GetCountCallCount.Should().Be(1);
+                collection.GetEnumeratorCallCount.Should().Be(0);
+            }
         }
+        
+        public class NotHaveCount
+        {
+            [Fact]
+            public void Should_succeed_when_asserting_collection_has_a_count_different_from_the_number_of_items()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-        #endregion
+                // Act / Assert
+                collection.Should().NotHaveCount(2);
+            }
+
+            [Fact]
+            public void Should_fail_when_asserting_collection_has_a_count_that_equals_the_number_of_items()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().NotHaveCount(3);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_collection_has_a_count_that_equals_than_the_number_of_items_it_should_fail_with_descriptive_message_()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action action = () => collection.Should().NotHaveCount(3, "because we want to test the failure {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("*not contain*3*because we want to test the failure message*3*");
+            }
+
+            [Fact]
+            public void When_collection_count_is_same_than_and_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotHaveCount(1, "we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
+            }
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThan.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThan.cs
@@ -11,62 +11,61 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Have Count Greater Than
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_has_a_count_greater_than_less_the_number_of_items()
+        public class HaveCountGreaterThan
         {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().HaveCountGreaterThan(2);
-        }
-
-        [Fact]
-        public void Should_fail_when_asserting_collection_has_a_count_greater_than_the_number_of_items()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().HaveCountGreaterThan(3);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_collection_has_a_count_greater_than_the_number_of_items_it_should_fail_with_descriptive_message_()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action action = () => collection.Should().HaveCountGreaterThan(3, "because we want to test the failure {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain more than 3 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
-        }
-
-        [Fact]
-        public void When_collection_count_is_greater_than_and_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<string> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void Should_succeed_when_asserting_collection_has_a_count_greater_than_less_the_number_of_items()
             {
-                using var _ = new AssertionScope();
-                collection.Should().HaveCountGreaterThan(1, "we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*more than*1*we want to test the behaviour with a null subject*found <null>*");
+                // Act / Assert
+                collection.Should().HaveCountGreaterThan(2);
+            }
+
+            [Fact]
+            public void Should_fail_when_asserting_collection_has_a_count_greater_than_the_number_of_items()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().HaveCountGreaterThan(3);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_collection_has_a_count_greater_than_the_number_of_items_it_should_fail_with_descriptive_message_()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action action = () => collection.Should().HaveCountGreaterThan(3, "because we want to test the failure {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to contain more than 3 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+            }
+
+            [Fact]
+            public void When_collection_count_is_greater_than_and_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<string> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().HaveCountGreaterThan(1, "we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*more than*1*we want to test the behaviour with a null subject*found <null>*");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
@@ -10,62 +10,61 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Have Count Greater Than Or Equal To
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_has_a_count_greater_than_or_equal_to_less_the_number_of_items()
+        public class HaveCountGreaterThanOrEqualTo
         {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().HaveCountGreaterThanOrEqualTo(3);
-        }
-
-        [Fact]
-        public void Should_fail_when_asserting_collection_has_a_count_greater_than_or_equal_to_the_number_of_items()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().HaveCountGreaterThanOrEqualTo(4);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_collection_has_a_count_greater_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action action = () => collection.Should().HaveCountGreaterThanOrEqualTo(4, "because we want to test the failure {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain at least 4 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
-        }
-
-        [Fact]
-        public void When_collection_count_is_greater_than_or_equal_to_and_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void Should_succeed_when_asserting_collection_has_a_count_greater_than_or_equal_to_less_the_number_of_items()
             {
-                using var _ = new AssertionScope();
-                collection.Should().HaveCountGreaterThanOrEqualTo(1, "we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
+                // Act / Assert
+                collection.Should().HaveCountGreaterThanOrEqualTo(3);
+            }
+
+            [Fact]
+            public void Should_fail_when_asserting_collection_has_a_count_greater_than_or_equal_to_the_number_of_items()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().HaveCountGreaterThanOrEqualTo(4);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_collection_has_a_count_greater_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action action = () => collection.Should().HaveCountGreaterThanOrEqualTo(4, "because we want to test the failure {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to contain at least 4 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+            }
+
+            [Fact]
+            public void When_collection_count_is_greater_than_or_equal_to_and_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().HaveCountGreaterThanOrEqualTo(1, "we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThan.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThan.cs
@@ -10,62 +10,61 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Have Count Less Than
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_has_a_count_less_than_less_the_number_of_items()
+        public class HaveCountLessThan
         {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().HaveCountLessThan(4);
-        }
-
-        [Fact]
-        public void Should_fail_when_asserting_collection_has_a_count_less_than_the_number_of_items()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().HaveCountLessThan(3);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_collection_has_a_count_less_than_the_number_of_items_it_should_fail_with_descriptive_message_()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action action = () => collection.Should().HaveCountLessThan(3, "because we want to test the failure {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain fewer than 3 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
-        }
-
-        [Fact]
-        public void When_collection_count_is_less_than_and_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void Should_succeed_when_asserting_collection_has_a_count_less_than_less_the_number_of_items()
             {
-                using var _ = new AssertionScope();
-                collection.Should().HaveCountLessThan(1, "we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*fewer than*1*we want to test the behaviour with a null subject*found <null>*");
+                // Act / Assert
+                collection.Should().HaveCountLessThan(4);
+            }
+
+            [Fact]
+            public void Should_fail_when_asserting_collection_has_a_count_less_than_the_number_of_items()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().HaveCountLessThan(3);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_collection_has_a_count_less_than_the_number_of_items_it_should_fail_with_descriptive_message_()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action action = () => collection.Should().HaveCountLessThan(3, "because we want to test the failure {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to contain fewer than 3 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+            }
+
+            [Fact]
+            public void When_collection_count_is_less_than_and_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().HaveCountLessThan(1, "we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*fewer than*1*we want to test the behaviour with a null subject*found <null>*");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
@@ -10,62 +10,61 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Have Count Less Than Or Equal To
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_has_a_count_less_than_or_equal_to_less_the_number_of_items()
+        public class HaveCountLessThanOrEqualTo
         {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().HaveCountLessThanOrEqualTo(3);
-        }
-
-        [Fact]
-        public void Should_fail_when_asserting_collection_has_a_count_less_than_or_equal_to_the_number_of_items()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().HaveCountLessThanOrEqualTo(2);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_collection_has_a_count_less_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action action = () => collection.Should().HaveCountLessThanOrEqualTo(2, "because we want to test the failure {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain at most 2 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
-        }
-
-        [Fact]
-        public void When_collection_count_is_less_than_or_equal_to_and_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void Should_succeed_when_asserting_collection_has_a_count_less_than_or_equal_to_less_the_number_of_items()
             {
-                using var _ = new AssertionScope();
-                collection.Should().HaveCountLessThanOrEqualTo(1, "we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
+                // Act / Assert
+                collection.Should().HaveCountLessThanOrEqualTo(3);
+            }
+
+            [Fact]
+            public void Should_fail_when_asserting_collection_has_a_count_less_than_or_equal_to_the_number_of_items()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().HaveCountLessThanOrEqualTo(2);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_collection_has_a_count_less_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action action = () => collection.Should().HaveCountLessThanOrEqualTo(2, "because we want to test the failure {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to contain at most 2 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+            }
+
+            [Fact]
+            public void When_collection_count_is_less_than_or_equal_to_and_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().HaveCountLessThanOrEqualTo(1, "we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementAt.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementAt.cs
@@ -10,89 +10,88 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Have Element At
-
-        [Fact]
-        public void When_collection_has_expected_element_at_specific_index_it_should_not_throw()
+        public class HaveElementAt
         {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().HaveElementAt(1, 2);
-        }
-
-        [Fact]
-        public void When_collection_does_not_have_the_expected_element_at_specific_index_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().HaveElementAt(1, 3, "we put it {0}", "there");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected 3 at index 1 because we put it there, but found 2.");
-        }
-
-        [Fact]
-        public void When_collection_does_not_have_an_element_at_the_specific_index_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().HaveElementAt(4, 3, "we put it {0}", "there");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected 3 at index 4 because we put it there, but found no element.");
-        }
-
-        [Fact]
-        public void When_asserting_collection_has_element_at_specific_index_against_null_collection_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_has_expected_element_at_specific_index_it_should_not_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().HaveElementAt(1, 1, "because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to have element at index 1 because we want to test the behaviour with a null subject, but found <null>.");
-        }
+                // Act / Assert
+                collection.Should().HaveElementAt(1, 2);
+            }
 
-        [Fact]
-        public void When_element_at_specific_index_was_found_it_should_allow_chaining()
-        {
-            // Arrange
-            var expectedElement = new
+            [Fact]
+            public void When_collection_does_not_have_the_expected_element_at_specific_index_it_should_throw()
             {
-                SomeProperty = "hello"
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            var collection = new[]
+                // Act
+                Action act = () => collection.Should().HaveElementAt(1, 3, "we put it {0}", "there");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected 3 at index 1 because we put it there, but found 2.");
+            }
+
+            [Fact]
+            public void When_collection_does_not_have_an_element_at_the_specific_index_it_should_throw()
             {
-                expectedElement
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Act
-            Action act = () => collection.Should()
-                .HaveElementAt(0, expectedElement)
-                .Which
-                .Should().BeAssignableTo<string>();
+                // Act
+                Action act = () => collection.Should().HaveElementAt(4, 3, "we put it {0}", "there");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*assignable*string*");
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected 3 at index 4 because we put it there, but found no element.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_has_element_at_specific_index_against_null_collection_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().HaveElementAt(1, 1, "because we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to have element at index 1 because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_element_at_specific_index_was_found_it_should_allow_chaining()
+            {
+                // Arrange
+                var expectedElement = new
+                {
+                    SomeProperty = "hello"
+                };
+
+                var collection = new[]
+                {
+                    expectedElement
+                };
+
+                // Act
+                Action act = () => collection.Should()
+                    .HaveElementAt(0, expectedElement)
+                    .Which
+                    .Should().BeAssignableTo<string>();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*assignable*string*");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementPreceding.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementPreceding.cs
@@ -12,141 +12,140 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region HaveElementPreceding
-
-        [Fact]
-        [SuppressMessage("ReSharper", "StringLiteralTypo")]
-        public void When_collection_has_the_correct_element_preceding_another_it_should_not_throw()
+        public class HaveElementPreceding
         {
-            // Arrange
-            var collection = new[] { "cris", "mick", "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementPreceding("mick", "cris");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        [SuppressMessage("ReSharper", "StringLiteralTypo")]
-        public void When_collection_has_the_wrong_element_preceding_another_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "cris", "mick", "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementPreceding("john", "cris", "because of some reason");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*cris*precede*john*because*reason*found*mick*");
-        }
-
-        [Fact]
-        [SuppressMessage("ReSharper", "StringLiteralTypo")]
-        public void When_nothing_is_preceding_an_element_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "cris", "mick", "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementPreceding("cris", "jane");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*jane*precede*cris*found*nothing*");
-        }
-
-        [Fact]
-        [SuppressMessage("ReSharper", "StringLiteralTypo")]
-        public void When_expecting_an_element_to_precede_another_but_collection_is_empty_it_should_throw()
-        {
-            // Arrange
-            var collection = new string[0];
-
-            // Act
-            Action act = () => collection.Should().HaveElementPreceding("mick", "cris");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*cris*precede*mick*collection*empty*");
-        }
-
-        [Fact]
-        public void When_a_null_element_is_preceding_another_element_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { null, "mick", "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementPreceding("mick", null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        [SuppressMessage("ReSharper", "StringLiteralTypo")]
-        public void When_a_null_element_is_not_preceding_another_element_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "cris", "mick", "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementPreceding("mick", null);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*null*precede*mick*but found*cris*");
-        }
-
-        [Fact]
-        public void When_an_element_is_preceding_a_null_element_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "mick", null, "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementPreceding(null, "mick");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_an_element_is_not_preceding_a_null_element_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "mick", null, "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementPreceding(null, "cris");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*cris*precede*null*but found*mick*");
-        }
-
-        [Fact]
-        public void When_collection_is_null_then_have_element_preceding_should_fail()
-        {
-            // Arrange
-            IEnumerable<string> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            [SuppressMessage("ReSharper", "StringLiteralTypo")]
+            public void When_collection_has_the_correct_element_preceding_another_it_should_not_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().HaveElementPreceding("mick", "cris", "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new[] { "cris", "mick", "john" };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected collection to have \"cris\" precede \"mick\" *failure message*, but the collection is <null>.");
+                // Act
+                Action act = () => collection.Should().HaveElementPreceding("mick", "cris");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            [SuppressMessage("ReSharper", "StringLiteralTypo")]
+            public void When_collection_has_the_wrong_element_preceding_another_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "cris", "mick", "john" };
+
+                // Act
+                Action act = () => collection.Should().HaveElementPreceding("john", "cris", "because of some reason");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*cris*precede*john*because*reason*found*mick*");
+            }
+
+            [Fact]
+            [SuppressMessage("ReSharper", "StringLiteralTypo")]
+            public void When_nothing_is_preceding_an_element_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "cris", "mick", "john" };
+
+                // Act
+                Action act = () => collection.Should().HaveElementPreceding("cris", "jane");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*jane*precede*cris*found*nothing*");
+            }
+
+            [Fact]
+            [SuppressMessage("ReSharper", "StringLiteralTypo")]
+            public void When_expecting_an_element_to_precede_another_but_collection_is_empty_it_should_throw()
+            {
+                // Arrange
+                var collection = new string[0];
+
+                // Act
+                Action act = () => collection.Should().HaveElementPreceding("mick", "cris");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*cris*precede*mick*collection*empty*");
+            }
+
+            [Fact]
+            public void When_a_null_element_is_preceding_another_element_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { null, "mick", "john" };
+
+                // Act
+                Action act = () => collection.Should().HaveElementPreceding("mick", null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            [SuppressMessage("ReSharper", "StringLiteralTypo")]
+            public void When_a_null_element_is_not_preceding_another_element_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "cris", "mick", "john" };
+
+                // Act
+                Action act = () => collection.Should().HaveElementPreceding("mick", null);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*null*precede*mick*but found*cris*");
+            }
+
+            [Fact]
+            public void When_an_element_is_preceding_a_null_element_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "mick", null, "john" };
+
+                // Act
+                Action act = () => collection.Should().HaveElementPreceding(null, "mick");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_an_element_is_not_preceding_a_null_element_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "mick", null, "john" };
+
+                // Act
+                Action act = () => collection.Should().HaveElementPreceding(null, "cris");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*cris*precede*null*but found*mick*");
+            }
+
+            [Fact]
+            public void When_collection_is_null_then_have_element_preceding_should_fail()
+            {
+                // Arrange
+                IEnumerable<string> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().HaveElementPreceding("mick", "cris", "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected collection to have \"cris\" precede \"mick\" *failure message*, but the collection is <null>.");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementSucceeding.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementSucceeding.cs
@@ -12,139 +12,138 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region HaveElementSucceeding
-
-        [Fact]
-        [SuppressMessage("ReSharper", "StringLiteralTypo")]
-        public void When_collection_has_the_correct_element_succeeding_another_it_should_not_throw()
+        public class HaveElementSucceeding
         {
-            // Arrange
-            var collection = new[] { "cris", "mick", "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementSucceeding("cris", "mick");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        [SuppressMessage("ReSharper", "StringLiteralTypo")]
-        public void When_collection_has_the_wrong_element_succeeding_another_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "cris", "mick", "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementSucceeding("mick", "cris", "because of some reason");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*cris*succeed*mick*because*reason*found*john*");
-        }
-
-        [Fact]
-        [SuppressMessage("ReSharper", "StringLiteralTypo")]
-        public void When_nothing_is_succeeding_an_element_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "cris", "mick", "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementSucceeding("john", "jane");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*jane*succeed*john*found*nothing*");
-        }
-
-        [Fact]
-        public void When_expecting_an_element_to_succeed_another_but_the_collection_is_empty_it_should_throw()
-        {
-            // Arrange
-            var collection = new string[0];
-
-            // Act
-            Action act = () => collection.Should().HaveElementSucceeding("mick", "cris");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*cris*succeed*mick*collection*empty*");
-        }
-
-        [Fact]
-        public void When_a_null_element_is_succeeding_another_element_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "mick", null, "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementSucceeding("mick", null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_null_element_is_not_succeeding_another_element_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "cris", "mick", "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementSucceeding("mick", null);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*null*succeed*mick*but found*john*");
-        }
-
-        [Fact]
-        public void When_an_element_is_succeeding_a_null_element_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "mick", null, "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementSucceeding(null, "john");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_an_element_is_not_succeeding_a_null_element_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "mick", null, "john" };
-
-            // Act
-            Action act = () => collection.Should().HaveElementSucceeding(null, "cris");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*cris*succeed*null*but found*john*");
-        }
-
-        [Fact]
-        public void When_collection_is_null_then_have_element_succeeding_should_fail()
-        {
-            // Arrange
-            IEnumerable<string> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            [SuppressMessage("ReSharper", "StringLiteralTypo")]
+            public void When_collection_has_the_correct_element_succeeding_another_it_should_not_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().HaveElementSucceeding("mick", "cris", "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new[] { "cris", "mick", "john" };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected collection to have \"cris\" succeed \"mick\" *failure message*, but the collection is <null>.");
+                // Act
+                Action act = () => collection.Should().HaveElementSucceeding("cris", "mick");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            [SuppressMessage("ReSharper", "StringLiteralTypo")]
+            public void When_collection_has_the_wrong_element_succeeding_another_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "cris", "mick", "john" };
+
+                // Act
+                Action act = () => collection.Should().HaveElementSucceeding("mick", "cris", "because of some reason");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*cris*succeed*mick*because*reason*found*john*");
+            }
+
+            [Fact]
+            [SuppressMessage("ReSharper", "StringLiteralTypo")]
+            public void When_nothing_is_succeeding_an_element_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "cris", "mick", "john" };
+
+                // Act
+                Action act = () => collection.Should().HaveElementSucceeding("john", "jane");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*jane*succeed*john*found*nothing*");
+            }
+
+            [Fact]
+            public void When_expecting_an_element_to_succeed_another_but_the_collection_is_empty_it_should_throw()
+            {
+                // Arrange
+                var collection = new string[0];
+
+                // Act
+                Action act = () => collection.Should().HaveElementSucceeding("mick", "cris");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*cris*succeed*mick*collection*empty*");
+            }
+
+            [Fact]
+            public void When_a_null_element_is_succeeding_another_element_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "mick", null, "john" };
+
+                // Act
+                Action act = () => collection.Should().HaveElementSucceeding("mick", null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_null_element_is_not_succeeding_another_element_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "cris", "mick", "john" };
+
+                // Act
+                Action act = () => collection.Should().HaveElementSucceeding("mick", null);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*null*succeed*mick*but found*john*");
+            }
+
+            [Fact]
+            public void When_an_element_is_succeeding_a_null_element_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "mick", null, "john" };
+
+                // Act
+                Action act = () => collection.Should().HaveElementSucceeding(null, "john");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_an_element_is_not_succeeding_a_null_element_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "mick", null, "john" };
+
+                // Act
+                Action act = () => collection.Should().HaveElementSucceeding(null, "cris");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*cris*succeed*null*but found*john*");
+            }
+
+            [Fact]
+            public void When_collection_is_null_then_have_element_succeeding_should_fail()
+            {
+                // Arrange
+                IEnumerable<string> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().HaveElementSucceeding("mick", "cris", "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected collection to have \"cris\" succeed \"mick\" *failure message*, but the collection is <null>.");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveSameCount.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveSameCount.cs
@@ -10,178 +10,176 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Have Same Count
-
-        [Fact]
-        public void When_both_collections_have_the_same_number_elements_it_should_succeed()
+        public class HaveSameCount
         {
-            // Arrange
-            var firstCollection = new[] { 1, 2, 3 };
-            var secondCollection = new[] { 4, 5, 6 };
-
-            // Act / Assert
-            firstCollection.Should().HaveSameCount(secondCollection);
-        }
-
-        [Fact]
-        public void When_both_collections_do_not_have_the_same_number_of_elements_it_should_fail()
-        {
-            // Arrange
-            var firstCollection = new[] { 1, 2, 3 };
-            var secondCollection = new[] { 4, 6 };
-
-            // Act
-            Action act = () => firstCollection.Should().HaveSameCount(secondCollection);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected firstCollection to have 2 item(s), but found 3.");
-        }
-
-        [Fact]
-        public void When_comparing_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
-        {
-            // Arrange
-            var firstCollection = new[] { 1, 2, 3 };
-            var secondCollection = new[] { 4, 6 };
-
-            // Act
-            Action act = () => firstCollection.Should().HaveSameCount(secondCollection, "we want to test the {0}", "reason");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected firstCollection to have 2 item(s) because we want to test the reason, but found 3.");
-        }
-
-        [Fact]
-        public void When_asserting_collections_to_have_same_count_against_null_collection_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-            var collection1 = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_both_collections_have_the_same_number_elements_it_should_succeed()
             {
-                using var _ = new AssertionScope();
-                collection.Should().HaveSameCount(collection1, "because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var firstCollection = new[] { 1, 2, 3 };
+                var secondCollection = new[] { 4, 5, 6 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
-        }
+                // Act / Assert
+                firstCollection.Should().HaveSameCount(secondCollection);
+            }
 
-        [Fact]
-        public void When_asserting_collections_to_have_same_count_against_an_other_null_collection_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            int[] otherCollection = null;
-
-            // Act
-            Action act = () => collection.Should().HaveSameCount(otherCollection);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot verify count against a <null> collection.*");
-        }
-
-        #endregion
-
-        #region Not Have Same Count
-
-        [Fact]
-        public void When_asserting_not_same_count_and_collections_have_different_number_elements_it_should_succeed()
-        {
-            // Arrange
-            var firstCollection = new[] { 1, 2, 3 };
-            var secondCollection = new[] { 4, 6 };
-
-            // Act / Assert
-            firstCollection.Should().NotHaveSameCount(secondCollection);
-        }
-
-        [Fact]
-        public void When_asserting_not_same_count_and_both_collections_have_the_same_number_elements_it_should_fail()
-        {
-            // Arrange
-            var firstCollection = new[] { 1, 2, 3 };
-            var secondCollection = new[] { 4, 5, 6 };
-
-            // Act
-            Action act = () => firstCollection.Should().NotHaveSameCount(secondCollection);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected firstCollection to not have 3 item(s), but found 3.");
-        }
-
-        [Fact]
-        public void When_comparing_not_same_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
-        {
-            // Arrange
-            var firstCollection = new[] { 1, 2, 3 };
-            var secondCollection = new[] { 4, 5, 6 };
-
-            // Act
-            Action act = () => firstCollection.Should().NotHaveSameCount(secondCollection, "we want to test the {0}", "reason");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected firstCollection to not have 3 item(s) because we want to test the reason, but found 3.");
-        }
-
-        [Fact]
-        public void When_asserting_collections_to_not_have_same_count_against_null_collection_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-            var collection1 = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_both_collections_do_not_have_the_same_number_of_elements_it_should_fail()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotHaveSameCount(collection1, "because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var firstCollection = new[] { 1, 2, 3 };
+                var secondCollection = new[] { 4, 6 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to not have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+                // Act
+                Action act = () => firstCollection.Should().HaveSameCount(secondCollection);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected firstCollection to have 2 item(s), but found 3.");
+            }
+
+            [Fact]
+            public void When_comparing_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
+            {
+                // Arrange
+                var firstCollection = new[] { 1, 2, 3 };
+                var secondCollection = new[] { 4, 6 };
+
+                // Act
+                Action act = () => firstCollection.Should().HaveSameCount(secondCollection, "we want to test the {0}", "reason");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected firstCollection to have 2 item(s) because we want to test the reason, but found 3.");
+            }
+
+            [Fact]
+            public void When_asserting_collections_to_have_same_count_against_null_collection_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+                var collection1 = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().HaveSameCount(collection1, "because we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_collections_to_have_same_count_against_an_other_null_collection_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                int[] otherCollection = null;
+
+                // Act
+                Action act = () => collection.Should().HaveSameCount(otherCollection);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot verify count against a <null> collection.*");
+            }
         }
 
-        [Fact]
-        public void When_asserting_collections_to_not_have_same_count_against_an_other_null_collection_it_should_throw()
+        public class NotHaveSameCount
         {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            int[] otherCollection = null;
+            [Fact]
+            public void When_asserting_not_same_count_and_collections_have_different_number_elements_it_should_succeed()
+            {
+                // Arrange
+                var firstCollection = new[] { 1, 2, 3 };
+                var secondCollection = new[] { 4, 6 };
 
-            // Act
-            Action act = () => collection.Should().NotHaveSameCount(otherCollection);
+                // Act / Assert
+                firstCollection.Should().NotHaveSameCount(secondCollection);
+            }
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot verify count against a <null> collection.*");
+            [Fact]
+            public void When_asserting_not_same_count_and_both_collections_have_the_same_number_elements_it_should_fail()
+            {
+                // Arrange
+                var firstCollection = new[] { 1, 2, 3 };
+                var secondCollection = new[] { 4, 5, 6 };
+
+                // Act
+                Action act = () => firstCollection.Should().NotHaveSameCount(secondCollection);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected firstCollection to not have 3 item(s), but found 3.");
+            }
+
+            [Fact]
+            public void When_comparing_not_same_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
+            {
+                // Arrange
+                var firstCollection = new[] { 1, 2, 3 };
+                var secondCollection = new[] { 4, 5, 6 };
+
+                // Act
+                Action act = () => firstCollection.Should().NotHaveSameCount(secondCollection, "we want to test the {0}", "reason");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected firstCollection to not have 3 item(s) because we want to test the reason, but found 3.");
+            }
+
+            [Fact]
+            public void When_asserting_collections_to_not_have_same_count_against_null_collection_it_should_throw()
+            {
+                // Arrange
+                int[] collection = null;
+                var collection1 = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotHaveSameCount(collection1, "because we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to not have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_collections_to_not_have_same_count_against_an_other_null_collection_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                int[] otherCollection = null;
+
+                // Act
+                Action act = () => collection.Should().NotHaveSameCount(otherCollection);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot verify count against a <null> collection.*");
+            }
+
+            [Fact]
+            public void When_asserting_collections_to_not_have_same_count_but_both_collections_references_the_same_object_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                var collection1 = collection;
+
+                // Act
+                Action act = () => collection.Should().NotHaveSameCount(collection1,
+                    "because we want to test the behaviour with same objects");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*not have the same count*because we want to test the behaviour with same objects*but they both reference the same object.");
+            }
         }
-
-        [Fact]
-        public void When_asserting_collections_to_not_have_same_count_but_both_collections_references_the_same_object_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            var collection1 = collection;
-
-            // Act
-            Action act = () => collection.Should().NotHaveSameCount(collection1,
-                "because we want to test the behaviour with same objects");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*not have the same count*because we want to test the behaviour with same objects*but they both reference the same object.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.IntersectWith.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.IntersectWith.cs
@@ -11,118 +11,116 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Intersect With
-
-        [Fact]
-        public void When_asserting_the_items_in_an_two_intersecting_collections_intersect_it_should_succeed()
+        public class IntersectWith
         {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            var otherCollection = new[] { 3, 4, 5 };
-
-            // Act / Assert
-            collection.Should().IntersectWith(otherCollection);
-        }
-
-        [Fact]
-        public void When_asserting_the_items_in_an_two_non_intersecting_collections_intersect_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            var otherCollection = new[] { 4, 5 };
-
-            // Act
-            Action action = () => collection.Should().IntersectWith(otherCollection, "they should share items");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to intersect with {4, 5} because they should share items," +
-                    " but {1, 2, 3} does not contain any shared items.");
-        }
-
-        [Fact]
-        public void When_collection_is_null_then_intersect_with_should_fail()
-        {
-            // Arrange
-            IEnumerable<int> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_asserting_the_items_in_an_two_intersecting_collections_intersect_it_should_succeed()
             {
-                using var _ = new AssertionScope();
-                collection.Should().IntersectWith(new[] { 4, 5 }, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                var otherCollection = new[] { 3, 4, 5 };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to intersect with {4, 5} *failure message*, but found <null>.");
-        }
+                // Act / Assert
+                collection.Should().IntersectWith(otherCollection);
+            }
 
-        #endregion
-
-        #region Not Intersect With
-
-        [Fact]
-        public void When_asserting_the_items_in_an_two_non_intersecting_collections_do_not_intersect_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            var otherCollection = new[] { 4, 5 };
-
-            // Act / Assert
-            collection.Should().NotIntersectWith(otherCollection);
-        }
-
-        [Fact]
-        public void When_asserting_the_items_in_an_two_intersecting_collections_do_not_intersect_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            var otherCollection = new[] { 2, 3, 4 };
-
-            // Act
-            Action action = () => collection.Should().NotIntersectWith(otherCollection, "they should not share items");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to intersect with {2, 3, 4} because they should not share items," +
-                    " but found the following shared items {2, 3}.");
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_not_intersect_with_same_collection_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-            var otherCollection = collection;
-
-            // Act
-            Action act = () => collection.Should().NotIntersectWith(otherCollection,
-                "because we want to test the behaviour with same objects");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect*to intersect with*because we want to test the behaviour with same objects*but they both reference the same object.");
-        }
-
-        [Fact]
-        public void When_collection_is_null_then_not_intersect_with_should_fail()
-        {
-            // Arrange
-            IEnumerable<int> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_asserting_the_items_in_an_two_non_intersecting_collections_intersect_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotIntersectWith(new[] { 4, 5 }, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                var otherCollection = new[] { 4, 5 };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to intersect with {4, 5} *failure message*, but found <null>.");
+                // Act
+                Action action = () => collection.Should().IntersectWith(otherCollection, "they should share items");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to intersect with {4, 5} because they should share items," +
+                        " but {1, 2, 3} does not contain any shared items.");
+            }
+
+            [Fact]
+            public void When_collection_is_null_then_intersect_with_should_fail()
+            {
+                // Arrange
+                IEnumerable<int> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().IntersectWith(new[] { 4, 5 }, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected collection to intersect with {4, 5} *failure message*, but found <null>.");
+            }
         }
 
-        #endregion
+        public class NotIntersectWith
+        {
+            [Fact]
+            public void When_asserting_the_items_in_an_two_non_intersecting_collections_do_not_intersect_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                var otherCollection = new[] { 4, 5 };
+
+                // Act / Assert
+                collection.Should().NotIntersectWith(otherCollection);
+            }
+
+            [Fact]
+            public void When_asserting_the_items_in_an_two_intersecting_collections_do_not_intersect_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                var otherCollection = new[] { 2, 3, 4 };
+
+                // Act
+                Action action = () => collection.Should().NotIntersectWith(otherCollection, "they should not share items");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect collection to intersect with {2, 3, 4} because they should not share items," +
+                        " but found the following shared items {2, 3}.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_not_intersect_with_same_collection_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+                var otherCollection = collection;
+
+                // Act
+                Action act = () => collection.Should().NotIntersectWith(otherCollection,
+                    "because we want to test the behaviour with same objects");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect*to intersect with*because we want to test the behaviour with same objects*but they both reference the same object.");
+            }
+
+            [Fact]
+            public void When_collection_is_null_then_not_intersect_with_should_fail()
+            {
+                // Arrange
+                IEnumerable<int> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotIntersectWith(new[] { 4, 5 }, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect collection to intersect with {4, 5} *failure message*, but found <null>.");
+            }
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainNulls.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainNulls.cs
@@ -11,163 +11,162 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Not Contain Nulls
-
-        [Fact]
-        public void When_collection_does_not_contain_nulls_it_should_not_throw()
+        public class NotContainNulls
         {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act / Assert
-            collection.Should().NotContainNulls();
-        }
-
-        [Fact]
-        public void When_collection_contains_nulls_that_are_unexpected_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { new object(), null };
-
-            // Act
-            Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s because they are evil, but found one at index 1.");
-        }
-
-        [Fact]
-        public void When_collection_contains_multiple_nulls_that_are_unexpected_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { new object(), null, new object(), null };
-
-            // Act
-            Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s*because they are evil*{1, 3}*");
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_not_contain_nulls_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () => collection.Should().NotContainNulls("because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s because we want to test the behaviour with a null subject, but collection is <null>.");
-        }
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_NotContainNulls_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<SomeClass> collection = new SomeClass[] { };
-
-            // Act
-            Action act = () => collection.Should().NotContainNulls<string>(predicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("predicate");
-        }
-
-        [Fact]
-        public void When_collection_does_not_contain_nulls_with_a_predicate_it_should_not_throw()
-        {
-            // Arrange
-            IEnumerable<SomeClass> collection = new[]
+            [Fact]
+            public void When_collection_does_not_contain_nulls_it_should_not_throw()
             {
-                new SomeClass { Text = "one" },
-                new SomeClass { Text = "two" },
-                new SomeClass { Text = "three" }
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
 
-            // Act / Assert
-            collection.Should().NotContainNulls(e => e.Text);
-        }
+                // Act / Assert
+                collection.Should().NotContainNulls();
+            }
 
-        [Fact]
-        public void When_collection_contains_nulls_that_are_unexpected_with_a_predicate_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<SomeClass> collection = new[]
+            [Fact]
+            public void When_collection_contains_nulls_that_are_unexpected_it_should_throw()
             {
-                new SomeClass { Text = "" },
-                new SomeClass { Text = null }
-            };
+                // Arrange
+                var collection = new[] { new object(), null };
 
-            // Act
-            Action act = () => collection.Should().NotContainNulls(e => e.Text, "because they are {0}", "evil");
+                // Act
+                Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s*on e.Text*because they are evil*Text = <null>*");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection not to contain <null>s because they are evil, but found one at index 1.");
+            }
 
-        [Fact]
-        public void When_collection_contains_multiple_nulls_that_are_unexpected_with_a_predicate_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<SomeClass> collection = new[]
+            [Fact]
+            public void When_collection_contains_multiple_nulls_that_are_unexpected_it_should_throw()
             {
-                new SomeClass { Text = "" },
-                new SomeClass { Text = null },
-                new SomeClass { Text = "" },
-                new SomeClass { Text = null }
-            };
+                // Arrange
+                var collection = new[] { new object(), null, new object(), null };
 
-            // Act
-            Action act = () => collection.Should().NotContainNulls(e => e.Text, "because they are {0}", "evil");
+                // Act
+                Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s*on e.Text*because they are evil*Text = <null>*Text = <null>*");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection not to contain <null>s*because they are evil*{1, 3}*");
+            }
 
-        [Fact]
-        public void When_asserting_collection_to_not_contain_nulls_but_collection_is_null_it_should_fail()
-        {
-            // Arrange
-            SomeClass[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_asserting_collection_to_not_contain_nulls_but_collection_is_null_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotContainNulls("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                int[] collection = null;
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s *failure message*, but collection is <null>.");
-        }
+                // Act
+                Action act = () => collection.Should().NotContainNulls("because we want to test the behaviour with a null subject");
 
-        [Fact]
-        public void When_asserting_collection_to_not_contain_nulls_with_predicate_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<SomeClass> collection = null;
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection not to contain <null>s because we want to test the behaviour with a null subject, but collection is <null>.");
+            }
 
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_injecting_a_null_predicate_into_NotContainNulls_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().NotContainNulls(e => e.Text, "because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                IEnumerable<SomeClass> collection = new SomeClass[] { };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s because we want to test the behaviour with a null subject, but collection is <null>.");
+                // Act
+                Action act = () => collection.Should().NotContainNulls<string>(predicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("predicate");
+            }
+
+            [Fact]
+            public void When_collection_does_not_contain_nulls_with_a_predicate_it_should_not_throw()
+            {
+                // Arrange
+                IEnumerable<SomeClass> collection = new[]
+                {
+                    new SomeClass { Text = "one" },
+                    new SomeClass { Text = "two" },
+                    new SomeClass { Text = "three" }
+                };
+
+                // Act / Assert
+                collection.Should().NotContainNulls(e => e.Text);
+            }
+
+            [Fact]
+            public void When_collection_contains_nulls_that_are_unexpected_with_a_predicate_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<SomeClass> collection = new[]
+                {
+                    new SomeClass { Text = "" },
+                    new SomeClass { Text = null }
+                };
+
+                // Act
+                Action act = () => collection.Should().NotContainNulls(e => e.Text, "because they are {0}", "evil");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection not to contain <null>s*on e.Text*because they are evil*Text = <null>*");
+            }
+
+            [Fact]
+            public void When_collection_contains_multiple_nulls_that_are_unexpected_with_a_predicate_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<SomeClass> collection = new[]
+                {
+                    new SomeClass { Text = "" },
+                    new SomeClass { Text = null },
+                    new SomeClass { Text = "" },
+                    new SomeClass { Text = null }
+                };
+
+                // Act
+                Action act = () => collection.Should().NotContainNulls(e => e.Text, "because they are {0}", "evil");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection not to contain <null>s*on e.Text*because they are evil*Text = <null>*Text = <null>*");
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_not_contain_nulls_but_collection_is_null_it_should_fail()
+            {
+                // Arrange
+                SomeClass[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotContainNulls("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection not to contain <null>s *failure message*, but collection is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_to_not_contain_nulls_with_predicate_but_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<SomeClass> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().NotContainNulls(e => e.Text, "because we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection not to contain <null>s because we want to test the behaviour with a null subject, but collection is <null>.");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyContain.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyContain.cs
@@ -12,97 +12,96 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Only Contain
-
-        [Fact]
-        public void When_a_collection_does_not_contain_the_unexpected_items_it_should_not_be_enumerated_twice()
+        public class OnlyContain
         {
-            // Arrange
-            var collection = new OneTimeEnumerable<int>(1, 2, 3);
-
-            // Act
-            Action act = () => collection.Should().OnlyContain(i => i > 3);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain only items matching*");
-        }
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_OnlyContain_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<int> collection = new int[] { };
-
-            // Act
-            Action act = () => collection.Should().OnlyContain(predicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("predicate");
-        }
-
-        [Fact]
-        public void When_a_collection_contains_items_not_matching_a_predicate_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<int> collection = new[] { 2, 12, 3, 11, 2 };
-
-            // Act
-            Action act = () => collection.Should().OnlyContain(i => i <= 10, "10 is the maximum");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain only items matching (i <= 10) because 10 is the maximum, but {12, 11} do(es) not match.");
-        }
-
-        [Fact]
-        public void When_a_collection_is_empty_and_should_contain_only_items_matching_a_predicate_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<string> strings = Enumerable.Empty<string>();
-
-            // Act
-            Action act = () => strings.Should().OnlyContain(e => e.Length > 0);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected strings to contain only items matching (e.Length > 0), but the collection is empty.");
-        }
-
-        [Fact]
-        public void When_a_collection_contains_only_items_matching_a_predicate_it_should_not_throw()
-        {
-            // Arrange
-            IEnumerable<int> collection = new[] { 2, 9, 3, 8, 2 };
-
-            // Act
-            Action act = () => collection.Should().OnlyContain(i => i <= 10);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_collection_is_null_then_only_contains_should_fail()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_a_collection_does_not_contain_the_unexpected_items_it_should_not_be_enumerated_twice()
             {
-                using var _ = new AssertionScope();
-                collection.Should().OnlyContain(i => i <= 10, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                var collection = new OneTimeEnumerable<int>(1, 2, 3);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected collection to contain only items matching (i <= 10) *failure message*," +
-                    " but the collection is <null>.");
+                // Act
+                Action act = () => collection.Should().OnlyContain(i => i > 3);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to contain only items matching*");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_predicate_into_OnlyContain_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<int> collection = new int[] { };
+
+                // Act
+                Action act = () => collection.Should().OnlyContain(predicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("predicate");
+            }
+
+            [Fact]
+            public void When_a_collection_contains_items_not_matching_a_predicate_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<int> collection = new[] { 2, 12, 3, 11, 2 };
+
+                // Act
+                Action act = () => collection.Should().OnlyContain(i => i <= 10, "10 is the maximum");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to contain only items matching (i <= 10) because 10 is the maximum, but {12, 11} do(es) not match.");
+            }
+
+            [Fact]
+            public void When_a_collection_is_empty_and_should_contain_only_items_matching_a_predicate_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<string> strings = Enumerable.Empty<string>();
+
+                // Act
+                Action act = () => strings.Should().OnlyContain(e => e.Length > 0);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected strings to contain only items matching (e.Length > 0), but the collection is empty.");
+            }
+
+            [Fact]
+            public void When_a_collection_contains_only_items_matching_a_predicate_it_should_not_throw()
+            {
+                // Arrange
+                IEnumerable<int> collection = new[] { 2, 9, 3, 8, 2 };
+
+                // Act
+                Action act = () => collection.Should().OnlyContain(i => i <= 10);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_collection_is_null_then_only_contains_should_fail()
+            {
+                // Arrange
+                int[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().OnlyContain(i => i <= 10, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected collection to contain only items matching (i <= 10) *failure message*," +
+                        " but the collection is <null>.");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyHaveUniqueItems.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyHaveUniqueItems.cs
@@ -11,153 +11,152 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Only Have Unique Items
-
-        [Fact]
-        public void Should_succeed_when_asserting_collection_with_unique_items_contains_only_unique_items()
+        public class OnlyHaveUniqueItems
         {
-            // Arrange
-            var collection = new[] { 1, 2, 3, 4 };
-
-            // Act / Assert
-            collection.Should().OnlyHaveUniqueItems();
-        }
-
-        [Fact]
-        public void When_a_collection_contains_duplicate_items_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3, 3 };
-
-            // Act
-            Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items because we don't like duplicates, but item 3 is not unique.");
-        }
-
-        [Fact]
-        public void When_a_collection_contains_multiple_duplicate_items_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 2, 3, 3 };
-
-            // Act
-            Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items because we don't like duplicates, but items {2, 3} are not unique.");
-        }
-
-        [Fact]
-        public void When_asserting_collection_to_only_have_unique_items_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            int[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void Should_succeed_when_asserting_collection_with_unique_items_contains_only_unique_items()
             {
-                using var _ = new AssertionScope();
-                collection.Should().OnlyHaveUniqueItems("because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3, 4 };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items because we want to test the behaviour with a null subject, but found <null>.");
-        }
+                // Act / Assert
+                collection.Should().OnlyHaveUniqueItems();
+            }
 
-        [Fact]
-        public void When_injecting_a_null_predicate_into_OnlyHaveUniqueItems_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<SomeClass> collection = new SomeClass[] { };
-
-            // Act
-            Action act = () => collection.Should().OnlyHaveUniqueItems<string>(predicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("predicate");
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_with_a_predicate_a_collection_with_unique_items_contains_only_unique_items()
-        {
-            // Arrange
-            IEnumerable<SomeClass> collection = new[]
+            [Fact]
+            public void When_a_collection_contains_duplicate_items_it_should_throw()
             {
-                new SomeClass { Text = "one" },
-                new SomeClass { Text = "two" },
-                new SomeClass { Text = "three" },
-                new SomeClass { Text = "four" }
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 3, 3 };
 
-            // Act / Assert
-            collection.Should().OnlyHaveUniqueItems(e => e.Text);
-        }
+                // Act
+                Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
 
-        [Fact]
-        public void When_a_collection_contains_duplicate_items_with_predicate_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<SomeClass> collection = new[]
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to only have unique items because we don't like duplicates, but item 3 is not unique.");
+            }
+
+            [Fact]
+            public void When_a_collection_contains_multiple_duplicate_items_it_should_throw()
             {
-                new SomeClass { Text = "one" },
-                new SomeClass { Text = "two" },
-                new SomeClass { Text = "three" },
-                new SomeClass { Text = "three" }
-            };
+                // Arrange
+                var collection = new[] { 1, 2, 2, 3, 3 };
 
-            // Act
-            Action act = () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "{0} don't like {1}", "we", "duplicates");
+                // Act
+                Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items*on e.Text*because we don't like duplicates, but item*three*is not unique.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to only have unique items because we don't like duplicates, but items {2, 3} are not unique.");
+            }
 
-        [Fact]
-        public void When_a_collection_contains_multiple_duplicate_items_with_a_predicate_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<SomeClass> collection = new[]
+            [Fact]
+            public void When_asserting_collection_to_only_have_unique_items_but_collection_is_null_it_should_throw()
             {
-                new SomeClass { Text = "one" },
-                new SomeClass { Text = "two" },
-                new SomeClass { Text = "two" },
-                new SomeClass { Text = "three" },
-                new SomeClass { Text = "three" }
-            };
+                // Arrange
+                int[] collection = null;
 
-            // Act
-            Action act = () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "{0} don't like {1}", "we", "duplicates");
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().OnlyHaveUniqueItems("because we want to test the behaviour with a null subject");
+                };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items*on e.Text*because we don't like duplicates, but items*two*two*three*three*are not unique.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to only have unique items because we want to test the behaviour with a null subject, but found <null>.");
+            }
 
-        [Fact]
-        public void When_asserting_with_a_predicate_a_collection_to_only_have_unique_items_but_collection_is_null_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<SomeClass> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_injecting_a_null_predicate_into_OnlyHaveUniqueItems_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().OnlyHaveUniqueItems(e => e.Text, "because we want to test the behaviour with a null subject");
-            };
+                // Arrange
+                IEnumerable<SomeClass> collection = new SomeClass[] { };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items because we want to test the behaviour with a null subject, but found <null>.");
+                // Act
+                Action act = () => collection.Should().OnlyHaveUniqueItems<string>(predicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("predicate");
+            }
+
+            [Fact]
+            public void Should_succeed_when_asserting_with_a_predicate_a_collection_with_unique_items_contains_only_unique_items()
+            {
+                // Arrange
+                IEnumerable<SomeClass> collection = new[]
+                {
+                    new SomeClass { Text = "one" },
+                    new SomeClass { Text = "two" },
+                    new SomeClass { Text = "three" },
+                    new SomeClass { Text = "four" }
+                };
+
+                // Act / Assert
+                collection.Should().OnlyHaveUniqueItems(e => e.Text);
+            }
+
+            [Fact]
+            public void When_a_collection_contains_duplicate_items_with_predicate_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<SomeClass> collection = new[]
+                {
+                    new SomeClass { Text = "one" },
+                    new SomeClass { Text = "two" },
+                    new SomeClass { Text = "three" },
+                    new SomeClass { Text = "three" }
+                };
+
+                // Act
+                Action act = () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "{0} don't like {1}", "we", "duplicates");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to only have unique items*on e.Text*because we don't like duplicates, but item*three*is not unique.");
+            }
+
+            [Fact]
+            public void When_a_collection_contains_multiple_duplicate_items_with_a_predicate_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<SomeClass> collection = new[]
+                {
+                    new SomeClass { Text = "one" },
+                    new SomeClass { Text = "two" },
+                    new SomeClass { Text = "two" },
+                    new SomeClass { Text = "three" },
+                    new SomeClass { Text = "three" }
+                };
+
+                // Act
+                Action act = () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "{0} don't like {1}", "we", "duplicates");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to only have unique items*on e.Text*because we don't like duplicates, but items*two*two*three*three*are not unique.");
+            }
+
+            [Fact]
+            public void When_asserting_with_a_predicate_a_collection_to_only_have_unique_items_but_collection_is_null_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<SomeClass> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().OnlyHaveUniqueItems(e => e.Text, "because we want to test the behaviour with a null subject");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to only have unique items because we want to test the behaviour with a null subject, but found <null>.");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Satisfy.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Satisfy.cs
@@ -13,179 +13,203 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        [Fact]
-        public void When_collection_element_at_each_position_matches_predicate_at_same_position_should_not_throw()
+        public class Satisfy
         {
-            // Arrange
-            var collection = new int[] { 1, 2, 3 };
+            [Fact]
+            public void When_collection_element_at_each_position_matches_predicate_at_same_position_should_not_throw()
+            {
+                // Arrange
+                var collection = new int[] { 1, 2, 3 };
 
-            // Act
-            Action act = () => collection.Should().Satisfy(
-                element => element == 1,
-                element => element == 2,
-                element => element == 3);
+                // Act
+                Action act = () => collection.Should().Satisfy(
+                    element => element == 1,
+                    element => element == 2,
+                    element => element == 3);
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_collection_element_at_each_position_matches_predicate_at_reverse_position_should_not_throw()
-        {
-            // Arrange
-            var collection = new int[] { 1, 2, 3 };
+            [Fact]
+            public void When_collection_element_at_each_position_matches_predicate_at_reverse_position_should_not_throw()
+            {
+                // Arrange
+                var collection = new int[] { 1, 2, 3 };
 
-            // Act
-            Action act = () => collection.Should().Satisfy(
-                element => element == 3,
-                element => element == 2,
-                element => element == 1);
+                // Act
+                Action act = () => collection.Should().Satisfy(
+                    element => element == 3,
+                    element => element == 2,
+                    element => element == 1);
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_one_element_does_not_have_matching_predicate_Satisfy_should_throw()
-        {
-            // Arrange
-            var collection = new int[] { 1, 2 };
+            [Fact]
+            public void When_one_element_does_not_have_matching_predicate_Satisfy_should_throw()
+            {
+                // Arrange
+                var collection = new int[] { 1, 2 };
 
-            // Act
-            Action act = () => collection.Should().Satisfy(
-                element => element == 3,
-                element => element == 1,
-                element => element == 2);
+                // Act
+                Action act = () => collection.Should().Satisfy(
+                    element => element == 3,
+                    element => element == 1,
+                    element => element == 2);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-@"Expected collection to satisfy all predicates, but:
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+    @"Expected collection to satisfy all predicates, but:
 *The following predicates did not have matching elements:
 *(element == 3)");
-        }
+            }
 
-        [Fact]
-        public void When_some_predicates_have_multiple_matching_elements_and_most_restricitve_predicates_are_last_should_not_throw()
-        {
-            // Arrange
-            var collection = new int[] { 1, 2, 3, 4 };
-
-            // Act
-            Action act = () => collection.Should().Satisfy(
-                element => element == 1 || element == 2 || element == 3 || element == 4,
-                element => element == 1 || element == 2 || element == 3,
-                element => element == 1 || element == 2,
-                element => element == 1);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_some_predicates_have_multiple_matching_elements_and_most_restricitve_predicates_are_first_should_not_throw()
-        {
-            // Arrange
-            var collection = new int[] { 1, 2, 3, 4 };
-
-            // Act
-            Action act = () => collection.Should().Satisfy(
-                element => element == 1,
-                element => element == 1 || element == 2,
-                element => element == 1 || element == 2 || element == 3,
-                element => element == 1 || element == 2 || element == 3 || element == 4);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_second_predicate_matches_first_and_last_element_and_solution_exists_should_not_throw()
-        {
-            // Arrange
-            var collection = new int[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().Satisfy(
-                element => element == 1,
-                element => element == 1 || element == 3,
-                element => element == 2);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_assertion_fails_then_failure_message_must_contain_predicates_without_matching_elements_and_elements_without_matching_predicates()
-        {
-            // Arrange
-            IEnumerable<SomeClass> collection = new[]
+            [Fact]
+            public void When_some_predicates_have_multiple_matching_elements_and_most_restricitve_predicates_are_last_should_not_throw()
             {
-                new SomeClass { Text = "one", Number = 1 },
-                new SomeClass { Text = "two", Number = 3 },
-                new SomeClass { Text = "three", Number = 3 },
-                new SomeClass { Text = "four", Number = 4 },
-            };
+                // Arrange
+                var collection = new int[] { 1, 2, 3, 4 };
 
-            // Act
-            Action act = () => collection.Should().Satisfy(
-                new Expression<Func<SomeClass, bool>>[]
+                // Act
+                Action act = () => collection.Should().Satisfy(
+                    element => element == 1 || element == 2 || element == 3 || element == 4,
+                    element => element == 1 || element == 2 || element == 3,
+                    element => element == 1 || element == 2,
+                    element => element == 1);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_some_predicates_have_multiple_matching_elements_and_most_restricitve_predicates_are_first_should_not_throw()
+            {
+                // Arrange
+                var collection = new int[] { 1, 2, 3, 4 };
+
+                // Act
+                Action act = () => collection.Should().Satisfy(
+                    element => element == 1,
+                    element => element == 1 || element == 2,
+                    element => element == 1 || element == 2 || element == 3,
+                    element => element == 1 || element == 2 || element == 3 || element == 4);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_second_predicate_matches_first_and_last_element_and_solution_exists_should_not_throw()
+            {
+                // Arrange
+                var collection = new int[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().Satisfy(
+                    element => element == 1,
+                    element => element == 1 || element == 3,
+                    element => element == 2);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_assertion_fails_then_failure_message_must_contain_predicates_without_matching_elements_and_elements_without_matching_predicates()
+            {
+                // Arrange
+                IEnumerable<SomeClass> collection = new[]
                 {
+                    new SomeClass { Text = "one", Number = 1 },
+                    new SomeClass { Text = "two", Number = 3 },
+                    new SomeClass { Text = "three", Number = 3 },
+                    new SomeClass { Text = "four", Number = 4 },
+                };
+
+                // Act
+                Action act = () => collection.Should().Satisfy(
+                    new Expression<Func<SomeClass, bool>>[]
+                    {
                     element => element.Text == "four" && element.Number == 4,
                     element => element.Text == "two" && element.Number == 2,
-                },
-                because: "we want to test formatting ({0})",
-                becauseArgs: "args");
+                    },
+                    because: "we want to test formatting ({0})",
+                    becauseArgs: "args");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-@"Expected collection to satisfy all predicates because we want to test formatting (args), but:
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+    @"Expected collection to satisfy all predicates because we want to test formatting (args), but:
 *The following predicates did not have matching elements:
 *(element.Text == ""two"") AndAlso (element.Number == 2)
 *The following elements did not match any predicate:
 *Index: 0, Element:*FluentAssertions.Specs.Collections.CollectionAssertionSpecs+SomeClass*{*Number = 1*Text = ""one""*}
 *Index: 1, Element:*FluentAssertions.Specs.Collections.CollectionAssertionSpecs+SomeClass*{*Number = 3*Text = ""two""*}
 *Index: 2, Element:*FluentAssertions.Specs.Collections.CollectionAssertionSpecs+SomeClass*{*Number = 3*Text = ""three""*}");
-        }
+            }
 
-        [Fact]
-        public void When_Satisfy_asserting_against_null_inspectors_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            IEnumerable<int> collection = new[] { 1, 2 };
-
-            // Act
-            Action act = () => collection.Should().Satisfy(null);
-
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify against a <null> collection of predicates*");
-        }
-
-        [Fact]
-        public void When_asserting_against_empty_inspectors_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            IEnumerable<int> collection = new[] { 1, 2 };
-
-            // Act
-            Action act = () => collection.Should().Satisfy();
-
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify against an empty collection of predicates*");
-        }
-
-        [Fact]
-        public void When_asserting_collection_which_is_null_should_throw()
-        {
-            // Arrange
-            IEnumerable<int> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_Satisfy_asserting_against_null_inspectors_it_should_throw_with_clear_explanation()
             {
-                using var _ = new AssertionScope();
-                collection.Should().Satisfy(
+                // Arrange
+                IEnumerable<int> collection = new[] { 1, 2 };
+
+                // Act
+                Action act = () => collection.Should().Satisfy(null);
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage(
+                    "Cannot verify against a <null> collection of predicates*");
+            }
+
+            [Fact]
+            public void When_asserting_against_empty_inspectors_should_throw_with_clear_explanation()
+            {
+                // Arrange
+                IEnumerable<int> collection = new[] { 1, 2 };
+
+                // Act
+                Action act = () => collection.Should().Satisfy();
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage(
+                    "Cannot verify against an empty collection of predicates*");
+            }
+
+            [Fact]
+            public void When_asserting_collection_which_is_null_should_throw()
+            {
+                // Arrange
+                IEnumerable<int> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().Satisfy(
+                        new Expression<Func<int, bool>>[]
+                        {
+                            element => element == 1,
+                            element => element == 2,
+                        },
+                        because: "we want to test the failure message ({0})",
+                        becauseArgs: "args");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to satisfy all predicates because we want to test the failure message (args), but collection is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_which_is_empty_should_throw()
+            {
+                // Arrange
+                var collection = Enumerable.Empty<int>();
+
+                // Act
+                Action act = () => collection.Should().Satisfy(
                     new Expression<Func<int, bool>>[]
                     {
                         element => element == 1,
@@ -193,52 +217,31 @@ namespace FluentAssertions.Specs.Collections
                     },
                     because: "we want to test the failure message ({0})",
                     becauseArgs: "args");
-            };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to satisfy all predicates because we want to test the failure message (args), but collection is <null>.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to satisfy all predicates because we want to test the failure message (args), but collection is empty.");
+            }
 
-        [Fact]
-        public void When_asserting_collection_which_is_empty_should_throw()
-        {
-            // Arrange
-            var collection = Enumerable.Empty<int>();
+            [Fact]
+            public void When_elements_are_integers_assertion_fails_then_failure_message_must_be_readable()
+            {
+                // Arrange
+                var collection = new List<int> { 1, 2, 3 };
 
-            // Act
-            Action act = () => collection.Should().Satisfy(
-                new Expression<Func<int, bool>>[]
-                {
-                    element => element == 1,
-                    element => element == 2,
-                },
-                because: "we want to test the failure message ({0})",
-                becauseArgs: "args");
+                // Act
+                Action act = () => collection.Should().Satisfy(
+                    element => element == 2);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to satisfy all predicates because we want to test the failure message (args), but collection is empty.");
-        }
-
-        [Fact]
-        public void When_elements_are_integers_assertion_fails_then_failure_message_must_be_readable()
-        {
-            // Arrange
-            var collection = new List<int> { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().Satisfy(
-                element => element == 2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-@"Expected collection to satisfy all predicates, but:
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+    @"Expected collection to satisfy all predicates, but:
 *The following elements did not match any predicate:
 *Index: 0, Element: 1
 *Index: 2, Element: 3");
+            }
         }
-
+        
         private class SomeClass
         {
             public string Text { get; set; }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.SatisfyRespectively.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.SatisfyRespectively.cs
@@ -12,88 +12,178 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Satisfy Respectively
-
-        [Fact]
-        public void When_collection_asserting_against_null_inspectors_it_should_throw_with_clear_explanation()
+        public class SatisfyRespectively
         {
-            // Arrange
-            IEnumerable<int> collection = new[] { 1, 2 };
-
-            // Act
-            Action act = () => collection.Should().SatisfyRespectively(null);
-
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify against a <null> collection of inspectors*");
-        }
-
-        [Fact]
-        public void When_collection_asserting_against_empty_inspectors_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            IEnumerable<int> collection = new[] { 1, 2 };
-
-            // Act
-            Action act = () => collection.Should().SatisfyRespectively();
-
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify against an empty collection of inspectors*");
-        }
-
-        [Fact]
-        public void When_collection_which_is_asserting_against_inspectors_is_null_it_should_throw()
-        {
-            // Arrange
-            IEnumerable<int> collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_asserting_against_null_inspectors_it_should_throw_with_clear_explanation()
             {
-                using var _ = new AssertionScope();
+                // Arrange
+                IEnumerable<int> collection = new[] { 1, 2 };
+
+                // Act
+                Action act = () => collection.Should().SatisfyRespectively(null);
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage(
+                    "Cannot verify against a <null> collection of inspectors*");
+            }
+
+            [Fact]
+            public void When_collection_asserting_against_empty_inspectors_it_should_throw_with_clear_explanation()
+            {
+                // Arrange
+                IEnumerable<int> collection = new[] { 1, 2 };
+
+                // Act
+                Action act = () => collection.Should().SatisfyRespectively();
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage(
+                    "Cannot verify against an empty collection of inspectors*");
+            }
+
+            [Fact]
+            public void When_collection_which_is_asserting_against_inspectors_is_null_it_should_throw()
+            {
+                // Arrange
+                IEnumerable<int> collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().SatisfyRespectively(
+                        new Action<int>[] { x => x.Should().Be(1) }, "because we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to satisfy all inspectors because we want to test the failure message, but collection is <null>.");
+            }
+
+            [Fact]
+            public void When_collection_which_is_asserting_against_inspectors_is_empty_it_should_throw()
+            {
+                // Arrange
+                var collection = Enumerable.Empty<int>();
+
+                // Act
+                Action act = () => collection.Should().SatisfyRespectively(new Action<int>[] { x => x.Should().Be(1) },
+                    "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to satisfy all inspectors because we want to test the failure message, but collection is empty.");
+            }
+
+            [Fact]
+            public void When_asserting_collection_satisfies_all_inspectors_it_should_succeed()
+            {
+                // Arrange
+                var collection = new[] { new Customer { Age = 21, Name = "John" }, new Customer { Age = 22, Name = "Jane" } };
+
+                // Act / Assert
                 collection.Should().SatisfyRespectively(
-                    new Action<int>[] { x => x.Should().Be(1) }, "because we want to test the failure {0}", "message");
-            };
+                    value =>
+                    {
+                        value.Age.Should().Be(21);
+                        value.Name.Should().Be("John");
+                    },
+                    value =>
+                    {
+                        value.Age.Should().Be(22);
+                        value.Name.Should().Be("Jane");
+                    });
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to satisfy all inspectors because we want to test the failure message, but collection is <null>.");
-        }
-
-        [Fact]
-        public void When_collection_which_is_asserting_against_inspectors_is_empty_it_should_throw()
-        {
-            // Arrange
-            var collection = Enumerable.Empty<int>();
-
-            // Act
-            Action act = () => collection.Should().SatisfyRespectively(new Action<int>[] { x => x.Should().Be(1) },
-                "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to satisfy all inspectors because we want to test the failure message, but collection is empty.");
-        }
-
-        [Fact]
-        public void When_asserting_collection_satisfies_all_inspectors_it_should_succeed()
-        {
-            // Arrange
-            var collection = new[] { new Customer { Age = 21, Name = "John" }, new Customer { Age = 22, Name = "Jane" } };
-
-            // Act / Assert
-            collection.Should().SatisfyRespectively(
-                value =>
+            [Fact]
+            public void When_asserting_collection_does_not_satisfy_any_inspector_it_should_throw()
+            {
+                // Arrange
+                var customers = new[]
                 {
-                    value.Age.Should().Be(21);
-                    value.Name.Should().Be("John");
-                },
-                value =>
-                {
-                    value.Age.Should().Be(22);
-                    value.Name.Should().Be("Jane");
-                });
+                    new CustomerWithItems { Age = 21, Items = new[] { 1, 2 } },
+                    new CustomerWithItems { Age = 22, Items = new[] { 3 } }
+                };
+
+                // Act
+                Action act = () => customers.Should().SatisfyRespectively(
+                    new Action<CustomerWithItems>[]
+                    {
+                    customer =>
+                    {
+                        customer.Age.Should().BeLessThan(21);
+                        customer.Items.Should().SatisfyRespectively(
+                            item => item.Should().Be(2),
+                            item => item.Should().Be(1));
+                    },
+                    customer =>
+                    {
+                        customer.Age.Should().BeLessThan(22);
+                        customer.Items.Should().SatisfyRespectively(item => item.Should().Be(2));
+                    }
+                    }, "because we want to test {0}", "nested assertions");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    @"Expected customers to satisfy all inspectors because we want to test nested assertions, but some inspectors are not satisfied:
+*At index 0:
+*Expected customer.Age to be less than 21, but found 21
+*Expected customer.Items to satisfy all inspectors, but some inspectors are not satisfied:
+*At index 0:
+*Expected item to be 2, but found 1
+*At index 1:
+*Expected item to be 1, but found 2
+*At index 1:
+*Expected customer.Age to be less than 22, but found 22
+*Expected customer.Items to satisfy all inspectors, but some inspectors are not satisfied:
+*At index 0:
+*Expected item to be 2, but found 3"
+                );
+            }
+
+            [Fact]
+            public void When_inspector_message_is_not_reformatable_it_should_not_throw()
+            {
+                // Arrange
+                byte[][] subject = { new byte[] { 1 } };
+
+                // Act
+                Action act = () => subject.Should().SatisfyRespectively(e => e.Should().BeEquivalentTo(new byte[] { 2, 3, 4 }));
+
+                // Assert
+                act.Should().NotThrow<FormatException>();
+            }
+
+            [Fact]
+            public void When_inspectors_count_does_not_equal_asserting_collection_length_it_should_throw_with_a_useful_message()
+            {
+                // Arrange
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => collection.Should().SatisfyRespectively(
+                    new Action<int>[] { value => value.Should().Be(1), value => value.Should().Be(2) },
+                    "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected collection to contain exactly 2 items*we want to test the failure message*, but it contains 3 items");
+            }
+
+            [Fact]
+            public void When_inspectors_count_does_not_equal_asserting_collection_length_it_should_fail_with_a_useful_message()
+            {
+                // Arrange
+                var collection = new int[0];
+
+                // Act
+                Action act = () => collection.Should().SatisfyRespectively(
+                    new Action<int>[] { value => value.Should().Be(1), }, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*because we want to test the failure*");
+            }
         }
 
         private class Customer
@@ -129,96 +219,5 @@ namespace FluentAssertions.Specs.Collections
         {
             public int[] Items { get; set; }
         }
-
-        [Fact]
-        public void When_asserting_collection_does_not_satisfy_any_inspector_it_should_throw()
-        {
-            // Arrange
-            var customers = new[]
-            {
-                new CustomerWithItems { Age = 21, Items = new[] { 1, 2 } },
-                new CustomerWithItems { Age = 22, Items = new[] { 3 } }
-            };
-
-            // Act
-            Action act = () => customers.Should().SatisfyRespectively(
-                new Action<CustomerWithItems>[]
-                {
-                    customer =>
-                    {
-                        customer.Age.Should().BeLessThan(21);
-                        customer.Items.Should().SatisfyRespectively(
-                            item => item.Should().Be(2),
-                            item => item.Should().Be(1));
-                    },
-                    customer =>
-                    {
-                        customer.Age.Should().BeLessThan(22);
-                        customer.Items.Should().SatisfyRespectively(item => item.Should().Be(2));
-                    }
-                }, "because we want to test {0}", "nested assertions");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                @"Expected customers to satisfy all inspectors because we want to test nested assertions, but some inspectors are not satisfied:
-*At index 0:
-*Expected customer.Age to be less than 21, but found 21
-*Expected customer.Items to satisfy all inspectors, but some inspectors are not satisfied:
-*At index 0:
-*Expected item to be 2, but found 1
-*At index 1:
-*Expected item to be 1, but found 2
-*At index 1:
-*Expected customer.Age to be less than 22, but found 22
-*Expected customer.Items to satisfy all inspectors, but some inspectors are not satisfied:
-*At index 0:
-*Expected item to be 2, but found 3"
-            );
-        }
-
-        [Fact]
-        public void When_inspector_message_is_not_reformatable_it_should_not_throw()
-        {
-            // Arrange
-            byte[][] subject = { new byte[] { 1 } };
-
-            // Act
-            Action act = () => subject.Should().SatisfyRespectively(e => e.Should().BeEquivalentTo(new byte[] { 2, 3, 4 }));
-
-            // Assert
-            act.Should().NotThrow<FormatException>();
-        }
-
-        [Fact]
-        public void When_inspectors_count_does_not_equal_asserting_collection_length_it_should_throw_with_a_useful_message()
-        {
-            // Arrange
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => collection.Should().SatisfyRespectively(
-                new Action<int>[] { value => value.Should().Be(1), value => value.Should().Be(2) },
-                "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain exactly 2 items*we want to test the failure message*, but it contains 3 items");
-        }
-
-        [Fact]
-        public void When_inspectors_count_does_not_equal_asserting_collection_length_it_should_fail_with_a_useful_message()
-        {
-            // Arrange
-            var collection = new int[0];
-
-            // Act
-            Action act = () => collection.Should().SatisfyRespectively(
-                new Action<int>[] { value => value.Should().Be(1), }, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*because we want to test the failure*");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.StartWith.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.StartWith.cs
@@ -11,214 +11,213 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Start With
-
-        [Fact]
-        public void When_collection_does_not_start_with_a_specific_element_it_should_throw()
+        public class StartWith
         {
-            // Arrange
-            var collection = new[] { "john", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().StartWith("ryan", "of some reason");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*start*ryan*because of some reason*but*john*");
-        }
-
-        [Fact]
-        public void When_collection_does_not_start_with_a_null_sequence_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "john" };
-
-            // Act
-            Action act = () => collection.Should().StartWith((IEnumerable<string>)null);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .Which.ParamName.Should().Be("expectation");
-        }
-
-        [Fact]
-        public void When_collection_does_not_start_with_a_null_sequence_using_a_comparer_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "john" };
-
-            // Act
-            Action act = () => collection.Should().StartWith((IEnumerable<string>)null, (_, _) => true);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .Which.ParamName.Should().Be("expectation");
-        }
-
-        [Fact]
-        public void When_collection_does_not_start_with_a_specific_element_in_a_sequence_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().StartWith(new[] { "john", "ryan", "jane" }, "of some reason");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*start*ryan*because of some reason*but*differs at index 1*");
-        }
-
-        [Fact]
-        public void When_collection_does_not_start_with_a_specific_element_in_a_sequence_using_custom_equality_comparison_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().StartWith(new[] { "john", "ryan", "jane" }, (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "of some reason");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*start*ryan*because of some reason*but*differs at index 1*");
-        }
-
-        [Fact]
-        public void When_collection_starts_with_the_specific_element_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "john", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().StartWith("john");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_starts_with_the_specific_sequence_of_elements_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().StartWith(new[] { "john", "bill" });
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_starts_with_the_specific_sequence_of_elements_using_custom_equality_comparison_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().StartWith(new[] { "JoHn", "bIlL" }, (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_starts_with_the_specific_null_element_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { null, "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().StartWith((string)null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_non_empty_collection_starts_with_the_empty_sequence_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().StartWith(new string[] { });
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_empty_collection_starts_with_the_empty_sequence_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new string[] { };
-
-            // Act
-            Action act = () => collection.Should().StartWith(new string[] { });
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_starts_with_the_specific_sequence_with_null_elements_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { null, "john", null, "bill", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().StartWith(new[] { null, "john", null, "bill" });
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_starts_with_the_specific_sequence_with_null_elements_using_custom_equality_comparison_it_should_not_throw()
-        {
-            // Arrange
-            var collection = new[] { null, "john", null, "bill", "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().StartWith(new[] { null, "JoHn", null, "bIlL" }, (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_collection_starts_with_null_but_that_wasnt_expected_it_should_throw()
-        {
-            // Arrange
-            var collection = new[] { null, "jane", "mike" };
-
-            // Act
-            Action act = () => collection.Should().StartWith("john");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*start*john*but*null*");
-        }
-
-        [Fact]
-        public void When_null_collection_is_expected_to_start_with_an_element_it_should_throw()
-        {
-            // Arrange
-            string[] collection = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_collection_does_not_start_with_a_specific_element_it_should_throw()
             {
-                using var _ = new AssertionScope();
-                collection.Should().StartWith("john");
-            };
+                // Arrange
+                var collection = new[] { "john", "jane", "mike" };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*start*john*but*collection*null*");
+                // Act
+                Action act = () => collection.Should().StartWith("ryan", "of some reason");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*start*ryan*because of some reason*but*john*");
+            }
+
+            [Fact]
+            public void When_collection_does_not_start_with_a_null_sequence_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "john" };
+
+                // Act
+                Action act = () => collection.Should().StartWith((IEnumerable<string>)null);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .Which.ParamName.Should().Be("expectation");
+            }
+
+            [Fact]
+            public void When_collection_does_not_start_with_a_null_sequence_using_a_comparer_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "john" };
+
+                // Act
+                Action act = () => collection.Should().StartWith((IEnumerable<string>)null, (_, _) => true);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .Which.ParamName.Should().Be("expectation");
+            }
+
+            [Fact]
+            public void When_collection_does_not_start_with_a_specific_element_in_a_sequence_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "john", "bill", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().StartWith(new[] { "john", "ryan", "jane" }, "of some reason");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*start*ryan*because of some reason*but*differs at index 1*");
+            }
+
+            [Fact]
+            public void When_collection_does_not_start_with_a_specific_element_in_a_sequence_using_custom_equality_comparison_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { "john", "bill", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().StartWith(new[] { "john", "ryan", "jane" }, (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "of some reason");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*start*ryan*because of some reason*but*differs at index 1*");
+            }
+
+            [Fact]
+            public void When_collection_starts_with_the_specific_element_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "john", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().StartWith("john");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_starts_with_the_specific_sequence_of_elements_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "john", "bill", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().StartWith(new[] { "john", "bill" });
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_starts_with_the_specific_sequence_of_elements_using_custom_equality_comparison_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "john", "bill", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().StartWith(new[] { "JoHn", "bIlL" }, (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_starts_with_the_specific_null_element_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { null, "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().StartWith((string)null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_non_empty_collection_starts_with_the_empty_sequence_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().StartWith(new string[] { });
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_empty_collection_starts_with_the_empty_sequence_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new string[] { };
+
+                // Act
+                Action act = () => collection.Should().StartWith(new string[] { });
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_starts_with_the_specific_sequence_with_null_elements_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { null, "john", null, "bill", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().StartWith(new[] { null, "john", null, "bill" });
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_starts_with_the_specific_sequence_with_null_elements_using_custom_equality_comparison_it_should_not_throw()
+            {
+                // Arrange
+                var collection = new[] { null, "john", null, "bill", "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().StartWith(new[] { null, "JoHn", null, "bIlL" }, (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_collection_starts_with_null_but_that_wasnt_expected_it_should_throw()
+            {
+                // Arrange
+                var collection = new[] { null, "jane", "mike" };
+
+                // Act
+                Action act = () => collection.Should().StartWith("john");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*start*john*but*null*");
+            }
+
+            [Fact]
+            public void When_null_collection_is_expected_to_start_with_an_element_it_should_throw()
+            {
+                // Arrange
+                string[] collection = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    collection.Should().StartWith("john");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected*start*john*but*collection*null*");
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -12,1338 +12,1541 @@ namespace FluentAssertions.Specs.Collections
     public class GenericDictionaryAssertionSpecs
     {
         // If you try to implement support for IReadOnlyDictionary, these tests should still succeed.
-        #region Sanity Checks
-
-        [Fact]
-        public void When_the_same_dictionaries_are_expected_to_be_the_same_it_should_not_fail()
+        public class SanityChecks
         {
-            // Arrange
-            IDictionary<int, string> dictionary = new Dictionary<int, string>();
-            IDictionary<int, string> referenceToDictionary = dictionary;
-
-            // Act / Assert
-            dictionary.Should().BeSameAs(referenceToDictionary);
-        }
-
-        [Fact]
-        public void When_the_same_custom_dictionaries_are_expected_to_be_the_same_it_should_not_fail()
-        {
-            // Arrange
-            IDictionary<int, string> dictionary = new DictionaryNotImplementingIReadOnlyDictionary<int, string>();
-            IDictionary<int, string> referenceToDictionary = dictionary;
-
-            // Act / Assert
-            dictionary.Should().BeSameAs(referenceToDictionary);
-        }
-
-        [Fact]
-        public void When_object_type_is_exactly_equal_to_the_specified_type_it_should_not_fail()
-        {
-            // Arrange
-            IDictionary<int, string> dictionary = new DictionaryNotImplementingIReadOnlyDictionary<int, string>();
-
-            // Act / Assert
-            dictionary.Should().BeOfType<DictionaryNotImplementingIReadOnlyDictionary<int, string>>();
-        }
-
-        [Fact]
-        public void When_a_dictionary_does_not_implement_the_read_only_interface_it_should_have_dictionary_assertions()
-        {
-            // Arrange
-            IDictionary<int, string> dictionary = new DictionaryNotImplementingIReadOnlyDictionary<int, string>();
-
-            // Act / Assert
-            dictionary.Should().NotContainKey(0, "Dictionaries not implementing IReadOnlyDictionary<TKey, TValue> "
-                + "should be supported at least until Fluent Assertions 6.0.");
-        }
-
-        #endregion
-
-        #region Be Null
-
-        [Fact]
-        public void When_dictionary_is_expected_to_be_null_and_it_is_it_should_not_throw()
-        {
-            // Arrange
-            IDictionary<int, string> someDictionary = null;
-
-            // Act / Assert
-            someDictionary.Should().BeNull();
-        }
-
-        [Fact]
-        public void When_a_custom_dictionary_implementation_is_expected_not_to_be_null_and_it_is_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new TrackingTestDictionary();
-
-            // Act / Assert
-            dictionary.Should().NotBeNull();
-        }
-
-        [Fact]
-        public void When_dictionary_is_expected_to_be_null_and_it_isnt_it_should_throw()
-        {
-            // Arrange
-            var someDictionary = new Dictionary<int, string>();
-
-            // Act
-            Action act = () => someDictionary.Should().BeNull("because {0} is valid", "null");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected someDictionary to be <null> because null is valid, but found {empty}.");
-        }
-
-        [Fact]
-        public void When_dictionary_is_not_expected_to_be_null_and_it_isnt_it_should_not_throw()
-        {
-            // Arrange
-            IDictionary<int, string> someDictionary = new Dictionary<int, string>();
-
-            // Act / Assert
-            someDictionary.Should().NotBeNull();
-        }
-
-        [Fact]
-        public void When_dictionary_is_not_expected_to_be_null_and_it_is_it_should_throw()
-        {
-            // Arrange
-            IDictionary<int, string> someDictionary = null;
-
-            // Act
-            Action act = () => someDictionary.Should().NotBeNull("because {0} should not", "someDictionary");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected someDictionary not to be <null> because someDictionary should not.");
-        }
-
-        #endregion
-
-        #region Have Count
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_has_a_count_that_equals_the_number_of_items()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_the_same_dictionaries_are_expected_to_be_the_same_it_should_not_fail()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                IDictionary<int, string> dictionary = new Dictionary<int, string>();
+                IDictionary<int, string> referenceToDictionary = dictionary;
 
-            // Act / Assert
-            dictionary.Should().HaveCount(3);
-        }
+                // Act / Assert
+                dictionary.Should().BeSameAs(referenceToDictionary);
+            }
 
-        [Fact]
-        public void Should_fail_when_asserting_dictionary_has_a_count_that_is_different_from_the_number_of_items()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_the_same_custom_dictionaries_are_expected_to_be_the_same_it_should_not_fail()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                IDictionary<int, string> dictionary = new DictionaryNotImplementingIReadOnlyDictionary<int, string>();
+                IDictionary<int, string> referenceToDictionary = dictionary;
 
-            // Act
-            Action act = () => dictionary.Should().HaveCount(4);
+                // Act / Assert
+                dictionary.Should().BeSameAs(referenceToDictionary);
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void
-            When_dictionary_has_a_count_that_is_different_from_the_number_of_items_it_should_fail_with_descriptive_message_()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_object_type_is_exactly_equal_to_the_specified_type_it_should_not_fail()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                IDictionary<int, string> dictionary = new DictionaryNotImplementingIReadOnlyDictionary<int, string>();
 
-            // Act
-            Action action = () => dictionary.Should().HaveCount(4, "because we want to test the failure {0}", "message");
+                // Act / Assert
+                dictionary.Should().BeOfType<DictionaryNotImplementingIReadOnlyDictionary<int, string>>();
+            }
 
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to contain 4 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
-        }
-
-        [Fact]
-        public void When_dictionary_has_a_count_larger_than_the_minimum_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_a_dictionary_does_not_implement_the_read_only_interface_it_should_have_dictionary_assertions()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                IDictionary<int, string> dictionary = new DictionaryNotImplementingIReadOnlyDictionary<int, string>();
 
-            // Act / Assert
-            dictionary.Should().HaveCount(c => c >= 3);
+                // Act / Assert
+                dictionary.Should().NotContainKey(0, "Dictionaries not implementing IReadOnlyDictionary<TKey, TValue> "
+                    + "should be supported at least until Fluent Assertions 6.0.");
+            }
         }
 
-        [Fact]
-        public void When_dictionary_has_a_count_that_not_matches_the_predicate_it_should_throw()
+        public class BeNull
         {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_is_expected_to_be_null_and_it_is_it_should_not_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                IDictionary<int, string> someDictionary = null;
 
-            // Act
-            Action act = () => dictionary.Should().HaveCount(c => c >= 4, "a minimum of 4 is required");
+                // Act / Assert
+                someDictionary.Should().BeNull();
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to have a count (c >= 4) because a minimum of 4 is required, but count is 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
-        }
-
-        [Fact]
-        public void When_dictionary_count_is_matched_against_a_null_predicate_it_should_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_a_custom_dictionary_implementation_is_expected_not_to_be_null_and_it_is_it_should_not_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                var dictionary = new TrackingTestDictionary();
 
-            // Act
-            Action act = () => dictionary.Should().HaveCount(null);
+                // Act / Assert
+                dictionary.Should().NotBeNull();
+            }
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare collection count against a <null> predicate.*");
-        }
-
-        [Fact]
-        public void When_dictionary_count_is_matched_and_dictionary_is_null_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-
-            // Act
-            Action act = () => dictionary.Should().HaveCount(1, "we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain 1 item(s) because we want to test the behaviour with a null subject, but found <null>.");
-        }
-
-        [Fact]
-        public void When_dictionary_count_is_matched_against_a_predicate_and_dictionary_is_null_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-
-            // Act
-            Action act = () => dictionary.Should().HaveCount(c => c < 3, "we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain (c < 3) items because we want to test the behaviour with a null subject, but found <null>.");
-        }
-
-        #endregion
-
-        #region Not Have Count
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_has_a_count_different_from_the_number_of_items()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_is_expected_to_be_null_and_it_isnt_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                var someDictionary = new Dictionary<int, string>();
 
-            // Act / Assert
-            dictionary.Should().NotHaveCount(2);
-        }
+                // Act
+                Action act = () => someDictionary.Should().BeNull("because {0} is valid", "null");
 
-        [Fact]
-        public void Should_fail_when_asserting_dictionary_has_a_count_that_equals_the_number_of_items()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected someDictionary to be <null> because null is valid, but found {empty}.");
+            }
+
+            [Fact]
+            public void When_dictionary_is_not_expected_to_be_null_and_it_isnt_it_should_not_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                IDictionary<int, string> someDictionary = new Dictionary<int, string>();
 
-            // Act
-            Action act = () => dictionary.Should().NotHaveCount(3);
+                // Act / Assert
+                someDictionary.Should().NotBeNull();
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_dictionary_has_a_count_that_equals_than_the_number_of_items_it_should_fail_with_descriptive_message_()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_is_not_expected_to_be_null_and_it_is_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                IDictionary<int, string> someDictionary = null;
 
-            // Act
-            Action action = () => dictionary.Should().NotHaveCount(3, "because we want to test the failure {0}", "message");
+                // Act
+                Action act = () => someDictionary.Should().NotBeNull("because {0} should not", "someDictionary");
 
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("*not contain*3*because we want to test the failure message*3*");
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected someDictionary not to be <null> because someDictionary should not.");
+            }
         }
 
-        [Fact]
-        public void When_dictionary_count_is_same_than_and_dictionary_is_null_it_should_throw()
+        public class HaveCount
         {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-
-            // Act
-            Action act = () => dictionary.Should().NotHaveCount(1, "we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
-        }
-
-        #endregion
-
-        #region Have Count Greater Than
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_has_a_count_greater_than_less_the_number_of_items()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_has_a_count_that_equals_the_number_of_items()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act / Assert
-            dictionary.Should().HaveCountGreaterThan(2);
-        }
+                // Act / Assert
+                dictionary.Should().HaveCount(3);
+            }
 
-        [Fact]
-        public void Should_fail_when_asserting_dictionary_has_a_count_greater_than_the_number_of_items()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_fail_when_asserting_dictionary_has_a_count_that_is_different_from_the_number_of_items()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().HaveCountGreaterThan(3);
+                // Act
+                Action act = () => dictionary.Should().HaveCount(4);
 
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
 
-        [Fact]
-        public void When_dictionary_has_a_count_greater_than_the_number_of_items_it_should_fail_with_descriptive_message_()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void
+                When_dictionary_has_a_count_that_is_different_from_the_number_of_items_it_should_fail_with_descriptive_message_()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action action = () => dictionary.Should().HaveCountGreaterThan(3, "because we want to test the failure {0}", "message");
+                // Act
+                Action action = () => dictionary.Should().HaveCount(4, "because we want to test the failure {0}", "message");
 
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to contain more than 3 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
-        }
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected dictionary to contain 4 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+            }
 
-        [Fact]
-        public void When_dictionary_count_is_greater_than_and_dictionary_is_null_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-
-            // Act
-            Action act = () => dictionary.Should().HaveCountGreaterThan(1, "we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*more than*1*we want to test the behaviour with a null subject*found <null>*");
-        }
-
-        #endregion
-
-        #region Have Count Greater Than Or Equal To
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_has_a_count_greater_than_or_equal_to_less_the_number_of_items()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_has_a_count_larger_than_the_minimum_it_should_not_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act / Assert
-            dictionary.Should().HaveCountGreaterThanOrEqualTo(3);
-        }
+                // Act / Assert
+                dictionary.Should().HaveCount(c => c >= 3);
+            }
 
-        [Fact]
-        public void Should_fail_when_asserting_dictionary_has_a_count_greater_than_or_equal_to_the_number_of_items()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_has_a_count_that_not_matches_the_predicate_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().HaveCountGreaterThanOrEqualTo(4);
+                // Act
+                Action act = () => dictionary.Should().HaveCount(c => c >= 4, "a minimum of 4 is required");
 
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to have a count (c >= 4) because a minimum of 4 is required, but count is 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+            }
 
-        [Fact]
-        public void When_dictionary_has_a_count_greater_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_count_is_matched_against_a_null_predicate_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action action = () => dictionary.Should().HaveCountGreaterThanOrEqualTo(4, "because we want to test the failure {0}", "message");
+                // Act
+                Action act = () => dictionary.Should().HaveCount(null);
 
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to contain at least 4 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
-        }
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot compare collection count against a <null> predicate.*");
+            }
 
-        [Fact]
-        public void When_dictionary_count_is_greater_than_or_equal_to_and_dictionary_is_null_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-
-            // Act
-            Action act = () => dictionary.Should().HaveCountGreaterThanOrEqualTo(1, "we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
-        }
-
-        #endregion
-
-        #region Have Count Less Than
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_has_a_count_less_than_less_the_number_of_items()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_count_is_matched_and_dictionary_is_null_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                Dictionary<int, string> dictionary = null;
 
-            // Act / Assert
-            dictionary.Should().HaveCountLessThan(4);
-        }
+                // Act
+                Action act = () => dictionary.Should().HaveCount(1, "we want to test the behaviour with a null subject");
 
-        [Fact]
-        public void Should_fail_when_asserting_dictionary_has_a_count_less_than_the_number_of_items()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to contain 1 item(s) because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_dictionary_count_is_matched_against_a_predicate_and_dictionary_is_null_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                Dictionary<int, string> dictionary = null;
 
-            // Act
-            Action act = () => dictionary.Should().HaveCountLessThan(3);
+                // Act
+                Action act = () => dictionary.Should().HaveCount(c => c < 3, "we want to test the behaviour with a null subject");
 
-            // Assert
-            act.Should().Throw<XunitException>();
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to contain (c < 3) items because we want to test the behaviour with a null subject, but found <null>.");
+            }
         }
 
-        [Fact]
-        public void When_dictionary_has_a_count_less_than_the_number_of_items_it_should_fail_with_descriptive_message_()
+        public class NotHaveCount
         {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_has_a_count_different_from_the_number_of_items()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action action = () => dictionary.Should().HaveCountLessThan(3, "because we want to test the failure {0}", "message");
+                // Act / Assert
+                dictionary.Should().NotHaveCount(2);
+            }
 
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to contain fewer than 3 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
-        }
-
-        [Fact]
-        public void When_dictionary_count_is_less_than_and_dictionary_is_null_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-
-            // Act
-            Action act = () => dictionary.Should().HaveCountLessThan(1, "we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*fewer than*1*we want to test the behaviour with a null subject*found <null>*");
-        }
-
-        #endregion
-
-        #region Have Count Less Than Or Equal To
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_has_a_count_less_than_or_equal_to_less_the_number_of_items()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_fail_when_asserting_dictionary_has_a_count_that_equals_the_number_of_items()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act / Assert
-            dictionary.Should().HaveCountLessThanOrEqualTo(3);
-        }
+                // Act
+                Action act = () => dictionary.Should().NotHaveCount(3);
 
-        [Fact]
-        public void Should_fail_when_asserting_dictionary_has_a_count_less_than_or_equal_to_the_number_of_items()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_dictionary_has_a_count_that_equals_than_the_number_of_items_it_should_fail_with_descriptive_message_()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().HaveCountLessThanOrEqualTo(2);
+                // Act
+                Action action = () => dictionary.Should().NotHaveCount(3, "because we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("*not contain*3*because we want to test the failure message*3*");
+            }
 
-        [Fact]
-        public void When_dictionary_has_a_count_less_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_count_is_same_than_and_dictionary_is_null_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
+                // Arrange
+                Dictionary<int, string> dictionary = null;
 
-            // Act
-            Action action = () => dictionary.Should().HaveCountLessThanOrEqualTo(2, "because we want to test the failure {0}", "message");
+                // Act
+                Action act = () => dictionary.Should().NotHaveCount(1, "we want to test the behaviour with a null subject");
 
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to contain at most 2 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
+            }
         }
 
-        [Fact]
-        public void When_dictionary_count_is_less_than_or_equal_to_and_dictionary_is_null_it_should_throw()
+        public class HaveCountGreaterThan
         {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-
-            // Act
-            Action act = () => dictionary.Should().HaveCountLessThanOrEqualTo(1, "we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
-        }
-
-        #endregion
-
-        #region Have Same Count
-
-        [Fact]
-        public void When_dictionary_and_collection_have_the_same_number_elements_it_should_succeed()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_has_a_count_greater_than_less_the_number_of_items()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
-            var collection = new[] { 4, 5, 6 };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act / Assert
-            dictionary.Should().HaveSameCount(collection);
-        }
+                // Act / Assert
+                dictionary.Should().HaveCountGreaterThan(2);
+            }
 
-        [Fact]
-        public void When_dictionary_and_collection_do_not_have_the_same_number_of_elements_it_should_fail()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_fail_when_asserting_dictionary_has_a_count_greater_than_the_number_of_items()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
-            var collection = new[] { 4, 6 };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().HaveSameCount(collection);
+                // Act
+                Action act = () => dictionary.Should().HaveCountGreaterThan(3);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to have 2 item(s), but found 3.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
 
-        [Fact]
-        public void When_comparing_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_has_a_count_greater_than_the_number_of_items_it_should_fail_with_descriptive_message_()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
-            var collection = new[] { 4, 6 };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().HaveSameCount(collection, "we want to test the {0}", "reason");
+                // Act
+                Action action = () => dictionary.Should().HaveCountGreaterThan(3, "because we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to have 2 item(s) because we want to test the reason, but found 3.");
-        }
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected dictionary to contain more than 3 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+            }
 
-        [Fact]
-        public void When_asserting_dictionary_and_collection_have_same_count_against_null_dictionary_it_should_throw()
-        {
-            // Arrange
-            Dictionary<string, int> dictionary = null;
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => dictionary.Should().HaveSameCount(collection,
-                "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_dictionary_and_collection_have_same_count_against_a_null_collection_it_should_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_count_is_greater_than_and_dictionary_is_null_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
-            int[] collection = null;
+                // Arrange
+                Dictionary<int, string> dictionary = null;
 
-            // Act
-            Action act = () => dictionary.Should().HaveSameCount(collection);
+                // Act
+                Action act = () => dictionary.Should().HaveCountGreaterThan(1, "we want to test the behaviour with a null subject");
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot verify count against a <null> collection.*");
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*more than*1*we want to test the behaviour with a null subject*found <null>*");
+            }
         }
 
-        #endregion
-
-        #region Not Have Same Count
-
-        [Fact]
-        public void When_asserting_not_same_count_and_collections_have_different_number_elements_it_should_succeed()
+        public class HaveCountGreaterThanOrEqualTo
         {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_has_a_count_greater_than_or_equal_to_less_the_number_of_items()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
-            var collection = new[] { 4, 6 };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act / Assert
-            dictionary.Should().NotHaveSameCount(collection);
-        }
+                // Act / Assert
+                dictionary.Should().HaveCountGreaterThanOrEqualTo(3);
+            }
 
-        [Fact]
-        public void When_asserting_not_same_count_and_both_collections_have_the_same_number_elements_it_should_fail()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_fail_when_asserting_dictionary_has_a_count_greater_than_or_equal_to_the_number_of_items()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
-            var collection = new[] { 4, 5, 6 };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().NotHaveSameCount(collection);
+                // Act
+                Action act = () => dictionary.Should().HaveCountGreaterThanOrEqualTo(4);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not have 3 item(s), but found 3.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
 
-        [Fact]
-        public void When_comparing_not_same_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_has_a_count_greater_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
-            var collection = new[] { 4, 5, 6 };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().NotHaveSameCount(collection, "we want to test the {0}", "reason");
+                // Act
+                Action action = () => dictionary.Should().HaveCountGreaterThanOrEqualTo(4, "because we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not have 3 item(s) because we want to test the reason, but found 3.");
-        }
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected dictionary to contain at least 4 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+            }
 
-        [Fact]
-        public void When_asserting_dictionary_and_collection_to_not_have_same_count_against_null_dictionary_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-            var collection = new[] { 1, 2, 3 };
-
-            // Act
-            Action act = () => dictionary.Should().NotHaveSameCount(collection,
-                "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_dictionary_and_collection_to_not_have_same_count_against_a_null_collection_it_should_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_count_is_greater_than_or_equal_to_and_dictionary_is_null_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
-            int[] collection = null;
+                // Arrange
+                Dictionary<int, string> dictionary = null;
 
-            // Act
-            Action act = () => dictionary.Should().NotHaveSameCount(collection);
+                // Act
+                Action act = () => dictionary.Should().HaveCountGreaterThanOrEqualTo(1, "we want to test the behaviour with a null subject");
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot verify count against a <null> collection.*");
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
+            }
         }
 
-        [Fact]
-        public void When_asserting_dictionary_and_collection_to_not_have_same_count_but_both_reference_the_same_object_it_should_throw()
+        public class HaveCountLessThan
         {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_has_a_count_less_than_less_the_number_of_items()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
-            var collection = dictionary;
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().NotHaveSameCount(collection,
-                "because we want to test the behaviour with same objects");
+                // Act / Assert
+                dictionary.Should().HaveCountLessThan(4);
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*not have the same count*because we want to test the behaviour with same objects*but they both reference the same object.");
-        }
-
-        #endregion
-
-        #region Be Empty
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_without_items_is_empty()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>();
-
-            // Act / Assert
-            dictionary.Should().BeEmpty();
-        }
-
-        [Fact]
-        public void Should_fail_when_asserting_dictionary_with_items_is_empty()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_fail_when_asserting_dictionary_has_a_count_less_than_the_number_of_items()
             {
-                [1] = "One"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().BeEmpty();
+                // Act
+                Action act = () => dictionary.Should().HaveCountLessThan(3);
 
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
 
-        [Fact]
-        public void Should_fail_with_descriptive_message_when_asserting_dictionary_with_items_is_empty()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_has_a_count_less_than_the_number_of_items_it_should_fail_with_descriptive_message_()
             {
-                [1] = "One"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().BeEmpty("because we want to test the failure {0}", "message");
+                // Act
+                Action action = () => dictionary.Should().HaveCountLessThan(3, "because we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to be empty because we want to test the failure message, but found {[1] = \"One\"}.");
-        }
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected dictionary to contain fewer than 3 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+            }
 
-        [Fact]
-        public void When_asserting_dictionary_with_items_is_not_empty_it_should_succeed()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_count_is_less_than_and_dictionary_is_null_it_should_throw()
             {
-                [1] = "One"
-            };
+                // Arrange
+                Dictionary<int, string> dictionary = null;
 
-            // Act / Assert
-            dictionary.Should().NotBeEmpty();
+                // Act
+                Action act = () => dictionary.Should().HaveCountLessThan(1, "we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*fewer than*1*we want to test the behaviour with a null subject*found <null>*");
+            }
         }
+
+        public class HaveCountLessThanOrEqualTo
+        {
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_has_a_count_less_than_or_equal_to_less_the_number_of_items()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+
+                // Act / Assert
+                dictionary.Should().HaveCountLessThanOrEqualTo(3);
+            }
+
+            [Fact]
+            public void Should_fail_when_asserting_dictionary_has_a_count_less_than_or_equal_to_the_number_of_items()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().HaveCountLessThanOrEqualTo(2);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_dictionary_has_a_count_less_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+
+                // Act
+                Action action = () => dictionary.Should().HaveCountLessThanOrEqualTo(2, "because we want to test the failure {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected dictionary to contain at most 2 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+            }
+
+            [Fact]
+            public void When_dictionary_count_is_less_than_or_equal_to_and_dictionary_is_null_it_should_throw()
+            {
+                // Arrange
+                Dictionary<int, string> dictionary = null;
+
+                // Act
+                Action act = () => dictionary.Should().HaveCountLessThanOrEqualTo(1, "we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
+            }
+        }
+
+        public class HaveSameCount
+        {
+            [Fact]
+            public void When_dictionary_and_collection_have_the_same_number_elements_it_should_succeed()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+                var collection = new[] { 4, 5, 6 };
+
+                // Act / Assert
+                dictionary.Should().HaveSameCount(collection);
+            }
+
+            [Fact]
+            public void When_dictionary_and_collection_do_not_have_the_same_number_of_elements_it_should_fail()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+                var collection = new[] { 4, 6 };
+
+                // Act
+                Action act = () => dictionary.Should().HaveSameCount(collection);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to have 2 item(s), but found 3.");
+            }
+
+            [Fact]
+            public void When_comparing_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+                var collection = new[] { 4, 6 };
+
+                // Act
+                Action act = () => dictionary.Should().HaveSameCount(collection, "we want to test the {0}", "reason");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to have 2 item(s) because we want to test the reason, but found 3.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_and_collection_have_same_count_against_null_dictionary_it_should_throw()
+            {
+                // Arrange
+                Dictionary<string, int> dictionary = null;
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => dictionary.Should().HaveSameCount(collection,
+                    "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_and_collection_have_same_count_against_a_null_collection_it_should_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+                int[] collection = null;
+
+                // Act
+                Action act = () => dictionary.Should().HaveSameCount(collection);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot verify count against a <null> collection.*");
+            }
+        }
+
+        public class NotHaveSameCount
+        {
+            [Fact]
+            public void When_asserting_not_same_count_and_collections_have_different_number_elements_it_should_succeed()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+                var collection = new[] { 4, 6 };
+
+                // Act / Assert
+                dictionary.Should().NotHaveSameCount(collection);
+            }
+
+            [Fact]
+            public void When_asserting_not_same_count_and_both_collections_have_the_same_number_elements_it_should_fail()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+                var collection = new[] { 4, 5, 6 };
+
+                // Act
+                Action act = () => dictionary.Should().NotHaveSameCount(collection);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to not have 3 item(s), but found 3.");
+            }
+
+            [Fact]
+            public void When_comparing_not_same_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+                var collection = new[] { 4, 5, 6 };
+
+                // Act
+                Action act = () => dictionary.Should().NotHaveSameCount(collection, "we want to test the {0}", "reason");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to not have 3 item(s) because we want to test the reason, but found 3.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_and_collection_to_not_have_same_count_against_null_dictionary_it_should_throw()
+            {
+                // Arrange
+                Dictionary<int, string> dictionary = null;
+                var collection = new[] { 1, 2, 3 };
+
+                // Act
+                Action act = () => dictionary.Should().NotHaveSameCount(collection,
+                    "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to not have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_and_collection_to_not_have_same_count_against_a_null_collection_it_should_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+                int[] collection = null;
+
+                // Act
+                Action act = () => dictionary.Should().NotHaveSameCount(collection);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot verify count against a <null> collection.*");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_and_collection_to_not_have_same_count_but_both_reference_the_same_object_it_should_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+                var collection = dictionary;
+
+                // Act
+                Action act = () => dictionary.Should().NotHaveSameCount(collection,
+                    "because we want to test the behaviour with same objects");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*not have the same count*because we want to test the behaviour with same objects*but they both reference the same object.");
+            }
+        }
+
+        public class BeEmpty
+        {
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_without_items_is_empty()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>();
+
+                // Act / Assert
+                dictionary.Should().BeEmpty();
+            }
+
+            [Fact]
+            public void Should_fail_when_asserting_dictionary_with_items_is_empty()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().BeEmpty();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void Should_fail_with_descriptive_message_when_asserting_dictionary_with_items_is_empty()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().BeEmpty("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected dictionary to be empty because we want to test the failure message, but found {[1] = \"One\"}.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_with_items_is_not_empty_it_should_succeed()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One"
+                };
+
+                // Act / Assert
+                dictionary.Should().NotBeEmpty();
+            }
 
 #if !NET5_0_OR_GREATER
 
-        [Fact]
-        public void When_asserting_dictionary_with_items_is_not_empty_it_should_enumerate_the_dictionary_only_once()
-        {
-            // Arrange
-            var trackingDictionary = new TrackingTestDictionary(new KeyValuePair<int, string>(1, "One"));
+            [Fact]
+            public void When_asserting_dictionary_with_items_is_not_empty_it_should_enumerate_the_dictionary_only_once()
+            {
+                // Arrange
+                var trackingDictionary = new TrackingTestDictionary(new KeyValuePair<int, string>(1, "One"));
 
-            // Act
-            trackingDictionary.Should().NotBeEmpty();
+                // Act
+                trackingDictionary.Should().NotBeEmpty();
 
-            // Assert
-            trackingDictionary.Enumerator.LoopCount.Should().Be(1);
-        }
+                // Assert
+                trackingDictionary.Enumerator.LoopCount.Should().Be(1);
+            }
 
 #endif
 
-        [Fact]
-        public void When_asserting_dictionary_without_items_is_not_empty_it_should_fail()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>();
+            [Fact]
+            public void When_asserting_dictionary_without_items_is_not_empty_it_should_fail()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>();
 
-            // Act
-            Action act = () => dictionary.Should().NotBeEmpty();
+                // Act
+                Action act = () => dictionary.Should().NotBeEmpty();
 
-            // Assert
-            act.Should().Throw<XunitException>();
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_without_items_is_not_empty_it_should_fail_with_descriptive_message_()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>();
+
+                // Act
+                Action act = () => dictionary.Should().NotBeEmpty("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected dictionary not to be empty because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_to_be_empty_but_dictionary_is_null_it_should_throw()
+            {
+                // Arrange
+                Dictionary<int, string> dictionary = null;
+
+                // Act
+                Action act = () => dictionary.Should().BeEmpty("because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to be empty because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_to_be_not_empty_but_dictionary_is_null_it_should_throw()
+            {
+                // Arrange
+                Dictionary<int, string> dictionary = null;
+
+                // Act
+                Action act = () => dictionary.Should().NotBeEmpty("because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary not to be empty because we want to test the behaviour with a null subject, but found <null>.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_dictionary_without_items_is_not_empty_it_should_fail_with_descriptive_message_()
+        public class Equal
         {
-            // Arrange
-            var dictionary = new Dictionary<int, string>();
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_is_equal_to_the_same_dictionary()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                var dictionary2 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().NotBeEmpty("because we want to test the failure {0}", "message");
+                // Act / Assert
+                dictionary1.Should().Equal(dictionary2);
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary not to be empty because we want to test the failure message.");
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_with_null_value_is_equal_to_the_same_dictionary()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = null
+                };
+                var dictionary2 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = null
+                };
+
+                // Act / Assert
+                dictionary1.Should().Equal(dictionary2);
+            }
+
+            [Fact]
+            public void When_asserting_dictionaries_to_be_equal_but_subject_dictionary_misses_a_value_it_should_throw()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                var dictionary2 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [22] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary1 to be equal to {[1] = \"One\", [22] = \"Two\"} because we want to test the failure message, but could not find keys {22}.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionaries_to_be_equal_but_subject_dictionary_has_extra_key_it_should_throw()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three"
+                };
+                var dictionary2 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"} because we want to test the failure message, but found additional keys {3}.");
+            }
+
+            [Fact]
+            public void When_two_dictionaries_are_not_equal_by_values_it_should_throw_using_the_reason()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                var dictionary2 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Three"
+                };
+
+                // Act
+                Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Three\"} because we want to test the failure message, but {[1] = \"One\", [2] = \"Two\"} differs at key 2.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionaries_to_be_equal_but_subject_dictionary_is_null_it_should_throw()
+            {
+                // Arrange
+                Dictionary<int, string> dictionary1 = null;
+                var dictionary2 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"} because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionaries_to_be_equal_but_expected_dictionary_is_null_it_should_throw()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                Dictionary<int, string> dictionary2 = null;
+
+                // Act
+                Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithMessage("Cannot compare dictionary with <null>.*")
+                    .WithParameterName("expected");
+            }
+
+            [Fact]
+            public void When_an_empty_dictionary_is_compared_for_equality_to_a_non_empty_dictionary_it_should_throw()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>();
+                var dictionary2 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary1.Should().Equal(dictionary2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"}, but could not find keys {1, 2}.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_dictionary_to_be_empty_but_dictionary_is_null_it_should_throw()
+        public class NotEqual
         {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_is_not_equal_to_a_dictionary_with_different_key()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                var dictionary2 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [22] = "Two"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().BeEmpty("because we want to test the behaviour with a null subject");
+                // Act / Assert
+                dictionary1.Should().NotEqual(dictionary2);
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to be empty because we want to test the behaviour with a null subject, but found <null>.");
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_is_not_equal_to_a_dictionary_with_different_value()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = null
+                };
+                var dictionary2 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act / Assert
+                dictionary1.Should().NotEqual(dictionary2);
+            }
+
+            [Fact]
+            public void When_two_equal_dictionaries_are_not_expected_to_be_equal_it_should_throw()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                var dictionary2 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary1.Should().NotEqual(dictionary2);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect dictionaries {[1] = \"One\", [2] = \"Two\"} and {[1] = \"One\", [2] = \"Two\"} to be equal.");
+            }
+
+            [Fact]
+            public void When_two_equal_dictionaries_are_not_expected_to_be_equal_it_should_report_a_clear_explanation()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                var dictionary2 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect dictionaries {[1] = \"One\", [2] = \"Two\"} and {[1] = \"One\", [2] = \"Two\"} to be equal because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionaries_not_to_be_equal_subject_but_dictionary_is_null_it_should_throw()
+            {
+                // Arrange
+                Dictionary<int, string> dictionary1 = null;
+                var dictionary2 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act =
+                    () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionaries not to be equal because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionaries_not_to_be_equal_but_expected_dictionary_is_null_it_should_throw()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                Dictionary<int, string> dictionary2 = null;
+
+                // Act
+                Action act =
+                    () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithMessage("Cannot compare dictionary with <null>.*")
+                    .WithParameterName("unexpected");
+            }
+
+            [Fact]
+            public void When_asserting_dictionaries_not_to_be_equal_subject_but_both_dictionaries_reference_the_same_object_it_should_throw()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                var dictionary2 = dictionary1;
+
+                // Act
+                Action act =
+                    () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the behaviour with same objects");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionaries not to be equal because we want to test the behaviour with same objects, but they both reference the same object.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_dictionary_to_be_not_empty_but_dictionary_is_null_it_should_throw()
+        public class ContainKey
         {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_contains_a_key_from_the_dictionary()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().NotBeEmpty("because we want to test the behaviour with a null subject");
+                // Act / Assert
+                dictionary.Should().ContainKey(1);
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary not to be empty because we want to test the behaviour with a null subject, but found <null>.");
+            [Fact]
+            public void When_a_dictionary_has_custom_equality_comparer_the_contains_key_assertion_should_work_accordingly()
+            {
+                // Arrange
+                var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["One"] = "One",
+                    ["Two"] = "Two"
+                };
+
+                // Act
+
+                // Assert
+                dictionary.Should().ContainKey("One");
+                dictionary.Should().ContainKey("ONE");
+                dictionary.Should().ContainKey("one");
+            }
+
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_contains_multiple_keys_from_the_dictionary()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act / Assert
+                dictionary.Should().ContainKeys(2, 1);
+            }
+
+            [Fact]
+            public void When_a_dictionary_does_not_contain_single_key_it_should_throw_with_clear_explanation()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().ContainKey(3, "because {0}", "we do");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key 3 because we do.");
+            }
+
+            [Fact]
+            public void When_the_requested_key_exists_it_should_allow_continuation_with_the_value()
+            {
+                // Arrange
+                var dictionary = new Dictionary<string, MyClass>
+                {
+                    ["Key"] = new MyClass { SomeProperty = 3 }
+                };
+
+                // Act
+                Action act = () => dictionary.Should().ContainKey("Key").WhoseValue.Should().Be(4);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected*4*3*.");
+            }
+
+            [Fact]
+            public void When_a_dictionary_does_not_contain_a_list_of_keys_it_should_throw_with_clear_explanation()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().ContainKeys(new[] { 2, 3 }, "because {0}", "we do");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key {2, 3} because we do, but could not find {3}.");
+            }
+
+            [Fact]
+            public void When_the_contents_of_a_dictionary_are_checked_against_an_empty_list_of_keys_it_should_throw_clear_explanation()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().ContainKeys(new int[0]);
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage(
+                    "Cannot verify key containment against an empty sequence*");
+            }
         }
 
-        #endregion
-
-        #region Equal
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_is_equal_to_the_same_dictionary()
+        public class NotContainKey
         {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_does_not_contain_a_key_that_is_not_in_the_dictionary_it_should_not_throw()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
-            var dictionary2 = new Dictionary<int, string>
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().NotContainKey(4);
+
+                // Assert
+                act.Should().NotThrow<XunitException>();
+            }
+
+            [Fact]
+            public void When_dictionary_does_not_contain_multiple_keys_from_the_dictionary_it_should_not_throw()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act / Assert
-            dictionary1.Should().Equal(dictionary2);
-        }
+                // Act
+                Action act = () => dictionary.Should().NotContainKeys(3, 4);
 
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_with_null_value_is_equal_to_the_same_dictionary()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
+                // Assert
+                act.Should().NotThrow<XunitException>();
+            }
+
+            [Fact]
+            public void When_dictionary_contains_an_unexpected_key_it_should_throw()
             {
-                [1] = "One",
-                [2] = null
-            };
-            var dictionary2 = new Dictionary<int, string>
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().NotContainKey(1, "because we {0} like it", "don't");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary {[1] = \"One\", [2] = \"Two\"} not to contain key 1 because we don't like it, but found it anyhow.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_does_not_contain_key_against_null_dictionary_it_should_throw()
             {
-                [1] = "One",
-                [2] = null
-            };
+                // Arrange
+                Dictionary<int, string> dictionary = null;
 
-            // Act / Assert
-            dictionary1.Should().Equal(dictionary2);
-        }
+                // Act
+                Action act = () => dictionary.Should()
+                    .NotContainKey(1, "because we want to test the behaviour with a null subject");
 
-        [Fact]
-        public void When_asserting_dictionaries_to_be_equal_but_subject_dictionary_misses_a_value_it_should_throw()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary not to contain key 1 because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_a_dictionary_contains_a_list_of_keys_it_should_throw_with_clear_explanation()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
-            var dictionary2 = new Dictionary<int, string>
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().NotContainKeys(new[] { 2, 3 }, "because {0}", "we do");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain key {2, 3} because we do, but found {2}.");
+            }
+
+            [Fact]
+            public void When_a_dictionary_contains_exactly_one_of_the_keys_it_should_throw_with_clear_explanation()
             {
-                [1] = "One",
-                [22] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act
-            Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the failure {0}", "message");
+                // Act
+                Action act = () => dictionary.Should().NotContainKeys(new[] { 2 }, "because {0}", "we do");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1] = \"One\", [22] = \"Two\"} because we want to test the failure message, but could not find keys {22}.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain key 2 because we do.");
+            }
 
-        [Fact]
-        public void When_asserting_dictionaries_to_be_equal_but_subject_dictionary_has_extra_key_it_should_throw()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
+            [Fact]
+            public void When_the_noncontents_of_a_dictionary_are_checked_against_an_empty_list_of_keys_it_should_throw_clear_explanation()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three"
-            };
-            var dictionary2 = new Dictionary<int, string>
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().NotContainKeys(new int[0]);
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage(
+                    "Cannot verify key containment against an empty sequence*");
+            }
+
+            [Fact]
+            public void When_a_dictionary_checks_a_list_of_keys_not_to_be_present_it_will_honor_the_case_sensitive_equality_comparer_of_the_dictionary()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["ONE"] = "One",
+                    ["TWO"] = "Two"
+                };
 
-            // Act
-            Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the failure {0}", "message");
+                // Act
+                Action act = () => dictionary.Should().NotContainKeys(new[] { "One", "Two" });
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"} because we want to test the failure message, but found additional keys {3}.");
-        }
+                // Assert
+                act.Should().NotThrow<XunitException>();
+            }
 
-        [Fact]
-        public void When_two_dictionaries_are_not_equal_by_values_it_should_throw_using_the_reason()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
+            [Fact]
+            public void When_a_dictionary_checks_a_list_of_keys_not_to_be_present_it_will_honor_the_case_insensitive_equality_comparer_of_the_dictionary()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
-            var dictionary2 = new Dictionary<int, string>
+                // Arrange
+                var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["ONE"] = "One",
+                    ["TWO"] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().NotContainKeys(new[] { "One", "Two" });
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_an_assertion_fails_on_ContainKey_succeeding_message_should_be_included()
             {
-                [1] = "One",
-                [2] = "Three"
-            };
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    var values = new Dictionary<int, int>();
+                    values.Should().ContainKey(0);
+                    values.Should().ContainKey(1);
+                };
 
-            // Act
-            Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Three\"} because we want to test the failure message, but {[1] = \"One\", [2] = \"Two\"} differs at key 2.");
-        }
-
-        [Fact]
-        public void When_asserting_dictionaries_to_be_equal_but_subject_dictionary_is_null_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary1 = null;
-            var dictionary2 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"} because we want to test the behaviour with a null subject, but found <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_dictionaries_to_be_equal_but_expected_dictionary_is_null_it_should_throw()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-            Dictionary<int, string> dictionary2 = null;
-
-            // Act
-            Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithMessage("Cannot compare dictionary with <null>.*")
-                .WithParameterName("expected");
-        }
-
-        [Fact]
-        public void When_an_empty_dictionary_is_compared_for_equality_to_a_non_empty_dictionary_it_should_throw()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>();
-            var dictionary2 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary1.Should().Equal(dictionary2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"}, but could not find keys {1, 2}.");
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_is_not_equal_to_a_dictionary_with_different_key()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-            var dictionary2 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [22] = "Two"
-            };
-
-            // Act / Assert
-            dictionary1.Should().NotEqual(dictionary2);
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_is_not_equal_to_a_dictionary_with_different_value()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = null
-            };
-            var dictionary2 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act / Assert
-            dictionary1.Should().NotEqual(dictionary2);
-        }
-
-        [Fact]
-        public void When_two_equal_dictionaries_are_not_expected_to_be_equal_it_should_throw()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-            var dictionary2 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary1.Should().NotEqual(dictionary2);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect dictionaries {[1] = \"One\", [2] = \"Two\"} and {[1] = \"One\", [2] = \"Two\"} to be equal.");
-        }
-
-        [Fact]
-        public void When_two_equal_dictionaries_are_not_expected_to_be_equal_it_should_report_a_clear_explanation()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-            var dictionary2 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect dictionaries {[1] = \"One\", [2] = \"Two\"} and {[1] = \"One\", [2] = \"Two\"} to be equal because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void When_asserting_dictionaries_not_to_be_equal_subject_but_dictionary_is_null_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary1 = null;
-            var dictionary2 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act =
-                () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionaries not to be equal because we want to test the behaviour with a null subject, but found <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_dictionaries_not_to_be_equal_but_expected_dictionary_is_null_it_should_throw()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-            Dictionary<int, string> dictionary2 = null;
-
-            // Act
-            Action act =
-                () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithMessage("Cannot compare dictionary with <null>.*")
-                .WithParameterName("unexpected");
-        }
-
-        [Fact]
-        public void When_asserting_dictionaries_not_to_be_equal_subject_but_both_dictionaries_reference_the_same_object_it_should_throw()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-            var dictionary2 = dictionary1;
-
-            // Act
-            Action act =
-                () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the behaviour with same objects");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionaries not to be equal because we want to test the behaviour with same objects, but they both reference the same object.");
-        }
-
-        #endregion
-
-        #region ContainKey
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_contains_a_key_from_the_dictionary()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act / Assert
-            dictionary.Should().ContainKey(1);
-        }
-
-        [Fact]
-        public void When_a_dictionary_has_custom_equality_comparer_the_contains_key_assertion_should_work_accordingly()
-        {
-            // Arrange
-            var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["One"] = "One",
-                ["Two"] = "Two"
-            };
-
-            // Act
-
-            // Assert
-            dictionary.Should().ContainKey("One");
-            dictionary.Should().ContainKey("ONE");
-            dictionary.Should().ContainKey("one");
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_contains_multiple_keys_from_the_dictionary()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act / Assert
-            dictionary.Should().ContainKeys(2, 1);
-        }
-
-        [Fact]
-        public void When_a_dictionary_does_not_contain_single_key_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().ContainKey(3, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key 3 because we do.");
-        }
-
-        [Fact]
-        public void When_the_requested_key_exists_it_should_allow_continuation_with_the_value()
-        {
-            // Arrange
-            var dictionary = new Dictionary<string, MyClass>
-            {
-                ["Key"] = new MyClass { SomeProperty = 3 }
-            };
-
-            // Act
-            Action act = () => dictionary.Should().ContainKey("Key").WhoseValue.Should().Be(4);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*4*3*.");
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*to contain key 0*Expected*to contain key 1*");
+            }
         }
 
         public class MyClass
@@ -1381,1339 +1584,1135 @@ namespace FluentAssertions.Specs.Collections
             }
         }
 
-        [Fact]
-        public void When_a_dictionary_does_not_contain_a_list_of_keys_it_should_throw_with_clear_explanation()
+        public class ContainValue
         {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_contains_expected_value_it_should_succeed()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().ContainKeys(new[] { 2, 3 }, "because {0}", "we do");
+                // Act
+                Action act = () => dictionary.Should().ContainValue("One");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key {2, 3} because we do, but could not find {3}.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_dictionary_contains_expected_null_value_it_should_succeed()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = null
+                };
+
+                // Act
+                Action act = () => dictionary.Should().ContainValue(null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_the_specified_value_exists_it_should_allow_continuation_using_that_value()
+            {
+                // Arrange
+                var myClass = new MyClass()
+                {
+                    SomeProperty = 0
+                };
+
+                var dictionary = new Dictionary<int, MyClass>
+                {
+                    [1] = myClass
+                };
+
+                // Act
+                Action act = () => dictionary.Should().ContainValue(myClass).Which.SomeProperty.Should().BeGreaterThan(0);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected*greater*0*0*");
+            }
+
+            [Fact]
+            public void When_multiple_matches_for_the_specified_value_exist_continuation_using_the_matched_value_should_fail()
+            {
+                // Arrange
+                var myClass = new MyClass { SomeProperty = 0 };
+
+                var dictionary = new Dictionary<int, MyClass>
+                {
+                    [1] = myClass,
+                    [2] = new MyClass { SomeProperty = 0 }
+                };
+
+                // Act
+                Action act =
+                    () =>
+                        dictionary.Should()
+                            .ContainValue(new MyClass { SomeProperty = 0 })
+                            .Which.Should()
+                            .BeSameAs(myClass);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_dictionary_contains_multiple_values_from_the_dictionary_it_should_not_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().ContainValues("Two", "One");
+
+                // Assert
+                act.Should().NotThrow<XunitException>();
+            }
+
+            [Fact]
+            public void When_a_dictionary_does_not_contain_single_value_it_should_throw_with_clear_explanation()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().ContainValue("Three", "because {0}", "we do");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain value \"Three\" because we do.");
+            }
+
+            [Fact]
+            public void When_a_dictionary_does_not_contain_a_number_of_values_it_should_throw_with_clear_explanation()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().ContainValues(new[] { "Two", "Three" }, "because {0}", "we do");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain value {\"Two\", \"Three\"} because we do, but could not find {\"Three\"}.");
+            }
+
+            [Fact]
+            public void When_the_contents_of_a_dictionary_are_checked_against_an_empty_list_of_values_it_should_throw_clear_explanation()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().ContainValues(new string[0]);
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage(
+                    "Cannot verify value containment with an empty sequence*");
+            }
         }
 
-        [Fact]
-        public void When_the_contents_of_a_dictionary_are_checked_against_an_empty_list_of_keys_it_should_throw_clear_explanation()
+        public class NotContainValue
         {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_does_not_contain_a_value_that_is_not_in_the_dictionary_it_should_not_throw()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().ContainKeys(new int[0]);
+                // Act
+                Action act = () => dictionary.Should().NotContainValue("Three");
 
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify key containment against an empty sequence*");
+                // Assert
+                act.Should().NotThrow<XunitException>();
+            }
+
+            [Fact]
+            public void When_dictionary_contains_an_unexpected_value_it_should_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().NotContainValue("One", "because we {0} like it", "don't");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary {[1] = \"One\", [2] = \"Two\"} not to contain value \"One\" because we don't like it, but found it anyhow.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_does_not_contain_value_against_null_dictionary_it_should_throw()
+            {
+                // Arrange
+                Dictionary<int, string> dictionary = null;
+
+                // Act
+                Action act = () => dictionary.Should()
+                    .NotContainValue("One", "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary not to contain value \"One\" because we want to test the behaviour with a null subject, but found <null>.");
+            }
+
+            [Fact]
+            public void When_dictionary_does_not_contain_multiple_values_that_is_not_in_the_dictionary_it_should_not_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().NotContainValues("Three", "Four");
+
+                // Assert
+                act.Should().NotThrow<XunitException>();
+            }
+
+            [Fact]
+            public void When_a_dictionary_contains_a_exactly_one_of_the_values_it_should_throw_with_clear_explanation()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().NotContainValues(new[] { "Two" }, "because {0}", "we do");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain value \"Two\" because we do.");
+            }
+
+            [Fact]
+            public void When_a_dictionary_contains_a_number_of_values_it_should_throw_with_clear_explanation()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().NotContainValues(new[] { "Two", "Three" }, "because {0}", "we do");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain value {\"Two\", \"Three\"} because we do, but found {\"Two\"}.");
+            }
+
+            [Fact]
+            public void When_the_noncontents_of_a_dictionary_are_checked_against_an_empty_list_of_values_it_should_throw_clear_explanation()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().NotContainValues(new string[0]);
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage(
+                    "Cannot verify value containment with an empty sequence*");
+            }
         }
 
-        [Fact]
-        public void When_dictionary_does_not_contain_a_key_that_is_not_in_the_dictionary_it_should_not_throw()
+        public class Contain
         {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_contains_single_key_value_pair()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainKey(4);
-
-            // Assert
-            act.Should().NotThrow<XunitException>();
-        }
-
-        [Fact]
-        public void When_dictionary_does_not_contain_multiple_keys_from_the_dictionary_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainKeys(3, 4);
-
-            // Assert
-            act.Should().NotThrow<XunitException>();
-        }
-
-        [Fact]
-        public void When_dictionary_contains_an_unexpected_key_it_should_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainKey(1, "because we {0} like it", "don't");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} not to contain key 1 because we don't like it, but found it anyhow.");
-        }
-
-        [Fact]
-        public void When_asserting_dictionary_does_not_contain_key_against_null_dictionary_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-
-            // Act
-            Action act = () => dictionary.Should()
-                .NotContainKey(1, "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary not to contain key 1 because we want to test the behaviour with a null subject, but found <null>.");
-        }
-
-        [Fact]
-        public void When_a_dictionary_contains_a_list_of_keys_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainKeys(new[] { 2, 3 }, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain key {2, 3} because we do, but found {2}.");
-        }
-
-        [Fact]
-        public void When_a_dictionary_contains_exactly_one_of_the_keys_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainKeys(new[] { 2 }, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain key 2 because we do.");
-        }
-
-        [Fact]
-        public void When_the_noncontents_of_a_dictionary_are_checked_against_an_empty_list_of_keys_it_should_throw_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainKeys(new int[0]);
-
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify key containment against an empty sequence*");
-        }
-
-        [Fact]
-        public void When_a_dictionary_checks_a_list_of_keys_not_to_be_present_it_will_honor_the_case_sensitive_equality_comparer_of_the_dictionary()
-        {
-            // Arrange
-            var dictionary = new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["ONE"] = "One",
-                ["TWO"] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainKeys(new[] { "One", "Two" });
-
-            // Assert
-            act.Should().NotThrow<XunitException>();
-        }
-
-        [Fact]
-        public void When_a_dictionary_checks_a_list_of_keys_not_to_be_present_it_will_honor_the_case_insensitive_equality_comparer_of_the_dictionary()
-        {
-            // Arrange
-            var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["ONE"] = "One",
-                ["TWO"] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainKeys(new[] { "One", "Two" });
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_an_assertion_fails_on_ContainKey_succeeding_message_should_be_included()
-        {
-            // Act
-            Action act = () =>
-            {
-                using var _ = new AssertionScope();
-                var values = new Dictionary<int, int>();
-                values.Should().ContainKey(0);
-                values.Should().ContainKey(1);
-            };
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*to contain key 0*Expected*to contain key 1*");
-        }
-
-        #endregion
-
-        #region ContainValue
-
-        [Fact]
-        public void When_dictionary_contains_expected_value_it_should_succeed()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().ContainValue("One");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_dictionary_contains_expected_null_value_it_should_succeed()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = null
-            };
-
-            // Act
-            Action act = () => dictionary.Should().ContainValue(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_the_specified_value_exists_it_should_allow_continuation_using_that_value()
-        {
-            // Arrange
-            var myClass = new MyClass()
-            {
-                SomeProperty = 0
-            };
-
-            var dictionary = new Dictionary<int, MyClass>
-            {
-                [1] = myClass
-            };
-
-            // Act
-            Action act = () => dictionary.Should().ContainValue(myClass).Which.SomeProperty.Should().BeGreaterThan(0);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*greater*0*0*");
-        }
-
-        [Fact]
-        public void When_multiple_matches_for_the_specified_value_exist_continuation_using_the_matched_value_should_fail()
-        {
-            // Arrange
-            var myClass = new MyClass { SomeProperty = 0 };
-
-            var dictionary = new Dictionary<int, MyClass>
-            {
-                [1] = myClass,
-                [2] = new MyClass { SomeProperty = 0 }
-            };
-
-            // Act
-            Action act =
-                () =>
-                    dictionary.Should()
-                        .ContainValue(new MyClass { SomeProperty = 0 })
-                        .Which.Should()
-                        .BeSameAs(myClass);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_dictionary_contains_multiple_values_from_the_dictionary_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().ContainValues("Two", "One");
-
-            // Assert
-            act.Should().NotThrow<XunitException>();
-        }
-
-        [Fact]
-        public void When_a_dictionary_does_not_contain_single_value_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().ContainValue("Three", "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain value \"Three\" because we do.");
-        }
-
-        [Fact]
-        public void When_a_dictionary_does_not_contain_a_number_of_values_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().ContainValues(new[] { "Two", "Three" }, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain value {\"Two\", \"Three\"} because we do, but could not find {\"Three\"}.");
-        }
-
-        [Fact]
-        public void When_the_contents_of_a_dictionary_are_checked_against_an_empty_list_of_values_it_should_throw_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().ContainValues(new string[0]);
-
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify value containment with an empty sequence*");
-        }
-
-        [Fact]
-        public void When_dictionary_does_not_contain_a_value_that_is_not_in_the_dictionary_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainValue("Three");
-
-            // Assert
-            act.Should().NotThrow<XunitException>();
-        }
-
-        [Fact]
-        public void When_dictionary_contains_an_unexpected_value_it_should_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainValue("One", "because we {0} like it", "don't");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} not to contain value \"One\" because we don't like it, but found it anyhow.");
-        }
-
-        [Fact]
-        public void When_asserting_dictionary_does_not_contain_value_against_null_dictionary_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-
-            // Act
-            Action act = () => dictionary.Should()
-                .NotContainValue("One", "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary not to contain value \"One\" because we want to test the behaviour with a null subject, but found <null>.");
-        }
-
-        [Fact]
-        public void When_dictionary_does_not_contain_multiple_values_that_is_not_in_the_dictionary_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainValues("Three", "Four");
-
-            // Assert
-            act.Should().NotThrow<XunitException>();
-        }
-
-        [Fact]
-        public void When_a_dictionary_contains_a_exactly_one_of_the_values_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainValues(new[] { "Two" }, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain value \"Two\" because we do.");
-        }
-
-        [Fact]
-        public void When_a_dictionary_contains_a_number_of_values_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainValues(new[] { "Two", "Three" }, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain value {\"Two\", \"Three\"} because we do, but found {\"Two\"}.");
-        }
-
-        [Fact]
-        public void When_the_noncontents_of_a_dictionary_are_checked_against_an_empty_list_of_values_it_should_throw_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContainValues(new string[0]);
-
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify value containment with an empty sequence*");
-        }
-
-        #endregion
-
-        #region Contain
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_contains_single_key_value_pair()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                var keyValuePairs = new List<KeyValuePair<int, string>>()
             {
                 new KeyValuePair<int, string>(1, "One")
             };
 
-            // Act / Assert
-            dictionary.Should().Contain(keyValuePairs);
-        }
+                // Act / Assert
+                dictionary.Should().Contain(keyValuePairs);
+            }
 
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_contains_multiple_key_value_pair()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_contains_multiple_key_value_pair()
             {
-                [1] = "One",
-                [2] = "Two",
-                [3] = "Three",
-                [4] = "Four"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two",
+                    [3] = "Three",
+                    [4] = "Four"
+                };
 
-            var expectedKeyValuePair1 = new KeyValuePair<int, string>(2, "Two");
-            var expectedKeyValuePair2 = new KeyValuePair<int, string>(3, "Three");
+                var expectedKeyValuePair1 = new KeyValuePair<int, string>(2, "Two");
+                var expectedKeyValuePair2 = new KeyValuePair<int, string>(3, "Three");
 
-            // Act / Assert
-            dictionary.Should().Contain(expectedKeyValuePair1, expectedKeyValuePair2);
-        }
+                // Act / Assert
+                dictionary.Should().Contain(expectedKeyValuePair1, expectedKeyValuePair2);
+            }
 
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_does_not_contain_single_key_value_pair()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_contains_multiple_key_value_pairs()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-            {
-                new KeyValuePair<int, string>(3, "Three")
-            };
-
-            // Act / Assert
-            dictionary.Should().NotContain(keyValuePairs);
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_key_value_pair()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            var unexpectedKeyValuePair1 = new KeyValuePair<int, string>(3, "Three");
-            var unexpectedKeyValuePair2 = new KeyValuePair<int, string>(4, "Four");
-
-            // Act / Assert
-            dictionary.Should().NotContain(unexpectedKeyValuePair1, unexpectedKeyValuePair2);
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_does_not_contain_single_key_value_pair_with_existing_key_but_different_value()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-            {
-                new KeyValuePair<int, string>(1, "Two")
-            };
-
-            // Act / Assert
-            dictionary.Should().NotContain(keyValuePairs);
-        }
-
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_contains_multiple_key_value_pairs()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
+                var keyValuePairs = new List<KeyValuePair<int, string>>()
             {
                 new KeyValuePair<int, string>(1, "One"),
                 new KeyValuePair<int, string>(2, "Two")
             };
 
-            // Act / Assert
-            dictionary.Should().Contain(keyValuePairs);
-        }
+                // Act / Assert
+                dictionary.Should().Contain(keyValuePairs);
+            }
 
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_key_value_pairs()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_a_dictionary_does_not_contain_single_value_for_key_value_pairs_it_should_throw_with_clear_explanation()
             {
-                [1] = "One",
-                [2] = "Two"
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(2, "Three")
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
+                // Act
+                Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to contain value \"Three\" at key 2 because we do, but found \"Two\".");
+            }
+
+            [Fact]
+            public void When_a_dictionary_does_not_contain_multiple_values_for_key_value_pairs_it_should_throw_with_clear_explanation()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "Two"),
+                new KeyValuePair<int, string>(2, "Three")
+            };
+
+                // Act
+                Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to contain {[1, Two], [2, Three]} because we do, but dictionary differs at keys {1, 2}.");
+            }
+
+            [Fact]
+            public void When_a_dictionary_does_not_contain_single_key_for_key_value_pairs_it_should_throw_with_clear_explanation()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(3, "Three")
+            };
+
+                // Act
+                Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key 3 because we do.");
+            }
+
+            [Fact]
+            public void When_a_dictionary_does_not_contain_multiple_keys_for_key_value_pairs_it_should_throw_with_clear_explanation()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(3, "Three"),
+                new KeyValuePair<int, string>(4, "Four")
+            };
+
+                // Act
+                Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key(s) {1, 3, 4} because we do, but could not find keys {3, 4}.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_contains_key_value_pairs_against_null_dictionary_it_should_throw()
+            {
+                // Arrange
+                Dictionary<int, string> dictionary = null;
+                List<KeyValuePair<int, string>> keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(1, "Two")
+            };
+
+                // Act
+                Action act = () => dictionary.Should().Contain(keyValuePairs,
+                    "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to contain key/value pairs {[1, One], [1, Two]} because we want to test the behaviour with a null subject, but dictionary is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_contains_key_value_pairs_but_expected_key_value_pairs_are_empty_it_should_throw()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                List<KeyValuePair<int, string>> keyValuePairs = new List<KeyValuePair<int, string>>();
+
+                // Act
+                Action act = () => dictionary1.Should().Contain(keyValuePairs, "because we want to test the behaviour with an empty set of key/value pairs");
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage(
+                    "Cannot verify key containment against an empty collection of key/value pairs*");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_contains_key_value_pairs_but_expected_key_value_pairs_are_null_it_should_throw()
+            {
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                List<KeyValuePair<int, string>> keyValuePairs = null;
+
+                // Act
+                Action act = () => dictionary1.Should().Contain(keyValuePairs, "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithMessage("Cannot compare dictionary with <null>.*")
+                    .WithParameterName("expected");
+            }
+
+            [Fact]
+            public void When_dictionary_contains_expected_value_at_specific_key_it_should_not_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act / Assert
+                dictionary.Should().Contain(1, "One");
+            }
+
+            [Fact]
+            public void When_dictionary_contains_expected_null_at_specific_key_it_should_not_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = null
+                };
+
+                // Act / Assert
+                dictionary.Should().Contain(1, null);
+            }
+
+            [Fact]
+            public void When_dictionary_contains_expected_key_value_pairs_it_should_not_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act / Assert
+                var items = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(2, "Two")
+            };
+                dictionary.Should().Contain(items);
+            }
+
+            [Fact]
+            public void When_dictionary_contains_expected_key_value_pair_it_should_not_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act / Assert
+                var item = new KeyValuePair<int, string>(1, "One");
+                dictionary.Should().Contain(item);
+            }
+
+            [Fact]
+            public void When_dictionary_does_not_contain_the_expected_value_at_specific_key_it_should_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                var item = new KeyValuePair<int, string>(1, "Two");
+                Action act = () => dictionary.Should().Contain(item, "we put it {0}", "there");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to contain value \"Two\" at key 1 because we put it there, but found \"One\".");
+            }
+
+            [Fact]
+            public void When_dictionary_does_not_contain_the_key_value_pairs_it_should_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                var items = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "Two"),
+                new KeyValuePair<int, string>(2, "Three")
+            };
+
+                // Act
+                Action act = () => dictionary.Should().Contain(items, "we put them {0}", "there");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to contain {[1, Two], [2, Three]} because we put them there, but dictionary differs at keys {1, 2}.");
+            }
+
+            [Fact]
+            public void When_dictionary_does_not_contain_the_key_value_pair_it_should_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().Contain(1, "Two", "we put it {0}", "there");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to contain value \"Two\" at key 1 because we put it there, but found \"One\".");
+            }
+
+            [Fact]
+            public void When_dictionary_does_not_contain_an_value_at_the_specific_key_it_should_throw()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                // Act
+                Action act = () => dictionary.Should().Contain(3, "Two", "we put it {0}", "there");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to contain value \"Two\" at key 3 because we put it there, but the key was not found.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_contains_value_at_specific_key_against_null_dictionary_it_should_throw()
+            {
+                // Arrange
+                Dictionary<int, string> dictionary = null;
+
+                // Act
+                Action act = () => dictionary.Should().Contain(1, "One",
+                    "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to contain value \"One\" at key 1 because we want to test the behaviour with a null subject, but dictionary is <null>.");
+            }
+
+            [Fact]
+            public void When_a_dictionary_like_collection_contains_the_default_key_it_should_succeed()
+            {
+                // Arrange
+                var subject = new List<KeyValuePair<int, int>>() { new(0, 0) };
+
+                // Act
+                Action act = () => subject.Should().Contain(0, 0);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+        }
+
+        public class NotContain
+        {
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_does_not_contain_single_key_value_pair()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(3, "Three")
+            };
+
+                // Act / Assert
+                dictionary.Should().NotContain(keyValuePairs);
+            }
+
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_key_value_pair()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                var unexpectedKeyValuePair1 = new KeyValuePair<int, string>(3, "Three");
+                var unexpectedKeyValuePair2 = new KeyValuePair<int, string>(4, "Four");
+
+                // Act / Assert
+                dictionary.Should().NotContain(unexpectedKeyValuePair1, unexpectedKeyValuePair2);
+            }
+
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_does_not_contain_single_key_value_pair_with_existing_key_but_different_value()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "Two")
+            };
+
+                // Act / Assert
+                dictionary.Should().NotContain(keyValuePairs);
+            }
+
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_key_value_pairs()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+
+                var keyValuePairs = new List<KeyValuePair<int, string>>()
             {
                 new KeyValuePair<int, string>(3, "Three"),
                 new KeyValuePair<int, string>(4, "Four")
             };
 
-            // Act / Assert
-            dictionary.Should().NotContain(keyValuePairs);
-        }
+                // Act / Assert
+                dictionary.Should().NotContain(keyValuePairs);
+            }
 
-        [Fact]
-        public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_key_value_pairs_with_existing_keys_but_different_values()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_key_value_pairs_with_existing_keys_but_different_values()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
+                var keyValuePairs = new List<KeyValuePair<int, string>>()
             {
                 new KeyValuePair<int, string>(1, "Three"),
                 new KeyValuePair<int, string>(2, "Four")
             };
 
-            // Act / Assert
-            dictionary.Should().NotContain(keyValuePairs);
-        }
+                // Act / Assert
+                dictionary.Should().NotContain(keyValuePairs);
+            }
 
-        [Fact]
-        public void When_a_dictionary_does_not_contain_single_value_for_key_value_pairs_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_a_dictionary_does_contain_single_key_value_pair_it_should_throw_with_clear_explanation()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-            {
-                new KeyValuePair<int, string>(1, "One"),
-                new KeyValuePair<int, string>(2, "Three")
-            };
-
-            // Act
-            Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain value \"Three\" at key 2 because we do, but found \"Two\".");
-        }
-
-        [Fact]
-        public void When_a_dictionary_does_not_contain_multiple_values_for_key_value_pairs_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-            {
-                new KeyValuePair<int, string>(1, "Two"),
-                new KeyValuePair<int, string>(2, "Three")
-            };
-
-            // Act
-            Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain {[1, Two], [2, Three]} because we do, but dictionary differs at keys {1, 2}.");
-        }
-
-        [Fact]
-        public void When_a_dictionary_does_not_contain_single_key_for_key_value_pairs_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-            {
-                new KeyValuePair<int, string>(3, "Three")
-            };
-
-            // Act
-            Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key 3 because we do.");
-        }
-
-        [Fact]
-        public void When_a_dictionary_does_not_contain_multiple_keys_for_key_value_pairs_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-            {
-                new KeyValuePair<int, string>(1, "One"),
-                new KeyValuePair<int, string>(3, "Three"),
-                new KeyValuePair<int, string>(4, "Four")
-            };
-
-            // Act
-            Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key(s) {1, 3, 4} because we do, but could not find keys {3, 4}.");
-        }
-
-        [Fact]
-        public void When_a_dictionary_does_contain_single_key_value_pair_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
+                var keyValuePairs = new List<KeyValuePair<int, string>>()
             {
                 new KeyValuePair<int, string>(1, "One")
             };
 
-            // Act
-            Action act = () => dictionary.Should().NotContain(keyValuePairs, "because {0}", "we do");
+                // Act
+                Action act = () => dictionary.Should().NotContain(keyValuePairs, "because {0}", "we do");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not contain value \"One\" at key 1 because we do, but found it anyhow.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to not contain value \"One\" at key 1 because we do, but found it anyhow.");
+            }
 
-        [Fact]
-        public void When_a_dictionary_does_contain_multiple_key_value_pairs_it_should_throw_with_clear_explanation()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_a_dictionary_does_contain_multiple_key_value_pairs_it_should_throw_with_clear_explanation()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-            {
-                new KeyValuePair<int, string>(1, "One"),
-                new KeyValuePair<int, string>(2, "Two")
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContain(keyValuePairs, "because {0}", "we do");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not contain key/value pairs {[1, One], [2, Two]} because we do, but found them anyhow.");
-        }
-
-        [Fact]
-        public void When_asserting_dictionary_contains_key_value_pairs_against_null_dictionary_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-            List<KeyValuePair<int, string>> keyValuePairs = new List<KeyValuePair<int, string>>()
-            {
-                new KeyValuePair<int, string>(1, "One"),
-                new KeyValuePair<int, string>(1, "Two")
-            };
-
-            // Act
-            Action act = () => dictionary.Should().Contain(keyValuePairs,
-                "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain key/value pairs {[1, One], [1, Two]} because we want to test the behaviour with a null subject, but dictionary is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_dictionary_contains_key_value_pairs_but_expected_key_value_pairs_are_empty_it_should_throw()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-            List<KeyValuePair<int, string>> keyValuePairs = new List<KeyValuePair<int, string>>();
-
-            // Act
-            Action act = () => dictionary1.Should().Contain(keyValuePairs, "because we want to test the behaviour with an empty set of key/value pairs");
-
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify key containment against an empty collection of key/value pairs*");
-        }
-
-        [Fact]
-        public void When_asserting_dictionary_contains_key_value_pairs_but_expected_key_value_pairs_are_null_it_should_throw()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-            List<KeyValuePair<int, string>> keyValuePairs = null;
-
-            // Act
-            Action act = () => dictionary1.Should().Contain(keyValuePairs, "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithMessage("Cannot compare dictionary with <null>.*")
-                .WithParameterName("expected");
-        }
-
-        [Fact]
-        public void When_asserting_dictionary_does_not_contain_key_value_pairs_against_null_dictionary_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-            List<KeyValuePair<int, string>> keyValuePairs = new List<KeyValuePair<int, string>>()
-            {
-                new KeyValuePair<int, string>(1, "One"),
-                new KeyValuePair<int, string>(1, "Two")
-            };
-
-            // Act
-            Action act = () => dictionary.Should().NotContain(keyValuePairs,
-                "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not contain key/value pairs {[1, One], [1, Two]} because we want to test the behaviour with a null subject, but dictionary is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_dictionary_does_not_contain_key_value_pairs_but_expected_key_value_pairs_are_empty_it_should_throw()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-            List<KeyValuePair<int, string>> keyValuePair = new List<KeyValuePair<int, string>>();
-
-            // Act
-            Action act = () => dictionary1.Should().NotContain(keyValuePair, "because we want to test the behaviour with an empty set of key/value pairs");
-
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify key containment against an empty collection of key/value pairs*");
-        }
-
-        [Fact]
-        public void When_asserting_dictionary_does_not_contain_key_value_pairs_but_expected_key_value_pairs_are_null_it_should_throw()
-        {
-            // Arrange
-            var dictionary1 = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-            List<KeyValuePair<int, string>> keyValuePairs = null;
-
-            // Act
-            Action act = () => dictionary1.Should().NotContain(keyValuePairs, "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithMessage("Cannot compare dictionary with <null>.*")
-                .WithParameterName("items");
-        }
-
-        [Fact]
-        public void When_dictionary_contains_expected_value_at_specific_key_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act / Assert
-            dictionary.Should().Contain(1, "One");
-        }
-
-        [Fact]
-        public void When_dictionary_contains_expected_null_at_specific_key_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = null
-            };
-
-            // Act / Assert
-            dictionary.Should().Contain(1, null);
-        }
-
-        [Fact]
-        public void When_dictionary_contains_expected_key_value_pairs_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
-            {
-                [1] = "One",
-                [2] = "Two"
-            };
-
-            // Act / Assert
-            var items = new List<KeyValuePair<int, string>>()
+                var keyValuePairs = new List<KeyValuePair<int, string>>()
             {
                 new KeyValuePair<int, string>(1, "One"),
                 new KeyValuePair<int, string>(2, "Two")
             };
-            dictionary.Should().Contain(items);
-        }
 
-        [Fact]
-        public void When_dictionary_contains_expected_key_value_pair_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+                // Act
+                Action act = () => dictionary.Should().NotContain(keyValuePairs, "because {0}", "we do");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to not contain key/value pairs {[1, One], [2, Two]} because we do, but found them anyhow.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_does_not_contain_key_value_pairs_against_null_dictionary_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                Dictionary<int, string> dictionary = null;
+                List<KeyValuePair<int, string>> keyValuePairs = new List<KeyValuePair<int, string>>()
+                {
+                    new KeyValuePair<int, string>(1, "One"),
+                    new KeyValuePair<int, string>(1, "Two")
+                };
 
-            // Act / Assert
-            var item = new KeyValuePair<int, string>(1, "One");
-            dictionary.Should().Contain(item);
-        }
+                // Act
+                Action act = () => dictionary.Should().NotContain(keyValuePairs,
+                    "because we want to test the behaviour with a null subject");
 
-        [Fact]
-        public void When_dictionary_does_not_contain_the_expected_value_at_specific_key_it_should_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to not contain key/value pairs {[1, One], [1, Two]} because we want to test the behaviour with a null subject, but dictionary is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_does_not_contain_key_value_pairs_but_expected_key_value_pairs_are_empty_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                List<KeyValuePair<int, string>> keyValuePair = new List<KeyValuePair<int, string>>();
 
-            // Act
-            var item = new KeyValuePair<int, string>(1, "Two");
-            Action act = () => dictionary.Should().Contain(item, "we put it {0}", "there");
+                // Act
+                Action act = () => dictionary1.Should().NotContain(keyValuePair, "because we want to test the behaviour with an empty set of key/value pairs");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain value \"Two\" at key 1 because we put it there, but found \"One\".");
-        }
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage(
+                    "Cannot verify key containment against an empty collection of key/value pairs*");
+            }
 
-        [Fact]
-        public void When_dictionary_does_not_contain_the_key_value_pairs_it_should_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_asserting_dictionary_does_not_contain_key_value_pairs_but_expected_key_value_pairs_are_null_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary1 = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
+                List<KeyValuePair<int, string>> keyValuePairs = null;
 
-            var items = new List<KeyValuePair<int, string>>()
+                // Act
+                Action act = () => dictionary1.Should().NotContain(keyValuePairs, "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithMessage("Cannot compare dictionary with <null>.*")
+                    .WithParameterName("items");
+            }
+
+            [Fact]
+            public void When_dictionary_does_not_contain_unexpected_value_or_key_it_should_not_throw()
             {
-                new KeyValuePair<int, string>(1, "Two"),
-                new KeyValuePair<int, string>(2, "Three")
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().Contain(items, "we put them {0}", "there");
+                // Act / Assert
+                dictionary.Should().NotContain(3, "Three");
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain {[1, Two], [2, Three]} because we put them there, but dictionary differs at keys {1, 2}.");
-        }
-
-        [Fact]
-        public void When_dictionary_does_not_contain_the_key_value_pair_it_should_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_does_not_contain_unexpected_value_at_existing_key_it_should_not_throw()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act
-            Action act = () => dictionary.Should().Contain(1, "Two", "we put it {0}", "there");
+                // Act / Assert
+                dictionary.Should().NotContain(2, "Three");
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain value \"Two\" at key 1 because we put it there, but found \"One\".");
-        }
-
-        [Fact]
-        public void When_dictionary_does_not_contain_an_value_at_the_specific_key_it_should_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_does_not_have_the_unexpected_value_but_null_at_existing_key_it_should_succeed()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = null
+                };
 
-            // Act
-            Action act = () => dictionary.Should().Contain(3, "Two", "we put it {0}", "there");
+                // Act
+                Action action = () => dictionary.Should().NotContain(1, "other");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain value \"Two\" at key 3 because we put it there, but the key was not found.");
-        }
+                // Assert
+                action.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_asserting_dictionary_contains_value_at_specific_key_against_null_dictionary_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-
-            // Act
-            Action act = () => dictionary.Should().Contain(1, "One",
-                "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain value \"One\" at key 1 because we want to test the behaviour with a null subject, but dictionary is <null>.");
-        }
-
-        [Fact]
-        public void When_dictionary_does_not_contain_unexpected_value_or_key_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_does_not_contain_unexpected_key_value_pairs_it_should_not_throw()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act / Assert
-            dictionary.Should().NotContain(3, "Three");
-        }
+                // Act / Assert
+                var items = new List<KeyValuePair<int, string>>()
+                {
+                    new KeyValuePair<int, string>(3, "Three"),
+                    new KeyValuePair<int, string>(4, "Four")
+                };
+                dictionary.Should().NotContain(items);
+            }
 
-        [Fact]
-        public void When_dictionary_does_not_contain_unexpected_value_at_existing_key_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_does_not_contain_unexpected_key_value_pair_it_should_not_throw()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act / Assert
-            dictionary.Should().NotContain(2, "Three");
-        }
+                // Act / Assert
+                var item = new KeyValuePair<int, string>(3, "Three");
+                dictionary.Should().NotContain(item);
+            }
 
-        [Fact]
-        public void When_dictionary_does_not_have_the_unexpected_value_but_null_at_existing_key_it_should_succeed()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_contains_the_unexpected_value_at_specific_key_it_should_throw()
             {
-                [1] = null
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act
-            Action action = () => dictionary.Should().NotContain(1, "other");
+                // Act
+                var item = new KeyValuePair<int, string>(1, "One");
+                Action act = () => dictionary.Should().NotContain(item, "we put it {0}", "there");
 
-            // Assert
-            action.Should().NotThrow();
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary not to contain value \"One\" at key 1 because we put it there, but found it anyhow.");
+            }
 
-        [Fact]
-        public void When_dictionary_does_not_contain_unexpected_key_value_pairs_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Fact]
+            public void When_dictionary_contains_the_key_value_pairs_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act / Assert
-            var items = new List<KeyValuePair<int, string>>()
+                // Act
+                var items = new List<KeyValuePair<int, string>>()
+                {
+                    new KeyValuePair<int, string>(1, "One"),
+                    new KeyValuePair<int, string>(2, "Two")
+                };
+                Action act = () => dictionary.Should().NotContain(items, "we did not put them {0}", "there");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary to not contain key/value pairs {[1, One], [2, Two]} because we did not put them there, but found them anyhow.");
+            }
+
+            [Fact]
+            public void When_dictionary_contains_the_key_value_pair_it_should_throw()
             {
-                new KeyValuePair<int, string>(3, "Three"),
-                new KeyValuePair<int, string>(4, "Four")
-            };
-            dictionary.Should().NotContain(items);
-        }
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-        [Fact]
-        public void When_dictionary_does_not_contain_unexpected_key_value_pair_it_should_not_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+                // Act
+                Action act = () => dictionary.Should().NotContain(1, "One", "we did not put it {0}", "there");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary not to contain value \"One\" at key 1 because we did not put it there, but found it anyhow.");
+            }
+
+            [Fact]
+            public void When_asserting_dictionary_does_not_contain_value_at_specific_key_against_null_dictionary_it_should_throw()
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Arrange
+                Dictionary<int, string> dictionary = null;
 
-            // Act / Assert
-            var item = new KeyValuePair<int, string>(3, "Three");
-            dictionary.Should().NotContain(item);
+                // Act
+                Action act = () => dictionary.Should().NotContain(1, "One",
+                    "because we want to test the behaviour with a null subject");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected dictionary not to contain value \"One\" at key 1 because we want to test the behaviour with a null subject, but dictionary is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_dictionary_contains_the_unexpected_value_at_specific_key_it_should_throw()
+        public class OtherDictionaryAssertions
         {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Theory]
+            [MemberData(nameof(SingleDictionaryData))]
+            public void When_a_dictionary_like_collection_contains_the_expected_key_and_value_it_should_succeed<T>(T subject)
+                where T : IEnumerable<KeyValuePair<int, int>>
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Assert
+                subject.Should().Contain(1, 42);
+            }
 
-            // Act
-            var item = new KeyValuePair<int, string>(1, "One");
-            Action act = () => dictionary.Should().NotContain(item, "we put it {0}", "there");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary not to contain value \"One\" at key 1 because we put it there, but found it anyhow.");
-        }
-
-        [Fact]
-        public void When_dictionary_contains_the_key_value_pairs_it_should_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Theory]
+            [MemberData(nameof(SingleDictionaryData))]
+            public void When_using_a_dictionary_like_collection_it_should_preserve_reference_equality<T>(T subject)
+                where T : IEnumerable<KeyValuePair<int, int>>
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Act
+                Action act = () => subject.Should().BeSameAs(subject);
 
-            // Act
-            var items = new List<KeyValuePair<int, string>>()
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Theory]
+            [MemberData(nameof(SingleDictionaryData))]
+            public void When_a_dictionary_like_collection_contains_the_expected_key_it_should_succeed<T>(T subject)
+                where T : IEnumerable<KeyValuePair<int, int>>
             {
-                new KeyValuePair<int, string>(1, "One"),
-                new KeyValuePair<int, string>(2, "Two")
-            };
-            Action act = () => dictionary.Should().NotContain(items, "we did not put them {0}", "there");
+                // Act
+                Action act = () => subject.Should().ContainKey(1);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not contain key/value pairs {[1, One], [2, Two]} because we did not put them there, but found them anyhow.");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_dictionary_contains_the_key_value_pair_it_should_throw()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Theory]
+            [MemberData(nameof(SingleDictionaryData))]
+            public void When_a_dictionary_like_collection_contains_the_expected_value_it_should_succeed<T>(T subject)
+                where T : IEnumerable<KeyValuePair<int, int>>
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Act
+                Action act = () => subject.Should().ContainValue(42);
 
-            // Act
-            Action act = () => dictionary.Should().NotContain(1, "One", "we did not put it {0}", "there");
+                // Assert
+                act.Should().NotThrow();
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary not to contain value \"One\" at key 1 because we did not put it there, but found it anyhow.");
-        }
-
-        [Fact]
-        public void When_asserting_dictionary_does_not_contain_value_at_specific_key_against_null_dictionary_it_should_throw()
-        {
-            // Arrange
-            Dictionary<int, string> dictionary = null;
-
-            // Act
-            Action act = () => dictionary.Should().NotContain(1, "One",
-                "because we want to test the behaviour with a null subject");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary not to contain value \"One\" at key 1 because we want to test the behaviour with a null subject, but dictionary is <null>.");
-        }
-
-        #endregion
-
-        #region Miscellaneous
-
-        [Fact]
-        public void Should_support_chaining_constraints_with_and()
-        {
-            // Arrange
-            var dictionary = new Dictionary<int, string>
+            [Theory]
+            [MemberData(nameof(DictionariesData))]
+            public void When_comparing_dictionary_like_collections_for_equality_it_should_succeed<T1, T2>(T1 subject, T2 expected)
+                where T1 : IEnumerable<KeyValuePair<int, int>>
+                where T2 : IEnumerable<KeyValuePair<int, int>>
             {
-                [1] = "One",
-                [2] = "Two"
-            };
+                // Act
+                Action act = () => subject.Should().Equal(expected);
 
-            // Act / Assert
-            dictionary.Should()
-                .HaveCount(2)
-                .And.ContainKey(1)
-                .And.ContainValue("Two");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        #endregion
-
-        [Theory]
-        [MemberData(nameof(DictionariesData))]
-        public void When_comparing_dictionary_like_collections_for_equality_it_should_succeed<T1, T2>(T1 subject, T2 expected)
-            where T1 : IEnumerable<KeyValuePair<int, int>>
-            where T2 : IEnumerable<KeyValuePair<int, int>>
-        {
-            // Act
-            Action act = () => subject.Should().Equal(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Theory]
-        [MemberData(nameof(DictionariesData))]
-        public void When_comparing_dictionary_like_collections_for_inequality_it_should_throw<T1, T2>(T1 subject, T2 expected)
-            where T1 : IEnumerable<KeyValuePair<int, int>>
-            where T2 : IEnumerable<KeyValuePair<int, int>>
-        {
-            // Act
-            Action act = () => subject.Should().NotEqual(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        public static IEnumerable<object[]> DictionariesData()
-        {
-            return from x in Dictionaries()
-                   from y in Dictionaries()
-                   select new[] { x, y };
-        }
-
-        [Theory]
-        [MemberData(nameof(SingleDictionaryData))]
-        public void When_a_dictionary_like_collection_contains_the_expected_key_it_should_succeed<T>(T subject)
-            where T : IEnumerable<KeyValuePair<int, int>>
-        {
-            // Act
-            Action act = () => subject.Should().ContainKey(1);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Theory]
-        [MemberData(nameof(SingleDictionaryData))]
-        public void When_a_dictionary_like_collection_contains_the_expected_key_and_value_it_should_succeed<T>(T subject)
-            where T : IEnumerable<KeyValuePair<int, int>>
-        {
-            // Assert
-            subject.Should().Contain(1, 42);
-        }
-
-        [Theory]
-        [MemberData(nameof(SingleDictionaryData))]
-        public void When_a_dictionary_like_collection_contains_the_expected_value_it_should_succeed<T>(T subject)
-            where T : IEnumerable<KeyValuePair<int, int>>
-        {
-            // Act
-            Action act = () => subject.Should().ContainValue(42);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Theory]
-        [MemberData(nameof(SingleDictionaryData))]
-        public void When_using_a_dictionary_like_collection_it_should_preserve_reference_equality<T>(T subject)
-            where T : IEnumerable<KeyValuePair<int, int>>
-        {
-            // Act
-            Action act = () => subject.Should().BeSameAs(subject);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        public static IEnumerable<object[]> SingleDictionaryData() =>
-            Dictionaries().Select(x => new[] { x });
-
-        private static object[] Dictionaries()
-        {
-            return new object[]
+            [Theory]
+            [MemberData(nameof(DictionariesData))]
+            public void When_comparing_dictionary_like_collections_for_inequality_it_should_throw<T1, T2>(T1 subject, T2 expected)
+                where T1 : IEnumerable<KeyValuePair<int, int>>
+                where T2 : IEnumerable<KeyValuePair<int, int>>
             {
+                // Act
+                Action act = () => subject.Should().NotEqual(expected);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            public static IEnumerable<object[]> SingleDictionaryData() =>
+                    Dictionaries().Select(x => new[] { x });
+
+            public static object[] Dictionaries()
+            {
+                return new object[]
+                {
                 new Dictionary<int, int>() { [1] = 42 },
                 new TrueReadOnlyDictionary<int, int>(new Dictionary<int, int>() { [1] = 42 }),
                 new List<KeyValuePair<int, int>> { new KeyValuePair<int, int>(1, 42) }
-            };
+                };
+            }
+
+            public static IEnumerable<object[]> DictionariesData()
+            {
+                return from x in Dictionaries()
+                       from y in Dictionaries()
+                       select new[] { x, y };
+            }
         }
 
-        [Fact]
-        public void When_a_dictionary_like_collection_contains_the_default_key_it_should_succeed()
+        public class Miscellaneous
         {
-            // Arrange
-            var subject = new List<KeyValuePair<int, int>>() { new(0, 0) };
+            [Fact]
+            public void Should_support_chaining_constraints_with_and()
+            {
+                // Arrange
+                var dictionary = new Dictionary<int, string>
+                {
+                    [1] = "One",
+                    [2] = "Two"
+                };
 
-            // Act
-            Action act = () => subject.Should().Contain(0, 0);
-
-            // Assert
-            act.Should().NotThrow();
+                // Act / Assert
+                dictionary.Should()
+                    .HaveCount(2)
+                    .And.ContainKey(1)
+                    .And.ContainValue("Two");
+            }
         }
 
         /// <summary>

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -17,797 +17,796 @@ namespace FluentAssertions.Specs.Events
     [Collection("EventMonitoring")]
     public class EventAssertionSpecs
     {
-        #region ShouldRaise
-
-        [Fact]
-        public void When_asserting_an_event_that_doesnt_exist_it_should_throw()
+        public class ShouldRaise
         {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitoredSubject = subject.Monitor();
-
-            // Act
-            // ReSharper disable once AccessToDisposedClosure
-            Action act = () => monitoredSubject.Should().Raise("NonExistingEvent");
-
-            // Assert
-            act.Should().Throw<InvalidOperationException>().WithMessage(
-                "Not monitoring any events named \"NonExistingEvent\".");
-        }
-
-        [Fact]
-        public void When_asserting_that_an_event_was_not_raised_and_it_doesnt_exist_it_should_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-
-            // Act
-            Action act = () => monitor.Should().NotRaise("NonExistingEvent");
-
-            // Assert
-            act.Should().Throw<InvalidOperationException>().WithMessage(
-                "Not monitoring any events named \"NonExistingEvent\".");
-        }
-
-        [Fact]
-        public void When_an_event_was_not_raised_it_should_throw_and_use_the_reason()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-
-            // Act
-            Action act = () => monitor.Should().Raise("PropertyChanged", "{0} should cause the event to get raised", "Foo()");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected object " + Formatter.ToString(subject) +
-                " to raise event \"PropertyChanged\" because Foo() should cause the event to get raised, but it did not.");
-        }
-
-        [Fact]
-        public void When_the_expected_event_was_raised_it_should_not_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseEventWithoutSender();
-
-            // Act
-            Action act = () => monitor.Should().Raise("PropertyChanged");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_an_unexpected_event_was_raised_it_should_throw_and_use_the_reason()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseEventWithoutSender();
-
-            // Act
-            Action act = () =>
-                monitor.Should().NotRaise("PropertyChanged", "{0} should cause the event to get raised", "Foo()");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected object " + Formatter.ToString(subject) +
-                             " to not raise event \"PropertyChanged\" because Foo() should cause the event to get raised, but it did.");
-        }
-
-        [Fact]
-        public void When_an_unexpected_event_was_not_raised_it_should_not_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-
-            // Act
-            Action act = () => monitor.Should().NotRaise("PropertyChanged");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_the_event_sender_is_not_the_expected_object_it_should_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseEventWithoutSender();
-
-            // Act
-            Action act = () => monitor.Should().Raise("PropertyChanged").WithSender(subject);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"Expected sender {Formatter.ToString(subject)}, but found {{<null>}}.");
-        }
-
-        [Fact]
-        public void When_the_event_sender_is_the_expected_object_it_should_not_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseEventWithSender();
-
-            // Act
-            Action act = () => monitor.Should().Raise("PropertyChanged").WithSender(subject);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_WithArgs_it_should_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
-
-            // Act
-            Action act = () => monitor.Should()
-                .Raise("NonConventionalEvent")
-                .WithArgs<string>(predicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("predicate");
-        }
-
-        [Fact]
-        public void When_the_event_parameters_dont_match_it_should_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseEventWithoutSender();
-
-            // Act
-            Action act = () => monitor
-                .Should().Raise("PropertyChanged")
-                .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "SomeProperty");
-
-            // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected at least one event with arguments matching (args.PropertyName == \"SomeProperty\"), but found none.");
-        }
-
-        [Fact]
-        public void When_the_event_args_are_of_a_different_type_it_should_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
-
-            // Act
-            Action act = () => monitor
-                .Should().Raise("PropertyChanged")
-                .WithArgs<CancelEventArgs>(args => args.Cancel);
-
-            // Assert
-            act
-                .Should().Throw<ArgumentException>()
-                .WithMessage("No argument of event PropertyChanged is of type *CancelEventArgs>*");
-        }
-
-        [Fact]
-        public void When_the_event_parameters_do_match_it_should_not_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
-
-            // Act
-            Action act = () => monitor
-                .Should().Raise("PropertyChanged")
-                .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "SomeProperty");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_running_in_parallel_it_should_not_throw()
-        {
-            // Arrange
-            void Action(int _)
+            [Fact]
+            public void When_asserting_an_event_that_doesnt_exist_it_should_throw()
             {
-                EventRaisingClass subject = new EventRaisingClass();
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitoredSubject = subject.Monitor();
+
+                // Act
+                // ReSharper disable once AccessToDisposedClosure
+                Action act = () => monitoredSubject.Should().Raise("NonExistingEvent");
+
+                // Assert
+                act.Should().Throw<InvalidOperationException>().WithMessage(
+                    "Not monitoring any events named \"NonExistingEvent\".");
+            }
+
+            [Fact]
+            public void When_asserting_that_an_event_was_not_raised_and_it_doesnt_exist_it_should_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+
+                // Act
+                Action act = () => monitor.Should().NotRaise("NonExistingEvent");
+
+                // Assert
+                act.Should().Throw<InvalidOperationException>().WithMessage(
+                    "Not monitoring any events named \"NonExistingEvent\".");
+            }
+
+            [Fact]
+            public void When_an_event_was_not_raised_it_should_throw_and_use_the_reason()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+
+                // Act
+                Action act = () => monitor.Should().Raise("PropertyChanged", "{0} should cause the event to get raised", "Foo()");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected object " + Formatter.ToString(subject) +
+                    " to raise event \"PropertyChanged\" because Foo() should cause the event to get raised, but it did not.");
+            }
+
+            [Fact]
+            public void When_the_expected_event_was_raised_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseEventWithoutSender();
+
+                // Act
+                Action act = () => monitor.Should().Raise("PropertyChanged");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_an_unexpected_event_was_raised_it_should_throw_and_use_the_reason()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseEventWithoutSender();
+
+                // Act
+                Action act = () =>
+                    monitor.Should().NotRaise("PropertyChanged", "{0} should cause the event to get raised", "Foo()");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected object " + Formatter.ToString(subject) +
+                                 " to not raise event \"PropertyChanged\" because Foo() should cause the event to get raised, but it did.");
+            }
+
+            [Fact]
+            public void When_an_unexpected_event_was_not_raised_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+
+                // Act
+                Action act = () => monitor.Should().NotRaise("PropertyChanged");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_the_event_sender_is_not_the_expected_object_it_should_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseEventWithoutSender();
+
+                // Act
+                Action act = () => monitor.Should().Raise("PropertyChanged").WithSender(subject);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"Expected sender {Formatter.ToString(subject)}, but found {{<null>}}.");
+            }
+
+            [Fact]
+            public void When_the_event_sender_is_the_expected_object_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
                 using var monitor = subject.Monitor();
                 subject.RaiseEventWithSender();
-                monitor.Should().Raise("PropertyChanged");
+
+                // Act
+                Action act = () => monitor.Should().Raise("PropertyChanged").WithSender(subject);
+
+                // Assert
+                act.Should().NotThrow();
             }
 
-            // Act
-            Action act = () => Enumerable.Range(0, 1000)
-                .AsParallel()
-                .ForAll(Action);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_monitored_class_event_has_fired_it_should_be_possible_to_reset_the_event_monitor()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var eventMonitor = subject.Monitor();
-            subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
-
-            // Act
-            eventMonitor.Clear();
-
-            // Assert
-            eventMonitor.Should().NotRaise("PropertyChanged");
-        }
-
-        [Fact]
-        public void When_a_non_conventional_event_with_a_specific_argument_was_raised_it_should_not_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
-
-            // Act
-            Action act = () => monitor
-                .Should().Raise("NonConventionalEvent")
-                .WithArgs<string>(args => args == "third argument");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_non_conventional_event_with_many_specific_arguments_was_raised_it_should_not_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
-
-            // Act
-            Action act = () => monitor
-                .Should().Raise("NonConventionalEvent")
-                .WithArgs<string>(null, args => args == "third argument");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_predicate_based_parameter_assertion_expects_more_parameters_then_an_event_has_it_should_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
-
-            // Act
-            Action act = () => monitor
-                .Should().Raise(nameof(EventRaisingClass.NonConventionalEvent))
-                .WithArgs<string>(null, null, null, args => args == "fourth argument");
-
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage("*4 parameters*String*, but*2*");
-        }
-
-        [Fact]
-        public void When_a_non_conventional_event_with_a_specific_argument_was_not_raised_it_should_throw()
-        {
-            // Arrange
-            const int wrongArgument = 3;
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
-
-            // Act
-            Action act = () => monitor
-                .Should().Raise("NonConventionalEvent")
-                .WithArgs<int>(args => args == wrongArgument);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected at least one event with arguments matching (args == " + wrongArgument + "), but found none.");
-        }
-
-        [Fact]
-        public void When_a_non_conventional_event_with_many_specific_arguments_was_not_raised_it_should_throw()
-        {
-            // Arrange
-            const string wrongArgument = "not a third argument";
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
-
-            // Act
-            Action act = () => monitor
-                .Should().Raise("NonConventionalEvent")
-                .WithArgs<string>(null, args => args == wrongArgument);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected at least one event with arguments matching \"(args == \"" + wrongArgument +
-                "\")\", but found none.");
-        }
-
-        [Fact]
-        public void When_a_specific_event_is_expected_it_should_return_only_relevant_events()
-        {
-            // Arrange
-            var observable = new EventRaisingClass();
-            using var monitor = observable.Monitor();
-
-            // Act
-            observable.RaiseEventWithSpecificSender("Foo");
-            observable.RaiseEventWithSpecificSender("Bar");
-            observable.RaiseNonConventionalEvent("don't care", 123, "don't care");
-
-            // Assert
-            var recording = monitor
-                .Should()
-                .Raise(nameof(observable.PropertyChanged));
-
-            recording.EventName.Should().Be(nameof(observable.PropertyChanged));
-            recording.EventObject.Should().BeSameAs(observable);
-            recording.EventHandlerType.Should().Be(typeof(PropertyChangedEventHandler));
-            recording.Should().HaveCount(2, "because only two property changed events were raised");
-        }
-
-        [Fact]
-        public void When_a_specific_sender_is_expected_it_should_return_only_relevant_events()
-        {
-            // Arrange
-            var observable = new EventRaisingClass();
-            using var monitor = observable.Monitor();
-
-            // Act
-            observable.RaiseEventWithSpecificSender(observable);
-            observable.RaiseEventWithSpecificSender(new object());
-
-            // Assert
-            var recording = monitor
-                .Should()
-                .Raise(nameof(observable.PropertyChanged))
-                .WithSender(observable);
-
-            recording.Should().ContainSingle().Which.Parameters.First().Should().BeSameAs(observable);
-        }
-
-        [Fact]
-        public void When_constraints_are_specified_it_should_filter_the_events_based_on_those_constraints()
-        {
-            // Arrange
-            var observable = new EventRaisingClass();
-            using var monitor = observable.Monitor();
-
-            // Act
-            observable.RaiseEventWithSenderAndPropertyName("Foo");
-            observable.RaiseEventWithSenderAndPropertyName("Boo");
-
-            // Assert
-            var recording = monitor
-                .Should()
-                .Raise(nameof(observable.PropertyChanged))
-                .WithSender(observable)
-                .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "Boo");
-
-            recording
-                .Should().ContainSingle("because we were expecting a specific property change")
-                .Which.Parameters.Last().Should().BeOfType<PropertyChangedEventArgs>()
-                .Which.PropertyName.Should().Be("Boo");
-        }
-
-        [Fact]
-        public void When_events_are_raised_regardless_of_time_tick_it_should_return_by_invokation_order()
-        {
-            // Arrange
-            var observable = new TestEventRaisingInOrder();
-            var utcNow = 11.January(2022).At(12, 00).AsUtc();
-            using var monitor = observable.Monitor(() => utcNow);
-
-            // Act
-            observable.RaiseAllEvents();
-
-            // Assert
-            monitor.OccurredEvents[0].EventName.Should().Be(nameof(TestEventRaisingInOrder.InterfaceEvent));
-            monitor.OccurredEvents[0].Sequence.Should().Be(0);
-
-            monitor.OccurredEvents[1].EventName.Should().Be(nameof(TestEventRaisingInOrder.Interface2Event));
-            monitor.OccurredEvents[1].Sequence.Should().Be(1);
-
-            monitor.OccurredEvents[2].EventName.Should().Be(nameof(TestEventRaisingInOrder.Interface3Event));
-            monitor.OccurredEvents[2].Sequence.Should().Be(2);
-        }
-
-        #endregion
-
-        #region Should(Not)RaisePropertyChanged events
-
-        [Fact]
-        public void When_a_property_changed_event_was_raised_for_the_expected_property_it_should_not_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
-            subject.RaiseEventWithSenderAndPropertyName("SomeOtherProperty");
-
-            // Act
-            Action act = () => monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_an_expected_property_changed_event_was_raised_for_all_properties_it_should_not_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseEventWithSenderAndPropertyName(null);
-
-            // Act
-            Action act = () => monitor.Should().RaisePropertyChangeFor(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_property_changed_event_was_raised_by_monitored_class_it_should_be_possible_to_reset_the_event_monitor()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var eventMonitor = subject.Monitor();
-            subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
-
-            // Act
-            eventMonitor.Clear();
-
-            // Assert
-            eventMonitor.Should().NotRaisePropertyChangeFor(e => e.SomeProperty);
-        }
-
-        [Fact]
-        public void When_a_property_changed_event_for_an_unexpected_property_was_raised_it_should_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
-
-            // Act
-            Action act = () => monitor.Should().NotRaisePropertyChangeFor(x => x.SomeProperty, "nothing happened");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect object " + Formatter.ToString(subject) +
-                " to raise the \"PropertyChanged\" event for property \"SomeProperty\" because nothing happened, but it did.");
-        }
-
-        [Fact]
-        public void When_a_property_changed_event_for_a_specific_property_was_not_raised_it_should_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-
-            // Act
-            Action act = () => monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty, "the property was changed");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected object " + Formatter.ToString(subject) +
-                " to raise event \"PropertyChanged\" for property \"SomeProperty\" because the property was changed, but it did not*");
-        }
-
-        [Fact]
-        public void When_a_property_agnostic_property_changed_event_for_was_not_raised_it_should_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-
-            // Act
-            Action act = () => monitor.Should().RaisePropertyChangeFor(null);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected object " + Formatter.ToString(subject) +
-                " to raise event \"PropertyChanged\" for property <null>, but it did not*");
-        }
-
-        [Fact]
-        public void When_a_property_changed_event_for_another_than_the_unexpected_property_was_raised_it_should_not_throw()
-        {
-            // Arrange
-            var subject = new EventRaisingClass();
-            using var monitor = subject.Monitor();
-            subject.RaiseEventWithSenderAndPropertyName("SomeOtherProperty");
-
-            // Act
-            Action act = () => monitor.Should().NotRaisePropertyChangeFor(x => x.SomeProperty);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_monitoring_a_class_it_should_be_possible_to_attach_to_additional_interfaces_on_the_same_object()
-        {
-            // Arrange
-            var subject = new TestEventRaising();
-            using var outerMonitor = subject.Monitor<IEventRaisingInterface>();
-            using var innerMonitor = subject.Monitor<IEventRaisingInterface2>();
-
-            // Act
-            subject.RaiseBothEvents();
-
-            // Assert
-            outerMonitor.Should().Raise("InterfaceEvent");
-            innerMonitor.Should().Raise("Interface2Event");
-        }
-
-        [Fact]
-        public void When_the_property_changed_event_was_raised_for_the_wrong_property_it_should_throw_and_include_the_actual_properties_raised()
-        {
-            // Arrange
-            var bar = new EventRaisingClass();
-            using var monitor = bar.Monitor();
-            bar.RaiseEventWithSenderAndPropertyName("OtherProperty1");
-            bar.RaiseEventWithSenderAndPropertyName("OtherProperty2");
-            bar.RaiseEventWithSenderAndPropertyName("OtherProperty2");
-
-            // Act
-            Action act = () => monitor.Should().RaisePropertyChangeFor(b => b.SomeProperty);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*property*SomeProperty*but*OtherProperty1*OtherProperty2*");
-        }
-
-        #endregion
-
-        #region Precondition Checks
-
-        [Fact]
-        public void When_monitoring_a_null_object_it_should_throw()
-        {
-            // Arrange
-            EventRaisingClass subject = null;
-
-            // Act
-            Action act = () => subject.Monitor();
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithMessage("Cannot monitor the events of a <null> object*");
-        }
-
-        [Fact]
-        public void When_nesting_monitoring_requests_scopes_should_be_isolated()
-        {
-            // Arrange
-            var eventSource = new EventRaisingClass();
-            using var outerScope = eventSource.Monitor();
-
-            // Act
-            using var innerScope = eventSource.Monitor();
-
-            // Assert
-            ((object)innerScope).Should().NotBeSameAs(outerScope);
-        }
-
-        [Fact]
-        public void When_monitoring_an_object_with_invalid_property_expression_it_should_throw()
-        {
-            // Arrange
-            var eventSource = new EventRaisingClass();
-            using var monitor = eventSource.Monitor();
-            Func<EventRaisingClass, int> func = e => e.SomeOtherProperty;
-
-            // Act
-            Action act = () => monitor.Should().RaisePropertyChangeFor(e => func(e));
-
-            // Assert
-            act.Should().Throw<ArgumentException>()
-                .WithParameterName("expression");
-        }
-
-        #endregion
-
-        #region Metadata
-
-        [Fact]
-        public void When_monitoring_an_object_it_should_monitor_all_the_events_it_exposes()
-        {
-            // Arrange
-            var eventSource = new ClassThatRaisesEventsItself();
-            using var eventMonitor = eventSource.Monitor();
-
-            // Act
-            EventMetadata[] metadata = eventMonitor.MonitoredEvents;
-
-            // Assert
-            metadata.Should().BeEquivalentTo(new[]
+            [Fact]
+            public void When_injecting_a_null_predicate_into_WithArgs_it_should_throw()
             {
-                new
-                {
-                    EventName = nameof(ClassThatRaisesEventsItself.InterfaceEvent),
-                    HandlerType = typeof(EventHandler)
-                },
-                new
-                {
-                    EventName = nameof(ClassThatRaisesEventsItself.PropertyChanged),
-                    HandlerType = typeof(PropertyChangedEventHandler)
-                }
-            });
-        }
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
 
-        [Fact]
-        public void When_monitoring_an_object_through_an_interface_it_should_monitor_only_the_events_it_exposes()
-        {
-            // Arrange
-            var eventSource = new ClassThatRaisesEventsItself();
-            using var monitor = eventSource.Monitor<IEventRaisingInterface>();
+                // Act
+                Action act = () => monitor.Should()
+                    .Raise("NonConventionalEvent")
+                    .WithArgs<string>(predicate: null);
 
-            // Act
-            EventMetadata[] metadata = monitor.MonitoredEvents;
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("predicate");
+            }
 
-            // Assert
-            metadata.Should().BeEquivalentTo(new[]
+            [Fact]
+            public void When_the_event_parameters_dont_match_it_should_throw()
             {
-                new
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseEventWithoutSender();
+
+                // Act
+                Action act = () => monitor
+                    .Should().Raise("PropertyChanged")
+                    .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "SomeProperty");
+
+                // Assert
+                act
+                    .Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected at least one event with arguments matching (args.PropertyName == \"SomeProperty\"), but found none.");
+            }
+
+            [Fact]
+            public void When_the_event_args_are_of_a_different_type_it_should_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
+
+                // Act
+                Action act = () => monitor
+                    .Should().Raise("PropertyChanged")
+                    .WithArgs<CancelEventArgs>(args => args.Cancel);
+
+                // Assert
+                act
+                    .Should().Throw<ArgumentException>()
+                    .WithMessage("No argument of event PropertyChanged is of type *CancelEventArgs>*");
+            }
+
+            [Fact]
+            public void When_the_event_parameters_do_match_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
+
+                // Act
+                Action act = () => monitor
+                    .Should().Raise("PropertyChanged")
+                    .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "SomeProperty");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_running_in_parallel_it_should_not_throw()
+            {
+                // Arrange
+                void Action(int _)
                 {
-                    EventName = nameof(IEventRaisingInterface.InterfaceEvent),
-                    HandlerType = typeof(EventHandler)
+                    EventRaisingClass subject = new EventRaisingClass();
+                    using var monitor = subject.Monitor();
+                    subject.RaiseEventWithSender();
+                    monitor.Should().Raise("PropertyChanged");
                 }
-            });
+
+                // Act
+                Action act = () => Enumerable.Range(0, 1000)
+                    .AsParallel()
+                    .ForAll(Action);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_monitored_class_event_has_fired_it_should_be_possible_to_reset_the_event_monitor()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var eventMonitor = subject.Monitor();
+                subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
+
+                // Act
+                eventMonitor.Clear();
+
+                // Assert
+                eventMonitor.Should().NotRaise("PropertyChanged");
+            }
+
+            [Fact]
+            public void When_a_non_conventional_event_with_a_specific_argument_was_raised_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
+
+                // Act
+                Action act = () => monitor
+                    .Should().Raise("NonConventionalEvent")
+                    .WithArgs<string>(args => args == "third argument");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_non_conventional_event_with_many_specific_arguments_was_raised_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
+
+                // Act
+                Action act = () => monitor
+                    .Should().Raise("NonConventionalEvent")
+                    .WithArgs<string>(null, args => args == "third argument");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_predicate_based_parameter_assertion_expects_more_parameters_then_an_event_has_it_should_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
+
+                // Act
+                Action act = () => monitor
+                    .Should().Raise(nameof(EventRaisingClass.NonConventionalEvent))
+                    .WithArgs<string>(null, null, null, args => args == "fourth argument");
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage("*4 parameters*String*, but*2*");
+            }
+
+            [Fact]
+            public void When_a_non_conventional_event_with_a_specific_argument_was_not_raised_it_should_throw()
+            {
+                // Arrange
+                const int wrongArgument = 3;
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
+
+                // Act
+                Action act = () => monitor
+                    .Should().Raise("NonConventionalEvent")
+                    .WithArgs<int>(args => args == wrongArgument);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected at least one event with arguments matching (args == " + wrongArgument + "), but found none.");
+            }
+
+            [Fact]
+            public void When_a_non_conventional_event_with_many_specific_arguments_was_not_raised_it_should_throw()
+            {
+                // Arrange
+                const string wrongArgument = "not a third argument";
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
+
+                // Act
+                Action act = () => monitor
+                    .Should().Raise("NonConventionalEvent")
+                    .WithArgs<string>(null, args => args == wrongArgument);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected at least one event with arguments matching \"(args == \"" + wrongArgument +
+                    "\")\", but found none.");
+            }
+
+            [Fact]
+            public void When_a_specific_event_is_expected_it_should_return_only_relevant_events()
+            {
+                // Arrange
+                var observable = new EventRaisingClass();
+                using var monitor = observable.Monitor();
+
+                // Act
+                observable.RaiseEventWithSpecificSender("Foo");
+                observable.RaiseEventWithSpecificSender("Bar");
+                observable.RaiseNonConventionalEvent("don't care", 123, "don't care");
+
+                // Assert
+                var recording = monitor
+                    .Should()
+                    .Raise(nameof(observable.PropertyChanged));
+
+                recording.EventName.Should().Be(nameof(observable.PropertyChanged));
+                recording.EventObject.Should().BeSameAs(observable);
+                recording.EventHandlerType.Should().Be(typeof(PropertyChangedEventHandler));
+                recording.Should().HaveCount(2, "because only two property changed events were raised");
+            }
+
+            [Fact]
+            public void When_a_specific_sender_is_expected_it_should_return_only_relevant_events()
+            {
+                // Arrange
+                var observable = new EventRaisingClass();
+                using var monitor = observable.Monitor();
+
+                // Act
+                observable.RaiseEventWithSpecificSender(observable);
+                observable.RaiseEventWithSpecificSender(new object());
+
+                // Assert
+                var recording = monitor
+                    .Should()
+                    .Raise(nameof(observable.PropertyChanged))
+                    .WithSender(observable);
+
+                recording.Should().ContainSingle().Which.Parameters.First().Should().BeSameAs(observable);
+            }
+
+            [Fact]
+            public void When_constraints_are_specified_it_should_filter_the_events_based_on_those_constraints()
+            {
+                // Arrange
+                var observable = new EventRaisingClass();
+                using var monitor = observable.Monitor();
+
+                // Act
+                observable.RaiseEventWithSenderAndPropertyName("Foo");
+                observable.RaiseEventWithSenderAndPropertyName("Boo");
+
+                // Assert
+                var recording = monitor
+                    .Should()
+                    .Raise(nameof(observable.PropertyChanged))
+                    .WithSender(observable)
+                    .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "Boo");
+
+                recording
+                    .Should().ContainSingle("because we were expecting a specific property change")
+                    .Which.Parameters.Last().Should().BeOfType<PropertyChangedEventArgs>()
+                    .Which.PropertyName.Should().Be("Boo");
+            }
+
+            [Fact]
+            public void When_events_are_raised_regardless_of_time_tick_it_should_return_by_invokation_order()
+            {
+                // Arrange
+                var observable = new TestEventRaisingInOrder();
+                var utcNow = 11.January(2022).At(12, 00).AsUtc();
+                using var monitor = observable.Monitor(() => utcNow);
+
+                // Act
+                observable.RaiseAllEvents();
+
+                // Assert
+                monitor.OccurredEvents[0].EventName.Should().Be(nameof(TestEventRaisingInOrder.InterfaceEvent));
+                monitor.OccurredEvents[0].Sequence.Should().Be(0);
+
+                monitor.OccurredEvents[1].EventName.Should().Be(nameof(TestEventRaisingInOrder.Interface2Event));
+                monitor.OccurredEvents[1].Sequence.Should().Be(1);
+
+                monitor.OccurredEvents[2].EventName.Should().Be(nameof(TestEventRaisingInOrder.Interface3Event));
+                monitor.OccurredEvents[2].Sequence.Should().Be(2);
+            }
+
+            [Fact]
+            public void When_monitoring_a_class_it_should_be_possible_to_attach_to_additional_interfaces_on_the_same_object()
+            {
+                // Arrange
+                var subject = new TestEventRaising();
+                using var outerMonitor = subject.Monitor<IEventRaisingInterface>();
+                using var innerMonitor = subject.Monitor<IEventRaisingInterface2>();
+
+                // Act
+                subject.RaiseBothEvents();
+
+                // Assert
+                outerMonitor.Should().Raise("InterfaceEvent");
+                innerMonitor.Should().Raise("Interface2Event");
+            }
         }
+
+        public class ShouldRaisePropertyChanged
+        {
+            [Fact]
+            public void When_a_property_changed_event_was_raised_for_the_expected_property_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
+                subject.RaiseEventWithSenderAndPropertyName("SomeOtherProperty");
+
+                // Act
+                Action act = () => monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_an_expected_property_changed_event_was_raised_for_all_properties_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseEventWithSenderAndPropertyName(null);
+
+                // Act
+                Action act = () => monitor.Should().RaisePropertyChangeFor(null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_property_changed_event_for_a_specific_property_was_not_raised_it_should_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+
+                // Act
+                Action act = () => monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty, "the property was changed");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected object " + Formatter.ToString(subject) +
+                    " to raise event \"PropertyChanged\" for property \"SomeProperty\" because the property was changed, but it did not*");
+            }
+
+            [Fact]
+            public void When_a_property_agnostic_property_changed_event_for_was_not_raised_it_should_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+
+                // Act
+                Action act = () => monitor.Should().RaisePropertyChangeFor(null);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected object " + Formatter.ToString(subject) +
+                    " to raise event \"PropertyChanged\" for property <null>, but it did not*");
+            }
+
+            [Fact]
+            public void When_the_property_changed_event_was_raised_for_the_wrong_property_it_should_throw_and_include_the_actual_properties_raised()
+            {
+                // Arrange
+                var bar = new EventRaisingClass();
+                using var monitor = bar.Monitor();
+                bar.RaiseEventWithSenderAndPropertyName("OtherProperty1");
+                bar.RaiseEventWithSenderAndPropertyName("OtherProperty2");
+                bar.RaiseEventWithSenderAndPropertyName("OtherProperty2");
+
+                // Act
+                Action act = () => monitor.Should().RaisePropertyChangeFor(b => b.SomeProperty);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected*property*SomeProperty*but*OtherProperty1*OtherProperty2*");
+            }
+        }
+
+        public class ShouldNotRaisePropertyChanged
+        {
+            [Fact]
+            public void When_a_property_changed_event_was_raised_by_monitored_class_it_should_be_possible_to_reset_the_event_monitor()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var eventMonitor = subject.Monitor();
+                subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
+
+                // Act
+                eventMonitor.Clear();
+
+                // Assert
+                eventMonitor.Should().NotRaisePropertyChangeFor(e => e.SomeProperty);
+            }
+
+            [Fact]
+            public void When_a_property_changed_event_for_an_unexpected_property_was_raised_it_should_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
+
+                // Act
+                Action act = () => monitor.Should().NotRaisePropertyChangeFor(x => x.SomeProperty, "nothing happened");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect object " + Formatter.ToString(subject) +
+                    " to raise the \"PropertyChanged\" event for property \"SomeProperty\" because nothing happened, but it did.");
+            }
+
+            [Fact]
+            public void When_a_property_changed_event_for_another_than_the_unexpected_property_was_raised_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new EventRaisingClass();
+                using var monitor = subject.Monitor();
+                subject.RaiseEventWithSenderAndPropertyName("SomeOtherProperty");
+
+                // Act
+                Action act = () => monitor.Should().NotRaisePropertyChangeFor(x => x.SomeProperty);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+        }
+
+        public class PreconditionChecks
+        {
+            [Fact]
+            public void When_monitoring_a_null_object_it_should_throw()
+            {
+                // Arrange
+                EventRaisingClass subject = null;
+
+                // Act
+                Action act = () => subject.Monitor();
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithMessage("Cannot monitor the events of a <null> object*");
+            }
+
+            [Fact]
+            public void When_nesting_monitoring_requests_scopes_should_be_isolated()
+            {
+                // Arrange
+                var eventSource = new EventRaisingClass();
+                using var outerScope = eventSource.Monitor();
+
+                // Act
+                using var innerScope = eventSource.Monitor();
+
+                // Assert
+                ((object)innerScope).Should().NotBeSameAs(outerScope);
+            }
+
+            [Fact]
+            public void When_monitoring_an_object_with_invalid_property_expression_it_should_throw()
+            {
+                // Arrange
+                var eventSource = new EventRaisingClass();
+                using var monitor = eventSource.Monitor();
+                Func<EventRaisingClass, int> func = e => e.SomeOtherProperty;
+
+                // Act
+                Action act = () => monitor.Should().RaisePropertyChangeFor(e => func(e));
+
+                // Assert
+                act.Should().Throw<ArgumentException>()
+                    .WithParameterName("expression");
+            }
+        }
+
+        public class Metadata
+        {
+            [Fact]
+            public void When_monitoring_an_object_it_should_monitor_all_the_events_it_exposes()
+            {
+                // Arrange
+                var eventSource = new ClassThatRaisesEventsItself();
+                using var eventMonitor = eventSource.Monitor();
+
+                // Act
+                EventMetadata[] metadata = eventMonitor.MonitoredEvents;
+
+                // Assert
+                metadata.Should().BeEquivalentTo(new[]
+                {
+                    new
+                    {
+                        EventName = nameof(ClassThatRaisesEventsItself.InterfaceEvent),
+                        HandlerType = typeof(EventHandler)
+                    },
+                    new
+                    {
+                        EventName = nameof(ClassThatRaisesEventsItself.PropertyChanged),
+                        HandlerType = typeof(PropertyChangedEventHandler)
+                    }
+                });
+            }
+
+            [Fact]
+            public void When_monitoring_an_object_through_an_interface_it_should_monitor_only_the_events_it_exposes()
+            {
+                // Arrange
+                var eventSource = new ClassThatRaisesEventsItself();
+                using var monitor = eventSource.Monitor<IEventRaisingInterface>();
+
+                // Act
+                EventMetadata[] metadata = monitor.MonitoredEvents;
+
+                // Assert
+                metadata.Should().BeEquivalentTo(new[]
+                {
+                    new
+                    {
+                        EventName = nameof(IEventRaisingInterface.InterfaceEvent),
+                        HandlerType = typeof(EventHandler)
+                    }
+                });
+            }
 
 #if NETFRAMEWORK // DefineDynamicAssembly is obsolete in .NET Core
-        [Fact]
-        public void When_an_object_doesnt_expose_any_events_it_should_throw()
-        {
-            // Arrange
-            object eventSource = CreateProxyObject();
-
-            // Act
-            Action act = () => eventSource.Monitor();
-
-            // Assert
-            act.Should().Throw<InvalidOperationException>().WithMessage("*not expose any events*");
-        }
-
-        [Fact]
-        public void When_monitoring_interface_of_a_class_and_no_recorder_exists_for_an_event_it_should_throw()
-        {
-            // Arrange
-            var eventSource = (IEventRaisingInterface)CreateProxyObject();
-            using var eventMonitor = eventSource.Monitor();
-
-            // Act
-            Action action = () => eventMonitor.GetRecordingFor("SomeEvent");
-
-            // Assert
-            action.Should().Throw<InvalidOperationException>()
-                .WithMessage("Not monitoring any events named \"SomeEvent\".");
-        }
-
-        private object CreateProxyObject()
-        {
-            Type baseType = typeof(EventRaisingClass);
-            Type interfaceType = typeof(IEventRaisingInterface);
-            AssemblyName assemblyName = new AssemblyName { Name = baseType.Assembly.FullName + ".GeneratedForTest" };
-            AssemblyBuilder assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName,
-                AssemblyBuilderAccess.Run);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name, false);
-            string typeName = baseType.Name + "_GeneratedForTest";
-            TypeBuilder typeBuilder = moduleBuilder.DefineType(typeName, TypeAttributes.Public, baseType, new[] { interfaceType });
-
-            MethodBuilder addHandler = EmitAddRemoveEventHandler("add");
-            typeBuilder.DefineMethodOverride(addHandler, interfaceType.GetMethod("add_InterfaceEvent"));
-            MethodBuilder removeHandler = EmitAddRemoveEventHandler("remove");
-            typeBuilder.DefineMethodOverride(removeHandler, interfaceType.GetMethod("remove_InterfaceEvent"));
-
-            Type generatedType = typeBuilder.CreateType();
-            return Activator.CreateInstance(generatedType);
-
-            MethodBuilder EmitAddRemoveEventHandler(string methodName)
+            [Fact]
+            public void When_an_object_doesnt_expose_any_events_it_should_throw()
             {
-                MethodBuilder method =
-                    typeBuilder.DefineMethod($"{interfaceType.FullName}.{methodName}_InterfaceEvent",
-                        MethodAttributes.Private | MethodAttributes.Virtual | MethodAttributes.Final |
-                        MethodAttributes.HideBySig |
-                        MethodAttributes.NewSlot);
-                method.SetReturnType(typeof(void));
-                method.SetParameters(typeof(EventHandler));
-                ILGenerator gen = method.GetILGenerator();
-                gen.Emit(OpCodes.Ret);
-                return method;
+                // Arrange
+                object eventSource = CreateProxyObject();
+
+                // Act
+                Action act = () => eventSource.Monitor();
+
+                // Assert
+                act.Should().Throw<InvalidOperationException>().WithMessage("*not expose any events*");
             }
-        }
+
+            [Fact]
+            public void When_monitoring_interface_of_a_class_and_no_recorder_exists_for_an_event_it_should_throw()
+            {
+                // Arrange
+                var eventSource = (IEventRaisingInterface)CreateProxyObject();
+                using var eventMonitor = eventSource.Monitor();
+
+                // Act
+                Action action = () => eventMonitor.GetRecordingFor("SomeEvent");
+
+                // Assert
+                action.Should().Throw<InvalidOperationException>()
+                    .WithMessage("Not monitoring any events named \"SomeEvent\".");
+            }
+
+            private object CreateProxyObject()
+            {
+                Type baseType = typeof(EventRaisingClass);
+                Type interfaceType = typeof(IEventRaisingInterface);
+                AssemblyName assemblyName = new AssemblyName { Name = baseType.Assembly.FullName + ".GeneratedForTest" };
+                AssemblyBuilder assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName,
+                    AssemblyBuilderAccess.Run);
+                ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name, false);
+                string typeName = baseType.Name + "_GeneratedForTest";
+                TypeBuilder typeBuilder = moduleBuilder.DefineType(typeName, TypeAttributes.Public, baseType, new[] { interfaceType });
+
+                MethodBuilder addHandler = EmitAddRemoveEventHandler("add");
+                typeBuilder.DefineMethodOverride(addHandler, interfaceType.GetMethod("add_InterfaceEvent"));
+                MethodBuilder removeHandler = EmitAddRemoveEventHandler("remove");
+                typeBuilder.DefineMethodOverride(removeHandler, interfaceType.GetMethod("remove_InterfaceEvent"));
+
+                Type generatedType = typeBuilder.CreateType();
+                return Activator.CreateInstance(generatedType);
+
+                MethodBuilder EmitAddRemoveEventHandler(string methodName)
+                {
+                    MethodBuilder method =
+                        typeBuilder.DefineMethod($"{interfaceType.FullName}.{methodName}_InterfaceEvent",
+                            MethodAttributes.Private | MethodAttributes.Virtual | MethodAttributes.Final |
+                            MethodAttributes.HideBySig |
+                            MethodAttributes.NewSlot);
+                    method.SetReturnType(typeof(void));
+                    method.SetParameters(typeof(EventHandler));
+                    ILGenerator gen = method.GetILGenerator();
+                    gen.Emit(OpCodes.Ret);
+                    return method;
+                }
+            }
 
 #endif
 
-        [Fact]
-        public void When_event_exists_on_class_but_not_on_monitored_interface_it_should_not_allow_monitoring_it()
-        {
-            // Arrange
-            var eventSource = new ClassThatRaisesEventsItself();
-            using var eventMonitor = eventSource.Monitor<IEventRaisingInterface>();
-
-            // Act
-            Action action = () => eventMonitor.GetRecordingFor("PropertyChanged");
-
-            // Assert
-            action.Should().Throw<InvalidOperationException>()
-                .WithMessage("Not monitoring any events named \"PropertyChanged\".");
-        }
-
-        [Fact]
-        public void When_an_object_raises_two_events_it_should_provide_the_data_about_those_occurrences()
-        {
-            // Arrange
-            DateTime utcNow = 17.September(2017).At(21, 00).AsUtc();
-
-            var eventSource = new EventRaisingClass();
-            using var monitor = eventSource.Monitor(() => utcNow);
-
-            // Act
-            eventSource.RaiseEventWithSenderAndPropertyName("theProperty");
-
-            utcNow += 1.Hours();
-
-            eventSource.RaiseNonConventionalEvent("first", 123, "third");
-
-            // Assert
-            monitor.OccurredEvents.Should().BeEquivalentTo(new[]
+            [Fact]
+            public void When_event_exists_on_class_but_not_on_monitored_interface_it_should_not_allow_monitoring_it()
             {
-                new
+                // Arrange
+                var eventSource = new ClassThatRaisesEventsItself();
+                using var eventMonitor = eventSource.Monitor<IEventRaisingInterface>();
+
+                // Act
+                Action action = () => eventMonitor.GetRecordingFor("PropertyChanged");
+
+                // Assert
+                action.Should().Throw<InvalidOperationException>()
+                    .WithMessage("Not monitoring any events named \"PropertyChanged\".");
+            }
+
+            [Fact]
+            public void When_an_object_raises_two_events_it_should_provide_the_data_about_those_occurrences()
+            {
+                // Arrange
+                DateTime utcNow = 17.September(2017).At(21, 00).AsUtc();
+
+                var eventSource = new EventRaisingClass();
+                using var monitor = eventSource.Monitor(() => utcNow);
+
+                // Act
+                eventSource.RaiseEventWithSenderAndPropertyName("theProperty");
+
+                utcNow += 1.Hours();
+
+                eventSource.RaiseNonConventionalEvent("first", 123, "third");
+
+                // Assert
+                monitor.OccurredEvents.Should().BeEquivalentTo(new[]
                 {
-                    EventName = "PropertyChanged",
-                    TimestampUtc = utcNow - 1.Hours(),
-                    Parameters = new object[] { eventSource, new PropertyChangedEventArgs("theProperty") }
-                },
-                new
-                {
-                    EventName = "NonConventionalEvent",
-                    TimestampUtc = utcNow,
-                    Parameters = new object[] { "first", 123, "third" }
-                }
-            }, o => o.WithStrictOrdering());
+                    new
+                    {
+                        EventName = "PropertyChanged",
+                        TimestampUtc = utcNow - 1.Hours(),
+                        Parameters = new object[] { eventSource, new PropertyChangedEventArgs("theProperty") }
+                    },
+                    new
+                    {
+                        EventName = "NonConventionalEvent",
+                        TimestampUtc = utcNow,
+                        Parameters = new object[] { "first", 123, "third" }
+                    }
+                }, o => o.WithStrictOrdering());
+            }
+
+            [Fact]
+            public void When_monitoring_interface_with_inherited_event_it_should_not_throw()
+            {
+                // Arrange
+                var eventSource = (IInheritsEventRaisingInterface)new ClassThatRaisesEventsItself();
+
+                // Act
+                Action action = () => eventSource.Monitor();
+
+                // Assert
+                action.Should().NotThrow<InvalidOperationException>();
+            }
         }
-
-        [Fact]
-        public void When_monitoring_interface_with_inherited_event_it_should_not_throw()
-        {
-            // Arrange
-            var eventSource = (IInheritsEventRaisingInterface)new ClassThatRaisesEventsItself();
-
-            // Act
-            Action action = () => eventSource.Monitor();
-
-            // Assert
-            action.Should().NotThrow<InvalidOperationException>();
-        }
-
-        #endregion
 
         public class ClassThatRaisesEventsItself : IInheritsEventRaisingInterface
         {

--- a/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
@@ -10,259 +10,255 @@ namespace FluentAssertions.Specs.Specialized
 {
     public class AssemblyAssertionSpecs
     {
-        #region NotReference
-
-        [Fact]
-        public void When_an_assembly_is_not_referenced_and_should_not_reference_is_asserted_it_should_succeed()
+        public class NotReference
         {
-            // Arrange
-            var assemblyA = FindAssembly.Containing<ClassA>();
-            var assemblyB = FindAssembly.Containing<ClassB>();
+            [Fact]
+            public void When_an_assembly_is_not_referenced_and_should_not_reference_is_asserted_it_should_succeed()
+            {
+                // Arrange
+                var assemblyA = FindAssembly.Containing<ClassA>();
+                var assemblyB = FindAssembly.Containing<ClassB>();
 
-            // Act
-            Action act = () => assemblyB.Should().NotReference(assemblyA);
+                // Act
+                Action act = () => assemblyB.Should().NotReference(assemblyA);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_an_assembly_is_not_referenced_it_should_allow_chaining()
+            {
+                // Arrange
+                var assemblyA = FindAssembly.Containing<ClassA>();
+                var assemblyB = FindAssembly.Containing<ClassB>();
+
+                // Act
+                Action act = () => assemblyB.Should().NotReference(assemblyA)
+                    .And.NotBeNull();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_an_assembly_is_referenced_and_should_not_reference_is_asserted_it_should_fail()
+            {
+                // Arrange
+                var assemblyA = FindAssembly.Containing<ClassA>();
+                var assemblyB = FindAssembly.Containing<ClassB>();
+
+                // Act
+                Action act = () => assemblyA.Should().NotReference(assemblyB);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_reference_should_fail()
+            {
+                // Arrange
+                Assembly assemblyA = null;
+                Assembly assemblyB = FindAssembly.Containing<ClassB>();
+
+                // Act
+                Action act = () => assemblyA.Should().NotReference(assemblyB, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected assembly not to reference assembly \"AssemblyB\" *failure message*, but assemblyA is <null>.");
+            }
+
+            [Fact]
+            public void When_an_assembly_is_not_referencing_null_it_should_throw()
+            {
+                // Arrange
+                var assemblyA = FindAssembly.Containing<ClassA>();
+
+                // Act
+                Action act = () => assemblyA.Should().NotReference(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("assembly");
+            }
         }
 
-        [Fact]
-        public void When_an_assembly_is_not_referenced_it_should_allow_chaining()
+        public class Reference
         {
-            // Arrange
-            var assemblyA = FindAssembly.Containing<ClassA>();
-            var assemblyB = FindAssembly.Containing<ClassB>();
+            [Fact]
+            public void When_an_assembly_is_referenced_and_should_reference_is_asserted_it_should_succeed()
+            {
+                // Arrange
+                var assemblyA = FindAssembly.Containing<ClassA>();
+                var assemblyB = FindAssembly.Containing<ClassB>();
 
-            // Act
-            Action act = () => assemblyB.Should().NotReference(assemblyA)
-                .And.NotBeNull();
+                // Act
+                Action act = () => assemblyA.Should().Reference(assemblyB);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_an_assembly_is_referenced_it_should_allow_chaining()
+            {
+                // Arrange
+                var assemblyA = FindAssembly.Containing<ClassA>();
+                var assemblyB = FindAssembly.Containing<ClassB>();
+
+                // Act
+                Action act = () => assemblyA.Should().Reference(assemblyB)
+                    .And.NotBeNull();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_an_assembly_is_not_referenced_and_should_reference_is_asserted_it_should_fail()
+            {
+                // Arrange
+                var assemblyA = FindAssembly.Containing<ClassA>();
+                var assemblyB = FindAssembly.Containing<ClassB>();
+
+                // Act
+                Action act = () => assemblyB.Should().Reference(assemblyA);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_subject_is_null_reference_should_fail()
+            {
+                // Arrange
+                Assembly assemblyA = null;
+                Assembly assemblyB = FindAssembly.Containing<ClassB>();
+
+                // Act
+                Action act = () => assemblyA.Should().Reference(assemblyB, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected assembly to reference assembly \"AssemblyB\" *failure message*, but assemblyA is <null>.");
+            }
+
+            [Fact]
+            public void When_an_assembly_is_referencing_null_it_should_throw()
+            {
+                // Arrange
+                var assemblyA = FindAssembly.Containing<ClassA>();
+
+                // Act
+                Action act = () => assemblyA.Should().Reference(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("assembly");
+            }
         }
 
-        [Fact]
-        public void When_an_assembly_is_referenced_and_should_not_reference_is_asserted_it_should_fail()
+        public class DefineType
         {
-            // Arrange
-            var assemblyA = FindAssembly.Containing<ClassA>();
-            var assemblyB = FindAssembly.Containing<ClassB>();
+            [Fact]
+            public void When_an_assembly_defines_a_type_and_Should_DefineType_is_asserted_it_should_succeed()
+            {
+                // Arrange
+                var thisAssembly = GetType().Assembly;
 
-            // Act
-            Action act = () => assemblyA.Should().NotReference(assemblyB);
+                // Act
+                Action act = () => thisAssembly
+                    .Should().DefineType(GetType().Namespace, typeof(WellKnownClassWithAttribute).Name)
+                    .Which.Should().BeDecoratedWith<DummyClassAttribute>();
 
-            // Assert
-            act.Should().Throw<XunitException>();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_an_assembly_does_not_define_a_type_and_Should_DefineType_is_asserted_it_should_fail_with_a_useful_message()
+            {
+                // Arrange
+                var thisAssembly = GetType().Assembly;
+
+                // Act
+                Action act = () => thisAssembly.Should().DefineType("FakeNamespace", "FakeName",
+                    "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage($"Expected assembly \"{thisAssembly.FullName}\" " +
+                                 "to define type \"FakeNamespace\".\"FakeName\" " +
+                                 "because we want to test the failure message, but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_define_type_should_fail()
+            {
+                // Arrange
+                Assembly thisAssembly = null;
+
+                // Act
+                Action act = () =>
+                    thisAssembly.Should().DefineType(GetType().Namespace, "WellKnownClassWithAttribute",
+                        "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected assembly to define type *.\"WellKnownClassWithAttribute\" *failure message*" +
+                        ", but thisAssembly is <null>.");
+            }
+
+            [Fact]
+            public void When_an_assembly_defining_a_type_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var thisAssembly = GetType().Assembly;
+
+                // Act
+                Action act = () => thisAssembly.Should().DefineType(GetType().Namespace, null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_an_assembly_defining_a_type_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var thisAssembly = GetType().Assembly;
+
+                // Act
+                Action act = () => thisAssembly.Should().DefineType(GetType().Namespace, string.Empty);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
         }
 
-        [Fact]
-        public void When_subject_is_null_not_reference_should_fail()
+        public class BeNull
         {
-            // Arrange
-            Assembly assemblyA = null;
-            Assembly assemblyB = FindAssembly.Containing<ClassB>();
+            [Fact]
+            public void When_an_assembly_is_null_and_Should_BeNull_is_asserted_it_should_succeed()
+            {
+                // Arrange
+                Assembly thisAssembly = null;
 
-            // Act
-            Action act = () => assemblyA.Should().NotReference(assemblyB, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () => thisAssembly
+                    .Should().BeNull();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected assembly not to reference assembly \"AssemblyB\" *failure message*, but assemblyA is <null>.");
+                // Assert
+                act.Should().NotThrow();
+            }
         }
-
-        [Fact]
-        public void When_an_assembly_is_not_referencing_null_it_should_throw()
-        {
-            // Arrange
-            var assemblyA = FindAssembly.Containing<ClassA>();
-
-            // Act
-            Action act = () => assemblyA.Should().NotReference(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("assembly");
-        }
-
-        #endregion
-
-        #region Reference
-
-        [Fact]
-        public void When_an_assembly_is_referenced_and_should_reference_is_asserted_it_should_succeed()
-        {
-            // Arrange
-            var assemblyA = FindAssembly.Containing<ClassA>();
-            var assemblyB = FindAssembly.Containing<ClassB>();
-
-            // Act
-            Action act = () => assemblyA.Should().Reference(assemblyB);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_an_assembly_is_referenced_it_should_allow_chaining()
-        {
-            // Arrange
-            var assemblyA = FindAssembly.Containing<ClassA>();
-            var assemblyB = FindAssembly.Containing<ClassB>();
-
-            // Act
-            Action act = () => assemblyA.Should().Reference(assemblyB)
-                .And.NotBeNull();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_an_assembly_is_not_referenced_and_should_reference_is_asserted_it_should_fail()
-        {
-            // Arrange
-            var assemblyA = FindAssembly.Containing<ClassA>();
-            var assemblyB = FindAssembly.Containing<ClassB>();
-
-            // Act
-            Action act = () => assemblyB.Should().Reference(assemblyA);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_subject_is_null_reference_should_fail()
-        {
-            // Arrange
-            Assembly assemblyA = null;
-            Assembly assemblyB = FindAssembly.Containing<ClassB>();
-
-            // Act
-            Action act = () => assemblyA.Should().Reference(assemblyB, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected assembly to reference assembly \"AssemblyB\" *failure message*, but assemblyA is <null>.");
-        }
-
-        [Fact]
-        public void When_an_assembly_is_referencing_null_it_should_throw()
-        {
-            // Arrange
-            var assemblyA = FindAssembly.Containing<ClassA>();
-
-            // Act
-            Action act = () => assemblyA.Should().Reference(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("assembly");
-        }
-
-        #endregion
-
-        #region DefineType
-
-        [Fact]
-        public void When_an_assembly_defines_a_type_and_Should_DefineType_is_asserted_it_should_succeed()
-        {
-            // Arrange
-            var thisAssembly = GetType().Assembly;
-
-            // Act
-            Action act = () => thisAssembly
-                .Should().DefineType(GetType().Namespace, typeof(WellKnownClassWithAttribute).Name)
-                .Which.Should().BeDecoratedWith<DummyClassAttribute>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_an_assembly_does_not_define_a_type_and_Should_DefineType_is_asserted_it_should_fail_with_a_useful_message()
-        {
-            // Arrange
-            var thisAssembly = GetType().Assembly;
-
-            // Act
-            Action act = () => thisAssembly.Should().DefineType("FakeNamespace", "FakeName",
-                "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"Expected assembly \"{thisAssembly.FullName}\" " +
-                             "to define type \"FakeNamespace\".\"FakeName\" " +
-                             "because we want to test the failure message, but it does not.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_define_type_should_fail()
-        {
-            // Arrange
-            Assembly thisAssembly = null;
-
-            // Act
-            Action act = () =>
-                thisAssembly.Should().DefineType(GetType().Namespace, "WellKnownClassWithAttribute",
-                    "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected assembly to define type *.\"WellKnownClassWithAttribute\" *failure message*" +
-                    ", but thisAssembly is <null>.");
-        }
-
-        [Fact]
-        public void When_an_assembly_defining_a_type_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var thisAssembly = GetType().Assembly;
-
-            // Act
-            Action act = () => thisAssembly.Should().DefineType(GetType().Namespace, null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_an_assembly_defining_a_type_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var thisAssembly = GetType().Assembly;
-
-            // Act
-            Action act = () => thisAssembly.Should().DefineType(GetType().Namespace, string.Empty);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        #endregion
-
-        #region BeNull
-
-        [Fact]
-        public void When_an_assembly_is_null_and_Should_BeNull_is_asserted_it_should_succeed()
-        {
-            // Arrange
-            Assembly thisAssembly = null;
-
-            // Act
-            Action act = () => thisAssembly
-                .Should().BeNull();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        #endregion
     }
 
     [DummyClass("name", true)]

--- a/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -10,535 +10,540 @@ namespace FluentAssertions.Specs.Specialized
 {
     public class ExecutionTimeAssertionsSpecs
     {
-        #region BeLessThanOrEqualTo
-        [Fact]
-        public void When_the_execution_time_of_a_member_is_not_less_than_or_equal_to_a_limit_it_should_throw()
+        public class BeLessThanOrEqualTo
         {
-            // Arrange
-            var subject = new SleepingClass();
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(610)).Should().BeLessThanOrEqualTo(500.Milliseconds(),
-                "we like speed");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*(s.Sleep(610)) should be less than or equal to 500ms because we like speed, but it required*");
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_a_member_is_less_than_or_equal_to_a_limit_it_should_not_throw()
-        {
-            // Arrange
-            var subject = new SleepingClass();
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(0)).Should().BeLessThanOrEqualTo(500.Milliseconds());
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_an_action_is_not_less_than_or_equal_to_a_limit_it_should_throw()
-        {
-            // Arrange
-            Action someAction = () => Thread.Sleep(510);
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessThanOrEqualTo(100.Milliseconds());
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*action should be less than or equal to 100ms, but it required*");
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_an_action_is_less_than_or_equal_to_a_limit_it_should_not_throw()
-        {
-            // Arrange
-            Action someAction = () => Thread.Sleep(100);
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessThanOrEqualTo(1.Seconds());
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_action_runs_indefinitely_it_should_be_stopped_and_throw_if_there_is_less_than_or_equal_condition()
-        {
-            // Arrange
-            Action someAction = () =>
+            [Fact]
+            public void When_the_execution_time_of_a_member_is_not_less_than_or_equal_to_a_limit_it_should_throw()
             {
+                // Arrange
+                var subject = new SleepingClass();
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(s => s.Sleep(610)).Should().BeLessThanOrEqualTo(500.Milliseconds(),
+                    "we like speed");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*(s.Sleep(610)) should be less than or equal to 500ms because we like speed, but it required*");
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_a_member_is_less_than_or_equal_to_a_limit_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new SleepingClass();
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(s => s.Sleep(0)).Should().BeLessThanOrEqualTo(500.Milliseconds());
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_an_action_is_not_less_than_or_equal_to_a_limit_it_should_throw()
+            {
+                // Arrange
+                Action someAction = () => Thread.Sleep(510);
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeLessThanOrEqualTo(100.Milliseconds());
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*action should be less than or equal to 100ms, but it required*");
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_an_action_is_less_than_or_equal_to_a_limit_it_should_not_throw()
+            {
+                // Arrange
+                Action someAction = () => Thread.Sleep(100);
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeLessThanOrEqualTo(1.Seconds());
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_action_runs_indefinitely_it_should_be_stopped_and_throw_if_there_is_less_than_or_equal_condition()
+            {
+                // Arrange
+                Action someAction = () =>
+                {
                 // lets cause a deadlock
-                var semaphore = new Semaphore(0, 1); // my weapon of choice is a semaphore
-                semaphore.WaitOne(); // oops
-            };
+                    var semaphore = new Semaphore(0, 1); // my weapon of choice is a semaphore
+                    semaphore.WaitOne(); // oops
+                };
 
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessThanOrEqualTo(100.Milliseconds());
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeLessThanOrEqualTo(100.Milliseconds());
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*action should be less than or equal to 100ms, but it required more than*");
-        }
-        #endregion
-
-        #region BeLessThan
-        [Fact]
-        public void When_the_execution_time_of_a_member_is_not_less_than_a_limit_it_should_throw()
-        {
-            // Arrange
-            var subject = new SleepingClass();
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(610)).Should().BeLessThan(500.Milliseconds(),
-                "we like speed");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*(s.Sleep(610)) should be less than 500ms because we like speed, but it required*");
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*action should be less than or equal to 100ms, but it required more than*");
+            }
         }
 
-        [Fact]
-        public void When_the_execution_time_of_a_member_is_less_than_a_limit_it_should_not_throw()
+        public class BeLessThan
         {
-            // Arrange
-            var subject = new SleepingClass();
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(0)).Should().BeLessThan(500.Milliseconds());
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_an_action_is_not_less_than_a_limit_it_should_throw()
-        {
-            // Arrange
-            Action someAction = () => Thread.Sleep(510);
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessThan(100.Milliseconds());
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*action should be less than 100ms, but it required*");
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_an_async_action_is_not_less_than_a_limit_it_should_throw()
-        {
-            // Arrange
-            Func<Task> someAction = () => Task.Delay(TimeSpan.FromMilliseconds(150));
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessThan(100.Milliseconds());
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*action should be less than 100ms, but it required*");
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_an_action_is_less_than_a_limit_it_should_not_throw()
-        {
-            // Arrange
-            Action someAction = () => Thread.Sleep(100);
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessThan(2.Seconds());
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_an_async_action_is_less_than_a_limit_it_should_not_throw()
-        {
-            // Arrange
-            Func<Task> someAction = () => Task.Delay(TimeSpan.FromMilliseconds(100));
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessThan(20.Seconds());
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_action_runs_indefinitely_it_should_be_stopped_and_throw_if_there_is_less_than_condition()
-        {
-            // Arrange
-            Action someAction = () =>
+            [Fact]
+            public void When_the_execution_time_of_a_member_is_not_less_than_a_limit_it_should_throw()
             {
+                // Arrange
+                var subject = new SleepingClass();
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(s => s.Sleep(610)).Should().BeLessThan(500.Milliseconds(),
+                    "we like speed");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*(s.Sleep(610)) should be less than 500ms because we like speed, but it required*");
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_a_member_is_less_than_a_limit_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new SleepingClass();
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(s => s.Sleep(0)).Should().BeLessThan(500.Milliseconds());
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_an_action_is_not_less_than_a_limit_it_should_throw()
+            {
+                // Arrange
+                Action someAction = () => Thread.Sleep(510);
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeLessThan(100.Milliseconds());
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*action should be less than 100ms, but it required*");
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_an_async_action_is_not_less_than_a_limit_it_should_throw()
+            {
+                // Arrange
+                Func<Task> someAction = () => Task.Delay(TimeSpan.FromMilliseconds(150));
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeLessThan(100.Milliseconds());
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*action should be less than 100ms, but it required*");
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_an_action_is_less_than_a_limit_it_should_not_throw()
+            {
+                // Arrange
+                Action someAction = () => Thread.Sleep(100);
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeLessThan(2.Seconds());
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_an_async_action_is_less_than_a_limit_it_should_not_throw()
+            {
+                // Arrange
+                Func<Task> someAction = () => Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeLessThan(20.Seconds());
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_action_runs_indefinitely_it_should_be_stopped_and_throw_if_there_is_less_than_condition()
+            {
+                // Arrange
+                Action someAction = () =>
+                {
                 // lets cause a deadlock
-                var semaphore = new Semaphore(0, 1); // my weapon of choice is a semaphore
-                semaphore.WaitOne(); // oops
-            };
+                    var semaphore = new Semaphore(0, 1); // my weapon of choice is a semaphore
+                    semaphore.WaitOne(); // oops
+                };
 
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessThan(100.Milliseconds());
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeLessThan(100.Milliseconds());
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*action should be less than 100ms, but it required more than*");
-        }
-        #endregion
-
-        #region BeGreaterThanOrEqualTo
-        [Fact]
-        public void When_the_execution_time_of_a_member_is_not_greater_than_or_equal_to_a_limit_it_should_throw()
-        {
-            // Arrange
-            var subject = new SleepingClass();
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterThanOrEqualTo(1.Seconds(),
-                "we like speed");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*(s.Sleep(100)) should be greater than or equal to 1s because we like speed, but it required*");
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*action should be less than 100ms, but it required more than*");
+            }
         }
 
-        [Fact]
-        public void When_the_execution_time_of_a_member_is_greater_than_or_equal_to_a_limit_it_should_not_throw()
+        public class BeGreaterThanOrEqualTo
         {
-            // Arrange
-            var subject = new SleepingClass();
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterThanOrEqualTo(50.Milliseconds());
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_an_action_is_not_greater_than_or_equal_to_a_limit_it_should_throw()
-        {
-            // Arrange
-            Action someAction = () => Thread.Sleep(100);
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeGreaterThanOrEqualTo(1.Seconds());
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*action should be greater than or equal to 1s, but it required*");
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_an_action_is_greater_than_or_equal_to_a_limit_it_should_not_throw()
-        {
-            // Arrange
-            Action someAction = () => Thread.Sleep(100);
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeGreaterThanOrEqualTo(50.Milliseconds());
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_action_runs_indefinitely_it_should_be_stopped_and_not_throw_if_there_is_greater_than_or_equal_condition()
-        {
-            // Arrange
-            Action someAction = () =>
+            [Fact]
+            public void When_the_execution_time_of_a_member_is_not_greater_than_or_equal_to_a_limit_it_should_throw()
             {
+                // Arrange
+                var subject = new SleepingClass();
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterThanOrEqualTo(1.Seconds(),
+                    "we like speed");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*(s.Sleep(100)) should be greater than or equal to 1s because we like speed, but it required*");
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_a_member_is_greater_than_or_equal_to_a_limit_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new SleepingClass();
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterThanOrEqualTo(50.Milliseconds());
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_an_action_is_not_greater_than_or_equal_to_a_limit_it_should_throw()
+            {
+                // Arrange
+                Action someAction = () => Thread.Sleep(100);
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeGreaterThanOrEqualTo(1.Seconds());
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*action should be greater than or equal to 1s, but it required*");
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_an_action_is_greater_than_or_equal_to_a_limit_it_should_not_throw()
+            {
+                // Arrange
+                Action someAction = () => Thread.Sleep(100);
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeGreaterThanOrEqualTo(50.Milliseconds());
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_action_runs_indefinitely_it_should_be_stopped_and_not_throw_if_there_is_greater_than_or_equal_condition()
+            {
+                // Arrange
+                Action someAction = () =>
+                {
                 // lets cause a deadlock
-                var semaphore = new Semaphore(0, 1); // my weapon of choice is a semaphore
-                semaphore.WaitOne(); // oops
-            };
+                    var semaphore = new Semaphore(0, 1); // my weapon of choice is a semaphore
+                    semaphore.WaitOne(); // oops
+                };
 
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeGreaterThanOrEqualTo(100.Milliseconds());
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeGreaterThanOrEqualTo(100.Milliseconds());
 
-            // Assert
-            act.Should().NotThrow<XunitException>();
-        }
-        #endregion
-
-        #region BeGreaterThan
-        [Fact]
-        public void When_the_execution_time_of_a_member_is_not_greater_than_a_limit_it_should_throw()
-        {
-            // Arrange
-            var subject = new SleepingClass();
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterThan(1.Seconds(),
-                "we like speed");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*(s.Sleep(100)) should be greater than 1s because we like speed, but it required*");
+                // Assert
+                act.Should().NotThrow<XunitException>();
+            }
         }
 
-        [Fact]
-        public void When_the_execution_time_of_a_member_is_greater_than_a_limit_it_should_not_throw()
+        public class BeGreaterThan
         {
-            // Arrange
-            var subject = new SleepingClass();
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(200)).Should().BeGreaterThan(100.Milliseconds());
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_an_action_is_not_greater_than_a_limit_it_should_throw()
-        {
-            // Arrange
-            Action someAction = () => Thread.Sleep(100);
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeGreaterThan(1.Seconds());
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*action should be greater than 1s, but it required*");
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_an_action_is_greater_than_a_limit_it_should_not_throw()
-        {
-            // Arrange
-            Action someAction = () => Thread.Sleep(200);
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeGreaterThan(100.Milliseconds());
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_action_runs_indefinitely_it_should_be_stopped_and_not_throw_if_there_is_greater_than_condition()
-        {
-            // Arrange
-            Action someAction = () =>
+            [Fact]
+            public void When_the_execution_time_of_a_member_is_not_greater_than_a_limit_it_should_throw()
             {
+                // Arrange
+                var subject = new SleepingClass();
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterThan(1.Seconds(),
+                    "we like speed");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*(s.Sleep(100)) should be greater than 1s because we like speed, but it required*");
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_a_member_is_greater_than_a_limit_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new SleepingClass();
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(s => s.Sleep(200)).Should().BeGreaterThan(100.Milliseconds());
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_an_action_is_not_greater_than_a_limit_it_should_throw()
+            {
+                // Arrange
+                Action someAction = () => Thread.Sleep(100);
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeGreaterThan(1.Seconds());
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*action should be greater than 1s, but it required*");
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_an_action_is_greater_than_a_limit_it_should_not_throw()
+            {
+                // Arrange
+                Action someAction = () => Thread.Sleep(200);
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeGreaterThan(100.Milliseconds());
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_action_runs_indefinitely_it_should_be_stopped_and_not_throw_if_there_is_greater_than_condition()
+            {
+                // Arrange
+                Action someAction = () =>
+                {
                 // lets cause a deadlock
-                var semaphore = new Semaphore(0, 1); // my weapon of choice is a semaphore
-                semaphore.WaitOne(); // oops
-            };
+                    var semaphore = new Semaphore(0, 1); // my weapon of choice is a semaphore
+                    semaphore.WaitOne(); // oops
+                };
 
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeGreaterThan(100.Milliseconds());
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeGreaterThan(100.Milliseconds());
 
-            // Assert
-            act.Should().NotThrow<XunitException>();
-        }
-        #endregion
-
-        #region BeCloseTo
-        [Fact]
-        public void When_asserting_that_execution_time_is_close_to_a_negative_precision_it_should_throw()
-        {
-            // Arrange
-            var subject = new SleepingClass();
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(200)).Should().BeCloseTo(100.Milliseconds(),
-                -1.Ticks());
-
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .WithMessage("* value of precision must be non-negative*");
+                // Assert
+                act.Should().NotThrow<XunitException>();
+            }
         }
 
-        [Fact]
-        public void When_the_execution_time_of_a_member_is_not_close_to_a_limit_it_should_throw()
+        public class BeCloseTo
         {
-            // Arrange
-            var subject = new SleepingClass();
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(200)).Should().BeCloseTo(100.Milliseconds(),
-                50.Milliseconds(),
-                "we like speed");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*(s.Sleep(200)) should be within 50ms from 100ms because we like speed, but it required*");
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_a_member_is_close_to_a_limit_it_should_not_throw()
-        {
-            // Arrange
-            var subject = new SleepingClass();
-            var timer = new TestTimer(() => 210.Milliseconds());
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(0), () => timer).Should().BeCloseTo(200.Milliseconds(),
-                150.Milliseconds());
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_an_action_is_not_close_to_a_limit_it_should_throw()
-        {
-            // Arrange
-            Action someAction = () => Thread.Sleep(200);
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeCloseTo(100.Milliseconds(), 50.Milliseconds());
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*action should be within 50ms from 100ms, but it required*");
-        }
-
-        [Fact]
-        public void When_the_execution_time_of_an_action_is_close_to_a_limit_it_should_not_throw()
-        {
-            // Arrange
-            Action someAction = () => { };
-            var timer = new TestTimer(() => 210.Milliseconds());
-
-            // Act
-            Action act = () => someAction.ExecutionTime(() => timer).Should().BeCloseTo(200.Milliseconds(), 15.Milliseconds());
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_action_runs_indefinitely_it_should_be_stopped_and_throw_if_there_is_be_close_to_condition()
-        {
-            // Arrange
-            Action someAction = () =>
+            [Fact]
+            public void When_asserting_that_execution_time_is_close_to_a_negative_precision_it_should_throw()
             {
+                // Arrange
+                var subject = new SleepingClass();
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(s => s.Sleep(200)).Should().BeCloseTo(100.Milliseconds(),
+                    -1.Ticks());
+
+                // Assert
+                act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of precision must be non-negative*");
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_a_member_is_not_close_to_a_limit_it_should_throw()
+            {
+                // Arrange
+                var subject = new SleepingClass();
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(s => s.Sleep(200)).Should().BeCloseTo(100.Milliseconds(),
+                    50.Milliseconds(),
+                    "we like speed");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*(s.Sleep(200)) should be within 50ms from 100ms because we like speed, but it required*");
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_a_member_is_close_to_a_limit_it_should_not_throw()
+            {
+                // Arrange
+                var subject = new SleepingClass();
+                var timer = new TestTimer(() => 210.Milliseconds());
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(s => s.Sleep(0), () => timer).Should().BeCloseTo(200.Milliseconds(),
+                    150.Milliseconds());
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_an_action_is_not_close_to_a_limit_it_should_throw()
+            {
+                // Arrange
+                Action someAction = () => Thread.Sleep(200);
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeCloseTo(100.Milliseconds(), 50.Milliseconds());
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*action should be within 50ms from 100ms, but it required*");
+            }
+
+            [Fact]
+            public void When_the_execution_time_of_an_action_is_close_to_a_limit_it_should_not_throw()
+            {
+                // Arrange
+                Action someAction = () => { };
+                var timer = new TestTimer(() => 210.Milliseconds());
+
+                // Act
+                Action act = () => someAction.ExecutionTime(() => timer).Should().BeCloseTo(200.Milliseconds(), 15.Milliseconds());
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_action_runs_indefinitely_it_should_be_stopped_and_throw_if_there_is_be_close_to_condition()
+            {
+                // Arrange
+                Action someAction = () =>
+                {
                 // lets cause a deadlock
-                var semaphore = new Semaphore(0, 1); // my weapon of choice is a semaphore
-                semaphore.WaitOne(); // oops
-            };
+                    var semaphore = new Semaphore(0, 1); // my weapon of choice is a semaphore
+                    semaphore.WaitOne(); // oops
+                };
 
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeCloseTo(100.Milliseconds(), 50.Milliseconds());
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeCloseTo(100.Milliseconds(), 50.Milliseconds());
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*action should be within 50ms from 100ms, but it required*");
-        }
-        #endregion
-
-        #region ExecutionTime
-        [Fact]
-        public void When_action_runs_inside_execution_time_exceptions_are_captured_and_rethrown()
-        {
-            // Arrange
-            Action someAction = () => throw new ArgumentException("Let's say somebody called the wrong method.");
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessThan(200.Milliseconds());
-
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage("Let's say somebody called the wrong method.");
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "*action should be within 50ms from 100ms, but it required*");
+            }
         }
 
-        [Fact]
-        public void Stopwatch_is_not_stopped_after_first_execution_time_assertion()
+        public class ExecutingTime
         {
-            // Arrange
-            Action someAction = () => Thread.Sleep(300);
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_action_runs_inside_execution_time_exceptions_are_captured_and_rethrown()
             {
+                // Arrange
+                Action someAction = () => throw new ArgumentException("Let's say somebody called the wrong method.");
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeLessThan(200.Milliseconds());
+
+                // Assert
+                act.Should().Throw<ArgumentException>().WithMessage("Let's say somebody called the wrong method.");
+            }
+
+            [Fact]
+            public void Stopwatch_is_not_stopped_after_first_execution_time_assertion()
+            {
+                // Arrange
+                Action someAction = () => Thread.Sleep(300);
+
+                // Act
+                Action act = () =>
+                {
                 // I know it's not meant to be used like this,
                 // but since you can, it should still give consistent results
-                ExecutionTime time = someAction.ExecutionTime();
-                time.Should().BeGreaterThan(100.Milliseconds());
-                time.Should().BeGreaterThan(200.Milliseconds());
-            };
+                    ExecutionTime time = someAction.ExecutionTime();
+                    time.Should().BeGreaterThan(100.Milliseconds());
+                    time.Should().BeGreaterThan(200.Milliseconds());
+                };
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_on_null_execution_it_should_throw()
+            {
+                // Arrange
+                ExecutionTime executionTime = null;
+
+                // Act
+                Func<ExecutionTimeAssertions> act = () => new ExecutionTimeAssertions(executionTime);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>()
+                    .WithParameterName("executionTime");
+            }
+
+            [Fact]
+            public void When_asserting_on_null_action_it_should_throw()
+            {
+                // Arrange
+                Action someAction = null;
+
+                // Act
+                Action act = () => someAction.ExecutionTime().Should().BeLessThan(1.Days());
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("action");
+            }
+
+            [Fact]
+            public void When_asserting_on_null_func_it_should_throw()
+            {
+                // Arrange
+                Func<Task> someFunc = null;
+
+                // Act
+                Action act = () => someFunc.ExecutionTime().Should().BeLessThan(1.Days());
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("action");
+            }
+
+            [Fact]
+            public void When_asserting_execution_time_of_null_action_it_should_throw()
+            {
+                // Arrange
+                object subject = null;
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(s => s.ToString()).Should().BeLessThan(1.Days());
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("subject");
+            }
+
+            [Fact]
+            public void When_asserting_execution_time_of_null_it_should_throw()
+            {
+                // Arrange
+                var subject = new object();
+
+                // Act
+                Action act = () => subject.ExecutionTimeOf(null).Should().BeLessThan(1.Days());
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("action");
+            }
         }
-
-        [Fact]
-        public void When_asserting_on_null_execution_it_should_throw()
-        {
-            // Arrange
-            ExecutionTime executionTime = null;
-
-            // Act
-            Func<ExecutionTimeAssertions> act = () => new ExecutionTimeAssertions(executionTime);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithParameterName("executionTime");
-        }
-
-        [Fact]
-        public void When_asserting_on_null_action_it_should_throw()
-        {
-            // Arrange
-            Action someAction = null;
-
-            // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessThan(1.Days());
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("action");
-        }
-
-        [Fact]
-        public void When_asserting_on_null_func_it_should_throw()
-        {
-            // Arrange
-            Func<Task> someFunc = null;
-
-            // Act
-            Action act = () => someFunc.ExecutionTime().Should().BeLessThan(1.Days());
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("action");
-        }
-
-        [Fact]
-        public void When_asserting_execution_time_of_null_action_it_should_throw()
-        {
-            // Arrange
-            object subject = null;
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.ToString()).Should().BeLessThan(1.Days());
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("subject");
-        }
-
-        [Fact]
-        public void When_asserting_execution_time_of_null_it_should_throw()
-        {
-            // Arrange
-            var subject = new object();
-
-            // Act
-            Action act = () => subject.ExecutionTimeOf(null).Should().BeLessThan(1.Days());
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("action");
-        }
-
-        #endregion
 
         internal class SleepingClass
         {

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -13,188 +13,161 @@ namespace FluentAssertions.Specs.Specialized
 {
     public class TaskOfTAssertionSpecs
     {
-        #region CompleteWithinAsync
-
-        [Fact]
-        public async Task When_subject_is_null_when_expecting_to_complete_async_it_should_throw()
+        public class CompleteWithinAsync
         {
-            // Arrange
-            var timeSpan = 0.Milliseconds();
-            Func<Task<int>> action = null;
-
-            // Act
-            Func<Task> testAction = () => action.Should().CompleteWithinAsync(
-                timeSpan, "because we want to test the failure {0}", "message");
-
-            // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
-                .WithMessage("*because we want to test the failure message*found <null>*");
-        }
-
-        [Fact]
-        public async Task When_task_completes_fast_async_it_should_succeed()
-        {
-            // Arrange
-            var timer = new FakeClock();
-            var taskFactory = new TaskCompletionSource<int>();
-
-            // Act
-            Func<Task> action = async () =>
+            [Fact]
+            public async Task When_subject_is_null_when_expecting_to_complete_async_it_should_throw()
             {
-                Func<Task<int>> func = () => taskFactory.Task;
+                // Arrange
+                var timeSpan = 0.Milliseconds();
+                Func<Task<int>> action = null;
 
-                (await func.Should(timer).CompleteWithinAsync(100.Milliseconds()))
-                    .Which.Should().Be(42);
-            };
+                // Act
+                Func<Task> testAction = () => action.Should().CompleteWithinAsync(
+                    timeSpan, "because we want to test the failure {0}", "message");
 
-            taskFactory.SetResult(42);
-            timer.Complete();
+                // Assert
+                await testAction.Should().ThrowAsync<XunitException>()
+                    .WithMessage("*because we want to test the failure message*found <null>*");
+            }
 
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task When_task_completes_async_and_result_is_not_expected_it_should_throw()
-        {
-            // Arrange
-            var timer = new FakeClock();
-            var taskFactory = new TaskCompletionSource<int>();
-
-            // Act
-            Func<Task> action = async () =>
+            [Fact]
+            public async Task When_task_completes_fast_async_it_should_succeed()
             {
-                Func<Task<int>> funcSubject = () => taskFactory.Task;
+                // Arrange
+                var timer = new FakeClock();
+                var taskFactory = new TaskCompletionSource<int>();
 
-                (await funcSubject.Should(timer).CompleteWithinAsync(100.Milliseconds()))
-                    .Which.Should().Be(42);
-            };
-
-            taskFactory.SetResult(99);
-            timer.Complete();
-
-            // Assert
-            // TODO message currently shows "Expected (await funcSubject to be...", but should be "Expected funcSubject to be...",
-            // maybe with or without await.
-            await action.Should().ThrowAsync<XunitException>().WithMessage("*to be 42, but found 99 (difference of 57).");
-        }
-
-        [Fact]
-        public async Task When_task_completes_async_and_async_result_is_not_expected_it_should_throw()
-        {
-            // Arrange
-            var timer = new FakeClock();
-            var taskFactory = new TaskCompletionSource<int>();
-
-            // Act
-            Func<Task> action = async () =>
-            {
-                Func<Task<int>> funcSubject = () => taskFactory.Task;
-
-                await funcSubject.Should(timer).CompleteWithinAsync(100.Milliseconds()).WithResult(42);
-            };
-
-            taskFactory.SetResult(99);
-            timer.Complete();
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>().WithMessage("Expected funcSubject to be 42, but found 99.");
-        }
-
-        [Fact]
-        public async Task When_task_completes_slow_async_it_should_fail()
-        {
-            // Arrange
-            var timer = new FakeClock();
-            var taskFactory = new TaskCompletionSource<int>();
-
-            // Act
-            Func<Task> action = () =>
-            {
-                Func<Task<int>> func = () => taskFactory.Task;
-
-                return func.Should(timer).CompleteWithinAsync(100.Milliseconds());
-            };
-
-            timer.Complete();
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>();
-        }
-
-        [Fact]
-        public async Task Sync_work_in_async_method_is_taken_into_account()
-        {
-            // Arrange
-            var timer = new FakeClock();
-            var taskFactory = new TaskCompletionSource<int>();
-
-            // Act
-            Func<Task> action = () =>
-            {
-                Func<Task<int>> func = () =>
+                // Act
+                Func<Task> action = async () =>
                 {
-                    timer.Delay(101.Milliseconds());
-                    return taskFactory.Task;
+                    Func<Task<int>> func = () => taskFactory.Task;
+
+                    (await func.Should(timer).CompleteWithinAsync(100.Milliseconds()))
+                        .Which.Should().Be(42);
                 };
 
-                return func.Should(timer).CompleteWithinAsync(100.Milliseconds());
-            };
+                taskFactory.SetResult(42);
+                timer.Complete();
 
-            taskFactory.SetResult(99);
-            timer.Complete();
+                // Assert
+                await action.Should().NotThrowAsync();
+            }
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>();
-        }
-
-        #endregion
-
-        #region NotThrowAfterAsync
-
-        [Fact]
-        public async Task When_subject_is_null_when_expecting_to_not_throw_async_it_should_throw()
-        {
-            // Arrange
-            Func<Task<int>> action = null;
-
-            // Act
-            Func<Task> testAction = () => action.Should().NotThrowAsync(
-                "because we want to test the failure {0}", "message");
-
-            // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
-                .WithMessage("*because we want to test the failure message*found <null>*");
-        }
-
-        [Fact]
-        public async Task When_task_does_not_throw_async_it_should_succeed()
-        {
-            // Arrange
-            var timer = new FakeClock();
-            var taskFactory = new TaskCompletionSource<int>();
-
-            // Act
-            Func<Task> action = async () =>
+            [Fact]
+            public async Task When_task_completes_async_and_result_is_not_expected_it_should_throw()
             {
-                Func<Task<int>> func = () => taskFactory.Task;
+                // Arrange
+                var timer = new FakeClock();
+                var taskFactory = new TaskCompletionSource<int>();
 
-                (await func.Should(timer).NotThrowAsync())
-                    .Which.Should().Be(42);
-            };
+                // Act
+                Func<Task> action = async () =>
+                {
+                    Func<Task<int>> funcSubject = () => taskFactory.Task;
 
-            taskFactory.SetResult(42);
-            timer.Complete();
+                    (await funcSubject.Should(timer).CompleteWithinAsync(100.Milliseconds()))
+                        .Which.Should().Be(42);
+                };
 
-            // Assert
-            await action.Should().NotThrowAsync();
+                taskFactory.SetResult(99);
+                timer.Complete();
+
+                // Assert
+                // TODO message currently shows "Expected (await funcSubject to be...", but should be "Expected funcSubject to be...",
+                // maybe with or without await.
+                await action.Should().ThrowAsync<XunitException>().WithMessage("*to be 42, but found 99 (difference of 57).");
+            }
+
+            [Fact]
+            public async Task When_task_completes_async_and_async_result_is_not_expected_it_should_throw()
+            {
+                // Arrange
+                var timer = new FakeClock();
+                var taskFactory = new TaskCompletionSource<int>();
+
+                // Act
+                Func<Task> action = async () =>
+                {
+                    Func<Task<int>> funcSubject = () => taskFactory.Task;
+
+                    await funcSubject.Should(timer).CompleteWithinAsync(100.Milliseconds()).WithResult(42);
+                };
+
+                taskFactory.SetResult(99);
+                timer.Complete();
+
+                // Assert
+                await action.Should().ThrowAsync<XunitException>().WithMessage("Expected funcSubject to be 42, but found 99.");
+            }
+
+            [Fact]
+            public async Task When_task_completes_slow_async_it_should_fail()
+            {
+                // Arrange
+                var timer = new FakeClock();
+                var taskFactory = new TaskCompletionSource<int>();
+
+                // Act
+                Func<Task> action = () =>
+                {
+                    Func<Task<int>> func = () => taskFactory.Task;
+
+                    return func.Should(timer).CompleteWithinAsync(100.Milliseconds());
+                };
+
+                timer.Complete();
+
+                // Assert
+                await action.Should().ThrowAsync<XunitException>();
+            }
+
+            [Fact]
+            public async Task Sync_work_in_async_method_is_taken_into_account()
+            {
+                // Arrange
+                var timer = new FakeClock();
+                var taskFactory = new TaskCompletionSource<int>();
+
+                // Act
+                Func<Task> action = () =>
+                {
+                    Func<Task<int>> func = () =>
+                    {
+                        timer.Delay(101.Milliseconds());
+                        return taskFactory.Task;
+                    };
+
+                    return func.Should(timer).CompleteWithinAsync(100.Milliseconds());
+                };
+
+                taskFactory.SetResult(99);
+                timer.Complete();
+
+                // Assert
+                await action.Should().ThrowAsync<XunitException>();
+            }
         }
 
-        [Collection("UIFacts")]
-        public partial class UIFacts
+        public class NotThrowAsync
         {
-            [UIFact]
-            public async Task When_task_does_not_throw_async_on_UI_thread_it_should_succeed()
+            [Fact]
+            public async Task When_subject_is_null_when_expecting_to_not_throw_async_it_should_throw()
+            {
+                // Arrange
+                Func<Task<int>> action = null;
+
+                // Act
+                Func<Task> testAction = () => action.Should().NotThrowAsync(
+                    "because we want to test the failure {0}", "message");
+
+                // Assert
+                await testAction.Should().ThrowAsync<XunitException>()
+                    .WithMessage("*because we want to test the failure message*found <null>*");
+            }
+
+            [Fact]
+            public async Task When_task_does_not_throw_async_it_should_succeed()
             {
                 // Arrange
                 var timer = new FakeClock();
@@ -215,30 +188,36 @@ namespace FluentAssertions.Specs.Specialized
                 // Assert
                 await action.Should().NotThrowAsync();
             }
-        }
 
-        [Fact]
-        public async Task When_task_throws_async_it_should_fail()
-        {
-            // Arrange
-            var timer = new FakeClock();
-
-            // Act
-            Func<Task> action = () =>
+            [Collection("UIFacts")]
+            public partial class UIFacts
             {
-                Func<Task<int>> func = () => throw new AggregateException();
+                [UIFact]
+                public async Task When_task_does_not_throw_async_on_UI_thread_it_should_succeed()
+                {
+                    // Arrange
+                    var timer = new FakeClock();
+                    var taskFactory = new TaskCompletionSource<int>();
 
-                return func.Should(timer).NotThrowAsync();
-            };
+                    // Act
+                    Func<Task> action = async () =>
+                    {
+                        Func<Task<int>> func = () => taskFactory.Task;
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>();
-        }
+                        (await func.Should(timer).NotThrowAsync())
+                            .Which.Should().Be(42);
+                    };
 
-        public partial class UIFacts
-        {
-            [UIFact]
-            public async Task When_task_throws_async_on_UI_thread_it_should_fail()
+                    taskFactory.SetResult(42);
+                    timer.Complete();
+
+                    // Assert
+                    await action.Should().NotThrowAsync();
+                }
+            }
+
+            [Fact]
+            public async Task When_task_throws_async_it_should_fail()
             {
                 // Arrange
                 var timer = new FakeClock();
@@ -254,114 +233,104 @@ namespace FluentAssertions.Specs.Specialized
                 // Assert
                 await action.Should().ThrowAsync<XunitException>();
             }
-        }
 
-        [Fact]
-        public async Task When_subject_is_null_and_expecting_to_not_throw_async_it_should_throw()
-        {
-            // Arrange
-            var waitTime = 0.Milliseconds();
-            var pollInterval = 0.Milliseconds();
-            Func<Task<int>> action = null;
-
-            // Act
-            Func<Task> testAction = () => action.Should().NotThrowAfterAsync(
-                waitTime, pollInterval, "because we want to test the failure {0}", "message");
-
-            // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
-                .WithMessage("*because we want to test the failure message*found <null>*");
-        }
-
-        [Fact]
-        public async Task When_wait_time_is_negative_and_expecting_to_not_throw_async_it_should_throw()
-        {
-            // Arrange
-            var waitTime = -1.Milliseconds();
-            var pollInterval = 10.Milliseconds();
-
-            var asyncObject = new AsyncClass();
-            Func<Task<int>> someFunc = () => asyncObject.ReturnTaskInt();
-
-            // Act
-            Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
-
-            // Assert
-            await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
-                .WithMessage("* value of waitTime must be non-negative*");
-        }
-
-        [Fact]
-        public async Task When_poll_interval_is_negative_and_expecting_to_not_throw_async_it_should_throw()
-        {
-            // Arrange
-            var waitTime = 10.Milliseconds();
-            var pollInterval = -1.Milliseconds();
-
-            var asyncObject = new AsyncClass();
-            Func<Task<int>> someFunc = () => asyncObject.ReturnTaskInt();
-
-            // Act
-            Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
-
-            // Assert
-            await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
-                .WithMessage("* value of pollInterval must be non-negative*");
-        }
-
-        [Fact]
-        public async Task When_no_exception_should_be_thrown_async_for_null_after_wait_time_it_should_throw()
-        {
-            // Arrange
-            var waitTime = 2.Seconds();
-            var pollInterval = 10.Milliseconds();
-
-            Func<Task<int>> func = null;
-
-            // Act
-            Func<Task> action = () => func.Should()
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("*but found <null>*");
-        }
-
-        [Fact]
-        public async Task When_no_exception_should_be_thrown_async_after_wait_time_but_it_was_it_should_throw()
-        {
-            // Arrange
-            var waitTime = 2.Seconds();
-            var pollInterval = 10.Milliseconds();
-
-            var clock = new FakeClock();
-            var timer = clock.StartTimer();
-            clock.CompleteAfter(waitTime);
-
-            Func<Task<int>> throwLongerThanWaitTime = async () =>
+            public partial class UIFacts
             {
-                if (timer.Elapsed <= waitTime.Multiply(1.5))
+                [UIFact]
+                public async Task When_task_throws_async_on_UI_thread_it_should_fail()
                 {
-                    throw new ArgumentException("An exception was forced");
+                    // Arrange
+                    var timer = new FakeClock();
+
+                    // Act
+                    Func<Task> action = () =>
+                    {
+                        Func<Task<int>> func = () => throw new AggregateException();
+
+                        return func.Should(timer).NotThrowAsync();
+                    };
+
+                    // Assert
+                    await action.Should().ThrowAsync<XunitException>();
                 }
-
-                await Task.Yield();
-                return 42;
-            };
-
-            // Act
-            Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+            }
         }
 
-        public partial class UIFacts
+        public class NotThrowAfterAsync
         {
-            [UIFact]
-            public async Task When_no_exception_should_be_thrown_async_on_UI_thread_after_wait_time_but_it_was_it_should_throw()
+            [Fact]
+            public async Task When_subject_is_null_and_expecting_to_not_throw_async_it_should_throw()
+            {
+                // Arrange
+                var waitTime = 0.Milliseconds();
+                var pollInterval = 0.Milliseconds();
+                Func<Task<int>> action = null;
+
+                // Act
+                Func<Task> testAction = () => action.Should().NotThrowAfterAsync(
+                    waitTime, pollInterval, "because we want to test the failure {0}", "message");
+
+                // Assert
+                await testAction.Should().ThrowAsync<XunitException>()
+                    .WithMessage("*because we want to test the failure message*found <null>*");
+            }
+
+            [Fact]
+            public async Task When_wait_time_is_negative_and_expecting_to_not_throw_async_it_should_throw()
+            {
+                // Arrange
+                var waitTime = -1.Milliseconds();
+                var pollInterval = 10.Milliseconds();
+
+                var asyncObject = new AsyncClass();
+                Func<Task<int>> someFunc = () => asyncObject.ReturnTaskInt();
+
+                // Act
+                Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
+
+                // Assert
+                await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of waitTime must be non-negative*");
+            }
+
+            [Fact]
+            public async Task When_poll_interval_is_negative_and_expecting_to_not_throw_async_it_should_throw()
+            {
+                // Arrange
+                var waitTime = 10.Milliseconds();
+                var pollInterval = -1.Milliseconds();
+
+                var asyncObject = new AsyncClass();
+                Func<Task<int>> someFunc = () => asyncObject.ReturnTaskInt();
+
+                // Act
+                Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
+
+                // Assert
+                await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
+                    .WithMessage("* value of pollInterval must be non-negative*");
+            }
+
+            [Fact]
+            public async Task When_no_exception_should_be_thrown_async_for_null_after_wait_time_it_should_throw()
+            {
+                // Arrange
+                var waitTime = 2.Seconds();
+                var pollInterval = 10.Milliseconds();
+
+                Func<Task<int>> func = null;
+
+                // Act
+                Func<Task> action = () => func.Should()
+                    .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+
+                // Assert
+                await action.Should().ThrowAsync<XunitException>()
+                    .WithMessage("*but found <null>*");
+            }
+
+            [Fact]
+            public async Task When_no_exception_should_be_thrown_async_after_wait_time_but_it_was_it_should_throw()
             {
                 // Arrange
                 var waitTime = 2.Seconds();
@@ -390,45 +359,43 @@ namespace FluentAssertions.Specs.Specialized
                 await action.Should().ThrowAsync<XunitException>()
                     .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
             }
-        }
 
-        [Fact]
-        public async Task When_no_exception_should_be_thrown_async_after_wait_time_and_none_was_it_should_not_throw()
-        {
-            // Arrange
-            var waitTime = 6.Seconds();
-            var pollInterval = 10.Milliseconds();
-
-            var clock = new FakeClock();
-            var timer = clock.StartTimer();
-            clock.Delay(waitTime);
-
-            Func<Task<int>> throwShorterThanWaitTime = async () =>
+            public partial class UIFacts
             {
-                if (timer.Elapsed <= waitTime.Divide(12))
+                [UIFact]
+                public async Task When_no_exception_should_be_thrown_async_on_UI_thread_after_wait_time_but_it_was_it_should_throw()
                 {
-                    throw new ArgumentException("An exception was forced");
+                    // Arrange
+                    var waitTime = 2.Seconds();
+                    var pollInterval = 10.Milliseconds();
+
+                    var clock = new FakeClock();
+                    var timer = clock.StartTimer();
+                    clock.CompleteAfter(waitTime);
+
+                    Func<Task<int>> throwLongerThanWaitTime = async () =>
+                    {
+                        if (timer.Elapsed <= waitTime.Multiply(1.5))
+                        {
+                            throw new ArgumentException("An exception was forced");
+                        }
+
+                        await Task.Yield();
+                        return 42;
+                    };
+
+                    // Act
+                    Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
+                        .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+
+                    // Assert
+                    await action.Should().ThrowAsync<XunitException>()
+                        .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
                 }
+            }
 
-                await Task.Yield();
-                return 42;
-            };
-
-            // Act
-            Func<Task> act = async () =>
-            {
-                (await throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval))
-                    .Which.Should().Be(42);
-            };
-
-            // Assert
-            await act.Should().NotThrowAsync();
-        }
-
-        public partial class UIFacts
-        {
-            [UIFact]
-            public async Task When_no_exception_should_be_thrown_async_on_UI_thread_after_wait_time_and_none_was_it_should_not_throw()
+            [Fact]
+            public async Task When_no_exception_should_be_thrown_async_after_wait_time_and_none_was_it_should_not_throw()
             {
                 // Arrange
                 var waitTime = 6.Seconds();
@@ -459,8 +426,42 @@ namespace FluentAssertions.Specs.Specialized
                 // Assert
                 await act.Should().NotThrowAsync();
             }
-        }
 
-        #endregion
+            public partial class UIFacts
+            {
+                [UIFact]
+                public async Task When_no_exception_should_be_thrown_async_on_UI_thread_after_wait_time_and_none_was_it_should_not_throw()
+                {
+                    // Arrange
+                    var waitTime = 6.Seconds();
+                    var pollInterval = 10.Milliseconds();
+
+                    var clock = new FakeClock();
+                    var timer = clock.StartTimer();
+                    clock.Delay(waitTime);
+
+                    Func<Task<int>> throwShorterThanWaitTime = async () =>
+                    {
+                        if (timer.Elapsed <= waitTime.Divide(12))
+                        {
+                            throw new ArgumentException("An exception was forced");
+                        }
+
+                        await Task.Yield();
+                        return 42;
+                    };
+
+                    // Act
+                    Func<Task> act = async () =>
+                    {
+                        (await throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval))
+                            .Which.Should().Be(42);
+                    };
+
+                    // Assert
+                    await act.Should().NotThrowAsync();
+                }
+            }
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Streams/BufferedStreamAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Streams/BufferedStreamAssertionSpecs.cs
@@ -11,103 +11,105 @@ namespace FluentAssertions.Specs.Streams
     public class BufferedStreamAssertionSpecs
     {
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1
-        #region HaveBufferSize / NotHaveBufferSize
-
-        [Fact]
-        public void When_a_stream_has_the_expected_buffer_size_it_should_succeed()
+        public class HaveBufferSize
         {
-            // Arrange
-            using var stream = new BufferedStream(new MemoryStream(), 10);
-
-            // Act
-            Action act = () =>
-                stream.Should().HaveBufferSize(10);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_stream_has_an_unexpected_buffer_size_should_fail()
-        {
-            // Arrange
-            using var stream = new BufferedStream(new MemoryStream(), 1);
-
-            // Act
-            Action act = () =>
-                stream.Should().HaveBufferSize(10, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the buffer size of stream to be 10 *failure message*, but it was 1.");
-        }
-
-        [Fact]
-        public void When_null_have_buffer_size_should_fail()
-        {
-            // Arrange
-            BufferedStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_a_stream_has_the_expected_buffer_size_it_should_succeed()
             {
-                using var _ = new AssertionScope();
-                stream.Should().HaveBufferSize(10, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new BufferedStream(new MemoryStream(), 10);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the buffer size of stream to be 10 *failure message*, but found a <null> reference.");
-        }
+                // Act
+                Action act = () =>
+                    stream.Should().HaveBufferSize(10);
 
-        [Fact]
-        public void When_a_stream_does_not_have_an_unexpected_buffer_size_it_should_succeed()
-        {
-            // Arrange
-            using var stream = new BufferedStream(new MemoryStream(), 1);
+                // Assert
+                act.Should().NotThrow();
+            }
 
-            // Act
-            Action act = () =>
-                stream.Should().NotHaveBufferSize(10);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_stream_does_have_the_unexpected_buffer_size_it_should_fail()
-        {
-            // Arrange
-            using var stream = new BufferedStream(new MemoryStream(), 10);
-
-            // Act
-            Action act = () =>
-                stream.Should().NotHaveBufferSize(10, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the buffer size of stream not to be 10 *failure message*, but it was.");
-        }
-
-        [Fact]
-        public void When_null_not_have_buffer_size_should_fail()
-        {
-            // Arrange
-            BufferedStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_a_stream_has_an_unexpected_buffer_size_should_fail()
             {
-                using var _ = new AssertionScope();
-                stream.Should().NotHaveBufferSize(10, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new BufferedStream(new MemoryStream(), 1);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the buffer size of stream not to be 10 *failure message*, but found a <null> reference.");
+                // Act
+                Action act = () =>
+                    stream.Should().HaveBufferSize(10, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the buffer size of stream to be 10 *failure message*, but it was 1.");
+            }
+
+            [Fact]
+            public void When_null_have_buffer_size_should_fail()
+            {
+                // Arrange
+                BufferedStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().HaveBufferSize(10, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the buffer size of stream to be 10 *failure message*, but found a <null> reference.");
+            }
         }
 
-        #endregion
+        public class NotHaveBufferSize
+        {
+            [Fact]
+            public void When_a_stream_does_not_have_an_unexpected_buffer_size_it_should_succeed()
+            {
+                // Arrange
+                using var stream = new BufferedStream(new MemoryStream(), 1);
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotHaveBufferSize(10);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_stream_does_have_the_unexpected_buffer_size_it_should_fail()
+            {
+                // Arrange
+                using var stream = new BufferedStream(new MemoryStream(), 10);
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotHaveBufferSize(10, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the buffer size of stream not to be 10 *failure message*, but it was.");
+            }
+
+            [Fact]
+            public void When_null_not_have_buffer_size_should_fail()
+            {
+                // Arrange
+                BufferedStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().NotHaveBufferSize(10, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the buffer size of stream not to be 10 *failure message*, but found a <null> reference.");
+            }
+        }
 #endif
     }
 }

--- a/Tests/FluentAssertions.Specs/Streams/StreamAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Streams/StreamAssertionSpecs.cs
@@ -9,301 +9,439 @@ namespace FluentAssertions.Specs.Streams
 {
     public class StreamAssertionSpecs
     {
-        #region BeWritable / NotBeWritable
-
-        [Fact]
-        public void When_having_a_writable_stream_be_writable_should_succeed()
+        public class BeWritable
         {
-            // Arrange
-            using var stream = new TestStream { Writable = true };
-
-            // Act
-            Action act = () =>
-                stream.Should().BeWritable();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_having_a_non_writable_stream_be_writable_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Writable = false };
-
-            // Act
-            Action act = () =>
-                stream.Should().BeWritable("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be writable *failure message*, but it was not.");
-        }
-
-        [Fact]
-        public void When_null_be_writable_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_having_a_writable_stream_be_writable_should_succeed()
             {
-                using var _ = new AssertionScope();
-                stream.Should().BeWritable("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new TestStream { Writable = true };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be writable *failure message*, but found a <null> reference.");
-        }
+                // Act
+                Action act = () =>
+                    stream.Should().BeWritable();
 
-        [Fact]
-        public void When_having_a_non_writable_stream_be_not_writable_should_succeed()
-        {
-            // Arrange
-            using var stream = new TestStream { Writable = false };
+                // Assert
+                act.Should().NotThrow();
+            }
 
-            // Act
-            Action act = () =>
-                stream.Should().NotBeWritable();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_having_a_writable_stream_be_not_writable_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Writable = true };
-
-            // Act
-            Action act = () =>
-                stream.Should().NotBeWritable("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be writable *failure message*, but it was.");
-        }
-
-        [Fact]
-        public void When_null_not_be_writable_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_having_a_non_writable_stream_be_writable_should_fail()
             {
-                using var _ = new AssertionScope();
-                stream.Should().NotBeWritable("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new TestStream { Writable = false };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be writable *failure message*, but found a <null> reference.");
-        }
+                // Act
+                Action act = () =>
+                    stream.Should().BeWritable("we want to test the failure {0}", "message");
 
-        #endregion
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream to be writable *failure message*, but it was not.");
+            }
 
-        #region BeSeekable / NotBeSeekable
-
-        [Fact]
-        public void When_having_a_seekable_stream_be_seekable_should_succeed()
-        {
-            // Arrange
-            using var stream = new TestStream { Seekable = true };
-
-            // Act
-            Action act = () =>
-                stream.Should().BeSeekable();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_having_a_non_seekable_stream_be_seekable_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Seekable = false };
-
-            // Act
-            Action act = () =>
-                stream.Should().BeSeekable("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be seekable *failure message*, but it was not.");
-        }
-
-        [Fact]
-        public void When_null_be_seekable_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_null_be_writable_should_fail()
             {
-                using var _ = new AssertionScope();
-                stream.Should().BeSeekable("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                TestStream stream = null;
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be seekable *failure message*, but found a <null> reference.");
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().BeWritable("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream to be writable *failure message*, but found a <null> reference.");
+            }
         }
 
-        [Fact]
-        public void When_having_a_non_seekable_stream_be_not_seekable_should_succeed()
+        public class NotBeWritable
         {
-            // Arrange
-            using var stream = new TestStream { Seekable = false };
-
-            // Act
-            Action act = () =>
-                stream.Should().NotBeSeekable();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_having_a_seekable_stream_be_not_seekable_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Seekable = true };
-
-            // Act
-            Action act = () =>
-                stream.Should().NotBeSeekable("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be seekable *failure message*, but it was.");
-        }
-
-        [Fact]
-        public void When_null_not_be_seekable_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_having_a_non_writable_stream_be_not_writable_should_succeed()
             {
-                using var _ = new AssertionScope();
-                stream.Should().NotBeSeekable("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new TestStream { Writable = false };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be seekable *failure message*, but found a <null> reference.");
-        }
+                // Act
+                Action act = () =>
+                    stream.Should().NotBeWritable();
 
-        #endregion
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        #region BeReadable / NotBeReadable
-
-        [Fact]
-        public void When_having_a_readable_stream_be_readable_should_succeed()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = true };
-
-            // Act
-            Action act = () =>
-                stream.Should().BeReadable();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_having_a_non_readable_stream_be_readable_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = false };
-
-            // Act
-            Action act = () =>
-                stream.Should().BeReadable("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be readable *failure message*, but it was not.");
-        }
-
-        [Fact]
-        public void When_null_be_readable_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_having_a_writable_stream_be_not_writable_should_fail()
             {
-                using var _ = new AssertionScope();
-                stream.Should().BeReadable("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new TestStream { Writable = true };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be readable *failure message*, but found a <null> reference.");
-        }
+                // Act
+                Action act = () =>
+                    stream.Should().NotBeWritable("we want to test the failure {0}", "message");
 
-        [Fact]
-        public void When_having_a_non_readable_stream_be_not_readable_should_succeed()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = false };
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream not to be writable *failure message*, but it was.");
+            }
 
-            // Act
-            Action act = () =>
-                stream.Should().NotBeReadable();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_having_a_readable_stream_be_not_readable_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = true };
-
-            // Act
-            Action act = () =>
-                stream.Should().NotBeReadable("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be readable *failure message*, but it was.");
-        }
-
-        [Fact]
-        public void When_null_not_be_readable_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_null_not_be_writable_should_fail()
             {
-                using var _ = new AssertionScope();
-                stream.Should().NotBeReadable("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                TestStream stream = null;
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be readable *failure message*, but found a <null> reference.");
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().NotBeWritable("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream not to be writable *failure message*, but found a <null> reference.");
+            }
         }
 
-        #endregion
+        public class BeSeekable
+        {
+            [Fact]
+            public void When_having_a_seekable_stream_be_seekable_should_succeed()
+            {
+                // Arrange
+                using var stream = new TestStream { Seekable = true };
 
-        #region HavePosition / NotHavePosition
+                // Act
+                Action act = () =>
+                    stream.Should().BeSeekable();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_having_a_non_seekable_stream_be_seekable_should_fail()
+            {
+                // Arrange
+                using var stream = new TestStream { Seekable = false };
+
+                // Act
+                Action act = () =>
+                    stream.Should().BeSeekable("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream to be seekable *failure message*, but it was not.");
+            }
+
+            [Fact]
+            public void When_null_be_seekable_should_fail()
+            {
+                // Arrange
+                TestStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().BeSeekable("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream to be seekable *failure message*, but found a <null> reference.");
+            }
+        }
+
+        public class NotBeSeekable
+        {
+            [Fact]
+            public void When_having_a_non_seekable_stream_be_not_seekable_should_succeed()
+            {
+                // Arrange
+                using var stream = new TestStream { Seekable = false };
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotBeSeekable();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_having_a_seekable_stream_be_not_seekable_should_fail()
+            {
+                // Arrange
+                using var stream = new TestStream { Seekable = true };
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotBeSeekable("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream not to be seekable *failure message*, but it was.");
+            }
+
+            [Fact]
+            public void When_null_not_be_seekable_should_fail()
+            {
+                // Arrange
+                TestStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().NotBeSeekable("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream not to be seekable *failure message*, but found a <null> reference.");
+            }
+        }
+
+        public class BeReadable
+        {
+            [Fact]
+            public void When_having_a_readable_stream_be_readable_should_succeed()
+            {
+                // Arrange
+                using var stream = new TestStream { Readable = true };
+
+                // Act
+                Action act = () =>
+                    stream.Should().BeReadable();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_having_a_non_readable_stream_be_readable_should_fail()
+            {
+                // Arrange
+                using var stream = new TestStream { Readable = false };
+
+                // Act
+                Action act = () =>
+                    stream.Should().BeReadable("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream to be readable *failure message*, but it was not.");
+            }
+
+            [Fact]
+            public void When_null_be_readable_should_fail()
+            {
+                // Arrange
+                TestStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().BeReadable("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream to be readable *failure message*, but found a <null> reference.");
+            }
+        }
+
+        public class NotBeReadable
+        {
+            [Fact]
+            public void When_having_a_non_readable_stream_be_not_readable_should_succeed()
+            {
+                // Arrange
+                using var stream = new TestStream { Readable = false };
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotBeReadable();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_having_a_readable_stream_be_not_readable_should_fail()
+            {
+                // Arrange
+                using var stream = new TestStream { Readable = true };
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotBeReadable("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream not to be readable *failure message*, but it was.");
+            }
+
+            [Fact]
+            public void When_null_not_be_readable_should_fail()
+            {
+                // Arrange
+                TestStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().NotBeReadable("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream not to be readable *failure message*, but found a <null> reference.");
+            }
+        }
+
+        public class HavePosition
+        {
+            [Fact]
+            public void When_a_stream_has_the_expected_position_it_should_succeed()
+            {
+                // Arrange
+                using var stream = new TestStream { Seekable = true, Position = 10 };
+
+                // Act
+                Action act = () =>
+                    stream.Should().HavePosition(10);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_stream_has_the_unexpected_position_it_should_fail()
+            {
+                // Arrange
+                using var stream = new TestStream { Seekable = true, Position = 1 };
+
+                // Act
+                Action act = () =>
+                    stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the position of stream to be 10* *failure message*, but it was 1*.");
+            }
+
+            [Fact]
+            public void When_null_have_position_should_fail()
+            {
+                // Arrange
+                TestStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the position of stream to be 10* *failure message*, but found a <null> reference.");
+            }
+
+            [Theory]
+            [MemberData(nameof(StreamAssertionSpecs.GetPositionExceptions), MemberType = typeof(StreamAssertionSpecs))]
+            public void When_a_throwing_stream_should_have_a_position_it_should_fail(Exception exception)
+            {
+                // Arrange
+                using var stream = new ExceptingStream(exception);
+
+                // Act
+                Action act = () =>
+                    stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the position of stream to be 10* *failure message*, " +
+                        "but it failed with*GetPositionExceptionMessage*");
+            }
+        }
+
+        public class NotHavePosition
+        {
+            [Fact]
+            public void When_a_stream_does_not_have_an_unexpected_position_it_should_succeed()
+            {
+                // Arrange
+                using var stream = new TestStream { Seekable = true, Position = 1 };
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotHavePosition(10);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_stream_does_have_the_unexpected_position_it_should_fail()
+            {
+                // Arrange
+                using var stream = new TestStream { Seekable = true, Position = 10 };
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the position of stream not to be 10* *failure message*, but it was.");
+            }
+
+            [Fact]
+            public void When_null_not_have_position_should_fail()
+            {
+                // Arrange
+                TestStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the position of stream not to be 10* *failure message*, but found a <null> reference.");
+            }
+
+            [Theory]
+            [MemberData(nameof(StreamAssertionSpecs.GetPositionExceptions), MemberType = typeof(StreamAssertionSpecs))]
+            public void When_a_throwing_stream_should_not_have_a_position_it_should_fail(Exception exception)
+            {
+                // Arrange
+                using var stream = new ExceptingStream(exception);
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the position of stream not to be 10* *failure message*, " +
+                        "but it failed with*GetPositionExceptionMessage*");
+            }
+        }
 
         public static IEnumerable<object[]> GetPositionExceptions()
         {
@@ -313,137 +451,139 @@ namespace FluentAssertions.Specs.Streams
             yield return new object[] { new ObjectDisposedException("GetPositionExceptionMessage") };
         }
 
-        [Fact]
-        public void When_a_stream_has_the_expected_position_it_should_succeed()
+        public class HaveLength
         {
-            // Arrange
-            using var stream = new TestStream { Seekable = true, Position = 10 };
-
-            // Act
-            Action act = () =>
-                stream.Should().HavePosition(10);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_stream_has_the_unexpected_position_it_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Seekable = true, Position = 1 };
-
-            // Act
-            Action act = () =>
-                stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream to be 10* *failure message*, but it was 1*.");
-        }
-
-        [Theory]
-        [MemberData(nameof(GetPositionExceptions))]
-        public void When_a_throwing_stream_should_have_a_position_it_should_fail(Exception exception)
-        {
-            // Arrange
-            using var stream = new ExceptingStream(exception);
-
-            // Act
-            Action act = () =>
-                stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream to be 10* *failure message*, " +
-                    "but it failed with*GetPositionExceptionMessage*");
-        }
-
-        [Fact]
-        public void When_null_have_position_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_a_stream_has_the_expected_length_it_should_succeed()
             {
-                using var _ = new AssertionScope();
-                stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new TestStream { Seekable = true, WithLength = 10 };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream to be 10* *failure message*, but found a <null> reference.");
-        }
+                // Act
+                Action act = () =>
+                    stream.Should().HaveLength(10);
 
-        [Fact]
-        public void When_a_stream_does_not_have_an_unexpected_position_it_should_succeed()
-        {
-            // Arrange
-            using var stream = new TestStream { Seekable = true, Position = 1 };
+                // Assert
+                act.Should().NotThrow();
+            }
 
-            // Act
-            Action act = () =>
-                stream.Should().NotHavePosition(10);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_stream_does_have_the_unexpected_position_it_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Seekable = true, Position = 10 };
-
-            // Act
-            Action act = () =>
-                stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream not to be 10* *failure message*, but it was.");
-        }
-
-        [Theory]
-        [MemberData(nameof(GetPositionExceptions))]
-        public void When_a_throwing_stream_should_not_have_a_position_it_should_fail(Exception exception)
-        {
-            // Arrange
-            using var stream = new ExceptingStream(exception);
-
-            // Act
-            Action act = () =>
-                stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream not to be 10* *failure message*, " +
-                    "but it failed with*GetPositionExceptionMessage*");
-        }
-
-        [Fact]
-        public void When_null_not_have_position_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_a_stream_has_an_unexpected_length_it_should_fail()
             {
-                using var _ = new AssertionScope();
-                stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new TestStream { Seekable = true, WithLength = 1 };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream not to be 10* *failure message*, but found a <null> reference.");
+                // Act
+                Action act = () =>
+                    stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the length of stream to be 10* *failure message*, but it was 1*.");
+            }
+
+            [Fact]
+            public void When_null_have_length_should_fail()
+            {
+                // Arrange
+                TestStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the length of stream to be 10* *failure message*, but found a <null> reference.");
+            }
+
+            [Theory]
+            [MemberData(nameof(StreamAssertionSpecs.GetLengthExceptions), MemberType = typeof(StreamAssertionSpecs))]
+            public void When_a_throwing_stream_should_have_a_length_it_should_fail(Exception exception)
+            {
+                // Arrange
+                using var stream = new ExceptingStream(exception);
+
+                // Act
+                Action act = () =>
+                    stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the length of stream to be 10* *failure message*, " +
+                        "but it failed with*GetLengthExceptionMessage*");
+            }
         }
 
-        #endregion
+        public class NotHaveLength
+        {
+            [Fact]
+            public void When_a_stream_does_not_have_an_unexpected_length_it_should_succeed()
+            {
+                // Arrange
+                using var stream = new TestStream { Seekable = true, WithLength = 1 };
 
-        #region HaveLength / NotHaveLength
+                // Act
+                Action act = () =>
+                    stream.Should().NotHaveLength(10);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_stream_does_have_the_unexpected_length_it_should_fail()
+            {
+                // Arrange
+                using var stream = new TestStream { Seekable = true, WithLength = 10 };
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the length of stream not to be 10* *failure message*, but it was.");
+            }
+
+            [Fact]
+            public void When_null_not_have_length_should_fail()
+            {
+                // Arrange
+                TestStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the length of stream not to be 10* *failure message*, but found a <null> reference.");
+            }
+
+            [Theory]
+            [MemberData(nameof(StreamAssertionSpecs.GetLengthExceptions), MemberType = typeof(StreamAssertionSpecs))]
+            public void When_a_throwing_stream_should_not_have_a_length_it_should_fail(Exception exception)
+            {
+                // Arrange
+                using var stream = new ExceptingStream(exception);
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the length of stream not to be 10* *failure message*, " +
+                        "but it failed with*GetLengthExceptionMessage*");
+            }
+        }
 
         public static IEnumerable<object[]> GetLengthExceptions()
         {
@@ -453,389 +593,263 @@ namespace FluentAssertions.Specs.Streams
             yield return new object[] { new ObjectDisposedException("GetLengthExceptionMessage") };
         }
 
-        [Fact]
-        public void When_a_stream_has_the_expected_length_it_should_succeed()
+        public class BeReadOnly
         {
-            // Arrange
-            using var stream = new TestStream { Seekable = true, WithLength = 10 };
-
-            // Act
-            Action act = () =>
-                stream.Should().HaveLength(10);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_stream_has_an_unexpected_length_it_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Seekable = true, WithLength = 1 };
-
-            // Act
-            Action act = () =>
-                stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream to be 10* *failure message*, but it was 1*.");
-        }
-
-        [Theory]
-        [MemberData(nameof(GetLengthExceptions))]
-        public void When_a_throwing_stream_should_have_a_length_it_should_fail(Exception exception)
-        {
-            // Arrange
-            using var stream = new ExceptingStream(exception);
-
-            // Act
-            Action act = () =>
-                stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream to be 10* *failure message*, " +
-                    "but it failed with*GetLengthExceptionMessage*");
-        }
-
-        [Fact]
-        public void When_null_have_length_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_having_a_readonly_stream_be_read_only_should_succeed()
             {
-                using var _ = new AssertionScope();
-                stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new TestStream { Readable = true, Writable = false };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream to be 10* *failure message*, but found a <null> reference.");
-        }
+                // Act
+                Action act = () =>
+                    stream.Should().BeReadOnly();
 
-        [Fact]
-        public void When_a_stream_does_not_have_an_unexpected_length_it_should_succeed()
-        {
-            // Arrange
-            using var stream = new TestStream { Seekable = true, WithLength = 1 };
+                // Assert
+                act.Should().NotThrow();
+            }
 
-            // Act
-            Action act = () =>
-                stream.Should().NotHaveLength(10);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_stream_does_have_the_unexpected_length_it_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Seekable = true, WithLength = 10 };
-
-            // Act
-            Action act = () =>
-                stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream not to be 10* *failure message*, but it was.");
-        }
-
-        [Theory]
-        [MemberData(nameof(GetLengthExceptions))]
-        public void When_a_throwing_stream_should_not_have_a_length_it_should_fail(Exception exception)
-        {
-            // Arrange
-            using var stream = new ExceptingStream(exception);
-
-            // Act
-            Action act = () =>
-                stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream not to be 10* *failure message*, " +
-                    "but it failed with*GetLengthExceptionMessage*");
-        }
-
-        [Fact]
-        public void When_null_not_have_length_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_having_a_writable_stream_be_read_only_should_fail()
             {
-                using var _ = new AssertionScope();
-                stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new TestStream { Readable = true, Writable = true };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream not to be 10* *failure message*, but found a <null> reference.");
-        }
+                // Act
+                Action act = () =>
+                    stream.Should().BeReadOnly("we want to test the failure {0}", "message");
 
-        #endregion
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream to be read-only *failure message*, but it was writable or not readable.");
+            }
 
-        #region BeReadOnly / NotBeReadOnly
-
-        [Fact]
-        public void When_having_a_readonly_stream_be_read_only_should_succeed()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = true, Writable = false };
-
-            // Act
-            Action act = () =>
-                stream.Should().BeReadOnly();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_having_a_writable_stream_be_read_only_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = true, Writable = true };
-
-            // Act
-            Action act = () =>
-                stream.Should().BeReadOnly("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be read-only *failure message*, but it was writable or not readable.");
-        }
-
-        [Fact]
-        public void When_having_a_non_readable_stream_be_read_only_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = false, Writable = false };
-
-            // Act
-            Action act = () =>
-                stream.Should().BeReadOnly("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be read-only *failure message*, but it was writable or not readable.");
-        }
-
-        [Fact]
-        public void When_null_be_read_only_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_having_a_non_readable_stream_be_read_only_should_fail()
             {
-                using var _ = new AssertionScope();
-                stream.Should().BeReadOnly("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new TestStream { Readable = false, Writable = false };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be read-only *failure message*, but found a <null> reference.");
-        }
+                // Act
+                Action act = () =>
+                    stream.Should().BeReadOnly("we want to test the failure {0}", "message");
 
-        [Fact]
-        public void When_having_a_non_readable_stream_be_not_read_only_should_succeed()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = false, Writable = false };
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream to be read-only *failure message*, but it was writable or not readable.");
+            }
 
-            // Act
-            Action act = () =>
-                stream.Should().NotBeReadOnly();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_having_a_writable_stream_be_not_read_only_should_succeed()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = true, Writable = true };
-
-            // Act
-            Action act = () =>
-                stream.Should().NotBeReadOnly();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_having_a_readonly_stream_be_not_read_only_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = true, Writable = false };
-
-            // Act
-            Action act = () =>
-                stream.Should().NotBeReadOnly("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be read-only *failure message*, but it was.");
-        }
-
-        [Fact]
-        public void When_null_not_be_read_only_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_null_be_read_only_should_fail()
             {
-                using var _ = new AssertionScope();
-                stream.Should().NotBeReadOnly("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                TestStream stream = null;
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be read-only *failure message*, but found a <null> reference.");
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().BeReadOnly("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream to be read-only *failure message*, but found a <null> reference.");
+            }
         }
 
-        #endregion
-
-        #region BeWriteOnly / NotBeWriteOnly
-
-        [Fact]
-        public void When_having_a_writeonly_stream_be_write_only_should_succeed()
+        public class NotBeReadOnly
         {
-            // Arrange
-            using var stream = new TestStream { Readable = false, Writable = true };
-
-            // Act
-            Action act = () =>
-                stream.Should().BeWriteOnly();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_having_a_readable_stream_be_write_only_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = true, Writable = true };
-
-            // Act
-            Action act = () =>
-                stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be write-only *failure message*, but it was readable or not writable.");
-        }
-
-        [Fact]
-        public void When_having_a_non_writable_stream_be_write_only_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = false, Writable = false };
-
-            // Act
-            Action act = () =>
-                stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be write-only *failure message*, but it was readable or not writable.");
-        }
-
-        [Fact]
-        public void When_null_be_write_only_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_having_a_non_readable_stream_be_not_read_only_should_succeed()
             {
-                using var _ = new AssertionScope();
-                stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new TestStream { Readable = false, Writable = false };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be write-only *failure message*, but found a <null> reference.");
-        }
+                // Act
+                Action act = () =>
+                    stream.Should().NotBeReadOnly();
 
-        [Fact]
-        public void When_having_a_non_writable_stream_be_not_write_only_should_succeed()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = false, Writable = false };
+                // Assert
+                act.Should().NotThrow();
+            }
 
-            // Act
-            Action act = () =>
-                stream.Should().NotBeWriteOnly();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_having_a_readable_stream_be_not_write_only_should_succeed()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = true, Writable = true };
-
-            // Act
-            Action act = () =>
-                stream.Should().NotBeWriteOnly();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_having_a_writeonly_stream_be_not_write_only_should_fail()
-        {
-            // Arrange
-            using var stream = new TestStream { Readable = false, Writable = true };
-
-            // Act
-            Action act = () =>
-                stream.Should().NotBeWriteOnly("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be write-only *failure message*, but it was.");
-        }
-
-        [Fact]
-        public void When_null_not_be_write_only_should_fail()
-        {
-            // Arrange
-            TestStream stream = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_having_a_writable_stream_be_not_read_only_should_succeed()
             {
-                using var _ = new AssertionScope();
-                stream.Should().NotBeWriteOnly("we want to test the failure {0}", "message");
-            };
+                // Arrange
+                using var stream = new TestStream { Readable = true, Writable = true };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be write-only *failure message*, but found a <null> reference.");
+                // Act
+                Action act = () =>
+                    stream.Should().NotBeReadOnly();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_having_a_readonly_stream_be_not_read_only_should_fail()
+            {
+                // Arrange
+                using var stream = new TestStream { Readable = true, Writable = false };
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotBeReadOnly("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream not to be read-only *failure message*, but it was.");
+            }
+
+            [Fact]
+            public void When_null_not_be_read_only_should_fail()
+            {
+                // Arrange
+                TestStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().NotBeReadOnly("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream not to be read-only *failure message*, but found a <null> reference.");
+            }
         }
 
-        #endregion
+        public class BeWriteOnly
+        {
+            [Fact]
+            public void When_having_a_writeonly_stream_be_write_only_should_succeed()
+            {
+                // Arrange
+                using var stream = new TestStream { Readable = false, Writable = true };
+
+                // Act
+                Action act = () =>
+                    stream.Should().BeWriteOnly();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_having_a_readable_stream_be_write_only_should_fail()
+            {
+                // Arrange
+                using var stream = new TestStream { Readable = true, Writable = true };
+
+                // Act
+                Action act = () =>
+                    stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream to be write-only *failure message*, but it was readable or not writable.");
+            }
+
+            [Fact]
+            public void When_having_a_non_writable_stream_be_write_only_should_fail()
+            {
+                // Arrange
+                using var stream = new TestStream { Readable = false, Writable = false };
+
+                // Act
+                Action act = () =>
+                    stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream to be write-only *failure message*, but it was readable or not writable.");
+            }
+
+            [Fact]
+            public void When_null_be_write_only_should_fail()
+            {
+                // Arrange
+                TestStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream to be write-only *failure message*, but found a <null> reference.");
+            }
+        }
+
+        public class NotBeWriteOnly
+        {
+            [Fact]
+            public void When_having_a_non_writable_stream_be_not_write_only_should_succeed()
+            {
+                // Arrange
+                using var stream = new TestStream { Readable = false, Writable = false };
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotBeWriteOnly();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_having_a_readable_stream_be_not_write_only_should_succeed()
+            {
+                // Arrange
+                using var stream = new TestStream { Readable = true, Writable = true };
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotBeWriteOnly();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_having_a_writeonly_stream_be_not_write_only_should_fail()
+            {
+                // Arrange
+                using var stream = new TestStream { Readable = false, Writable = true };
+
+                // Act
+                Action act = () =>
+                    stream.Should().NotBeWriteOnly("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream not to be write-only *failure message*, but it was.");
+            }
+
+            [Fact]
+            public void When_null_not_be_write_only_should_fail()
+            {
+                // Arrange
+                TestStream stream = null;
+
+                // Act
+                Action act = () =>
+                {
+                    using var _ = new AssertionScope();
+                    stream.Should().NotBeWriteOnly("we want to test the failure {0}", "message");
+                };
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected stream not to be write-only *failure message*, but found a <null> reference.");
+            }
+        }
     }
 
     internal class ExceptingStream : Stream


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).