### PR TITLE
Structure assertions with nested classes instead of regions (Part 5)

### DIFF
--- a/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
@@ -8,774 +8,766 @@ namespace FluentAssertions.Specs.Types
 {
     public class MethodBaseAssertionSpecs
     {
-        #region Return
-
-        [Fact]
-        public void When_asserting_an_int_method_returns_int_it_succeeds()
+        public class Return
         {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+            [Fact]
+            public void When_asserting_an_int_method_returns_int_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().Return(typeof(int));
+                // Act
+                Action act = () =>
+                    methodInfo.Should().Return(typeof(int));
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_int_method_returns_string_it_fails_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().Return(typeof(string), "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the return type of method IntMethod to be System.String because we want to test the " +
+                                 "error message, but it is \"System.Int32\".");
+            }
+
+            [Fact]
+            public void When_asserting_a_void_method_returns_string_it_fails_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("VoidMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().Return(typeof(string), "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the return type of method VoidMethod to be System.String because we want to test the " +
+                                 "error message, but it is \"System.Void\".");
+            }
+
+            [Fact]
+            public void When_subject_is_null_return_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().Return(typeof(string), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected the return type of method to be *.String *failure message*, but methodInfo is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_method_return_type_is_null_it_should_throw()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().Return(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("returnType");
+            }
+        }
+        
+        public class NotReturn
+        {
+            [Fact]
+            public void When_asserting_an_int_method_does_not_return_string_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotReturn(typeof(string));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_int_method_does_not_return_int_it_fails_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotReturn(typeof(int), "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the return type of*IntMethod*not to be System.Int32*because we want to test the " +
+                                 "error message, but it is.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_return_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotReturn(typeof(string), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the return type of method not to be *.String *failure message*, but methodInfo is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_method_return_type_is_not_null_it_should_throw()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotReturn(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("returnType");
+            }
         }
 
-        [Fact]
-        public void When_asserting_an_int_method_returns_string_it_fails_with_a_useful_message()
+        public class ReturnOfT
         {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+            [Fact]
+            public void When_asserting_an_int_method_returnsOfT_int_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().Return(typeof(string), "we want to test the error {0}", "message");
+                // Act
+                Action act = () =>
+                    methodInfo.Should().Return<int>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method IntMethod to be System.String because we want to test the " +
-                             "error message, but it is \"System.Int32\".");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_int_method_returnsOfT_string_it_fails_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().Return<string>("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the return type of method IntMethod to be System.String because we want to test the " +
+                                 "error message, but it is \"System.Int32\".");
+            }
+
+            [Fact]
+            public void When_subject_is_null_returnOfT_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().Return<string>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the return type of method to be *.String *failure message*, but methodInfo is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_void_method_returns_string_it_fails_with_a_useful_message()
+        public class NotReturnOfT
         {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("VoidMethod");
+            [Fact]
+            public void When_asserting_an_int_method_does_not_returnsOfT_string_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().Return(typeof(string), "we want to test the error {0}", "message");
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotReturn<string>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method VoidMethod to be System.String because we want to test the " +
-                             "error message, but it is \"System.Void\".");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_int_method_does_not_returnsOfT_int_it_fails_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotReturn<int>("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the return type of*IntMethod*not to be System.Int32*because we want to test the " +
+                                 "error message, but it is.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_returnOfT_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotReturn<string>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the return type of method not to be *.String *failure message*, but methodInfo is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_subject_is_null_return_should_fail()
+        public class ReturnVoid
         {
-            // Arrange
-            MethodInfo methodInfo = null;
+            [Fact]
+            public void When_asserting_a_void_method_returns_void_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("VoidMethod");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().Return(typeof(string), "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    methodInfo.Should().ReturnVoid();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected the return type of method to be *.String *failure message*, but methodInfo is <null>.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_int_method_returns_void_it_fails_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().ReturnVoid("because we want to test the error message {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the return type of method IntMethod to be void because we want to test the error message " +
+                                 "message, but it is \"System.Int32\".");
+            }
+
+            [Fact]
+            public void When_subject_is_null_return_void_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().ReturnVoid("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the return type of method to be void *failure message*, but methodInfo is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_method_return_type_is_null_it_should_throw()
+        public class NotReturnVoid
         {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+            [Fact]
+            public void When_asserting_an_int_method_does_not_return_void_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().Return(null);
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotReturnVoid();
 
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("returnType");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_void_method_does_not_return_void_it_fails_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("VoidMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotReturnVoid("because we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the return type of*VoidMethod*not to be void*because we want to test the error message*");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_return_void_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotReturnVoid("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the return type of method not to be void *failure message*, but methodInfo is <null>.");
+            }
         }
 
-        #endregion
-
-        #region NotReturn
-
-        [Fact]
-        public void When_asserting_an_int_method_does_not_return_string_it_succeeds()
+        public class HaveAccessModifier
         {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+            [Fact]
+            public void When_asserting_a_private_member_is_private_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotReturn(typeof(string));
+                // Act
+                Action act = () =>
+                    methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Private);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_private_protected_member_is_private_protected_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateProtectedMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.PrivateProtected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_private_member_is_protected_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method PrivateMethod to be Protected because we want to test the error message, but it is " +
+                                 "Private.");
+            }
+
+            [Fact]
+            public void When_asserting_a_protected_member_is_protected_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("ProtectedSetProperty");
+
+                MethodInfo setMethod = propertyInfo.SetMethod;
+
+                // Act
+                Action act = () =>
+                    setMethod.Should().HaveAccessModifier(CSharpAccessModifier.Protected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_protected_member_is_public_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("ProtectedSetProperty");
+
+                MethodInfo setMethod = propertyInfo.SetMethod;
+
+                // Act
+                Action act = () =>
+                    setMethod
+                        .Should()
+                        .HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method set_ProtectedSetProperty to be Public because we want to test the error message, but it" +
+                                 " is Protected.");
+            }
+
+            [Fact]
+            public void When_asserting_a_public_member_is_public_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetProperty");
+
+                MethodInfo getMethod = propertyInfo.GetMethod;
+
+                // Act
+                Action act = () =>
+                    getMethod.Should().HaveAccessModifier(CSharpAccessModifier.Public);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_public_member_is_internal_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetProperty");
+
+                MethodInfo getMethod = propertyInfo.GetMethod;
+
+                // Act
+                Action act = () =>
+                    getMethod
+                        .Should()
+                        .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method get_PublicGetProperty to be Internal because we want to test the error message, but it" +
+                                 " is Public.");
+            }
+
+            [Fact]
+            public void When_asserting_an_internal_member_is_internal_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("InternalMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_internal_member_is_protectedInternal_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("InternalMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "because we want to test the" +
+                                                                                                    " error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method InternalMethod to be ProtectedInternal because we want to test the error message, but" +
+                                 " it is Internal.");
+            }
+
+            [Fact]
+            public void When_asserting_a_protected_internal_member_is_protected_internal_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("ProtectedInternalMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_protected_internal_member_is_private_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("ProtectedInternalMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Private, "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method ProtectedInternalMethod to be Private because we want to test the error message, but it is " +
+                                 "ProtectedInternal.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_access_modifier_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method to be Public *failure message*, but methodInfo is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_method_has_access_modifier_with_an_invalid_enum_value_it_should_throw()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().HaveAccessModifier((CSharpAccessModifier)int.MaxValue);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                    .WithParameterName("accessModifier");
+            }
         }
 
-        [Fact]
-        public void When_asserting_an_int_method_does_not_return_int_it_fails_with_a_useful_message()
+        public class NotHaveAccessModifier
         {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+            [Fact]
+            public void When_asserting_a_private_member_is_not_protected_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotReturn(typeof(int), "we want to test the error {0}", "message");
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.Protected);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of*IntMethod*not to be System.Int32*because we want to test the " +
-                             "error message, but it is.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_private_member_is_not_private_protected_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.PrivateProtected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_private_member_is_not_private_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.Private, "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method PrivateMethod not to be Private*because we want to test the error message*");
+            }
+
+            [Fact]
+            public void When_asserting_a_protected_member_is_not_internal_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("ProtectedSetProperty");
+                MethodInfo setMethod = propertyInfo.SetMethod;
+
+                // Act
+                Action act = () =>
+                    setMethod.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_protected_member_is_not_protected_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("ProtectedSetProperty");
+                MethodInfo setMethod = propertyInfo.SetMethod;
+
+                // Act
+                Action act = () =>
+                    setMethod
+                        .Should()
+                        .NotHaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method set_ProtectedSetProperty not to be Protected*because we want to test the error message*");
+            }
+
+            [Fact]
+            public void When_asserting_a_public_member_is_not_private_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetProperty");
+                MethodInfo getMethod = propertyInfo.GetMethod;
+
+                // Act
+                Action act = () =>
+                    getMethod.Should().NotHaveAccessModifier(CSharpAccessModifier.Private);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_private_protected_member_is_not_private_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetPrivateProtectedSet");
+                MethodInfo setMethod = propertyInfo.SetMethod;
+
+                // Act
+                Action act = () =>
+                    setMethod.Should().NotHaveAccessModifier(CSharpAccessModifier.Private);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_public_member_is_not_public_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetProperty");
+                MethodInfo getMethod = propertyInfo.GetMethod;
+
+                // Act
+                Action act = () =>
+                    getMethod
+                        .Should()
+                        .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method get_PublicGetProperty not to be Public*because we want to test the error message*");
+            }
+
+            [Fact]
+            public void When_asserting_an_internal_member_is_not_protectedInternal_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("InternalMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_internal_member_is_not_internal_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("InternalMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "because we want to test the" +
+                                                                                                    " error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method InternalMethod not to be Internal*because we want to test the error message*");
+            }
+
+            [Fact]
+            public void When_asserting_a_protected_internal_member_is_not_public_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("ProtectedInternalMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.Public);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_protected_internal_member_is_not_protected_internal_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("ProtectedInternalMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method ProtectedInternalMethod not to be ProtectedInternal*because we want to test the error message*");
+            }
+
+            [Fact]
+            public void When_subject_is_not_null_have_access_modifier_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotHaveAccessModifier(
+                        CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method not to be Public *failure message*, but methodInfo is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_method_does_not_have_access_modifier_with_an_invalid_enum_value_it_should_throw()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotHaveAccessModifier((CSharpAccessModifier)int.MaxValue);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                    .WithParameterName("accessModifier");
+            }
         }
-
-        [Fact]
-        public void When_subject_is_null_not_return_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = null;
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotReturn(typeof(string), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method not to be *.String *failure message*, but methodInfo is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_method_return_type_is_not_null_it_should_throw()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotReturn(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("returnType");
-        }
-
-        #endregion
-
-        #region ReturnOfT
-
-        [Fact]
-        public void When_asserting_an_int_method_returnsOfT_int_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().Return<int>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_int_method_returnsOfT_string_it_fails_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().Return<string>("we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method IntMethod to be System.String because we want to test the " +
-                             "error message, but it is \"System.Int32\".");
-        }
-
-        [Fact]
-        public void When_subject_is_null_returnOfT_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = null;
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().Return<string>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method to be *.String *failure message*, but methodInfo is <null>.");
-        }
-
-        #endregion
-
-        #region NotReturnOfT
-
-        [Fact]
-        public void When_asserting_an_int_method_does_not_returnsOfT_string_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotReturn<string>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_int_method_does_not_returnsOfT_int_it_fails_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotReturn<int>("we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of*IntMethod*not to be System.Int32*because we want to test the " +
-                             "error message, but it is.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_returnOfT_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = null;
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotReturn<string>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method not to be *.String *failure message*, but methodInfo is <null>.");
-        }
-
-        #endregion
-
-        #region ReturnVoid
-
-        [Fact]
-        public void When_asserting_a_void_method_returns_void_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("VoidMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().ReturnVoid();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_int_method_returns_void_it_fails_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().ReturnVoid("because we want to test the error message {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method IntMethod to be void because we want to test the error message " +
-                             "message, but it is \"System.Int32\".");
-        }
-
-        [Fact]
-        public void When_subject_is_null_return_void_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = null;
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().ReturnVoid("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method to be void *failure message*, but methodInfo is <null>.");
-        }
-
-        #endregion
-
-        #region NotReturnVoid
-
-        [Fact]
-        public void When_asserting_an_int_method_does_not_return_void_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotReturnVoid();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_void_method_does_not_return_void_it_fails_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("VoidMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotReturnVoid("because we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of*VoidMethod*not to be void*because we want to test the error message*");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_return_void_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = null;
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotReturnVoid("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method not to be void *failure message*, but methodInfo is <null>.");
-        }
-
-        #endregion
-
-        #region HaveAccessModifier
-
-        [Fact]
-        public void When_asserting_a_private_member_is_private_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Private);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_private_protected_member_is_private_protected_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateProtectedMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.PrivateProtected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_private_member_is_protected_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method PrivateMethod to be Protected because we want to test the error message, but it is " +
-                             "Private.");
-        }
-
-        [Fact]
-        public void When_asserting_a_protected_member_is_protected_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("ProtectedSetProperty");
-
-            MethodInfo setMethod = propertyInfo.SetMethod;
-
-            // Act
-            Action act = () =>
-                setMethod.Should().HaveAccessModifier(CSharpAccessModifier.Protected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_protected_member_is_public_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("ProtectedSetProperty");
-
-            MethodInfo setMethod = propertyInfo.SetMethod;
-
-            // Act
-            Action act = () =>
-                setMethod
-                    .Should()
-                    .HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method set_ProtectedSetProperty to be Public because we want to test the error message, but it" +
-                             " is Protected.");
-        }
-
-        [Fact]
-        public void When_asserting_a_public_member_is_public_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetProperty");
-
-            MethodInfo getMethod = propertyInfo.GetMethod;
-
-            // Act
-            Action act = () =>
-                getMethod.Should().HaveAccessModifier(CSharpAccessModifier.Public);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_public_member_is_internal_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetProperty");
-
-            MethodInfo getMethod = propertyInfo.GetMethod;
-
-            // Act
-            Action act = () =>
-                getMethod
-                    .Should()
-                    .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method get_PublicGetProperty to be Internal because we want to test the error message, but it" +
-                             " is Public.");
-        }
-
-        [Fact]
-        public void When_asserting_an_internal_member_is_internal_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("InternalMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_internal_member_is_protectedInternal_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("InternalMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "because we want to test the" +
-                                                                                                " error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method InternalMethod to be ProtectedInternal because we want to test the error message, but" +
-                             " it is Internal.");
-        }
-
-        [Fact]
-        public void When_asserting_a_protected_internal_member_is_protected_internal_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("ProtectedInternalMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_protected_internal_member_is_private_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("ProtectedInternalMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Private, "we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method ProtectedInternalMethod to be Private because we want to test the error message, but it is " +
-                             "ProtectedInternal.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_have_access_modifier_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = null;
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method to be Public *failure message*, but methodInfo is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_method_has_access_modifier_with_an_invalid_enum_value_it_should_throw()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().HaveAccessModifier((CSharpAccessModifier)int.MaxValue);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentOutOfRangeException>()
-                .WithParameterName("accessModifier");
-        }
-
-        #endregion
-
-        #region NotHaveAccessModifier
-
-        [Fact]
-        public void When_asserting_a_private_member_is_not_protected_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.Protected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_private_member_is_not_private_protected_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.PrivateProtected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_private_member_is_not_private_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.Private, "we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method PrivateMethod not to be Private*because we want to test the error message*");
-        }
-
-        [Fact]
-        public void When_asserting_a_protected_member_is_not_internal_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("ProtectedSetProperty");
-            MethodInfo setMethod = propertyInfo.SetMethod;
-
-            // Act
-            Action act = () =>
-                setMethod.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_protected_member_is_not_protected_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("ProtectedSetProperty");
-            MethodInfo setMethod = propertyInfo.SetMethod;
-
-            // Act
-            Action act = () =>
-                setMethod
-                    .Should()
-                    .NotHaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method set_ProtectedSetProperty not to be Protected*because we want to test the error message*");
-        }
-
-        [Fact]
-        public void When_asserting_a_public_member_is_not_private_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetProperty");
-            MethodInfo getMethod = propertyInfo.GetMethod;
-
-            // Act
-            Action act = () =>
-                getMethod.Should().NotHaveAccessModifier(CSharpAccessModifier.Private);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_private_protected_member_is_not_private_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetPrivateProtectedSet");
-            MethodInfo setMethod = propertyInfo.SetMethod;
-
-            // Act
-            Action act = () =>
-                setMethod.Should().NotHaveAccessModifier(CSharpAccessModifier.Private);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_public_member_is_not_public_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetProperty");
-            MethodInfo getMethod = propertyInfo.GetMethod;
-
-            // Act
-            Action act = () =>
-                getMethod
-                    .Should()
-                    .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method get_PublicGetProperty not to be Public*because we want to test the error message*");
-        }
-
-        [Fact]
-        public void When_asserting_an_internal_member_is_not_protectedInternal_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("InternalMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_internal_member_is_not_internal_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("InternalMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "because we want to test the" +
-                                                                                                " error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method InternalMethod not to be Internal*because we want to test the error message*");
-        }
-
-        [Fact]
-        public void When_asserting_a_protected_internal_member_is_not_public_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("ProtectedInternalMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.Public);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_protected_internal_member_is_not_protected_internal_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("ProtectedInternalMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method ProtectedInternalMethod not to be ProtectedInternal*because we want to test the error message*");
-        }
-
-        [Fact]
-        public void When_subject_is_not_null_have_access_modifier_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = null;
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier(
-                    CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method not to be Public *failure message*, but methodInfo is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_method_does_not_have_access_modifier_with_an_invalid_enum_value_it_should_throw()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier((CSharpAccessModifier)int.MaxValue);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentOutOfRangeException>()
-                .WithParameterName("accessModifier");
-        }
-
-        #endregion
     }
 
     #region Internal classes used in unit tests

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
@@ -10,604 +10,598 @@ namespace FluentAssertions.Specs.Types
 {
     public class MethodInfoAssertionSpecs
     {
-        #region BeVirtual
-
-        [Fact]
-        public void When_asserting_a_method_is_virtual_and_it_is_then_it_succeeds()
+        public class BeVirtual
         {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsVirtual).GetParameterlessMethod("PublicVirtualDoNothing");
+            [Fact]
+            public void When_asserting_a_method_is_virtual_and_it_is_then_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsVirtual).GetParameterlessMethod("PublicVirtualDoNothing");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeVirtual();
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeVirtual();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_virtual_but_it_is_not_then_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithNonVirtualPublicMethods).GetParameterlessMethod("PublicDoNothing");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeVirtual("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method Void FluentAssertions*ClassWithNonVirtualPublicMethods.PublicDoNothing" +
+                        " to be virtual because we want to test the error message," +
+                        " but it is not virtual.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_be_virtual_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeVirtual("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method to be virtual *failure message*, but methodInfo is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_method_is_virtual_but_it_is_not_then_it_throws_with_a_useful_message()
+        public class NotBeVirtual
         {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithNonVirtualPublicMethods).GetParameterlessMethod("PublicDoNothing");
+            [Fact]
+            public void When_asserting_a_method_is_not_virtual_and_it_is_not_then_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithNonVirtualPublicMethods).GetParameterlessMethod("PublicDoNothing");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeVirtual("we want to test the error {0}", "message");
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeVirtual();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method Void FluentAssertions*ClassWithNonVirtualPublicMethods.PublicDoNothing" +
-                    " to be virtual because we want to test the error message," +
-                    " but it is not virtual.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_not_virtual_but_it_is_then_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsVirtual).GetParameterlessMethod("PublicVirtualDoNothing");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeVirtual("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method *ClassWithAllMethodsVirtual.PublicVirtualDoNothing" +
+                        " not to be virtual because we want to test the error message," +
+                        " but it is.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_be_virtual_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeVirtual("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method not to be virtual *failure message*, but methodInfo is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_subject_is_null_be_virtual_should_fail()
+        public class BeDecoratedWithOfT
         {
-            // Arrange
-            MethodInfo methodInfo = null;
+            [Fact]
+            public void When_asserting_a_method_is_decorated_with_attribute_and_it_is_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeVirtual("we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method to be virtual *failure message*, but methodInfo is <null>.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_decorated_with_MethodImpl_attribute_and_it_is_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("DoNotInlineMe");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeDecoratedWith<MethodImplAttribute>();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_constructor_is_decorated_with_MethodImpl_attribute_and_it_is_it_succeeds()
+            {
+                // Arrange
+                ConstructorInfo constructorMethodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetConstructor(Type.EmptyTypes);
+
+                // Act
+                Action act = () =>
+                    constructorMethodInfo.Should().BeDecoratedWith<MethodImplAttribute>();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_decorated_with_MethodImpl_attribute_and_it_is_not_it_throws()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeDecoratedWith<MethodImplAttribute>();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected method Void FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
+                            "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_decorated_with_MethodImpl_attribute_with_no_options_and_it_is_it_throws()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("NoOptions");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeDecoratedWith<MethodImplAttribute>();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.NoOptions to be decorated with " +
+                            "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_decorated_with_MethodImpl_attribute_with_zero_as_options_and_it_is_it_throws()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("ZeroOptions");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeDecoratedWith<MethodImplAttribute>();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.ZeroOptions to be decorated with " +
+                            "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
+            }
+
+            [Fact]
+            public void When_asserting_a_class_is_decorated_with_MethodImpl_attribute_and_it_is_not_it_throws()
+            {
+                // Arrange
+                var type = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute);
+
+                // Act
+                Action act = () =>
+                    type.Should().BeDecoratedWith<MethodImplAttribute>();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute to be decorated with " +
+                            "System.Runtime.CompilerServices.MethodImplAttribute, but the attribute was not found.");
+            }
+
+            [Fact]
+            public void When_a_method_is_decorated_with_an_attribute_it_should_allow_chaining_assertions_on_it()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+
+                // Act
+                Action act = () => methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>().Which.Filter.Should().BeFalse();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_decorated_with_an_attribute_but_it_is_not_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected method Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
+                            "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
+                            " but that attribute was not found.");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_predicate_into_BeDecoratedWith_it_should_throw()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+
+                // Act
+                Action act = () => methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>(isMatchingAttributePredicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_decorated_with_attribute_matching_a_predicate_and_it_is_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>(d => d.Filter);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_decorated_with_MethodImpl_attribute_matching_a_predicate_and_it_is_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("DoNotInlineMe");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeDecoratedWith<MethodImplAttribute>(x => x.Value == MethodImplOptions.NoInlining);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_decorated_with_an_attribute_matching_a_predicate_but_it_is_not_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>(d => !d.Filter, "because we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected method Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
+                            "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
+                            " but that attribute was not found.");
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_decorated_with_an_MethodImpl_attribute_matching_a_predicate_but_it_is_not_it_throws()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("DoNotInlineMe");
+
+                // Act
+                Action act = () =>
+                   methodInfo.Should().BeDecoratedWith<MethodImplAttribute>(x => x.Value == MethodImplOptions.AggressiveInlining);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.DoNotInlineMe to be decorated with " +
+                            "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_decorated_with_an_attribute_and_multiple_attributes_match_continuation_using_the_matched_value_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothingWithSameAttributeTwice");
+
+                // Act
+                Action act =
+                    () =>
+                        methodInfo.Should()
+                            .BeDecoratedWith<DummyMethodAttribute>()
+                            .Which.Filter.Should()
+                            .BeTrue();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_subject_is_null_be_decorated_withOfT_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected method to be decorated with *.DummyMethodAttribute *failure message*, but methodInfo is <null>.");
+            }
         }
 
-        #endregion
-
-        #region NotBeVirtual
-
-        [Fact]
-        public void When_asserting_a_method_is_not_virtual_and_it_is_not_then_it_succeeds()
+        public class NotBeDecoratedWithOfT
         {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithNonVirtualPublicMethods).GetParameterlessMethod("PublicDoNothing");
+            [Fact]
+            public void When_asserting_a_method_is_not_decorated_with_attribute_and_it_is_not_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeVirtual();
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>();
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_asserting_a_method_is_not_virtual_but_it_is_then_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsVirtual).GetParameterlessMethod("PublicVirtualDoNothing");
+            [Fact]
+            public void When_asserting_a_method_is_not_decorated_with_MethodImpl_attribute_and_it_is_not_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeVirtual("we want to test the error {0}", "message");
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeDecoratedWith<MethodImplAttribute>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method *ClassWithAllMethodsVirtual.PublicVirtualDoNothing" +
-                    " not to be virtual because we want to test the error message," +
-                    " but it is.");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_subject_is_null_not_be_virtual_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = null;
+            [Fact]
+            public void When_asserting_a_constructor_is_not_decorated_with_MethodImpl_attribute_and_it_is_not_it_succeeds()
+            {
+                // Arrange
+                ConstructorInfo constructorMethodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetConstructor(new[] { typeof(string) });
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeVirtual("we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    constructorMethodInfo.Should().NotBeDecoratedWith<MethodImplAttribute>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method not to be virtual *failure message*, but methodInfo is <null>.");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        #endregion
+            [Fact]
+            public void When_asserting_a_method_is_not_decorated_with_an_attribute_but_it_is_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
-        #region BeDecoratedWithOfT
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
 
-        [Fact]
-        public void When_asserting_a_method_is_decorated_with_attribute_and_it_is_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected method Void FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to not be decorated with " +
+                            "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
+                            " but that attribute was found.");
+            }
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>();
+            [Fact]
+            public void When_asserting_a_method_is_not_decorated_with_MethodImpl_attribute_and_it_is_it_throws()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("DoNotInlineMe");
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeDecoratedWith<MethodImplAttribute>();
 
-        [Fact]
-        public void When_asserting_a_method_is_decorated_with_MethodImpl_attribute_and_it_is_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("DoNotInlineMe");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeDecoratedWith<MethodImplAttribute>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_constructor_is_decorated_with_MethodImpl_attribute_and_it_is_it_succeeds()
-        {
-            // Arrange
-            ConstructorInfo constructorMethodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetConstructor(Type.EmptyTypes);
-
-            // Act
-            Action act = () =>
-                constructorMethodInfo.Should().BeDecoratedWith<MethodImplAttribute>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_decorated_with_MethodImpl_attribute_and_it_is_not_it_throws()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeDecoratedWith<MethodImplAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>()
+                // Assert
+                act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method Void FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
-                        "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
+                    "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.DoNotInlineMe to not be decorated with " +
+                        "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was found.");
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_not_decorated_with_attribute_matching_a_predicate_and_it_is_not_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>(d => !d.Filter);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_injecting_a_null_predicate_into_NotBeDecoratedWith_it_should_throw()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+
+                // Act
+                Action act = () => methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>(isMatchingAttributePredicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_not_decorated_with_an_attribute_matching_a_predicate_but_it_is_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>(d => d.Filter, "because we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected method Void FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to not be decorated with " +
+                            "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
+                            " but that attribute was found.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_be_decorated_withOfT_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected method to not be decorated with *.DummyMethodAttribute *failure message*" +
+                        ", but methodInfo is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_method_is_decorated_with_MethodImpl_attribute_with_no_options_and_it_is_it_throws()
+        public class BeAsync
         {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("NoOptions");
+            [Fact]
+            public void When_asserting_a_method_is_async_and_it_is_then_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsAsync).GetParameterlessMethod("PublicAsyncDoNothing");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeDecoratedWith<MethodImplAttribute>();
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeAsync();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.NoOptions to be decorated with " +
-                        "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_async_but_it_is_not_then_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithNonAsyncMethods).GetParameterlessMethod("PublicDoNothing");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeAsync("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method Task FluentAssertions*ClassWithNonAsyncMethods.PublicDoNothing" +
+                        " to be async because we want to test the error message," +
+                        " but it is not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_be_async_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().BeAsync("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method to be async *failure message*, but methodInfo is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_method_is_decorated_with_MethodImpl_attribute_with_zero_as_options_and_it_is_it_throws()
+        public class NotBeAsync
         {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("ZeroOptions");
+            [Fact]
+            public void When_asserting_a_method_is_not_async_and_it_is_not_then_it_succeeds()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithNonAsyncMethods).GetParameterlessMethod("PublicDoNothing");
 
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeDecoratedWith<MethodImplAttribute>();
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeAsync();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.ZeroOptions to be decorated with " +
-                        "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_method_is_not_async_but_it_is_then_it_throws_with_a_useful_message()
+            {
+                // Arrange
+                MethodInfo methodInfo = typeof(ClassWithAllMethodsAsync).GetParameterlessMethod("PublicAsyncDoNothing");
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeAsync("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*ClassWithAllMethodsAsync.PublicAsyncDoNothing*" +
+                        "not to be async*because we want to test the error message*");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_be_async_should_fail()
+            {
+                // Arrange
+                MethodInfo methodInfo = null;
+
+                // Act
+                Action act = () =>
+                    methodInfo.Should().NotBeAsync("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method not to be async *failure message*, but methodInfo is <null>.");
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_class_is_decorated_with_MethodImpl_attribute_and_it_is_not_it_throws()
-        {
-            // Arrange
-            var type = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute);
-
-            // Act
-            Action act = () =>
-                type.Should().BeDecoratedWith<MethodImplAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute to be decorated with " +
-                        "System.Runtime.CompilerServices.MethodImplAttribute, but the attribute was not found.");
-        }
-
-        [Fact]
-        public void When_a_method_is_decorated_with_an_attribute_it_should_allow_chaining_assertions_on_it()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () => methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>().Which.Filter.Should().BeFalse();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_decorated_with_an_attribute_but_it_is_not_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
-                        "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
-                        " but that attribute was not found.");
-        }
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_BeDecoratedWith_it_should_throw()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () => methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>(isMatchingAttributePredicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_decorated_with_attribute_matching_a_predicate_and_it_is_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>(d => d.Filter);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_decorated_with_MethodImpl_attribute_matching_a_predicate_and_it_is_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("DoNotInlineMe");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeDecoratedWith<MethodImplAttribute>(x => x.Value == MethodImplOptions.NoInlining);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_decorated_with_an_attribute_matching_a_predicate_but_it_is_not_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>(d => !d.Filter, "because we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
-                        "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
-                        " but that attribute was not found.");
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_decorated_with_an_MethodImpl_attribute_matching_a_predicate_but_it_is_not_it_throws()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("DoNotInlineMe");
-
-            // Act
-            Action act = () =>
-               methodInfo.Should().BeDecoratedWith<MethodImplAttribute>(x => x.Value == MethodImplOptions.AggressiveInlining);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.DoNotInlineMe to be decorated with " +
-                        "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_decorated_with_an_attribute_and_multiple_attributes_match_continuation_using_the_matched_value_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothingWithSameAttributeTwice");
-
-            // Act
-            Action act =
-                () =>
-                    methodInfo.Should()
-                        .BeDecoratedWith<DummyMethodAttribute>()
-                        .Which.Filter.Should()
-                        .BeTrue();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_subject_is_null_be_decorated_withOfT_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = null;
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method to be decorated with *.DummyMethodAttribute *failure message*, but methodInfo is <null>.");
-        }
-
-        #endregion
-
-        #region NotBeDecoratedWithOfT
-
-        [Fact]
-        public void When_asserting_a_method_is_not_decorated_with_attribute_and_it_is_not_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_not_decorated_with_MethodImpl_attribute_and_it_is_not_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeDecoratedWith<MethodImplAttribute>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_constructor_is_not_decorated_with_MethodImpl_attribute_and_it_is_not_it_succeeds()
-        {
-            // Arrange
-            ConstructorInfo constructorMethodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetConstructor(new[] { typeof(string) });
-
-            // Act
-            Action act = () =>
-                constructorMethodInfo.Should().NotBeDecoratedWith<MethodImplAttribute>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_not_decorated_with_an_attribute_but_it_is_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method Void FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to not be decorated with " +
-                        "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
-                        " but that attribute was found.");
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_not_decorated_with_MethodImpl_attribute_and_it_is_it_throws()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("DoNotInlineMe");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeDecoratedWith<MethodImplAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.DoNotInlineMe to not be decorated with " +
-                    "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was found.");
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_not_decorated_with_attribute_matching_a_predicate_and_it_is_not_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>(d => !d.Filter);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_NotBeDecoratedWith_it_should_throw()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () => methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>(isMatchingAttributePredicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_not_decorated_with_an_attribute_matching_a_predicate_but_it_is_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>(d => d.Filter, "because we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method Void FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to not be decorated with " +
-                        "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
-                        " but that attribute was found.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_be_decorated_withOfT_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = null;
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method to not be decorated with *.DummyMethodAttribute *failure message*" +
-                    ", but methodInfo is <null>.");
-        }
-
-        #endregion
-
-        #region BeAsync
-
-        [Fact]
-        public void When_asserting_a_method_is_async_and_it_is_then_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsAsync).GetParameterlessMethod("PublicAsyncDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeAsync();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_async_but_it_is_not_then_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithNonAsyncMethods).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeAsync("we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method Task FluentAssertions*ClassWithNonAsyncMethods.PublicDoNothing" +
-                    " to be async because we want to test the error message," +
-                    " but it is not.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_be_async_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = null;
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().BeAsync("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method to be async *failure message*, but methodInfo is <null>.");
-        }
-
-        #endregion
-
-        #region NotBeAsync
-
-        [Fact]
-        public void When_asserting_a_method_is_not_async_and_it_is_not_then_it_succeeds()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithNonAsyncMethods).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeAsync();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_method_is_not_async_but_it_is_then_it_throws_with_a_useful_message()
-        {
-            // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsAsync).GetParameterlessMethod("PublicAsyncDoNothing");
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeAsync("we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*ClassWithAllMethodsAsync.PublicAsyncDoNothing*" +
-                    "not to be async*because we want to test the error message*");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_be_async_should_fail()
-        {
-            // Arrange
-            MethodInfo methodInfo = null;
-
-            // Act
-            Action act = () =>
-                methodInfo.Should().NotBeAsync("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method not to be async *failure message*, but methodInfo is <null>.");
-        }
-
-        #endregion
     }
 
     #region Internal classes used in unit tests
@@ -764,6 +758,6 @@ namespace FluentAssertions.Specs.Types
         {
         }
     }
-
-    #endregion
 }
+
+#endregion

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorAssertionSpecs.cs
@@ -8,427 +8,419 @@ namespace FluentAssertions.Specs.Types
 {
     public class MethodInfoSelectorAssertionSpecs
     {
-        #region BeVirtual
-
-        [Fact]
-        public void When_asserting_methods_are_virtual_and_they_are_it_should_succeed()
+        public class BeVirtual
         {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsVirtual));
+            [Fact]
+            public void When_asserting_methods_are_virtual_and_they_are_it_should_succeed()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsVirtual));
 
-            // Act
-            Action act = () =>
-                methodSelector.Should().BeVirtual();
+                // Act
+                Action act = () =>
+                    methodSelector.Should().BeVirtual();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_methods_are_virtual_but_non_virtual_methods_are_found_it_should_throw()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithNonVirtualPublicMethods));
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().BeVirtual();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_methods_are_virtual_but_non_virtual_methods_are_found_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithNonVirtualPublicMethods));
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().BeVirtual("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all selected methods" +
+                                 " to be virtual because we want to test the error message," +
+                                 " but the following methods are not virtual:*" +
+                                 "Void FluentAssertions*ClassWithNonVirtualPublicMethods.PublicDoNothing*" +
+                                 "Void FluentAssertions*ClassWithNonVirtualPublicMethods.InternalDoNothing*" +
+                                 "Void FluentAssertions*ClassWithNonVirtualPublicMethods.ProtectedDoNothing");
+            }
         }
 
-        [Fact]
-        public void When_asserting_methods_are_virtual_but_non_virtual_methods_are_found_it_should_throw()
+        public class NotBeVirtual
         {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithNonVirtualPublicMethods));
+            [Fact]
+            public void When_asserting_methods_are_not_virtual_and_they_are_not_it_should_succeed()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithNonVirtualPublicMethods));
 
-            // Act
-            Action act = () =>
-                methodSelector.Should().BeVirtual();
+                // Act
+                Action act = () =>
+                    methodSelector.Should().NotBeVirtual();
 
-            // Assert
-            act.Should().Throw<XunitException>();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_methods_are_not_virtual_but_virtual_methods_are_found_it_should_throw()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsVirtual));
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().NotBeVirtual();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_methods_are_not_virtual_but_virtual_methods_are_found_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsVirtual));
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().NotBeVirtual("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all selected methods" +
+                                 " not to be virtual because we want to test the error message," +
+                                 " but the following methods are virtual" +
+                                 "*ClassWithAllMethodsVirtual.PublicVirtualDoNothing" +
+                                 "*ClassWithAllMethodsVirtual.InternalVirtualDoNothing" +
+                                 "*ClassWithAllMethodsVirtual.ProtectedVirtualDoNothing*");
+            }
         }
 
-        [Fact]
-        public void When_asserting_methods_are_virtual_but_non_virtual_methods_are_found_it_should_throw_with_descriptive_message()
+        public class BeDecoratedWith
         {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithNonVirtualPublicMethods));
+            [Fact]
+            public void When_injecting_a_null_predicate_into_BeDecoratedWith_it_should_throw()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute));
 
-            // Act
-            Action act = () =>
-                methodSelector.Should().BeVirtual("we want to test the error {0}", "message");
+                // Act
+                Action act = () =>
+                    methodSelector.Should().BeDecoratedWith<DummyMethodAttribute>(isMatchingAttributePredicate: null);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected methods" +
-                             " to be virtual because we want to test the error message," +
-                             " but the following methods are not virtual:*" +
-                             "Void FluentAssertions*ClassWithNonVirtualPublicMethods.PublicDoNothing*" +
-                             "Void FluentAssertions*ClassWithNonVirtualPublicMethods.InternalDoNothing*" +
-                             "Void FluentAssertions*ClassWithNonVirtualPublicMethods.ProtectedDoNothing");
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
+
+            [Fact]
+            public void When_asserting_methods_are_decorated_with_attribute_and_they_are_it_should_succeed()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute));
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().BeDecoratedWith<DummyMethodAttribute>();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_methods_are_decorated_with_attribute_but_they_are_not_it_should_throw()
+            {
+                // Arrange
+                MethodInfoSelector methodSelector =
+                    new MethodInfoSelector(typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute))
+                        .ThatArePublicOrInternal;
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().BeDecoratedWith<DummyMethodAttribute>();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_methods_are_decorated_with_attribute_but_they_are_not_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute));
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().BeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all selected methods to be decorated with" +
+                                 " FluentAssertions*DummyMethodAttribute because we want to test the error message," +
+                                 " but the following methods are not:*" +
+                                 "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing*" +
+                                 "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.ProtectedDoNothing*" +
+                                 "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PrivateDoNothing");
+            }
         }
 
-        #endregion
-
-        #region NotBeVirtual
-
-        [Fact]
-        public void When_asserting_methods_are_not_virtual_and_they_are_not_it_should_succeed()
+        public class NotBeDecoratedWith
         {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithNonVirtualPublicMethods));
+            [Fact]
+            public void When_injecting_a_null_predicate_into_NotBeDecoratedWith_it_should_throw()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute));
 
-            // Act
-            Action act = () =>
-                methodSelector.Should().NotBeVirtual();
+                // Act
+                Action act = () =>
+                    methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>(isMatchingAttributePredicate: null);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
+
+            [Fact]
+            public void When_asserting_methods_are_not_decorated_with_attribute_and_they_are_not_it_should_succeed()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute));
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_methods_are_not_decorated_with_attribute_but_they_are_it_should_throw()
+            {
+                // Arrange
+                MethodInfoSelector methodSelector =
+                    new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute))
+                        .ThatArePublicOrInternal;
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_methods_are_not_decorated_with_attribute_but_they_are_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute));
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all selected methods to not be decorated*DummyMethodAttribute*because we want to test the error message" +
+                                 "*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing*" +
+                                 "*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothingWithSameAttributeTwice*" +
+                                 "*ClassWithAllMethodsDecoratedWithDummyAttribute.ProtectedDoNothing*" +
+                                 "*ClassWithAllMethodsDecoratedWithDummyAttribute.PrivateDoNothing");
+            }
         }
 
-        [Fact]
-        public void When_asserting_methods_are_not_virtual_but_virtual_methods_are_found_it_should_throw()
+        public class Be
         {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsVirtual));
+            [Fact]
+            public void When_all_methods_have_specified_accessor_it_should_succeed()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithPublicMethods));
 
-            // Act
-            Action act = () =>
-                methodSelector.Should().NotBeVirtual();
+                // Act
+                Action act = () =>
+                    methodSelector.Should().Be(CSharpAccessModifier.Public);
 
-            // Assert
-            act.Should().Throw<XunitException>();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_not_all_methods_have_specified_accessor_it_should_throw()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithNonPublicMethods));
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().Be(CSharpAccessModifier.Public);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all selected methods to be Public" +
+                                 ", but the following methods are not:*" +
+                                 "Void FluentAssertions*ClassWithNonPublicMethods.PublicDoNothing*" +
+                                 "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithParameter*" +
+                                 "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
+            }
+
+            [Fact]
+            public void When_not_all_methods_have_specified_accessor_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithNonPublicMethods));
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().Be(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all selected methods to be Public" +
+                                 " because we want to test the error message" +
+                                 ", but the following methods are not:*" +
+                                 "Void FluentAssertions*ClassWithNonPublicMethods.PublicDoNothing*" +
+                                 "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithParameter*" +
+                                 "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
+            }
         }
 
-        [Fact]
-        public void When_asserting_methods_are_not_virtual_but_virtual_methods_are_found_it_should_throw_with_descriptive_message()
+        public class NotBe
         {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsVirtual));
+            [Fact]
+            public void When_all_methods_does_not_have_specified_accessor_it_should_succeed()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithNonPublicMethods));
 
-            // Act
-            Action act = () =>
-                methodSelector.Should().NotBeVirtual("we want to test the error {0}", "message");
+                // Act
+                Action act = () =>
+                    methodSelector.Should().NotBe(CSharpAccessModifier.Public);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected methods" +
-                             " not to be virtual because we want to test the error message," +
-                             " but the following methods are virtual" +
-                             "*ClassWithAllMethodsVirtual.PublicVirtualDoNothing" +
-                             "*ClassWithAllMethodsVirtual.InternalVirtualDoNothing" +
-                             "*ClassWithAllMethodsVirtual.ProtectedVirtualDoNothing*");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_any_method_have_specified_accessor_it_should_throw()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithPublicMethods));
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().NotBe(CSharpAccessModifier.Public);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all selected methods to not be Public" +
+                                 ", but the following methods are:*" +
+                                 "Void FluentAssertions*ClassWithPublicMethods.PublicDoNothing*");
+            }
+
+            [Fact]
+            public void When_any_method_have_specified_accessor_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithPublicMethods));
+
+                // Act
+                Action act = () =>
+                    methodSelector.Should().NotBe(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all selected methods to not be Public" +
+                                 " because we want to test the error message" +
+                                 ", but the following methods are:*" +
+                                 "Void FluentAssertions*ClassWithPublicMethods.PublicDoNothing*");
+            }
         }
 
-        #endregion
-
-        #region BeDecoratedWith
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_BeDecoratedWith_it_should_throw()
+        public class BeAsync
         {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute));
+            [Fact]
+            public void When_asserting_methods_are_async_and_they_are_then_it_succeeds()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsAsync));
 
-            // Act
-            Action act = () =>
-                methodSelector.Should().BeDecoratedWith<DummyMethodAttribute>(isMatchingAttributePredicate: null);
+                // Act
+                Action act = () => methodSelector.Should().BeAsync();
 
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_methods_are_async_but_non_async_methods_are_found_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithNonAsyncMethods));
+
+                // Act
+                Action act = () => methodSelector.Should().BeAsync("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all selected methods" +
+                        " to be async because we want to test the error message," +
+                        " but the following methods are not:" + Environment.NewLine +
+                        "Task FluentAssertions.Specs.Types.ClassWithNonAsyncMethods.PublicDoNothing" + Environment.NewLine +
+                        "Task FluentAssertions.Specs.Types.ClassWithNonAsyncMethods.InternalDoNothing" + Environment.NewLine +
+                        "Task FluentAssertions.Specs.Types.ClassWithNonAsyncMethods.ProtectedDoNothing");
+            }
         }
 
-        [Fact]
-        public void When_asserting_methods_are_decorated_with_attribute_and_they_are_it_should_succeed()
+        public class NotBeAsync
         {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute));
+            [Fact]
+            public void When_asserting_methods_are_not_async_and_they_are_not_then_it_succeeds()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithNonAsyncMethods));
 
-            // Act
-            Action act = () =>
-                methodSelector.Should().BeDecoratedWith<DummyMethodAttribute>();
+                // Act
+                Action act = () => methodSelector.Should().NotBeAsync();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_methods_are_not_async_but_async_methods_are_found_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsAsync));
+
+                // Act
+                Action act = () => methodSelector.Should().NotBeAsync("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all selected methods" +
+                        " not to be async because we want to test the error message," +
+                        " but the following methods are:" + Environment.NewLine +
+                        "Task FluentAssertions.Specs.Types.ClassWithAllMethodsAsync.PublicAsyncDoNothing" + Environment.NewLine +
+                        "Task FluentAssertions.Specs.Types.ClassWithAllMethodsAsync.InternalAsyncDoNothing" + Environment.NewLine +
+                        "Task FluentAssertions.Specs.Types.ClassWithAllMethodsAsync.ProtectedAsyncDoNothing");
+            }
         }
-
-        [Fact]
-        public void When_asserting_methods_are_decorated_with_attribute_but_they_are_not_it_should_throw()
-        {
-            // Arrange
-            MethodInfoSelector methodSelector =
-                new MethodInfoSelector(typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute))
-                    .ThatArePublicOrInternal;
-
-            // Act
-            Action act = () =>
-                methodSelector.Should().BeDecoratedWith<DummyMethodAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_asserting_methods_are_decorated_with_attribute_but_they_are_not_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute));
-
-            // Act
-            Action act = () =>
-                methodSelector.Should().BeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected methods to be decorated with" +
-                             " FluentAssertions*DummyMethodAttribute because we want to test the error message," +
-                             " but the following methods are not:*" +
-                             "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing*" +
-                             "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.ProtectedDoNothing*" +
-                             "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PrivateDoNothing");
-        }
-
-        #endregion
-
-        #region NotBeDecoratedWith
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_NotBeDecoratedWith_it_should_throw()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute));
-
-            // Act
-            Action act = () =>
-                methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>(isMatchingAttributePredicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
-        }
-
-        [Fact]
-        public void When_asserting_methods_are_not_decorated_with_attribute_and_they_are_not_it_should_succeed()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute));
-
-            // Act
-            Action act = () =>
-                methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_methods_are_not_decorated_with_attribute_but_they_are_it_should_throw()
-        {
-            // Arrange
-            MethodInfoSelector methodSelector =
-                new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute))
-                    .ThatArePublicOrInternal;
-
-            // Act
-            Action act = () =>
-                methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_asserting_methods_are_not_decorated_with_attribute_but_they_are_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute));
-
-            // Act
-            Action act = () =>
-                methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected methods to not be decorated*DummyMethodAttribute*because we want to test the error message" +
-                             "*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing*" +
-                             "*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothingWithSameAttributeTwice*" +
-                             "*ClassWithAllMethodsDecoratedWithDummyAttribute.ProtectedDoNothing*" +
-                             "*ClassWithAllMethodsDecoratedWithDummyAttribute.PrivateDoNothing");
-        }
-
-        #endregion
-
-        #region Be
-
-        [Fact]
-        public void When_all_methods_have_specified_accessor_it_should_succeed()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithPublicMethods));
-
-            // Act
-            Action act = () =>
-                methodSelector.Should().Be(CSharpAccessModifier.Public);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_not_all_methods_have_specified_accessor_it_should_throw()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithNonPublicMethods));
-
-            // Act
-            Action act = () =>
-                methodSelector.Should().Be(CSharpAccessModifier.Public);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected methods to be Public" +
-                             ", but the following methods are not:*" +
-                             "Void FluentAssertions*ClassWithNonPublicMethods.PublicDoNothing*" +
-                             "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithParameter*" +
-                             "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
-        }
-
-        [Fact]
-        public void When_not_all_methods_have_specified_accessor_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithNonPublicMethods));
-
-            // Act
-            Action act = () =>
-                methodSelector.Should().Be(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected methods to be Public" +
-                             " because we want to test the error message" +
-                             ", but the following methods are not:*" +
-                             "Void FluentAssertions*ClassWithNonPublicMethods.PublicDoNothing*" +
-                             "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithParameter*" +
-                             "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
-        }
-
-        #endregion
-
-        #region NotBe
-
-        [Fact]
-        public void When_all_methods_does_not_have_specified_accessor_it_should_succeed()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithNonPublicMethods));
-
-            // Act
-            Action act = () =>
-                methodSelector.Should().NotBe(CSharpAccessModifier.Public);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_any_method_have_specified_accessor_it_should_throw()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithPublicMethods));
-
-            // Act
-            Action act = () =>
-                methodSelector.Should().NotBe(CSharpAccessModifier.Public);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected methods to not be Public" +
-                             ", but the following methods are:*" +
-                             "Void FluentAssertions*ClassWithPublicMethods.PublicDoNothing*");
-        }
-
-        [Fact]
-        public void When_any_method_have_specified_accessor_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithPublicMethods));
-
-            // Act
-            Action act = () =>
-                methodSelector.Should().NotBe(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected methods to not be Public" +
-                             " because we want to test the error message" +
-                             ", but the following methods are:*" +
-                             "Void FluentAssertions*ClassWithPublicMethods.PublicDoNothing*");
-        }
-
-        #endregion
-
-        #region BeAsync
-
-        [Fact]
-        public void When_asserting_methods_are_async_and_they_are_then_it_succeeds()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsAsync));
-
-            // Act
-            Action act = () => methodSelector.Should().BeAsync();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_methods_are_async_but_non_async_methods_are_found_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithNonAsyncMethods));
-
-            // Act
-            Action act = () => methodSelector.Should().BeAsync("we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected methods" +
-                    " to be async because we want to test the error message," +
-                    " but the following methods are not:" + Environment.NewLine +
-                    "Task FluentAssertions.Specs.Types.ClassWithNonAsyncMethods.PublicDoNothing" + Environment.NewLine +
-                    "Task FluentAssertions.Specs.Types.ClassWithNonAsyncMethods.InternalDoNothing" + Environment.NewLine +
-                    "Task FluentAssertions.Specs.Types.ClassWithNonAsyncMethods.ProtectedDoNothing");
-        }
-
-        #endregion
-
-        #region NotBeAsync
-
-        [Fact]
-        public void When_asserting_methods_are_not_async_and_they_are_not_then_it_succeeds()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithNonAsyncMethods));
-
-            // Act
-            Action act = () => methodSelector.Should().NotBeAsync();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_methods_are_not_async_but_async_methods_are_found_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsAsync));
-
-            // Act
-            Action act = () => methodSelector.Should().NotBeAsync("we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected methods" +
-                    " not to be async because we want to test the error message," +
-                    " but the following methods are:" + Environment.NewLine +
-                    "Task FluentAssertions.Specs.Types.ClassWithAllMethodsAsync.PublicAsyncDoNothing" + Environment.NewLine +
-                    "Task FluentAssertions.Specs.Types.ClassWithAllMethodsAsync.InternalAsyncDoNothing" + Environment.NewLine +
-                    "Task FluentAssertions.Specs.Types.ClassWithAllMethodsAsync.ProtectedAsyncDoNothing");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
@@ -9,820 +9,806 @@ namespace FluentAssertions.Specs.Types
 {
     public class PropertyInfoAssertionSpecs
     {
-        #region BeVirtual
-
-        [Fact]
-        public void When_asserting_that_a_property_is_virtual_and_it_is_then_it_succeeds()
+        public class BeVirtual
         {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesVirtual).GetRuntimeProperty("PublicVirtualProperty");
+            [Fact]
+            public void When_asserting_that_a_property_is_virtual_and_it_is_then_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesVirtual).GetRuntimeProperty("PublicVirtualProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeVirtual();
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeVirtual();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_that_a_property_is_virtual_and_it_is_not_then_it_fails_with_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithNonVirtualPublicProperties).GetRuntimeProperty("PublicNonVirtualProperty");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeVirtual("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                   .WithMessage(
+                       "Expected property String FluentAssertions*ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty" +
+                           " to be virtual because we want to test the error message," +
+                           " but it is not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_be_virtual_should_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = null;
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeVirtual("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected property to be virtual *failure message*, but propertyInfo is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_that_a_property_is_virtual_and_it_is_not_then_it_fails_with_useful_message()
+        public class NotBeVirtual
         {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithNonVirtualPublicProperties).GetRuntimeProperty("PublicNonVirtualProperty");
+            [Fact]
+            public void When_asserting_that_a_property_is_not_virtual_and_it_is_not_then_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithNonVirtualPublicProperties).GetRuntimeProperty("PublicNonVirtualProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeVirtual("we want to test the error {0}", "message");
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().NotBeVirtual();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-               .WithMessage(
-                   "Expected property String FluentAssertions*ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty" +
-                       " to be virtual because we want to test the error message," +
-                       " but it is not.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_that_a_property_is_not_virtual_and_it_is_then_it_fails_with_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesVirtual).GetRuntimeProperty("PublicVirtualProperty");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().NotBeVirtual("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                   .WithMessage(
+                       "Expected property *ClassWithAllPropertiesVirtual.PublicVirtualProperty" +
+                           " not to be virtual because we want to test the error message," +
+                           " but it is.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_be_virtual_should_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = null;
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().NotBeVirtual("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected property not to be virtual *failure message*, but propertyInfo is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_subject_is_null_be_virtual_should_fail()
+        public class BeDecortatedWithOfT
         {
-            // Arrange
-            PropertyInfo propertyInfo = null;
+            [Fact]
+            public void When_asserting_a_property_is_decorated_with_attribute_and_it_is_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeVirtual("we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected property to be virtual *failure message*, but propertyInfo is <null>.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_property_is_decorated_with_an_attribute_it_allow_chaining_assertions()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>().Which.Value.Should().Be("OtherValue");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected*OtherValue*Value*");
+            }
+
+            [Fact]
+            public void When_a_property_is_decorated_with_an_attribute_and_multiple_attributes_match_continuation_using_the_matched_value_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicPropertyWithSameAttributeTwice");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>().Which.Value.Should().Be("OtherValue");
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_a_property_is_decorated_with_attribute_and_it_is_not_it_throw_with_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>("because we want to test the error message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                   .WithMessage("Expected property String " +
+                       "FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
+                       "FluentAssertions*DummyPropertyAttribute because we want to test the error message, but that attribute was not found.");
+            }
+
+            [Fact]
+            public void When_asserting_a_property_is_decorated_with_an_attribute_matching_a_predicate_but_it_is_not_it_throw_with_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>(d => d.Value == "NotARealValue", "because we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected property String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
+                            "FluentAssertions*DummyPropertyAttribute because we want to test the error message," +
+                            " but that attribute was not found.");
+            }
+
+            [Fact]
+            public void When_asserting_a_property_is_decorated_with_attribute_matching_a_predicate_and_it_is_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>(d => d.Value == "Value");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_subject_is_null_be_decorated_withOfT_should_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = null;
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected property to be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_property_is_decorated_with_null_it_should_throw()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeDecoratedWith((Expression<Func<DummyPropertyAttribute, bool>>)null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
         }
 
-        #endregion
-
-        #region NotBeVirtual
-
-        [Fact]
-        public void When_asserting_that_a_property_is_not_virtual_and_it_is_not_then_it_succeeds()
+        public class NotBeDecoratedWithOfT
         {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithNonVirtualPublicProperties).GetRuntimeProperty("PublicNonVirtualProperty");
+            [Fact]
+            public void When_subject_is_null_not_be_decorated_withOfT_should_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = null;
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().NotBeVirtual();
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().NotBeDecoratedWith<DummyPropertyAttribute>("we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected property to not be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_property_is_not_decorated_with_null_it_should_throw()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().NotBeDecoratedWith((Expression<Func<DummyPropertyAttribute, bool>>)null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
         }
 
-        [Fact]
-        public void When_asserting_that_a_property_is_not_virtual_and_it_is_then_it_fails_with_useful_message()
+        public class BeWritable
         {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesVirtual).GetRuntimeProperty("PublicVirtualProperty");
+            [Fact]
+            public void When_asserting_a_readonly_property_is_writable_it_fails_with_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadOnlyProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().NotBeVirtual("we want to test the error {0}", "message");
+                // Act
+                Action action = () => propertyInfo.Should().BeWritable("we want to test the error {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-               .WithMessage(
-                   "Expected property *ClassWithAllPropertiesVirtual.PublicVirtualProperty" +
-                       " not to be virtual because we want to test the error message," +
-                       " but it is.");
+                // Assert
+                action
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected propertyInfo ReadOnlyProperty to have a setter because we want to test the error message.");
+            }
+
+            [Fact]
+            public void When_asserting_a_readwrite_property_is_writable_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadWriteProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().BeWritable("that's required");
+
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_writeonly_property_is_writable_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WriteOnlyProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().BeWritable("that's required");
+
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_subject_is_null_be_writable_should_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = null;
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeWritable("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected property to have a setter *failure message*, but propertyInfo is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_subject_is_null_not_be_virtual_should_fail()
+        public class BeReadable
         {
-            // Arrange
-            PropertyInfo propertyInfo = null;
+            [Fact]
+            public void When_asserting_a_readonly_property_is_readable_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadOnlyProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().NotBeVirtual("we want to test the failure {0}", "message");
+                // Act
+                Action action = () => propertyInfo.Should().BeReadable("that's required");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected property not to be virtual *failure message*, but propertyInfo is <null>.");
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_readwrite_property_is_readable_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadWriteProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().BeReadable("that's required");
+
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_writeonly_property_is_readable_it_fails_with_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WriteOnlyProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().BeReadable("we want to test the error {0}", "message");
+
+                // Assert
+                action
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected property WriteOnlyProperty to have a getter because we want to test the error message, but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_be_readable_should_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = null;
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeReadable("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected property to have a getter *failure message*, but propertyInfo is <null>.");
+            }
         }
 
-        #endregion
-
-        #region BeDecortatedWithOfT
-
-        [Fact]
-        public void When_asserting_a_property_is_decorated_with_attribute_and_it_is_it_succeeds()
+        public class NotBeWritable
         {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+            [Fact]
+            public void When_asserting_a_readonly_property_is_not_writable_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadOnlyProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>();
+                // Act
+                Action action = () => propertyInfo.Should().NotBeWritable("that's required");
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_readwrite_property_is_not_writable_it_fails_with_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadWriteProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().NotBeWritable("we want to test the error {0}", "message");
+
+                // Assert
+                action
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected propertyInfo ReadWriteProperty not to have a setter because we want to test the error message.");
+            }
+
+            [Fact]
+            public void When_asserting_a_writeonly_property_is_not_writable_it_fails_with_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WriteOnlyProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().NotBeWritable("we want to test the error {0}", "message");
+
+                // Assert
+                action
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected propertyInfo WriteOnlyProperty not to have a setter because we want to test the error message.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_be_writable_should_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = null;
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().NotBeWritable("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected property not to have a setter *failure message*, but propertyInfo is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_a_property_is_decorated_with_an_attribute_it_allow_chaining_assertions()
+        public class NotBeReadable
         {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+            [Fact]
+            public void When_asserting_a_readonly_property_is_not_readable_it_fails_with_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadOnlyProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>().Which.Value.Should().Be("OtherValue");
+                // Act
+                Action action = () => propertyInfo.Should().NotBeReadable("we want to test the error {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*OtherValue*Value*");
+                // Assert
+                action
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected propertyInfo ReadOnlyProperty not to have a getter because we want to test the error message.");
+            }
+
+            [Fact]
+            public void When_asserting_a_readwrite_property_is_not_readable_it_fails_with_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadWriteProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().NotBeReadable("we want to test the error {0}", "message");
+
+                // Assert
+                action
+                    .Should().Throw<XunitException>()
+                    .WithMessage("Expected propertyInfo ReadWriteProperty not to have a getter because we want to test the error message.");
+            }
+
+            [Fact]
+            public void When_asserting_a_writeonly_property_is_not_readable_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WriteOnlyProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().NotBeReadable("that's required");
+
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_be_readable_should_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = null;
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().NotBeReadable("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected property not to have a getter *failure message*, but propertyInfo is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_a_property_is_decorated_with_an_attribute_and_multiple_attributes_match_continuation_using_the_matched_value_fail()
+        public class BeReadableAccessModifier
         {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicPropertyWithSameAttributeTwice");
+            [Fact]
+            public void When_asserting_a_public_read_private_write_property_is_public_readable_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadPrivateWriteProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>().Which.Value.Should().Be("OtherValue");
+                // Act
+                Action action = () => propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "that's required");
 
-            // Assert
-            act.Should().Throw<XunitException>();
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_private_read_public_write_property_is_public_readable_it_fails_with_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WritePrivateReadProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected method get_WritePrivateReadProperty to be Public because we want to test the error message, but it is Private.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_be_readable_with_accessmodifier_should_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = null;
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected property to be Public *failure message*, but propertyInfo is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_is_readable_with_an_invalid_enum_value_it_should_throw()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeReadable((CSharpAccessModifier)int.MaxValue);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                    .WithParameterName("accessModifier");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_property_is_decorated_with_attribute_and_it_is_not_it_throw_with_useful_message()
+        public class BeWritableAccessModifier
         {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+            [Fact]
+            public void When_asserting_a_public_write_private_read_property_is_public_writable_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WritePrivateReadProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>("because we want to test the error message");
+                // Act
+                Action action = () => propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "that's required");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-               .WithMessage("Expected property String " +
-                   "FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
-                   "FluentAssertions*DummyPropertyAttribute because we want to test the error message, but that attribute was not found.");
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_private_write_public_read_property_is_public_writable_it_fails_with_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadPrivateWriteProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected method set_ReadPrivateWriteProperty to be Public because we want to test the error message, but it is Private.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_be_writable_with_accessmodifier_should_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = null;
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected property to be Public *failure message*, but propertyInfo is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_is_writable_with_an_invalid_enum_value_it_should_throw()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().BeWritable((CSharpAccessModifier)int.MaxValue);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                    .WithParameterName("accessModifier");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_property_is_decorated_with_an_attribute_matching_a_predicate_but_it_is_not_it_throw_with_useful_message()
+        public class Return
         {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+            [Fact]
+            public void When_asserting_a_String_property_returns_a_String_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>(d => d.Value == "NotARealValue", "because we want to test the error {0}", "message");
+                // Act
+                Action action = () => propertyInfo.Should().Return(typeof(string));
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected property String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
-                        "FluentAssertions*DummyPropertyAttribute because we want to test the error message," +
-                        " but that attribute was not found.");
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_String_property_returns_an_Int32_it_throw_with_a_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().Return(typeof(int), "we want to test the error {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected Type of property StringProperty to be System.Int32 because we want to test the error " +
+                                 "message, but it is System.String.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_return_should_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = null;
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().Return(typeof(int), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type of property to be *.Int32 *failure message*, but propertyInfo is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_property_type_is_null_it_should_throw()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().Return(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("propertyType");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_property_is_decorated_with_attribute_matching_a_predicate_and_it_is_it_succeeds()
+        public class ReturnOfT
         {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+            [Fact]
+            public void When_asserting_a_String_property_returnsOfT_a_String_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>(d => d.Value == "Value");
+                // Act
+                Action action = () => propertyInfo.Should().Return<string>();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_String_property_returnsOfT_an_Int32_it_throw_with_a_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().Return<int>("we want to test the error {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected Type of property StringProperty to be System.Int32 because we want to test the error " +
+                                 "message, but it is System.String.");
+            }
         }
 
-        [Fact]
-        public void When_subject_is_null_be_decorated_withOfT_should_fail()
+        public class NotReturn
         {
-            // Arrange
-            PropertyInfo propertyInfo = null;
+            [Fact]
+            public void When_asserting_a_String_property_does_not_returns_an_Int32_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>("we want to test the failure {0}", "message");
+                // Act
+                Action action = () => propertyInfo.Should().NotReturn(typeof(int));
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected property to be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_String_property_does_not_return_a_String_it_throw_with_a_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().NotReturn(typeof(string), "we want to test the error {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected Type of property StringProperty not to be*String*because we want to test the error " +
+                                 "message, but it is.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_return_should_fail()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = null;
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().NotReturn(typeof(int), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type of property not to be *.Int32 *failure message*, but propertyInfo is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_property_type_is_not_null_it_should_throw()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+                // Act
+                Action act = () =>
+                    propertyInfo.Should().NotReturn(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("propertyType");
+            }
         }
 
-        [Fact]
-        public void When_asserting_property_is_decorated_with_null_it_should_throw()
+        public class NotReturnOfT
         {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+            [Fact]
+            public void When_asserting_a_String_property_does_not_returnOfT_an_Int32_it_succeeds()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
 
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeDecoratedWith((Expression<Func<DummyPropertyAttribute, bool>>)null);
+                // Act
+                Action action = () => propertyInfo.Should().NotReturn<int>();
 
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
+                // Assert
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_String_property_does_not_returnsOfT_a_String_it_throw_with_a_useful_message()
+            {
+                // Arrange
+                PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+                // Act
+                Action action = () => propertyInfo.Should().NotReturn<string>("we want to test the error {0}", "message");
+
+                // Assert
+                action.Should().Throw<XunitException>()
+                    .WithMessage("Expected Type of property StringProperty not to be*String*because we want to test the error " +
+                                 "message, but it is.");
+            }
         }
-
-        #endregion
-
-        #region NotBeDecoratedWithOfT
-
-        [Fact]
-        public void When_subject_is_null_not_be_decorated_withOfT_should_fail()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = null;
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().NotBeDecoratedWith<DummyPropertyAttribute>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected property to not be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_property_is_not_decorated_with_null_it_should_throw()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().NotBeDecoratedWith((Expression<Func<DummyPropertyAttribute, bool>>)null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
-        }
-
-        #endregion
-
-        #region BeWritable
-
-        [Fact]
-        public void When_asserting_a_readonly_property_is_writable_it_fails_with_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadOnlyProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().BeWritable("we want to test the error {0}", "message");
-
-            // Assert
-            action
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo ReadOnlyProperty to have a setter because we want to test the error message.");
-        }
-
-        [Fact]
-        public void When_asserting_a_readwrite_property_is_writable_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadWriteProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().BeWritable("that's required");
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_writeonly_property_is_writable_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WriteOnlyProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().BeWritable("that's required");
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_subject_is_null_be_writable_should_fail()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = null;
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeWritable("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected property to have a setter *failure message*, but propertyInfo is <null>.");
-        }
-
-        #endregion
-
-        #region BeReadable
-
-        [Fact]
-        public void When_asserting_a_readonly_property_is_readable_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadOnlyProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().BeReadable("that's required");
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_readwrite_property_is_readable_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadWriteProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().BeReadable("that's required");
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_writeonly_property_is_readable_it_fails_with_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WriteOnlyProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().BeReadable("we want to test the error {0}", "message");
-
-            // Assert
-            action
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected property WriteOnlyProperty to have a getter because we want to test the error message, but it does not.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_be_readable_should_fail()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = null;
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeReadable("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected property to have a getter *failure message*, but propertyInfo is <null>.");
-        }
-
-        #endregion
-
-        #region NotBeWritable
-
-        [Fact]
-        public void When_asserting_a_readonly_property_is_not_writable_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadOnlyProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().NotBeWritable("that's required");
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_readwrite_property_is_not_writable_it_fails_with_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadWriteProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().NotBeWritable("we want to test the error {0}", "message");
-
-            // Assert
-            action
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo ReadWriteProperty not to have a setter because we want to test the error message.");
-        }
-
-        [Fact]
-        public void When_asserting_a_writeonly_property_is_not_writable_it_fails_with_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WriteOnlyProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().NotBeWritable("we want to test the error {0}", "message");
-
-            // Assert
-            action
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo WriteOnlyProperty not to have a setter because we want to test the error message.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_be_writable_should_fail()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = null;
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().NotBeWritable("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected property not to have a setter *failure message*, but propertyInfo is <null>.");
-        }
-
-        #endregion
-
-        #region NotBeReadable
-
-        [Fact]
-        public void When_asserting_a_readonly_property_is_not_readable_it_fails_with_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadOnlyProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().NotBeReadable("we want to test the error {0}", "message");
-
-            // Assert
-            action
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo ReadOnlyProperty not to have a getter because we want to test the error message.");
-        }
-
-        [Fact]
-        public void When_asserting_a_readwrite_property_is_not_readable_it_fails_with_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadWriteProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().NotBeReadable("we want to test the error {0}", "message");
-
-            // Assert
-            action
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo ReadWriteProperty not to have a getter because we want to test the error message.");
-        }
-
-        [Fact]
-        public void When_asserting_a_writeonly_property_is_not_readable_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WriteOnlyProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().NotBeReadable("that's required");
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_be_readable_should_fail()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = null;
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().NotBeReadable("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected property not to have a getter *failure message*, but propertyInfo is <null>.");
-        }
-
-        #endregion
-
-        #region BeReadableAccessModifier
-
-        [Fact]
-        public void When_asserting_a_public_read_private_write_property_is_public_readable_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadPrivateWriteProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "that's required");
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_private_read_public_write_property_is_public_readable_it_fails_with_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WritePrivateReadProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected method get_WritePrivateReadProperty to be Public because we want to test the error message, but it is Private.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_be_readable_with_accessmodifier_should_fail()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = null;
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected property to be Public *failure message*, but propertyInfo is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_is_readable_with_an_invalid_enum_value_it_should_throw()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeReadable((CSharpAccessModifier)int.MaxValue);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentOutOfRangeException>()
-                .WithParameterName("accessModifier");
-        }
-
-        #endregion
-
-        #region BeWritableAccessModifier
-
-        [Fact]
-        public void When_asserting_a_public_write_private_read_property_is_public_writable_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WritePrivateReadProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "that's required");
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_private_write_public_read_property_is_public_writable_it_fails_with_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadPrivateWriteProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected method set_ReadPrivateWriteProperty to be Public because we want to test the error message, but it is Private.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_be_writable_with_accessmodifier_should_fail()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = null;
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected property to be Public *failure message*, but propertyInfo is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_is_writable_with_an_invalid_enum_value_it_should_throw()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().BeWritable((CSharpAccessModifier)int.MaxValue);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentOutOfRangeException>()
-                .WithParameterName("accessModifier");
-        }
-
-        #endregion
-
-        #region Return
-
-        [Fact]
-        public void When_asserting_a_String_property_returns_a_String_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().Return(typeof(string));
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_String_property_returns_an_Int32_it_throw_with_a_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().Return(typeof(int), "we want to test the error {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected Type of property StringProperty to be System.Int32 because we want to test the error " +
-                             "message, but it is System.String.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_return_should_fail()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = null;
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().Return(typeof(int), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type of property to be *.Int32 *failure message*, but propertyInfo is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_property_type_is_null_it_should_throw()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().Return(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("propertyType");
-        }
-
-        #endregion
-
-        #region ReturnOfT
-
-        [Fact]
-        public void When_asserting_a_String_property_returnsOfT_a_String_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().Return<string>();
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_String_property_returnsOfT_an_Int32_it_throw_with_a_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().Return<int>("we want to test the error {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected Type of property StringProperty to be System.Int32 because we want to test the error " +
-                             "message, but it is System.String.");
-        }
-
-        #endregion
-
-        #region NotReturn
-
-        [Fact]
-        public void When_asserting_a_String_property_does_not_returns_an_Int32_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().NotReturn(typeof(int));
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_String_property_does_not_return_a_String_it_throw_with_a_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().NotReturn(typeof(string), "we want to test the error {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected Type of property StringProperty not to be*String*because we want to test the error " +
-                             "message, but it is.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_return_should_fail()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = null;
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().NotReturn(typeof(int), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type of property not to be *.Int32 *failure message*, but propertyInfo is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_property_type_is_not_null_it_should_throw()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action act = () =>
-                propertyInfo.Should().NotReturn(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("propertyType");
-        }
-
-        #endregion
-
-        #region NotReturnOfT
-
-        [Fact]
-        public void When_asserting_a_String_property_does_not_returnOfT_an_Int32_it_succeeds()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().NotReturn<int>();
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_String_property_does_not_returnsOfT_a_String_it_throw_with_a_useful_message()
-        {
-            // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
-
-            // Act
-            Action action = () => propertyInfo.Should().NotReturn<string>("we want to test the error {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected Type of property StringProperty not to be*String*because we want to test the error " +
-                             "message, but it is.");
-        }
-
-        #endregion
 
         #region Internal classes used in unit tests
 

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorAssertionSpecs.cs
@@ -7,293 +7,287 @@ namespace FluentAssertions.Specs.Types
 {
     public class PropertyInfoSelectorAssertionSpecs
     {
-        #region BeVirtual
-
-        [Fact]
-        public void When_asserting_properties_are_virtual_and_they_are_it_should_succeed()
+        public class BeVirtual
         {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesVirtual));
+            [Fact]
+            public void When_asserting_properties_are_virtual_and_they_are_it_should_succeed()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesVirtual));
 
-            // Act
-            Action act = () =>
-                propertyInfoSelector.Should().BeVirtual();
+                // Act
+                Action act = () =>
+                    propertyInfoSelector.Should().BeVirtual();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_properties_are_virtual_but_non_virtual_properties_are_found_it_should_throw()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithNonVirtualPublicProperties));
+
+                // Act
+                Action act = () =>
+                    propertyInfoSelector.Should().BeVirtual();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void
+                When_asserting_properties_are_virtual_but_non_virtual_properties_are_found_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithNonVirtualPublicProperties));
+
+                // Act
+                Action act = () =>
+                    propertyInfoSelector.Should().BeVirtual("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                   .WithMessage("Expected all selected properties" +
+                       " to be virtual because we want to test the error message," +
+                       " but the following properties are not virtual:*" +
+                       "String FluentAssertions*ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty*" +
+                       "String FluentAssertions*ClassWithNonVirtualPublicProperties.InternalNonVirtualProperty*" +
+                       "String FluentAssertions*ClassWithNonVirtualPublicProperties.ProtectedNonVirtualProperty");
+            }
         }
 
-        [Fact]
-        public void When_asserting_properties_are_virtual_but_non_virtual_properties_are_found_it_should_throw()
+        public class NotBeVirtual
         {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithNonVirtualPublicProperties));
+            [Fact]
+            public void When_asserting_properties_are_not_virtual_and_they_are_not_it_should_succeed()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithNonVirtualPublicProperties));
 
-            // Act
-            Action act = () =>
-                propertyInfoSelector.Should().BeVirtual();
+                // Act
+                Action act = () =>
+                    propertyInfoSelector.Should().NotBeVirtual();
 
-            // Assert
-            act.Should().Throw<XunitException>();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_properties_are_not_virtual_but_virtual_properties_are_found_it_should_throw()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesVirtual));
+
+                // Act
+                Action act = () =>
+                    propertyInfoSelector.Should().NotBeVirtual();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void
+                When_asserting_properties_are_not_virtual_but_virtual_properties_are_found_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesVirtual));
+
+                // Act
+                Action act = () =>
+                    propertyInfoSelector.Should().NotBeVirtual("we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                   .WithMessage("Expected all selected properties" +
+                       " not to be virtual because we want to test the error message," +
+                       " but the following properties are virtual*" +
+                       "*ClassWithAllPropertiesVirtual.PublicVirtualProperty" +
+                       "*ClassWithAllPropertiesVirtual.InternalVirtualProperty" +
+                       "*ClassWithAllPropertiesVirtual.ProtectedVirtualProperty");
+            }
         }
 
-        [Fact]
-        public void
-            When_asserting_properties_are_virtual_but_non_virtual_properties_are_found_it_should_throw_with_descriptive_message()
+        public class BeDecoratedWith
         {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithNonVirtualPublicProperties));
+            [Fact]
+            public void When_asserting_properties_are_decorated_with_attribute_and_they_are_it_should_succeed()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute));
 
-            // Act
-            Action act = () =>
-                propertyInfoSelector.Should().BeVirtual("we want to test the error {0}", "message");
+                // Act
+                Action act = () =>
+                    propertyInfoSelector.Should().BeDecoratedWith<DummyPropertyAttribute>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-               .WithMessage("Expected all selected properties" +
-                   " to be virtual because we want to test the error message," +
-                   " but the following properties are not virtual:*" +
-                   "String FluentAssertions*ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty*" +
-                   "String FluentAssertions*ClassWithNonVirtualPublicProperties.InternalNonVirtualProperty*" +
-                   "String FluentAssertions*ClassWithNonVirtualPublicProperties.ProtectedNonVirtualProperty");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_properties_are_decorated_with_attribute_and_they_are_not_it_should_throw()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute))
+                    .ThatArePublicOrInternal;
+
+                // Act
+                Action act = () =>
+                    propertyInfoSelector.Should().BeDecoratedWith<DummyPropertyAttribute>();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void
+                When_asserting_properties_are_decorated_with_attribute_and_they_are_not_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute));
+
+                // Act
+                Action act = () =>
+                    propertyInfoSelector.Should()
+                                        .BeDecoratedWith<DummyPropertyAttribute>("because we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all selected properties to be decorated with" +
+                       " FluentAssertions*DummyPropertyAttribute because we want to test the error message," +
+                       " but the following properties are not:*" +
+                       "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty*" +
+                       "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.InternalProperty*" +
+                       "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.ProtectedProperty");
+            }
         }
 
-        #endregion
-
-        #region NotBeVirtual
-
-        [Fact]
-        public void When_asserting_properties_are_not_virtual_and_they_are_not_it_should_succeed()
+        public class NotBeDecoratedWith
         {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithNonVirtualPublicProperties));
+            [Fact]
+            public void When_asserting_properties_are_not_decorated_with_attribute_and_they_are_not_it_should_succeed()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute));
 
-            // Act
-            Action act = () =>
-                propertyInfoSelector.Should().NotBeVirtual();
+                // Act
+                Action act = () =>
+                    propertyInfoSelector.Should().NotBeDecoratedWith<DummyPropertyAttribute>();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_properties_are_not_decorated_with_attribute_and_they_are_it_should_throw()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute))
+                    .ThatArePublicOrInternal;
+
+                // Act
+                Action act = () =>
+                    propertyInfoSelector.Should().NotBeDecoratedWith<DummyPropertyAttribute>();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void
+                When_asserting_properties_are_not_decorated_with_attribute_and_they_are_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute));
+
+                // Act
+                Action act = () =>
+                    propertyInfoSelector.Should()
+                                        .NotBeDecoratedWith<DummyPropertyAttribute>("because we want to test the error {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all selected properties not to be decorated*" +
+                       "DummyPropertyAttribute*" +
+                       "because we want to test the error message*" +
+                       "ClassWithAllPropertiesDecoratedWithDummyAttribute.PublicProperty*" +
+                       "ClassWithAllPropertiesDecoratedWithDummyAttribute.InternalProperty*" +
+                       "ClassWithAllPropertiesDecoratedWithDummyAttribute.ProtectedProperty*");
+            }
         }
 
-        [Fact]
-        public void When_asserting_properties_are_not_virtual_but_virtual_properties_are_found_it_should_throw()
+        public class BeWritable
         {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesVirtual));
+            [Fact]
+            public void When_a_read_only_property_is_expected_to_be_writable_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithReadOnlyProperties));
 
-            // Act
-            Action act = () =>
-                propertyInfoSelector.Should().NotBeVirtual();
+                // Act
+                Action action = () => propertyInfoSelector.Should().BeWritable("because we want to test the error {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>();
+                // Assert
+                action
+                    .Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all selected properties to have a setter because we want to test the error message, " +
+                        "but the following properties do not:*" +
+                        "String FluentAssertions*ClassWithReadOnlyProperties.ReadOnlyProperty*" +
+                        "String FluentAssertions*ClassWithReadOnlyProperties.ReadOnlyProperty2");
+            }
+
+            [Fact]
+            public void When_writable_properties_are_expected_to_be_writable_it_should_not_throw()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithOnlyWritableProperties));
+
+                // Act
+                Action action = () => propertyInfoSelector.Should().BeWritable();
+
+                // Assert
+                action.Should().NotThrow();
+            }
         }
 
-        [Fact]
-        public void
-            When_asserting_properties_are_not_virtual_but_virtual_properties_are_found_it_should_throw_with_descriptive_message()
+        public class NotBeWritable
         {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesVirtual));
+            [Fact]
+            public void When_a_writable_property_is_expected_to_be_read_only_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithWritableProperties));
 
-            // Act
-            Action act = () =>
-                propertyInfoSelector.Should().NotBeVirtual("we want to test the error {0}", "message");
+                // Act
+                Action action = () => propertyInfoSelector.Should().NotBeWritable("because we want to test the error {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-               .WithMessage("Expected all selected properties" +
-                   " not to be virtual because we want to test the error message," +
-                   " but the following properties are virtual*" +
-                   "*ClassWithAllPropertiesVirtual.PublicVirtualProperty" +
-                   "*ClassWithAllPropertiesVirtual.InternalVirtualProperty" +
-                   "*ClassWithAllPropertiesVirtual.ProtectedVirtualProperty");
+                // Assert
+                action
+                    .Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected selected properties to not have a setter because we want to test the error message, " +
+                        "but the following properties do:*" +
+                        "String FluentAssertions*ClassWithWritableProperties.ReadWriteProperty*" +
+                        "String FluentAssertions*ClassWithWritableProperties.ReadWriteProperty2");
+            }
+
+            [Fact]
+            public void When_read_only_properties_are_expected_to_not_be_writable_it_should_not_throw()
+            {
+                // Arrange
+                var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithOnlyReadOnlyProperties));
+
+                // Act
+                Action action = () => propertyInfoSelector.Should().NotBeWritable();
+
+                // Assert
+                action.Should().NotThrow();
+            }
         }
-
-        #endregion
-
-        #region BeDecoratedWith
-
-        [Fact]
-        public void When_asserting_properties_are_decorated_with_attribute_and_they_are_it_should_succeed()
-        {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute));
-
-            // Act
-            Action act = () =>
-                propertyInfoSelector.Should().BeDecoratedWith<DummyPropertyAttribute>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_properties_are_decorated_with_attribute_and_they_are_not_it_should_throw()
-        {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute))
-                .ThatArePublicOrInternal;
-
-            // Act
-            Action act = () =>
-                propertyInfoSelector.Should().BeDecoratedWith<DummyPropertyAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void
-            When_asserting_properties_are_decorated_with_attribute_and_they_are_not_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute));
-
-            // Act
-            Action act = () =>
-                propertyInfoSelector.Should()
-                                    .BeDecoratedWith<DummyPropertyAttribute>("because we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected properties to be decorated with" +
-                   " FluentAssertions*DummyPropertyAttribute because we want to test the error message," +
-                   " but the following properties are not:*" +
-                   "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty*" +
-                   "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.InternalProperty*" +
-                   "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.ProtectedProperty");
-        }
-
-        #endregion
-
-        #region NotBeDecoratedWith
-
-        [Fact]
-        public void When_asserting_properties_are_not_decorated_with_attribute_and_they_are_not_it_should_succeed()
-        {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute));
-
-            // Act
-            Action act = () =>
-                propertyInfoSelector.Should().NotBeDecoratedWith<DummyPropertyAttribute>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_properties_are_not_decorated_with_attribute_and_they_are_it_should_throw()
-        {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute))
-                .ThatArePublicOrInternal;
-
-            // Act
-            Action act = () =>
-                propertyInfoSelector.Should().NotBeDecoratedWith<DummyPropertyAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void
-            When_asserting_properties_are_not_decorated_with_attribute_and_they_are_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute));
-
-            // Act
-            Action act = () =>
-                propertyInfoSelector.Should()
-                                    .NotBeDecoratedWith<DummyPropertyAttribute>("because we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected properties not to be decorated*" +
-                   "DummyPropertyAttribute*" +
-                   "because we want to test the error message*" +
-                   "ClassWithAllPropertiesDecoratedWithDummyAttribute.PublicProperty*" +
-                   "ClassWithAllPropertiesDecoratedWithDummyAttribute.InternalProperty*" +
-                   "ClassWithAllPropertiesDecoratedWithDummyAttribute.ProtectedProperty*");
-        }
-
-        #endregion
-
-        #region BeWritable
-
-        [Fact]
-        public void When_a_read_only_property_is_expected_to_be_writable_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithReadOnlyProperties));
-
-            // Act
-            Action action = () => propertyInfoSelector.Should().BeWritable("because we want to test the error {0}", "message");
-
-            // Assert
-            action
-                .Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all selected properties to have a setter because we want to test the error message, " +
-                    "but the following properties do not:*" +
-                    "String FluentAssertions*ClassWithReadOnlyProperties.ReadOnlyProperty*" +
-                    "String FluentAssertions*ClassWithReadOnlyProperties.ReadOnlyProperty2");
-        }
-
-        [Fact]
-        public void When_writable_properties_are_expected_to_be_writable_it_should_not_throw()
-        {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithOnlyWritableProperties));
-
-            // Act
-            Action action = () => propertyInfoSelector.Should().BeWritable();
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        #endregion
-
-        #region NotBeWritable
-
-        [Fact]
-        public void When_a_writable_property_is_expected_to_be_read_only_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithWritableProperties));
-
-            // Act
-            Action action = () => propertyInfoSelector.Should().NotBeWritable("because we want to test the error {0}", "message");
-
-            // Assert
-            action
-                .Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected selected properties to not have a setter because we want to test the error message, " +
-                    "but the following properties do:*" +
-                    "String FluentAssertions*ClassWithWritableProperties.ReadWriteProperty*" +
-                    "String FluentAssertions*ClassWithWritableProperties.ReadWriteProperty2");
-        }
-
-        [Fact]
-        public void When_read_only_properties_are_expected_to_not_be_writable_it_should_not_throw()
-        {
-            // Arrange
-            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithOnlyReadOnlyProperties));
-
-            // Act
-            Action action = () => propertyInfoSelector.Should().NotBeWritable();
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        #endregion
     }
 
     #region Internal classes used in unit tests
@@ -375,6 +369,5 @@ namespace FluentAssertions.Specs.Types
 
         protected string ProtectedProperty { get; set; }
     }
-
     #endregion
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.Be.cs
@@ -11,215 +11,213 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region Be
-
-        [Fact]
-        public void When_type_is_equal_to_the_same_type_it_succeeds()
+        public class Be
         {
-            // Arrange
-            Type type = typeof(ClassWithAttribute);
-            Type sameType = typeof(ClassWithAttribute);
+            [Fact]
+            public void When_type_is_equal_to_the_same_type_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(ClassWithAttribute);
+                Type sameType = typeof(ClassWithAttribute);
 
-            // Act
-            Action act = () =>
-                type.Should().Be(sameType);
+                // Act
+                Action act = () =>
+                    type.Should().Be(sameType);
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_type_is_equal_to_another_type_it_fails()
-        {
-            // Arrange
-            Type type = typeof(ClassWithAttribute);
-            Type differentType = typeof(ClassWithoutAttribute);
+            [Fact]
+            public void When_type_is_equal_to_another_type_it_fails()
+            {
+                // Arrange
+                Type type = typeof(ClassWithAttribute);
+                Type differentType = typeof(ClassWithoutAttribute);
 
-            // Act
-            Action act = () =>
-                type.Should().Be(differentType, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should().Be(differentType, "we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be *.ClassWithoutAttribute *failure message*, but found *.ClassWithAttribute.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be *.ClassWithoutAttribute *failure message*, but found *.ClassWithAttribute.");
+            }
 
-        [Fact]
-        public void When_asserting_equality_of_two_null_types_it_succeeds()
-        {
-            // Arrange
-            Type nullType = null;
-            Type someType = null;
+            [Fact]
+            public void When_asserting_equality_of_two_null_types_it_succeeds()
+            {
+                // Arrange
+                Type nullType = null;
+                Type someType = null;
 
-            // Act
-            Action act = () => nullType.Should().Be(someType);
+                // Act
+                Action act = () => nullType.Should().Be(someType);
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_asserting_equality_of_a_type_but_the_type_is_null_it_fails()
-        {
-            // Arrange
-            Type nullType = null;
-            Type someType = typeof(ClassWithAttribute);
+            [Fact]
+            public void When_asserting_equality_of_a_type_but_the_type_is_null_it_fails()
+            {
+                // Arrange
+                Type nullType = null;
+                Type someType = typeof(ClassWithAttribute);
 
-            // Act
-            Action act = () =>
-                nullType.Should().Be(someType, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    nullType.Should().Be(someType, "we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be *.ClassWithAttribute *failure message*, but found <null>.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be *.ClassWithAttribute *failure message*, but found <null>.");
+            }
 
-        [Fact]
-        public void When_asserting_equality_of_a_type_with_null_it_fails()
-        {
-            // Arrange
-            Type someType = typeof(ClassWithAttribute);
-            Type nullType = null;
+            [Fact]
+            public void When_asserting_equality_of_a_type_with_null_it_fails()
+            {
+                // Arrange
+                Type someType = typeof(ClassWithAttribute);
+                Type nullType = null;
 
-            // Act
-            Action act = () =>
-                someType.Should().Be(nullType, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    someType.Should().Be(nullType, "we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be <null> *failure message*, but found *.ClassWithAttribute.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be <null> *failure message*, but found *.ClassWithAttribute.");
+            }
 
-        [Fact]
-        public void When_type_is_equal_to_same_type_from_different_assembly_it_fails_with_assembly_qualified_name()
-        {
-            // Arrange
+            [Fact]
+            public void When_type_is_equal_to_same_type_from_different_assembly_it_fails_with_assembly_qualified_name()
+            {
+                // Arrange
 #pragma warning disable 436 // disable the warning on conflicting types, as this is the intention for the spec
 
-            Type typeFromThisAssembly = typeof(AssemblyB.ClassC);
+                Type typeFromThisAssembly = typeof(AssemblyB.ClassC);
 
-            Type typeFromOtherAssembly =
-                new AssemblyA.ClassA().ReturnClassC().GetType();
+                Type typeFromOtherAssembly =
+                    new AssemblyA.ClassA().ReturnClassC().GetType();
 
 #pragma warning restore 436
 
-            // Act
-            Action act = () =>
-                typeFromThisAssembly.Should().Be(typeFromOtherAssembly, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    typeFromThisAssembly.Should().Be(typeFromOtherAssembly, "we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be [AssemblyB.ClassC, AssemblyB*] *failure message*, but found [AssemblyB.ClassC, FluentAssertions.Specs*].");
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be [AssemblyB.ClassC, AssemblyB*] *failure message*, but found [AssemblyB.ClassC, FluentAssertions.Specs*].");
+            }
+
+            [Fact]
+            public void When_type_is_equal_to_the_same_type_using_generics_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () =>
+                    type.Should().Be<ClassWithAttribute>();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_is_equal_to_another_type_using_generics_it_fails()
+            {
+                // Arrange
+                Type type = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () =>
+                    type.Should().Be<ClassWithoutAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be *.ClassWithoutAttribute *failure message*, but found *.ClassWithAttribute.");
+            }
         }
 
-        [Fact]
-        public void When_type_is_equal_to_the_same_type_using_generics_it_succeeds()
+        public class NotBe
         {
-            // Arrange
-            Type type = typeof(ClassWithAttribute);
+            [Fact]
+            public void When_type_is_not_equal_to_the_another_type_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(ClassWithAttribute);
+                Type otherType = typeof(ClassWithoutAttribute);
 
-            // Act
-            Action act = () =>
-                type.Should().Be<ClassWithAttribute>();
+                // Act
+                Action act = () =>
+                    type.Should().NotBe(otherType);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_is_not_equal_to_the_same_type_it_fails()
+            {
+                // Arrange
+                Type type = typeof(ClassWithAttribute);
+                Type sameType = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBe(sameType, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type not to be [*.ClassWithAttribute*] *failure message*, but it is.");
+            }
+
+            [Fact]
+            public void When_type_is_not_equal_to_the_same_null_type_it_fails()
+            {
+                // Arrange
+                Type type = null;
+                Type sameType = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBe(sameType);
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_type_is_not_equal_to_another_type_using_generics_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBe<ClassWithoutAttribute>();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_is_not_equal_to_the_same_type_using_generics_it_fails()
+            {
+                // Arrange
+                Type type = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBe<ClassWithAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type not to be [*.ClassWithAttribute*] *failure message*, but it is.");
+            }
         }
-
-        [Fact]
-        public void When_type_is_equal_to_another_type_using_generics_it_fails()
-        {
-            // Arrange
-            Type type = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                type.Should().Be<ClassWithoutAttribute>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be *.ClassWithoutAttribute *failure message*, but found *.ClassWithAttribute.");
-        }
-
-        #endregion
-
-        #region NotBe
-
-        [Fact]
-        public void When_type_is_not_equal_to_the_another_type_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(ClassWithAttribute);
-            Type otherType = typeof(ClassWithoutAttribute);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBe(otherType);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_type_is_not_equal_to_the_same_type_it_fails()
-        {
-            // Arrange
-            Type type = typeof(ClassWithAttribute);
-            Type sameType = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBe(sameType, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be [*.ClassWithAttribute*] *failure message*, but it is.");
-        }
-
-        [Fact]
-        public void When_type_is_not_equal_to_the_same_null_type_it_fails()
-        {
-            // Arrange
-            Type type = null;
-            Type sameType = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotBe(sameType);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_type_is_not_equal_to_another_type_using_generics_it_succeeds()
-        {
-            // Arrange
-            Type type = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBe<ClassWithoutAttribute>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_type_is_not_equal_to_the_same_type_using_generics_it_fails()
-        {
-            // Arrange
-            Type type = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBe<ClassWithAttribute>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be [*.ClassWithAttribute*] *failure message*, but it is.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeAbstract.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeAbstract.cs
@@ -9,143 +9,141 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region BeAbstract
-
-        [Fact]
-        public void When_type_is_abstract_it_succeeds()
+        public class BeAbstract
         {
-            // Arrange / Act / Assert
-            typeof(Abstract).Should().BeAbstract();
+            [Fact]
+            public void When_type_is_abstract_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(Abstract).Should().BeAbstract();
+            }
+
+            [Theory]
+            [InlineData(typeof(ClassWithoutMembers), "Expected type *.ClassWithoutMembers to be abstract.")]
+            [InlineData(typeof(Sealed), "Expected type *.Sealed to be abstract.")]
+            [InlineData(typeof(Static), "Expected type *.Static to be abstract.")]
+            public void When_type_is_not_abstract_it_fails(Type type, string exceptionMessage)
+            {
+                // Act
+                Action act = () => type.Should().BeAbstract();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(exceptionMessage);
+            }
+
+            [Fact]
+            public void When_type_is_not_abstract_it_fails_with_a_meaningful_message()
+            {
+                // Arrange
+                var type = typeof(ClassWithoutMembers);
+
+                // Act
+                Action act = () => type.Should().BeAbstract("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type *.ClassWithoutMembers to be abstract *failure message*.");
+            }
+
+            [Theory]
+            [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
+            [InlineData(typeof(Struct), "*.Struct must be a class.")]
+            [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
+            public void When_type_is_not_valid_for_BeAbstract_it_throws_exception(Type type, string exceptionMessage)
+            {
+                // Act
+                Action act = () => type.Should().BeAbstract();
+
+                // Assert
+                act.Should().Throw<InvalidOperationException>()
+                    .WithMessage(exceptionMessage);
+            }
+
+            [Fact]
+            public void When_subject_is_null_be_abstract_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().BeAbstract("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be abstract *failure message*, but type is <null>.");
+            }
         }
 
-        [Theory]
-        [InlineData(typeof(ClassWithoutMembers), "Expected type *.ClassWithoutMembers to be abstract.")]
-        [InlineData(typeof(Sealed), "Expected type *.Sealed to be abstract.")]
-        [InlineData(typeof(Static), "Expected type *.Static to be abstract.")]
-        public void When_type_is_not_abstract_it_fails(Type type, string exceptionMessage)
+        public class NotBeAbstract
         {
-            // Act
-            Action act = () => type.Should().BeAbstract();
+            [Theory]
+            [InlineData(typeof(ClassWithoutMembers))]
+            [InlineData(typeof(Sealed))]
+            [InlineData(typeof(Static))]
+            public void When_type_is_not_abstract_it_succeeds(Type type)
+            {
+                // Arrange / Act / Assert
+                type.Should().NotBeAbstract();
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(exceptionMessage);
+            [Fact]
+            public void When_type_is_abstract_it_fails()
+            {
+                // Arrange
+                var type = typeof(Abstract);
+
+                // Act
+                Action act = () => type.Should().NotBeAbstract();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type *.Abstract not to be abstract.");
+            }
+
+            [Fact]
+            public void When_type_is_abstract_it_fails_with_a_meaningful_message()
+            {
+                // Arrange
+                var type = typeof(Abstract);
+
+                // Act
+                Action act = () => type.Should().NotBeAbstract("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type *.Abstract not to be abstract *failure message*.");
+            }
+
+            [Theory]
+            [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
+            [InlineData(typeof(Struct), "*.Struct must be a class.")]
+            [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
+            public void When_type_is_not_valid_for_NotBeAbstract_it_throws_exception(Type type, string exceptionMessage)
+            {
+                // Act
+                Action act = () => type.Should().NotBeAbstract();
+
+                // Assert
+                act.Should().Throw<InvalidOperationException>()
+                    .WithMessage(exceptionMessage);
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_be_abstract_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeAbstract("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type not to be abstract *failure message*, but type is <null>.");
+            }
         }
-
-        [Fact]
-        public void When_type_is_not_abstract_it_fails_with_a_meaningful_message()
-        {
-            // Arrange
-            var type = typeof(ClassWithoutMembers);
-
-            // Act
-            Action act = () => type.Should().BeAbstract("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithoutMembers to be abstract *failure message*.");
-        }
-
-        [Theory]
-        [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "*.Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
-        public void When_type_is_not_valid_for_BeAbstract_it_throws_exception(Type type, string exceptionMessage)
-        {
-            // Act
-            Action act = () => type.Should().BeAbstract();
-
-            // Assert
-            act.Should().Throw<InvalidOperationException>()
-                .WithMessage(exceptionMessage);
-        }
-
-        [Fact]
-        public void When_subject_is_null_be_abstract_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().BeAbstract("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be abstract *failure message*, but type is <null>.");
-        }
-
-        #endregion
-
-        #region NotBeAbstract
-
-        [Theory]
-        [InlineData(typeof(ClassWithoutMembers))]
-        [InlineData(typeof(Sealed))]
-        [InlineData(typeof(Static))]
-        public void When_type_is_not_abstract_it_succeeds(Type type)
-        {
-            // Arrange / Act / Assert
-            type.Should().NotBeAbstract();
-        }
-
-        [Fact]
-        public void When_type_is_abstract_it_fails()
-        {
-            // Arrange
-            var type = typeof(Abstract);
-
-            // Act
-            Action act = () => type.Should().NotBeAbstract();
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.Abstract not to be abstract.");
-        }
-
-        [Fact]
-        public void When_type_is_abstract_it_fails_with_a_meaningful_message()
-        {
-            // Arrange
-            var type = typeof(Abstract);
-
-            // Act
-            Action act = () => type.Should().NotBeAbstract("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.Abstract not to be abstract *failure message*.");
-        }
-
-        [Theory]
-        [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "*.Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
-        public void When_type_is_not_valid_for_NotBeAbstract_it_throws_exception(Type type, string exceptionMessage)
-        {
-            // Act
-            Action act = () => type.Should().NotBeAbstract();
-
-            // Assert
-            act.Should().Throw<InvalidOperationException>()
-                .WithMessage(exceptionMessage);
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_be_abstract_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeAbstract("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be abstract *failure message*, but type is <null>.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeAssignableTo.cs
@@ -10,332 +10,330 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region BeAssignableTo
-
-        [Fact]
-        public void When_its_own_type_it_succeeds()
+        public class BeAssignableTo
         {
-            // Arrange / Act / Assert
-            typeof(DummyImplementingClass).Should().BeAssignableTo<DummyImplementingClass>();
+            [Fact]
+            public void When_its_own_type_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(DummyImplementingClass).Should().BeAssignableTo<DummyImplementingClass>();
+            }
+
+            [Fact]
+            public void When_its_base_type_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(DummyImplementingClass).Should().BeAssignableTo<DummyBaseClass>();
+            }
+
+            [Fact]
+            public void When_implemented_interface_type_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(DummyImplementingClass).Should().BeAssignableTo<IDisposable>();
+            }
+
+            [Fact]
+            public void When_an_unrelated_type_it_fails()
+            {
+                // Arrange
+                Type someType = typeof(DummyImplementingClass);
+                Action act = () => someType.Should().BeAssignableTo<DateTime>("we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected someType *.DummyImplementingClass to be assignable to *.DateTime *failure message*" +
+                        ", but it is not.");
+            }
+
+            [Fact]
+            public void When_its_own_type_instance_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(DummyImplementingClass).Should().BeAssignableTo(typeof(DummyImplementingClass));
+            }
+
+            [Fact]
+            public void When_its_base_type_instance_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(DummyImplementingClass).Should().BeAssignableTo(typeof(DummyBaseClass));
+            }
+
+            [Fact]
+            public void When_an_implemented_interface_type_instance_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(DummyImplementingClass).Should().BeAssignableTo(typeof(IDisposable));
+            }
+
+            [Fact]
+            public void When_an_unrelated_type_instance_it_fails()
+            {
+                // Arrange
+                Type someType = typeof(DummyImplementingClass);
+
+                // Act
+                Action act = () =>
+                    someType.Should().BeAssignableTo(typeof(DateTime), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*.DummyImplementingClass to be assignable to *.DateTime *failure message*");
+            }
+
+            [Fact]
+            public void When_constructed_of_open_generic_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(IDummyInterface<IDummyInterface>).Should().BeAssignableTo(typeof(IDummyInterface<>));
+            }
+
+            [Fact]
+            public void When_implementation_of_open_generic_interface_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(ClassWithGenericBaseType).Should().BeAssignableTo(typeof(IDummyInterface<>));
+            }
+
+            [Fact]
+            public void When_derived_of_open_generic_class_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(ClassWithGenericBaseType).Should().BeAssignableTo(typeof(DummyBaseType<>));
+            }
+
+            [Fact]
+            public void When_unrelated_to_open_generic_interface_it_fails()
+            {
+                // Arrange
+                Type someType = typeof(IDummyInterface);
+
+                // Act
+                Action act = () =>
+                    someType.Should().BeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected someType *.IDummyInterface to be assignable to *.IDummyInterface`1[T] *failure message*" +
+                        ", but it is not.");
+            }
+
+            [Fact]
+            public void When_unrelated_to_open_generic_type_it_fails()
+            {
+                // Arrange
+                Type someType = typeof(ClassWithAttribute);
+                Action act = () =>
+                    someType.Should().BeAssignableTo(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("*.ClassWithAttribute to be assignable to *.DummyBaseType* *failure message*");
+            }
+
+            [Fact]
+            public void When_asserting_an_open_generic_class_is_assignable_to_itself_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(DummyBaseType<>).Should().BeAssignableTo(typeof(DummyBaseType<>));
+            }
+
+            [Fact]
+            public void When_asserting_a_type_to_be_assignable_to_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(DummyBaseType<>);
+
+                // Act
+                Action act = () =>
+                    type.Should().BeAssignableTo(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("type");
+            }
         }
 
-        [Fact]
-        public void When_its_base_type_it_succeeds()
+        public class NotBeAssignableTo
         {
-            // Arrange / Act / Assert
-            typeof(DummyImplementingClass).Should().BeAssignableTo<DummyBaseClass>();
+            [Fact]
+            public void When_its_own_type_and_asserting_not_assignable_it_fails()
+            {
+                // Arrange
+                var type = typeof(DummyImplementingClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeAssignableTo<DummyImplementingClass>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.DummyImplementingClass to not be assignable to *.DummyImplementingClass *failure message*");
+            }
+
+            [Fact]
+            public void When_its_base_type_and_asserting_not_assignable_it_fails()
+            {
+                // Arrange
+                var type = typeof(DummyImplementingClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeAssignableTo<DummyBaseClass>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.DummyImplementingClass to not be assignable to *.DummyBaseClass *failure message*" +
+                        ", but it is.");
+            }
+
+            [Fact]
+            public void When_implemented_interface_type_and_asserting_not_assignable_it_fails()
+            {
+                // Arrange
+                var type = typeof(DummyImplementingClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeAssignableTo<IDisposable>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.DummyImplementingClass to not be assignable to *.IDisposable *failure message*, but it is.");
+            }
+
+            [Fact]
+            public void When_an_unrelated_type_and_asserting_not_assignable_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(DummyImplementingClass).Should().NotBeAssignableTo<DateTime>();
+            }
+
+            [Fact]
+            public void When_its_own_type_instance_and_asserting_not_assignable_it_fails()
+            {
+                // Arrange
+                var type = typeof(DummyImplementingClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeAssignableTo(typeof(DummyImplementingClass), "we want to test the failure {0}", "message");
+
+                // Act / Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.DummyImplementingClass to not be assignable to *.DummyImplementingClass *failure message*" +
+                        ", but it is.");
+            }
+
+            [Fact]
+            public void When_its_base_type_instance_and_asserting_not_assignable_it_fails()
+            {
+                // Arrange
+                var type = typeof(DummyImplementingClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeAssignableTo(typeof(DummyBaseClass), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.DummyImplementingClass to not be assignable to *.DummyBaseClass *failure message*" +
+                        ", but it is.");
+            }
+
+            [Fact]
+            public void When_an_implemented_interface_type_instance_and_asserting_not_assignable_it_fails()
+            {
+                // Arrange
+                var type = typeof(DummyImplementingClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeAssignableTo(typeof(IDisposable), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.DummyImplementingClass to not be assignable to *.IDisposable *failure message*, but it is.");
+            }
+
+            [Fact]
+            public void When_an_unrelated_type_instance_and_asserting_not_assignable_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DateTime));
+            }
+
+            [Fact]
+            public void When_unrelated_to_open_generic_interface_and_asserting_not_assignable_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(ClassWithAttribute).Should().NotBeAssignableTo(typeof(IDummyInterface<>));
+            }
+
+            [Fact]
+            public void When_unrelated_to_open_generic_class_and_asserting_not_assignable_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(ClassWithAttribute).Should().NotBeAssignableTo(typeof(DummyBaseType<>));
+            }
+
+            [Fact]
+            public void When_implementation_of_open_generic_interface_and_asserting_not_assignable_it_fails()
+            {
+                // Arrange
+                Type type = typeof(ClassWithGenericBaseType);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface`1[T] *failure message*" +
+                        ", but it is.");
+            }
+
+            [Fact]
+            public void When_derived_from_open_generic_class_and_asserting_not_assignable_it_fails()
+            {
+                // Arrange
+                Type type = typeof(ClassWithGenericBaseType);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface`1[T] *failure message*" +
+                        ", but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_not_to_be_assignable_to_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(DummyBaseType<>);
+
+                // Act
+                Action act =
+                    () => type.Should().NotBeAssignableTo(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("type");
+            }
         }
-
-        [Fact]
-        public void When_implemented_interface_type_it_succeeds()
-        {
-            // Arrange / Act / Assert
-            typeof(DummyImplementingClass).Should().BeAssignableTo<IDisposable>();
-        }
-
-        [Fact]
-        public void When_an_unrelated_type_it_fails()
-        {
-            // Arrange
-            Type someType = typeof(DummyImplementingClass);
-            Action act = () => someType.Should().BeAssignableTo<DateTime>("we want to test the failure {0}", "message");
-
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected someType *.DummyImplementingClass to be assignable to *.DateTime *failure message*" +
-                    ", but it is not.");
-        }
-
-        [Fact]
-        public void When_its_own_type_instance_it_succeeds()
-        {
-            // Arrange / Act / Assert
-            typeof(DummyImplementingClass).Should().BeAssignableTo(typeof(DummyImplementingClass));
-        }
-
-        [Fact]
-        public void When_its_base_type_instance_it_succeeds()
-        {
-            // Arrange / Act / Assert
-            typeof(DummyImplementingClass).Should().BeAssignableTo(typeof(DummyBaseClass));
-        }
-
-        [Fact]
-        public void When_an_implemented_interface_type_instance_it_succeeds()
-        {
-            // Arrange / Act / Assert
-            typeof(DummyImplementingClass).Should().BeAssignableTo(typeof(IDisposable));
-        }
-
-        [Fact]
-        public void When_an_unrelated_type_instance_it_fails()
-        {
-            // Arrange
-            Type someType = typeof(DummyImplementingClass);
-
-            // Act
-            Action act = () =>
-                someType.Should().BeAssignableTo(typeof(DateTime), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*.DummyImplementingClass to be assignable to *.DateTime *failure message*");
-        }
-
-        [Fact]
-        public void When_constructed_of_open_generic_it_succeeds()
-        {
-            // Arrange / Act / Assert
-            typeof(IDummyInterface<IDummyInterface>).Should().BeAssignableTo(typeof(IDummyInterface<>));
-        }
-
-        [Fact]
-        public void When_implementation_of_open_generic_interface_it_succeeds()
-        {
-            // Arrange / Act / Assert
-            typeof(ClassWithGenericBaseType).Should().BeAssignableTo(typeof(IDummyInterface<>));
-        }
-
-        [Fact]
-        public void When_derived_of_open_generic_class_it_succeeds()
-        {
-            // Arrange / Act / Assert
-            typeof(ClassWithGenericBaseType).Should().BeAssignableTo(typeof(DummyBaseType<>));
-        }
-
-        [Fact]
-        public void When_unrelated_to_open_generic_interface_it_fails()
-        {
-            // Arrange
-            Type someType = typeof(IDummyInterface);
-
-            // Act
-            Action act = () =>
-                someType.Should().BeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected someType *.IDummyInterface to be assignable to *.IDummyInterface`1[T] *failure message*" +
-                    ", but it is not.");
-        }
-
-        [Fact]
-        public void When_unrelated_to_open_generic_type_it_fails()
-        {
-            // Arrange
-            Type someType = typeof(ClassWithAttribute);
-            Action act = () =>
-                someType.Should().BeAssignableTo(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
-
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*.ClassWithAttribute to be assignable to *.DummyBaseType* *failure message*");
-        }
-
-        [Fact]
-        public void When_asserting_an_open_generic_class_is_assignable_to_itself_it_succeeds()
-        {
-            // Arrange / Act / Assert
-            typeof(DummyBaseType<>).Should().BeAssignableTo(typeof(DummyBaseType<>));
-        }
-
-        [Fact]
-        public void When_asserting_a_type_to_be_assignable_to_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(DummyBaseType<>);
-
-            // Act
-            Action act = () =>
-                type.Should().BeAssignableTo(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("type");
-        }
-
-        #endregion
-
-        #region NotBeAssignableTo
-
-        [Fact]
-        public void When_its_own_type_and_asserting_not_assignable_it_fails()
-        {
-            // Arrange
-            var type = typeof(DummyImplementingClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeAssignableTo<DummyImplementingClass>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass to not be assignable to *.DummyImplementingClass *failure message*");
-        }
-
-        [Fact]
-        public void When_its_base_type_and_asserting_not_assignable_it_fails()
-        {
-            // Arrange
-            var type = typeof(DummyImplementingClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeAssignableTo<DummyBaseClass>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass to not be assignable to *.DummyBaseClass *failure message*" +
-                    ", but it is.");
-        }
-
-        [Fact]
-        public void When_implemented_interface_type_and_asserting_not_assignable_it_fails()
-        {
-            // Arrange
-            var type = typeof(DummyImplementingClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeAssignableTo<IDisposable>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass to not be assignable to *.IDisposable *failure message*, but it is.");
-        }
-
-        [Fact]
-        public void When_an_unrelated_type_and_asserting_not_assignable_it_succeeds()
-        {
-            // Arrange / Act / Assert
-            typeof(DummyImplementingClass).Should().NotBeAssignableTo<DateTime>();
-        }
-
-        [Fact]
-        public void When_its_own_type_instance_and_asserting_not_assignable_it_fails()
-        {
-            // Arrange
-            var type = typeof(DummyImplementingClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeAssignableTo(typeof(DummyImplementingClass), "we want to test the failure {0}", "message");
-
-            // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass to not be assignable to *.DummyImplementingClass *failure message*" +
-                    ", but it is.");
-        }
-
-        [Fact]
-        public void When_its_base_type_instance_and_asserting_not_assignable_it_fails()
-        {
-            // Arrange
-            var type = typeof(DummyImplementingClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeAssignableTo(typeof(DummyBaseClass), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass to not be assignable to *.DummyBaseClass *failure message*" +
-                    ", but it is.");
-        }
-
-        [Fact]
-        public void When_an_implemented_interface_type_instance_and_asserting_not_assignable_it_fails()
-        {
-            // Arrange
-            var type = typeof(DummyImplementingClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeAssignableTo(typeof(IDisposable), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass to not be assignable to *.IDisposable *failure message*, but it is.");
-        }
-
-        [Fact]
-        public void When_an_unrelated_type_instance_and_asserting_not_assignable_it_succeeds()
-        {
-            // Arrange / Act / Assert
-            typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DateTime));
-        }
-
-        [Fact]
-        public void When_unrelated_to_open_generic_interface_and_asserting_not_assignable_it_succeeds()
-        {
-            // Arrange / Act / Assert
-            typeof(ClassWithAttribute).Should().NotBeAssignableTo(typeof(IDummyInterface<>));
-        }
-
-        [Fact]
-        public void When_unrelated_to_open_generic_class_and_asserting_not_assignable_it_succeeds()
-        {
-            // Arrange / Act / Assert
-            typeof(ClassWithAttribute).Should().NotBeAssignableTo(typeof(DummyBaseType<>));
-        }
-
-        [Fact]
-        public void When_implementation_of_open_generic_interface_and_asserting_not_assignable_it_fails()
-        {
-            // Arrange
-            Type type = typeof(ClassWithGenericBaseType);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface`1[T] *failure message*" +
-                    ", but it is.");
-        }
-
-        [Fact]
-        public void When_derived_from_open_generic_class_and_asserting_not_assignable_it_fails()
-        {
-            // Arrange
-            Type type = typeof(ClassWithGenericBaseType);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface`1[T] *failure message*" +
-                    ", but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_not_to_be_assignable_to_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(DummyBaseType<>);
-
-            // Act
-            Action act =
-                () => type.Should().NotBeAssignableTo(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("type");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWith.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWith.cs
@@ -9,201 +9,199 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region BeDecoratedWith
-
-        [Fact]
-        public void When_type_is_decorated_with_expected_attribute_it_succeeds()
+        public class BeDecoratedWith
         {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithAttribute);
+            [Fact]
+            public void When_type_is_decorated_with_expected_attribute_it_succeeds()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithAttribute);
 
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should().BeDecoratedWith<DummyClassAttribute>();
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should().BeDecoratedWith<DummyClassAttribute>();
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_type_is_decorated_with_expected_attribute_it_should_allow_chaining()
-        {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithAttribute);
+            [Fact]
+            public void When_type_is_decorated_with_expected_attribute_it_should_allow_chaining()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithAttribute);
 
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should().BeDecoratedWith<DummyClassAttribute>()
-                    .Which.IsEnabled.Should().BeTrue();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_type_is_not_decorated_with_expected_attribute_it_fails()
-        {
-            // Arrange
-            Type typeWithoutAttribute = typeof(ClassWithoutAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithoutAttribute.Should().BeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithoutAttribute to be decorated with *.DummyClassAttribute *failure message*" +
-                    ", but the attribute was not found.");
-        }
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_BeDecoratedWith_it_should_throw()
-        {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should().BeDecoratedWith<DummyClassAttribute>(isMatchingAttributePredicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
-        }
-
-        [Fact]
-        public void When_type_is_decorated_with_expected_attribute_with_the_expected_properties_it_succeeds()
-        {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should()
-                    .BeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_type_is_decorated_with_expected_attribute_with_the_expected_properties_it_should_allow_chaining()
-        {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should()
-                    .BeDecoratedWith<DummyClassAttribute>(a => a.Name == "Expected")
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should().BeDecoratedWith<DummyClassAttribute>()
                         .Which.IsEnabled.Should().BeTrue();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_is_not_decorated_with_expected_attribute_it_fails()
+            {
+                // Arrange
+                Type typeWithoutAttribute = typeof(ClassWithoutAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithoutAttribute.Should().BeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassWithoutAttribute to be decorated with *.DummyClassAttribute *failure message*" +
+                        ", but the attribute was not found.");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_predicate_into_BeDecoratedWith_it_should_throw()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should().BeDecoratedWith<DummyClassAttribute>(isMatchingAttributePredicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
+
+            [Fact]
+            public void When_type_is_decorated_with_expected_attribute_with_the_expected_properties_it_succeeds()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should()
+                        .BeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_is_decorated_with_expected_attribute_with_the_expected_properties_it_should_allow_chaining()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should()
+                        .BeDecoratedWith<DummyClassAttribute>(a => a.Name == "Expected")
+                            .Which.IsEnabled.Should().BeTrue();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_is_decorated_with_expected_attribute_that_has_an_unexpected_property_it_fails()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should()
+                        .BeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Unexpected") && a.IsEnabled);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassWithAttribute to be decorated with *.DummyClassAttribute that matches " +
+                        "(a.Name == \"Unexpected\")*a.IsEnabled, but no matching attribute was found.");
+            }
         }
 
-        [Fact]
-        public void When_type_is_decorated_with_expected_attribute_that_has_an_unexpected_property_it_fails()
+        public class NotBeDecoratedWith
         {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithAttribute);
+            [Fact]
+            public void When_type_is_not_decorated_with_unexpected_attribute_it_succeeds()
+            {
+                // Arrange
+                Type typeWithoutAttribute = typeof(ClassWithoutAttribute);
 
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should()
-                    .BeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Unexpected") && a.IsEnabled);
+                // Act
+                Action act = () =>
+                    typeWithoutAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithAttribute to be decorated with *.DummyClassAttribute that matches " +
-                    "(a.Name == \"Unexpected\")*a.IsEnabled, but no matching attribute was found.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_is_decorated_with_unexpected_attribute_it_fails()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute* *failure message*" +
+                        ", but the attribute was found.");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_predicate_into_NotBeDecoratedWith_it_should_throw()
+            {
+                // Arrange
+                Type typeWithoutAttribute = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () => typeWithoutAttribute.Should()
+                    .NotBeDecoratedWith<DummyClassAttribute>(isMatchingAttributePredicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
+
+            [Fact]
+            public void When_type_is_not_decorated_with_unexpected_attribute_with_the_expected_properties_it_succeeds()
+            {
+                // Arrange
+                Type typeWithoutAttribute = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithoutAttribute.Should()
+                        .NotBeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Unexpected") && a.IsEnabled);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_is_not_decorated_with_expected_attribute_that_has_an_unexpected_property_it_fails()
+            {
+                // Arrange
+                Type typeWithoutAttribute = typeof(ClassWithAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithoutAttribute.Should()
+                        .NotBeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute that matches " +
+                        "(a.Name == \"Expected\") * a.IsEnabled, but a matching attribute was found.");
+            }
         }
-
-        #endregion
-
-        #region NotBeDecoratedWith
-
-        [Fact]
-        public void When_type_is_not_decorated_with_unexpected_attribute_it_succeeds()
-        {
-            // Arrange
-            Type typeWithoutAttribute = typeof(ClassWithoutAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithoutAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_type_is_decorated_with_unexpected_attribute_it_fails()
-        {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute* *failure message*" +
-                    ", but the attribute was found.");
-        }
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_NotBeDecoratedWith_it_should_throw()
-        {
-            // Arrange
-            Type typeWithoutAttribute = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () => typeWithoutAttribute.Should()
-                .NotBeDecoratedWith<DummyClassAttribute>(isMatchingAttributePredicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
-        }
-
-        [Fact]
-        public void When_type_is_not_decorated_with_unexpected_attribute_with_the_expected_properties_it_succeeds()
-        {
-            // Arrange
-            Type typeWithoutAttribute = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithoutAttribute.Should()
-                    .NotBeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Unexpected") && a.IsEnabled);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_type_is_not_decorated_with_expected_attribute_that_has_an_unexpected_property_it_fails()
-        {
-            // Arrange
-            Type typeWithoutAttribute = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithoutAttribute.Should()
-                    .NotBeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute that matches " +
-                    "(a.Name == \"Expected\") * a.IsEnabled, but a matching attribute was found.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWithOrInherit.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWithOrInherit.cs
@@ -9,202 +9,200 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region BeDecoratedWithOrInherit
-
-        [Fact]
-        public void When_type_inherits_expected_attribute_it_succeeds()
+        public class BeDecoratedWithOrInherit
         {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
+            [Fact]
+            public void When_type_inherits_expected_attribute_it_succeeds()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
 
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should().BeDecoratedWithOrInherit<DummyClassAttribute>();
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should().BeDecoratedWithOrInherit<DummyClassAttribute>();
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_type_inherits_expected_attribute_it_should_allow_chaining()
-        {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
+            [Fact]
+            public void When_type_inherits_expected_attribute_it_should_allow_chaining()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
 
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should().BeDecoratedWithOrInherit<DummyClassAttribute>()
-                    .Which.IsEnabled.Should().BeTrue();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_type_does_not_inherit_expected_attribute_it_fails()
-        {
-            // Arrange
-            Type type = typeof(ClassWithoutAttribute);
-
-            // Act
-            Action act = () =>
-                type.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithoutAttribute to be decorated with or inherit *.DummyClassAttribute " +
-                    "*failure message*, but the attribute was not found.");
-        }
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_BeDecoratedWithOrInherit_it_should_throw()
-        {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
-
-            // Act
-            Action act = () => typeWithAttribute.Should()
-                .BeDecoratedWithOrInherit<DummyClassAttribute>(isMatchingAttributePredicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
-        }
-
-        [Fact]
-        public void When_type_inherits_expected_attribute_with_the_expected_properties_it_succeeds()
-        {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should()
-                    .BeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_type_inherits_expected_attribute_with_the_expected_properties_it_should_allow_chaining()
-        {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should()
-                    .BeDecoratedWithOrInherit<DummyClassAttribute>(a => a.Name == "Expected")
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should().BeDecoratedWithOrInherit<DummyClassAttribute>()
                         .Which.IsEnabled.Should().BeTrue();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_does_not_inherit_expected_attribute_it_fails()
+            {
+                // Arrange
+                Type type = typeof(ClassWithoutAttribute);
+
+                // Act
+                Action act = () =>
+                    type.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassWithoutAttribute to be decorated with or inherit *.DummyClassAttribute " +
+                        "*failure message*, but the attribute was not found.");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_predicate_into_BeDecoratedWithOrInherit_it_should_throw()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
+
+                // Act
+                Action act = () => typeWithAttribute.Should()
+                    .BeDecoratedWithOrInherit<DummyClassAttribute>(isMatchingAttributePredicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
+
+            [Fact]
+            public void When_type_inherits_expected_attribute_with_the_expected_properties_it_succeeds()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should()
+                        .BeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_inherits_expected_attribute_with_the_expected_properties_it_should_allow_chaining()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should()
+                        .BeDecoratedWithOrInherit<DummyClassAttribute>(a => a.Name == "Expected")
+                            .Which.IsEnabled.Should().BeTrue();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_inherits_expected_attribute_that_has_an_unexpected_property_it_fails()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should()
+                        .BeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Unexpected") && a.IsEnabled);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassWithInheritedAttribute to be decorated with or inherit *.DummyClassAttribute " +
+                        "that matches (a.Name == \"Unexpected\")*a.IsEnabled, but no matching attribute was found.");
+            }
         }
 
-        [Fact]
-        public void When_type_inherits_expected_attribute_that_has_an_unexpected_property_it_fails()
+        public class NotBeDecoratedWithOrInherit
         {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
+            [Fact]
+            public void When_type_does_not_inherit_unexpected_attribute_it_succeeds()
+            {
+                // Arrange
+                Type typeWithoutAttribute = typeof(ClassWithoutAttribute);
 
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should()
-                    .BeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Unexpected") && a.IsEnabled);
+                // Act
+                Action act = () =>
+                    typeWithoutAttribute.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithInheritedAttribute to be decorated with or inherit *.DummyClassAttribute " +
-                    "that matches (a.Name == \"Unexpected\")*a.IsEnabled, but no matching attribute was found.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_inherits_unexpected_attribute_it_fails()
+            {
+                // Arrange
+                Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithAttribute.Should()
+                        .NotBeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute " +
+                        "*failure message* attribute was found.");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_predicate_into_NotBeDecoratedWithOrInherit_it_should_throw()
+            {
+                // Arrange
+                Type typeWithoutAttribute = typeof(ClassWithInheritedAttribute);
+
+                // Act
+                Action act = () => typeWithoutAttribute.Should()
+                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>(isMatchingAttributePredicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
+
+            [Fact]
+            public void When_type_does_not_inherit_unexpected_attribute_with_the_expected_properties_it_succeeds()
+            {
+                // Arrange
+                Type typeWithoutAttribute = typeof(ClassWithInheritedAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithoutAttribute.Should()
+                        .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Unexpected") && a.IsEnabled);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_type_does_not_inherit_expected_attribute_that_has_an_unexpected_property_it_fails()
+            {
+                // Arrange
+                Type typeWithoutAttribute = typeof(ClassWithInheritedAttribute);
+
+                // Act
+                Action act = () =>
+                    typeWithoutAttribute.Should()
+                        .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute " +
+                        "that matches (a.Name == \"Expected\") * a.IsEnabled, but a matching attribute was found.");
+            }
         }
-
-        #endregion
-
-        #region NotBeDecoratedWithOrInherit
-
-        [Fact]
-        public void When_type_does_not_inherit_unexpected_attribute_it_succeeds()
-        {
-            // Arrange
-            Type typeWithoutAttribute = typeof(ClassWithoutAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithoutAttribute.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_type_inherits_unexpected_attribute_it_fails()
-        {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should()
-                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute " +
-                    "*failure message* attribute was found.");
-        }
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_NotBeDecoratedWithOrInherit_it_should_throw()
-        {
-            // Arrange
-            Type typeWithoutAttribute = typeof(ClassWithInheritedAttribute);
-
-            // Act
-            Action act = () => typeWithoutAttribute.Should()
-                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(isMatchingAttributePredicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
-        }
-
-        [Fact]
-        public void When_type_does_not_inherit_unexpected_attribute_with_the_expected_properties_it_succeeds()
-        {
-            // Arrange
-            Type typeWithoutAttribute = typeof(ClassWithInheritedAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithoutAttribute.Should()
-                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Unexpected") && a.IsEnabled);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_type_does_not_inherit_expected_attribute_that_has_an_unexpected_property_it_fails()
-        {
-            // Arrange
-            Type typeWithoutAttribute = typeof(ClassWithInheritedAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithoutAttribute.Should()
-                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute " +
-                    "that matches (a.Name == \"Expected\") * a.IsEnabled, but a matching attribute was found.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDerivedFrom.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDerivedFrom.cs
@@ -10,262 +10,258 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region BeDerivedFrom
-
-        [Fact]
-        public void When_asserting_a_type_is_derived_from_its_base_class_it_succeeds()
+        public class BeDerivedFrom
         {
-            // Arrange
-            var type = typeof(DummyImplementingClass);
+            [Fact]
+            public void When_asserting_a_type_is_derived_from_its_base_class_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(DummyImplementingClass);
 
-            // Act
-            Action act = () =>
-                type.Should().BeDerivedFrom(typeof(DummyBaseClass));
+                // Act
+                Action act = () =>
+                    type.Should().BeDerivedFrom(typeof(DummyBaseClass));
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_is_derived_from_an_unrelated_class_it_fails()
+            {
+                // Arrange
+                var type = typeof(DummyBaseClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().BeDerivedFrom(typeof(ClassWithMembers), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.DummyBaseClass to be derived from *.ClassWithMembers *failure message*, but it is not.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_is_derived_from_an_interface_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassThatImplementsInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().BeDerivedFrom(typeof(IDummyInterface), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassThatImplementsInterface to be derived from *.IDummyInterface *failure message*" +
+                        ", but *.IDummyInterface is an interface.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_is_derived_from_an_open_generic_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(DummyBaseType<ClassWithGenericBaseType>);
+
+                // Act
+                Action act = () =>
+                    type.Should().BeDerivedFrom(typeof(DummyBaseType<>));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_is_derived_from_an_open_generic_base_class_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithGenericBaseType);
+
+                // Act
+                Action act = () =>
+                    type.Should().BeDerivedFrom(typeof(DummyBaseType<>));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_is_derived_from_an_unrelated_open_generic_class_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().BeDerivedFrom(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassWithMembers to be derived from *.DummyBaseType`* *failure message*, but it is not.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_to_be_derived_from_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(DummyBaseType<>);
+
+                // Act
+                Action act =
+                    () => type.Should().BeDerivedFrom(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("baseType");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_is_derived_from_an_unrelated_class_it_fails()
+        public class BeDerivedFromOfT
         {
-            // Arrange
-            var type = typeof(DummyBaseClass);
+            [Fact]
+            public void When_asserting_a_type_is_DerivedFromOfT_its_base_class_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(DummyImplementingClass);
 
-            // Act
-            Action act = () =>
-                type.Should().BeDerivedFrom(typeof(ClassWithMembers), "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should().BeDerivedFrom<DummyBaseClass>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyBaseClass to be derived from *.ClassWithMembers *failure message*, but it is not.");
+                // Assert
+                act.Should().NotThrow();
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_is_derived_from_an_interface_it_fails()
+        public class NotBeDerivedFrom
         {
-            // Arrange
-            var type = typeof(ClassThatImplementsInterface);
+            [Fact]
+            public void When_asserting_a_type_is_not_derived_from_an_unrelated_class_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(DummyBaseClass);
 
-            // Act
-            Action act = () =>
-                type.Should().BeDerivedFrom(typeof(IDummyInterface), "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should().NotBeDerivedFrom(typeof(ClassWithMembers));
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassThatImplementsInterface to be derived from *.IDummyInterface *failure message*" +
-                    ", but *.IDummyInterface is an interface.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_is_not_derived_from_its_base_class_it_fails()
+            {
+                // Arrange
+                var type = typeof(DummyImplementingClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeDerivedFrom(typeof(DummyBaseClass), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.DummyImplementingClass not to be derived from *.DummyBaseClass *failure message*" +
+                        ", but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_is_not_derived_from_an_interface_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassThatImplementsInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeDerivedFrom(typeof(IDummyInterface), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassThatImplementsInterface not to be derived from *.IDummyInterface *failure message*" +
+                        ", but *.IDummyInterface is an interface.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_is_not_derived_from_an_unrelated_open_generic_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeDerivedFrom(typeof(DummyBaseType<>));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_open_generic_type_is_not_derived_from_itself_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(DummyBaseType<>);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeDerivedFrom(typeof(DummyBaseType<>));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_is_not_derived_from_its_open_generic_it_fails()
+            {
+                // Arrange
+                var type = typeof(DummyBaseType<ClassWithGenericBaseType>);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeDerivedFrom(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.DummyBaseType`1[*.ClassWithGenericBaseType] not to be derived from *.DummyBaseType`1[T] " +
+                        "*failure message*, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_not_to_be_derived_from_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(DummyBaseType<>);
+
+                // Act
+                Action act =
+                    () => type.Should().NotBeDerivedFrom(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("baseType");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_is_derived_from_an_open_generic_it_succeeds()
+        public class NotBeDerivedFromOfT
         {
-            // Arrange
-            var type = typeof(DummyBaseType<ClassWithGenericBaseType>);
+            [Fact]
+            public void When_asserting_a_type_is_not_DerivedFromOfT_an_unrelated_class_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(DummyBaseClass);
 
-            // Act
-            Action act = () =>
-                type.Should().BeDerivedFrom(typeof(DummyBaseType<>));
+                // Act
+                Action act = () =>
+                    type.Should().NotBeDerivedFrom<ClassWithMembers>();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_type_is_derived_from_an_open_generic_base_class_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassWithGenericBaseType);
-
-            // Act
-            Action act = () =>
-                type.Should().BeDerivedFrom(typeof(DummyBaseType<>));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_is_derived_from_an_unrelated_open_generic_class_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().BeDerivedFrom(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithMembers to be derived from *.DummyBaseType`* *failure message*, but it is not.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_to_be_derived_from_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(DummyBaseType<>);
-
-            // Act
-            Action act =
-                () => type.Should().BeDerivedFrom(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("baseType");
-        }
-
-        #endregion
-
-        #region BeDerivedFromOfT
-
-        [Fact]
-        public void When_asserting_a_type_is_DerivedFromOfT_its_base_class_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(DummyImplementingClass);
-
-            // Act
-            Action act = () =>
-                type.Should().BeDerivedFrom<DummyBaseClass>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        #endregion
-
-        #region NotBeDerivedFrom
-
-        [Fact]
-        public void When_asserting_a_type_is_not_derived_from_an_unrelated_class_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(DummyBaseClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeDerivedFrom(typeof(ClassWithMembers));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_is_not_derived_from_its_base_class_it_fails()
-        {
-            // Arrange
-            var type = typeof(DummyImplementingClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeDerivedFrom(typeof(DummyBaseClass), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass not to be derived from *.DummyBaseClass *failure message*" +
-                    ", but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_is_not_derived_from_an_interface_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassThatImplementsInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeDerivedFrom(typeof(IDummyInterface), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassThatImplementsInterface not to be derived from *.IDummyInterface *failure message*" +
-                    ", but *.IDummyInterface is an interface.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_is_not_derived_from_an_unrelated_open_generic_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeDerivedFrom(typeof(DummyBaseType<>));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_open_generic_type_is_not_derived_from_itself_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(DummyBaseType<>);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeDerivedFrom(typeof(DummyBaseType<>));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_is_not_derived_from_its_open_generic_it_fails()
-        {
-            // Arrange
-            var type = typeof(DummyBaseType<ClassWithGenericBaseType>);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeDerivedFrom(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyBaseType`1[*.ClassWithGenericBaseType] not to be derived from *.DummyBaseType`1[T] " +
-                    "*failure message*, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_not_to_be_derived_from_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(DummyBaseType<>);
-
-            // Act
-            Action act =
-                () => type.Should().NotBeDerivedFrom(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("baseType");
-        }
-
-        #endregion
-
-        #region NotBeDerivedFromOfT
-
-        [Fact]
-        public void When_asserting_a_type_is_not_DerivedFromOfT_an_unrelated_class_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(DummyBaseClass);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeDerivedFrom<ClassWithMembers>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeSealed.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeSealed.cs
@@ -9,143 +9,141 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region BeSealed
-
-        [Fact]
-        public void When_type_is_sealed_it_succeeds()
+        public class BeSealed
         {
-            // Arrange / Act / Assert
-            typeof(Sealed).Should().BeSealed();
+            [Fact]
+            public void When_type_is_sealed_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(Sealed).Should().BeSealed();
+            }
+
+            [Theory]
+            [InlineData(typeof(ClassWithoutMembers), "Expected type *.ClassWithoutMembers to be sealed.")]
+            [InlineData(typeof(Abstract), "Expected type *.Abstract to be sealed.")]
+            [InlineData(typeof(Static), "Expected type *.Static to be sealed.")]
+            public void When_type_is_not_sealed_it_fails(Type type, string exceptionMessage)
+            {
+                // Act
+                Action act = () => type.Should().BeSealed();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(exceptionMessage);
+            }
+
+            [Fact]
+            public void When_type_is_not_sealed_it_fails_with_a_meaningful_message()
+            {
+                // Arrange
+                var type = typeof(ClassWithoutMembers);
+
+                // Act
+                Action act = () => type.Should().BeSealed("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type *.ClassWithoutMembers to be sealed *failure message*.");
+            }
+
+            [Theory]
+            [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
+            [InlineData(typeof(Struct), "*.Struct must be a class.")]
+            [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
+            public void When_type_is_not_valid_for_BeSealed_it_throws_exception(Type type, string exceptionMessage)
+            {
+                // Act
+                Action act = () => type.Should().BeSealed();
+
+                // Assert
+                act.Should().Throw<InvalidOperationException>()
+                    .WithMessage(exceptionMessage);
+            }
+
+            [Fact]
+            public void When_subject_is_null_be_sealed_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().BeSealed("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be sealed *failure message*, but type is <null>.");
+            }
         }
 
-        [Theory]
-        [InlineData(typeof(ClassWithoutMembers), "Expected type *.ClassWithoutMembers to be sealed.")]
-        [InlineData(typeof(Abstract), "Expected type *.Abstract to be sealed.")]
-        [InlineData(typeof(Static), "Expected type *.Static to be sealed.")]
-        public void When_type_is_not_sealed_it_fails(Type type, string exceptionMessage)
+        public class NotBeSealed
         {
-            // Act
-            Action act = () => type.Should().BeSealed();
+            [Theory]
+            [InlineData(typeof(ClassWithoutMembers))]
+            [InlineData(typeof(Abstract))]
+            [InlineData(typeof(Static))]
+            public void When_type_is_not_sealed_it_succeeds(Type type)
+            {
+                // Arrange / Act / Assert
+                type.Should().NotBeSealed();
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(exceptionMessage);
+            [Fact]
+            public void When_type_is_sealed_it_fails()
+            {
+                // Arrange
+                var type = typeof(Sealed);
+
+                // Act
+                Action act = () => type.Should().NotBeSealed();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type *.Sealed not to be sealed.");
+            }
+
+            [Fact]
+            public void When_type_is_sealed_it_fails_with_a_meaningful_message()
+            {
+                // Arrange
+                var type = typeof(Sealed);
+
+                // Act
+                Action act = () => type.Should().NotBeSealed("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type *.Sealed not to be sealed *failure message*.");
+            }
+
+            [Theory]
+            [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
+            [InlineData(typeof(Struct), "*.Struct must be a class.")]
+            [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
+            public void When_type_is_not_valid_for_NotBeSealed_it_throws_exception(Type type, string exceptionMessage)
+            {
+                // Act
+                Action act = () => type.Should().NotBeSealed();
+
+                // Assert
+                act.Should().Throw<InvalidOperationException>()
+                    .WithMessage(exceptionMessage);
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_be_sealed_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeSealed("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type not to be sealed *failure message*, but type is <null>.");
+            }
         }
-
-        [Fact]
-        public void When_type_is_not_sealed_it_fails_with_a_meaningful_message()
-        {
-            // Arrange
-            var type = typeof(ClassWithoutMembers);
-
-            // Act
-            Action act = () => type.Should().BeSealed("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithoutMembers to be sealed *failure message*.");
-        }
-
-        [Theory]
-        [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "*.Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
-        public void When_type_is_not_valid_for_BeSealed_it_throws_exception(Type type, string exceptionMessage)
-        {
-            // Act
-            Action act = () => type.Should().BeSealed();
-
-            // Assert
-            act.Should().Throw<InvalidOperationException>()
-                .WithMessage(exceptionMessage);
-        }
-
-        [Fact]
-        public void When_subject_is_null_be_sealed_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().BeSealed("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be sealed *failure message*, but type is <null>.");
-        }
-
-        #endregion
-
-        #region NotBeSealed
-
-        [Theory]
-        [InlineData(typeof(ClassWithoutMembers))]
-        [InlineData(typeof(Abstract))]
-        [InlineData(typeof(Static))]
-        public void When_type_is_not_sealed_it_succeeds(Type type)
-        {
-            // Arrange / Act / Assert
-            type.Should().NotBeSealed();
-        }
-
-        [Fact]
-        public void When_type_is_sealed_it_fails()
-        {
-            // Arrange
-            var type = typeof(Sealed);
-
-            // Act
-            Action act = () => type.Should().NotBeSealed();
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.Sealed not to be sealed.");
-        }
-
-        [Fact]
-        public void When_type_is_sealed_it_fails_with_a_meaningful_message()
-        {
-            // Arrange
-            var type = typeof(Sealed);
-
-            // Act
-            Action act = () => type.Should().NotBeSealed("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.Sealed not to be sealed *failure message*.");
-        }
-
-        [Theory]
-        [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "*.Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
-        public void When_type_is_not_valid_for_NotBeSealed_it_throws_exception(Type type, string exceptionMessage)
-        {
-            // Act
-            Action act = () => type.Should().NotBeSealed();
-
-            // Assert
-            act.Should().Throw<InvalidOperationException>()
-                .WithMessage(exceptionMessage);
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_be_sealed_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeSealed("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be sealed *failure message*, but type is <null>.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeStatic.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeStatic.cs
@@ -9,143 +9,141 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region BeStatic
-
-        [Fact]
-        public void When_type_is_static_it_succeeds()
+        public class BeStatic
         {
-            // Arrange / Act / Assert
-            typeof(Static).Should().BeStatic();
+            [Fact]
+            public void When_type_is_static_it_succeeds()
+            {
+                // Arrange / Act / Assert
+                typeof(Static).Should().BeStatic();
+            }
+
+            [Theory]
+            [InlineData(typeof(ClassWithoutMembers), "Expected type *.ClassWithoutMembers to be static.")]
+            [InlineData(typeof(Sealed), "Expected type *.Sealed to be static.")]
+            [InlineData(typeof(Abstract), "Expected type *.Abstract to be static.")]
+            public void When_type_is_not_static_it_fails(Type type, string exceptionMessage)
+            {
+                // Act
+                Action act = () => type.Should().BeStatic();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(exceptionMessage);
+            }
+
+            [Fact]
+            public void When_type_is_not_static_it_fails_with_a_meaningful_message()
+            {
+                // Arrange
+                var type = typeof(ClassWithoutMembers);
+
+                // Act
+                Action act = () => type.Should().BeStatic("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type *.ClassWithoutMembers to be static *failure message*.");
+            }
+
+            [Theory]
+            [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
+            [InlineData(typeof(Struct), "*.Struct must be a class.")]
+            [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
+            public void When_type_is_not_valid_for_BeStatic_it_throws_exception(Type type, string exceptionMessage)
+            {
+                // Act
+                Action act = () => type.Should().BeStatic();
+
+                // Assert
+                act.Should().Throw<InvalidOperationException>()
+                    .WithMessage(exceptionMessage);
+            }
+
+            [Fact]
+            public void When_subject_is_null_be_static_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().BeStatic("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be static *failure message*, but type is <null>.");
+            }
         }
 
-        [Theory]
-        [InlineData(typeof(ClassWithoutMembers), "Expected type *.ClassWithoutMembers to be static.")]
-        [InlineData(typeof(Sealed), "Expected type *.Sealed to be static.")]
-        [InlineData(typeof(Abstract), "Expected type *.Abstract to be static.")]
-        public void When_type_is_not_static_it_fails(Type type, string exceptionMessage)
+        public class NotBeStatic
         {
-            // Act
-            Action act = () => type.Should().BeStatic();
+            [Theory]
+            [InlineData(typeof(ClassWithoutMembers))]
+            [InlineData(typeof(Sealed))]
+            [InlineData(typeof(Abstract))]
+            public void When_type_is_not_static_it_succeeds(Type type)
+            {
+                // Arrange / Act / Assert
+                type.Should().NotBeStatic();
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(exceptionMessage);
+            [Fact]
+            public void When_type_is_static_it_fails()
+            {
+                // Arrange
+                var type = typeof(Static);
+
+                // Act
+                Action act = () => type.Should().NotBeStatic();
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type *.Static not to be static.");
+            }
+
+            [Fact]
+            public void When_type_is_static_it_fails_with_a_meaningful_message()
+            {
+                // Arrange
+                var type = typeof(Static);
+
+                // Act
+                Action act = () => type.Should().NotBeStatic("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type *.Static not to be static *failure message*.");
+            }
+
+            [Theory]
+            [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
+            [InlineData(typeof(Struct), "*.Struct must be a class.")]
+            [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
+            public void When_type_is_not_valid_for_NotBeStatic_it_throws_exception(Type type, string exceptionMessage)
+            {
+                // Act
+                Action act = () => type.Should().NotBeStatic();
+
+                // Assert
+                act.Should().Throw<InvalidOperationException>()
+                    .WithMessage(exceptionMessage);
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_be_static_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotBeStatic("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type not to be static *failure message*, but type is <null>.");
+            }
         }
-
-        [Fact]
-        public void When_type_is_not_static_it_fails_with_a_meaningful_message()
-        {
-            // Arrange
-            var type = typeof(ClassWithoutMembers);
-
-            // Act
-            Action act = () => type.Should().BeStatic("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithoutMembers to be static *failure message*.");
-        }
-
-        [Theory]
-        [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "*.Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
-        public void When_type_is_not_valid_for_BeStatic_it_throws_exception(Type type, string exceptionMessage)
-        {
-            // Act
-            Action act = () => type.Should().BeStatic();
-
-            // Assert
-            act.Should().Throw<InvalidOperationException>()
-                .WithMessage(exceptionMessage);
-        }
-
-        [Fact]
-        public void When_subject_is_null_be_static_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().BeStatic("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be static *failure message*, but type is <null>.");
-        }
-
-        #endregion
-
-        #region NotBeStatic
-
-        [Theory]
-        [InlineData(typeof(ClassWithoutMembers))]
-        [InlineData(typeof(Sealed))]
-        [InlineData(typeof(Abstract))]
-        public void When_type_is_not_static_it_succeeds(Type type)
-        {
-            // Arrange / Act / Assert
-            type.Should().NotBeStatic();
-        }
-
-        [Fact]
-        public void When_type_is_static_it_fails()
-        {
-            // Arrange
-            var type = typeof(Static);
-
-            // Act
-            Action act = () => type.Should().NotBeStatic();
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.Static not to be static.");
-        }
-
-        [Fact]
-        public void When_type_is_static_it_fails_with_a_meaningful_message()
-        {
-            // Arrange
-            var type = typeof(Static);
-
-            // Act
-            Action act = () => type.Should().NotBeStatic("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.Static not to be static *failure message*.");
-        }
-
-        [Theory]
-        [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "*.Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
-        public void When_type_is_not_valid_for_NotBeStatic_it_throws_exception(Type type, string exceptionMessage)
-        {
-            // Act
-            Action act = () => type.Should().NotBeStatic();
-
-            // Assert
-            act.Should().Throw<InvalidOperationException>()
-                .WithMessage(exceptionMessage);
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_be_static_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotBeStatic("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be static *failure message*, but type is <null>.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveAccessModifier.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveAccessModifier.cs
@@ -11,327 +11,327 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        public class NotHaveAccessModifier
+        public class HaveAccessModifier
         {
-            public class HaveAccessModifier
+            [Fact]
+            public void When_asserting_a_public_type_is_public_it_succeeds()
             {
-                [Fact]
-                public void When_asserting_a_public_type_is_public_it_succeeds()
-                {
-                    // Arrange
-                    Type type = typeof(IPublicInterface);
+                // Arrange
+                Type type = typeof(IPublicInterface);
 
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(CSharpAccessModifier.Public);
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Public);
 
-                    // Assert
-                    act.Should().NotThrow();
-                }
-
-                [Fact]
-                public void When_asserting_a_public_member_is_internal_it_throws()
-                {
-                    // Arrange
-                    Type type = typeof(IPublicInterface);
-
-                    // Act
-                    Action act = () =>
-                        type
-                            .Should()
-                            .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
-
-                    // Assert
-                    act.Should().Throw<XunitException>()
-                        .WithMessage("Expected type IPublicInterface to be Internal *failure message*, but it is Public.");
-                }
-
-                [Fact]
-                public void An_internal_class_has_an_internal_access_modifier()
-                {
-                    // Arrange
-                    Type type = typeof(InternalClass);
-
-                    // Act / Assert
-                    type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
-                }
-
-                [Fact]
-                public void An_internal_interface_has_an_internal_access_modifier()
-                {
-                    // Arrange
-                    Type type = typeof(IInternalInterface);
-
-                    // Act / Assert
-                    type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
-                }
-
-                [Fact]
-                public void An_internal_struct_has_an_internal_access_modifier()
-                {
-                    // Arrange
-                    Type type = typeof(InternalStruct);
-
-                    // Act / Assert
-                    type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
-                }
-
-                [Fact]
-                public void An_internal_enum_has_an_internal_access_modifier()
-                {
-                    // Arrange
-                    Type type = typeof(InternalEnum);
-
-                    // Act / Assert
-                    type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
-                }
-
-                [Fact]
-                public void An_internal_class_does_not_have_a_protected_internal_modifier()
-                {
-                    // Arrange
-                    Type type = typeof(InternalClass);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(
-                            CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
-
-                    // Assert
-                    act.Should().Throw<XunitException>()
-                        .WithMessage("Expected type InternalClass to be ProtectedInternal *failure message*, but it is Internal.");
-                }
-
-                [Fact]
-                public void An_internal_interface_does_not_have_a_protected_internal_modifier()
-                {
-                    // Arrange
-                    Type type = typeof(IInternalInterface);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(
-                            CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
-
-                    // Assert
-                    act.Should().Throw<XunitException>()
-                        .WithMessage(
-                            "Expected type IInternalInterface to be ProtectedInternal *failure message*, but it is Internal.");
-                }
-
-                [Fact]
-                public void An_internal_struct_does_not_have_a_protected_internal_modifier()
-                {
-                    // Arrange
-                    Type type = typeof(InternalStruct);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(
-                            CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
-
-                    // Assert
-                    act.Should().Throw<XunitException>()
-                        .WithMessage("Expected type InternalStruct to be ProtectedInternal *failure message*, but it is Internal.");
-                }
-
-                [Fact]
-                public void An_internal_enum_does_not_have_a_protected_internal_modifier()
-                {
-                    // Arrange
-                    Type type = typeof(InternalEnum);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(
-                            CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
-
-                    // Assert
-                    act.Should().Throw<XunitException>()
-                        .WithMessage("Expected type InternalEnum to be ProtectedInternal *failure message*, but it is Internal.");
-                }
-
-                [Fact]
-                public void When_asserting_a_nested_private_type_is_private_it_succeeds()
-                {
-                    // Arrange
-                    Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(CSharpAccessModifier.Private);
-
-                    // Assert
-                    act.Should().NotThrow();
-                }
-
-                [Fact]
-                public void When_asserting_a_nested_private_type_is_protected_it_throws()
-                {
-                    // Arrange
-                    Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the failure {0}",
-                            "message");
-
-                    // Assert
-                    act.Should().Throw<XunitException>()
-                        .WithMessage("Expected type PrivateClass to be Protected *failure message*, but it is Private.");
-                }
-
-                [Fact]
-                public void When_asserting_a_nested_protected_type_is_protected_it_succeeds()
-                {
-                    // Arrange
-                    Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(CSharpAccessModifier.Protected);
-
-                    // Assert
-                    act.Should().NotThrow();
-                }
-
-                [Fact]
-                public void When_asserting_a_nested_protected_type_is_public_it_throws()
-                {
-                    // Arrange
-                    Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(CSharpAccessModifier.Public);
-
-                    // Assert
-                    act.Should().Throw<XunitException>()
-                        .WithMessage("Expected type ProtectedEnum to be Public, but it is Protected.");
-                }
-
-                [Fact]
-                public void When_asserting_a_nested_public_type_is_public_it_succeeds()
-                {
-                    // Arrange
-                    Type type = typeof(Nested.IPublicInterface);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(CSharpAccessModifier.Public);
-
-                    // Assert
-                    act.Should().NotThrow();
-                }
-
-                [Fact]
-                public void When_asserting_a_nested_public_member_is_internal_it_throws()
-                {
-                    // Arrange
-                    Type type = typeof(Nested.IPublicInterface);
-
-                    // Act
-                    Action act = () =>
-                        type
-                            .Should()
-                            .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
-
-                    // Assert
-                    act.Should().Throw<XunitException>()
-                        .WithMessage("Expected type IPublicInterface to be Internal *failure message*, but it is Public.");
-                }
-
-                [Fact]
-                public void When_asserting_a_nested_internal_type_is_internal_it_succeeds()
-                {
-                    // Arrange
-                    Type type = typeof(Nested.InternalClass);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
-
-                    // Assert
-                    act.Should().NotThrow();
-                }
-
-                [Fact]
-                public void When_asserting_a_nested_internal_type_is_protected_internal_it_throws()
-                {
-                    // Arrange
-                    Type type = typeof(Nested.InternalClass);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(
-                            CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
-
-                    // Assert
-                    act.Should().Throw<XunitException>()
-                        .WithMessage("Expected type InternalClass to be ProtectedInternal *failure message*, but it is Internal.");
-                }
-
-                [Fact]
-                public void When_asserting_a_nested_protected_internal_member_is_protected_internal_it_succeeds()
-                {
-                    // Arrange
-                    Type type = typeof(Nested.IProtectedInternalInterface);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
-
-                    // Assert
-                    act.Should().NotThrow();
-                }
-
-                [Fact]
-                public void When_asserting_a_nested_protected_internal_member_is_private_it_throws()
-                {
-                    // Arrange
-                    Type type = typeof(Nested.IProtectedInternalInterface);
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(CSharpAccessModifier.Private, "we want to test the failure {0}", "message");
-
-                    // Assert
-                    act.Should().Throw<XunitException>()
-                        .WithMessage(
-                            "Expected type IProtectedInternalInterface to be Private *failure message*, but it is ProtectedInternal.");
-                }
-
-                [Fact]
-                public void When_subject_is_null_have_access_modifier_should_fail()
-                {
-                    // Arrange
-                    Type type = null;
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
-
-                    // Assert
-                    act.Should().Throw<XunitException>()
-                        .WithMessage("Expected type to be Public *failure message*, but type is <null>.");
-                }
-
-                [Fact]
-                public void When_asserting_a_type_has_an_access_modifier_with_an_invalid_enum_value_it_should_throw()
-                {
-                    // Arrange
-                    Type type = null;
-
-                    // Act
-                    Action act = () =>
-                        type.Should().HaveAccessModifier((CSharpAccessModifier)int.MaxValue);
-
-                    // Assert
-                    act.Should().ThrowExactly<ArgumentOutOfRangeException>()
-                        .WithParameterName("accessModifier");
-                }
+                // Assert
+                act.Should().NotThrow();
             }
 
+            [Fact]
+            public void When_asserting_a_public_member_is_internal_it_throws()
+            {
+                // Arrange
+                Type type = typeof(IPublicInterface);
+
+                // Act
+                Action act = () =>
+                    type
+                        .Should()
+                        .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type IPublicInterface to be Internal *failure message*, but it is Public.");
+            }
+
+            [Fact]
+            public void An_internal_class_has_an_internal_access_modifier()
+            {
+                // Arrange
+                Type type = typeof(InternalClass);
+
+                // Act / Assert
+                type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+            }
+
+            [Fact]
+            public void An_internal_interface_has_an_internal_access_modifier()
+            {
+                // Arrange
+                Type type = typeof(IInternalInterface);
+
+                // Act / Assert
+                type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+            }
+
+            [Fact]
+            public void An_internal_struct_has_an_internal_access_modifier()
+            {
+                // Arrange
+                Type type = typeof(InternalStruct);
+
+                // Act / Assert
+                type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+            }
+
+            [Fact]
+            public void An_internal_enum_has_an_internal_access_modifier()
+            {
+                // Arrange
+                Type type = typeof(InternalEnum);
+
+                // Act / Assert
+                type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+            }
+
+            [Fact]
+            public void An_internal_class_does_not_have_a_protected_internal_modifier()
+            {
+                // Arrange
+                Type type = typeof(InternalClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(
+                        CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type InternalClass to be ProtectedInternal *failure message*, but it is Internal.");
+            }
+
+            [Fact]
+            public void An_internal_interface_does_not_have_a_protected_internal_modifier()
+            {
+                // Arrange
+                Type type = typeof(IInternalInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(
+                        CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type IInternalInterface to be ProtectedInternal *failure message*, but it is Internal.");
+            }
+
+            [Fact]
+            public void An_internal_struct_does_not_have_a_protected_internal_modifier()
+            {
+                // Arrange
+                Type type = typeof(InternalStruct);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(
+                        CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type InternalStruct to be ProtectedInternal *failure message*, but it is Internal.");
+            }
+
+            [Fact]
+            public void An_internal_enum_does_not_have_a_protected_internal_modifier()
+            {
+                // Arrange
+                Type type = typeof(InternalEnum);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(
+                        CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type InternalEnum to be ProtectedInternal *failure message*, but it is Internal.");
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_private_type_is_private_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Private);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_private_type_is_protected_it_throws()
+            {
+                // Arrange
+                Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the failure {0}",
+                        "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type PrivateClass to be Protected *failure message*, but it is Private.");
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_protected_type_is_protected_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Protected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_protected_type_is_public_it_throws()
+            {
+                // Arrange
+                Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Public);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type ProtectedEnum to be Public, but it is Protected.");
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_public_type_is_public_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(Nested.IPublicInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Public);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_public_member_is_internal_it_throws()
+            {
+                // Arrange
+                Type type = typeof(Nested.IPublicInterface);
+
+                // Act
+                Action act = () =>
+                    type
+                        .Should()
+                        .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type IPublicInterface to be Internal *failure message*, but it is Public.");
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_internal_type_is_internal_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(Nested.InternalClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Internal);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_internal_type_is_protected_internal_it_throws()
+            {
+                // Arrange
+                Type type = typeof(Nested.InternalClass);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(
+                        CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type InternalClass to be ProtectedInternal *failure message*, but it is Internal.");
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_protected_internal_member_is_protected_internal_it_succeeds()
+            {
+                // Arrange
+                Type type = typeof(Nested.IProtectedInternalInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_nested_protected_internal_member_is_private_it_throws()
+            {
+                // Arrange
+                Type type = typeof(Nested.IProtectedInternalInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Private, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type IProtectedInternalInterface to be Private *failure message*, but it is ProtectedInternal.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_access_modifier_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type to be Public *failure message*, but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_access_modifier_with_an_invalid_enum_value_it_should_throw()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveAccessModifier((CSharpAccessModifier)int.MaxValue);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                    .WithParameterName("accessModifier");
+            }
+        }
+
+        public class NotHaveAccessModifier
+        {
             [Fact]
             public void When_asserting_a_public_type_is_not_private_it_succeeds()
             {

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveConstructor.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveConstructor.cs
@@ -10,137 +10,135 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region HaveConstructor
-
-        [Fact]
-        public void When_asserting_a_type_has_a_constructor_which_it_does_it_succeeds()
+        public class HaveConstructor
         {
-            // Arrange
-            var type = typeof(ClassWithMembers);
+            [Fact]
+            public void When_asserting_a_type_has_a_constructor_which_it_does_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveConstructor(new Type[] { typeof(string) })
-                    .Which.Should()
-                        .HaveAccessModifier(CSharpAccessModifier.Private);
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveConstructor(new Type[] { typeof(string) })
+                        .Which.Should()
+                            .HaveAccessModifier(CSharpAccessModifier.Private);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_constructor_which_it_does_not_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithNoMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveConstructor(new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected constructor *ClassWithNoMembers(System.Int32, System.Type) to exist *failure message*" +
+                        ", but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_constructor_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveConstructor(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected constructor type(System.String) to exist *failure message*, but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_constructor_of_null_it_should_throw()
+            {
+                // Arrange
+                Type type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveConstructor(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("parameterTypes");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_has_a_constructor_which_it_does_not_it_fails()
+        public class NotHaveConstructor
         {
-            // Arrange
-            var type = typeof(ClassWithNoMembers);
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_constructor_which_it_does_not_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithNoMembers);
 
-            // Act
-            Action act = () =>
-                type.Should().HaveConstructor(new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveConstructor(new Type[] { typeof(string) });
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected constructor *ClassWithNoMembers(System.Int32, System.Type) to exist *failure message*" +
-                    ", but it does not.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_constructor_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveConstructor(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected constructor *.ClassWithMembers(System.String) not to exist *failure message*, but it does.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_have_constructor_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveConstructor(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected constructor type(System.String) not to exist *failure message*, but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_constructor_of_null_it_should_throw()
+            {
+                // Arrange
+                Type type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveConstructor(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("parameterTypes");
+            }
         }
-
-        [Fact]
-        public void When_subject_is_null_have_constructor_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveConstructor(new[] { typeof(string) }, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor type(System.String) to exist *failure message*, but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_a_constructor_of_null_it_should_throw()
-        {
-            // Arrange
-            Type type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveConstructor(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("parameterTypes");
-        }
-
-        #endregion
-
-        #region NotHaveConstructor
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_constructor_which_it_does_not_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassWithNoMembers);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveConstructor(new Type[] { typeof(string) });
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_constructor_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveConstructor(new[] { typeof(string) }, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected constructor *.ClassWithMembers(System.String) not to exist *failure message*, but it does.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_constructor_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveConstructor(new[] { typeof(string) }, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor type(System.String) not to exist *failure message*, but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_constructor_of_null_it_should_throw()
-        {
-            // Arrange
-            Type type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveConstructor(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("parameterTypes");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveDefaultConstructor.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveDefaultConstructor.cs
@@ -10,175 +10,173 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region HaveDefaultConstructor
-
-        [Fact]
-        public void When_asserting_a_type_has_a_default_constructor_which_it_does_it_succeeds()
+        public class HaveDefaultConstructor
         {
-            // Arrange
-            var type = typeof(ClassWithMembers);
+            [Fact]
+            public void When_asserting_a_type_has_a_default_constructor_which_it_does_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
 
-            // Act
-            Action act = () =>
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveDefaultConstructor()
+                        .Which.Should()
+                            .HaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_default_constructor_which_it_does_not_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithNoMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveDefaultConstructor()
+                        .Which.Should()
+                            .HaveAccessModifier(CSharpAccessModifier.Public);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_default_constructor_which_it_does_not_and_a_cctor_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithCctor);
+
+                // Act
                 type.Should()
-                    .HaveDefaultConstructor()
-                    .Which.Should()
-                        .HaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
+                        .HaveDefaultConstructor()
+                        .Which.Should()
+                            .HaveAccessModifier(CSharpAccessModifier.Public);
+                Action act = () =>
+                    type.Should()
+                        .HaveDefaultConstructor()
+                        .Which.Should()
+                            .HaveAccessModifier(CSharpAccessModifier.Public);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_default_constructor_which_it_does_not_and_a_cctor_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithCctorAndNonDefaultConstructor);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveDefaultConstructor("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected constructor *ClassWithCctorAndNonDefaultConstructor() to exist *failure message*" +
+                        ", but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_default_constructor_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveDefaultConstructor("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected constructor type() to exist *failure message*, but type is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_has_a_default_constructor_which_it_does_not_it_succeeds()
+        public class NotHaveDefaultConstructor
         {
-            // Arrange
-            var type = typeof(ClassWithNoMembers);
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_default_constructor_which_it_does_not_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithCctorAndNonDefaultConstructor);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveDefaultConstructor()
-                    .Which.Should()
-                        .HaveAccessModifier(CSharpAccessModifier.Public);
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveDefaultConstructor();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_default_constructor_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveDefaultConstructor("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected constructor *.ClassWithMembers() not to exist *failure message*, but it does.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_default_constructor_which_it_does_and_a_cctor_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithCctor);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveDefaultConstructor("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected constructor *ClassWithCctor*() not to exist *failure message*, but it does.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_default_constructor_which_it_does_not_and_a_cctor_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithCctorAndNonDefaultConstructor);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveDefaultConstructor();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_have_default_constructor_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveDefaultConstructor("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected constructor type() not to exist *failure message*, but type is <null>.");
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_type_has_a_default_constructor_which_it_does_not_and_a_cctor_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassWithCctor);
-
-            // Act
-            type.Should()
-                    .HaveDefaultConstructor()
-                    .Which.Should()
-                        .HaveAccessModifier(CSharpAccessModifier.Public);
-            Action act = () =>
-                type.Should()
-                    .HaveDefaultConstructor()
-                    .Which.Should()
-                        .HaveAccessModifier(CSharpAccessModifier.Public);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_a_default_constructor_which_it_does_not_and_a_cctor_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassWithCctorAndNonDefaultConstructor);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveDefaultConstructor("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected constructor *ClassWithCctorAndNonDefaultConstructor() to exist *failure message*" +
-                    ", but it does not.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_have_default_constructor_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveDefaultConstructor("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor type() to exist *failure message*, but type is <null>.");
-        }
-
-        #endregion
-
-        #region NotHaveDefaultConstructor
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_default_constructor_which_it_does_not_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassWithCctorAndNonDefaultConstructor);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveDefaultConstructor();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_default_constructor_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveDefaultConstructor("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor *.ClassWithMembers() not to exist *failure message*, but it does.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_default_constructor_which_it_does_and_a_cctor_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassWithCctor);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveDefaultConstructor("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor *ClassWithCctor*() not to exist *failure message*, but it does.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_default_constructor_which_it_does_not_and_a_cctor_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassWithCctorAndNonDefaultConstructor);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveDefaultConstructor();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_default_constructor_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveDefaultConstructor("we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor type() not to exist *failure message*, but type is <null>.");
-        }
-
-        #endregion
 
         internal class ClassWithNoMembers
         {

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitConversionOperator.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitConversionOperator.cs
@@ -9,278 +9,274 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region HaveExplicitConversionOperator
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_conversion_operator_which_it_does_it_succeeds()
+        public class HaveExplicitConversionOperator
         {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-            var sourceType = typeof(TypeWithConversionOperators);
-            var targetType = typeof(byte);
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_conversion_operator_which_it_does_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+                var sourceType = typeof(TypeWithConversionOperators);
+                var targetType = typeof(byte);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitConversionOperator(sourceType, targetType)
-                    .Which.Should()
-                        .NotBeNull();
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitConversionOperator(sourceType, targetType)
+                        .Which.Should()
+                            .NotBeNull();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_conversion_operator_which_it_does_not_it_fails_with_a_useful_message()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+                var sourceType = typeof(TypeWithConversionOperators);
+                var targetType = typeof(string);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitConversionOperator(
+                        sourceType, targetType, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                        ", but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_explicit_conversion_operator_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitConversionOperator(
+                        typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                        ", but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_conversion_operator_from_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitConversionOperator(null, typeof(string));
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("sourceType");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_conversion_operator_to_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitConversionOperator(typeof(TypeWithConversionOperators), null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("targetType");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_conversion_operator_which_it_does_not_it_fails_with_a_useful_message()
+        public class HaveExplicitConversionOperatorOfT
         {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-            var sourceType = typeof(TypeWithConversionOperators);
-            var targetType = typeof(string);
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_conversion_operatorOfT_which_it_does_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
 
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitConversionOperator(
-                    sourceType, targetType, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitConversionOperator<TypeWithConversionOperators, byte>()
+                        .Which.Should()
+                            .NotBeNull();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but it does not.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_conversion_operatorOfT_which_it_does_not_it_fails()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>(
+                        "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                        ", but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_explicit_conversion_operatorOfT_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>(
+                        "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                        ", but type is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_subject_is_null_have_explicit_conversion_operator_should_fail()
+        public class NotHaveExplicitConversionOperator
         {
-            // Arrange
-            Type type = null;
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_which_it_does_not_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+                var sourceType = typeof(TypeWithConversionOperators);
+                var targetType = typeof(string);
 
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitConversionOperator(
-                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitConversionOperator(sourceType, targetType);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but type is <null>.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+                var sourceType = typeof(TypeWithConversionOperators);
+                var targetType = typeof(byte);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitConversionOperator(
+                        sourceType, targetType, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static explicit *.Byte(*.TypeWithConversionOperators) to not exist *failure message*" +
+                        ", but it does.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_have_explicit_conversion_operator_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitConversionOperator(
+                        typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static explicit *.String(*.TypeWithConversionOperators) to not exist *failure message*" +
+                        ", but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_from_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitConversionOperator(null, typeof(string));
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("sourceType");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_to_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitConversionOperator(typeof(TypeWithConversionOperators), null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("targetType");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_conversion_operator_from_null_it_should_throw()
+        public class NotHaveExplicitConversionOperatorOfT
         {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_conversion_operatorOfT_which_it_does_not_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
 
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitConversionOperator(null, typeof(string));
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitConversionOperator<TypeWithConversionOperators, string>();
 
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("sourceType");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_conversion_operatorOfT_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitConversionOperator<TypeWithConversionOperators, byte>(
+                        "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static explicit *.Byte(*.TypeWithConversionOperators) to not exist *failure message*" +
+                        ", but it does.");
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_conversion_operator_to_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitConversionOperator(typeof(TypeWithConversionOperators), null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("targetType");
-        }
-
-        #endregion
-
-        #region HaveExplicitConversionOperatorOfT
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_conversion_operatorOfT_which_it_does_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitConversionOperator<TypeWithConversionOperators, byte>()
-                    .Which.Should()
-                        .NotBeNull();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_conversion_operatorOfT_which_it_does_not_it_fails()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>(
-                    "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but it does not.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_have_explicit_conversion_operatorOfT_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>(
-                    "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        #endregion
-
-        #region NotHaveExplicitConversionOperator
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_which_it_does_not_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-            var sourceType = typeof(TypeWithConversionOperators);
-            var targetType = typeof(string);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitConversionOperator(sourceType, targetType);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-            var sourceType = typeof(TypeWithConversionOperators);
-            var targetType = typeof(byte);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator(
-                    sourceType, targetType, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit *.Byte(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but it does.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_explicit_conversion_operator_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator(
-                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit *.String(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_from_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator(null, typeof(string));
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("sourceType");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_to_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator(typeof(TypeWithConversionOperators), null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("targetType");
-        }
-
-        #endregion
-
-        #region NotHaveExplicitConversionOperatorOfT
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operatorOfT_which_it_does_not_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitConversionOperator<TypeWithConversionOperators, string>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operatorOfT_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator<TypeWithConversionOperators, byte>(
-                    "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit *.Byte(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but it does.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitMethod.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitMethod.cs
@@ -9,523 +9,519 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region HaveExplicitMethod
-
-        [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_method_which_it_does_it_succeeds()
+        public class HaveExplicitMethod
         {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
+            [Fact]
+            public void When_asserting_a_type_explicitly_implements_a_method_which_it_does_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
 
-            var interfaceType = typeof(IExplicitInterface);
+                var interfaceType = typeof(IExplicitInterface);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitMethod(interfaceType, "ExplicitMethod", new Type[0]);
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitMethod(interfaceType, "ExplicitMethod", new Type[0]);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_explicitly_implements_a_method_which_it_implements_implicitly_and_explicitly_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IExplicitInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitMethod(interfaceType, "ExplicitImplicitMethod", new Type[0]);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_explicitly_implements_a_method_which_it_implements_implicitly_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IExplicitInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitMethod(interfaceType, "ImplicitMethod", new Type[0]);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected *.ClassExplicitlyImplementingInterface to explicitly implement " +
+                        "*.IExplicitInterface.ImplicitMethod(), but it does not.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_explicitly_implements_a_method_which_it_does_not_implement_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IExplicitInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitMethod(interfaceType, "NonExistentMethod", new Type[0]);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected *.ClassExplicitlyImplementingInterface to explicitly implement " +
+                        "*.IExplicitInterface.NonExistentMethod(), but it does not.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_explicitly_implements_a_method_from_an_unimplemented_interface_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IDummyInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitMethod(interfaceType, "NonExistentProperty", new Type[0]);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassExplicitlyImplementingInterface to implement interface " +
+                        "*.IDummyInterface, but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_explicit_method_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitMethod(
+                        typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
+                        ", but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_method_with_a_null_interface_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitMethod(null, "ExplicitMethod", new Type[0]);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("interfaceType");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_method_with_a_null_parameter_type_list_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitMethod(typeof(IExplicitInterface), "ExplicitMethod", null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("parameterTypes");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_method_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitMethod(typeof(IExplicitInterface), null, new Type[0]);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_method_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitMethod(typeof(IExplicitInterface), string.Empty, new Type[0]);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_method_which_it_implements_implicitly_and_explicitly_it_succeeds()
+        public class HaveExplicitMethodOfT
         {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
+            [Fact]
+            public void When_asserting_a_type_explicitly_implementsOfT_a_method_which_it_does_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
 
-            var interfaceType = typeof(IExplicitInterface);
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitMethod<IExplicitInterface>("ExplicitMethod", new Type[0]);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitMethod(interfaceType, "ExplicitImplicitMethod", new Type[0]);
+                // Assert
+                act.Should().NotThrow();
+            }
 
-            // Assert
-            act.Should().NotThrow();
+            [Fact]
+            public void When_subject_is_null_have_explicit_methodOfT_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitMethod<IExplicitInterface>(
+                        "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
+                        ", but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_methodOfT_with_a_null_parameter_type_list_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitMethod<IExplicitInterface>("ExplicitMethod", null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("parameterTypes");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_methodOfT_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitMethod<IExplicitInterface>(null, new Type[0]);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_methodOfT_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitMethod<IExplicitInterface>(string.Empty, new Type[0]);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_method_which_it_implements_implicitly_it_fails()
+        public class NotHaveExplicitMethod
         {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
+            [Fact]
+            public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
 
-            var interfaceType = typeof(IExplicitInterface);
+                var interfaceType = typeof(IExplicitInterface);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitMethod(interfaceType, "ImplicitMethod", new Type[0]);
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitMethod(interfaceType, "ExplicitMethod", new Type[0]);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected *.ClassExplicitlyImplementingInterface to explicitly implement " +
-                    "*.IExplicitInterface.ImplicitMethod(), but it does not.");
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
+                        "*.IExplicitInterface.ExplicitMethod(), but it does.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_implements_implicitly_and_explicitly_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IExplicitInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitMethod(interfaceType, "ExplicitImplicitMethod", new Type[0]);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
+                        "*.IExplicitInterface.ExplicitImplicitMethod(), but it does.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_implements_implicitly_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IExplicitInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitMethod(interfaceType, "ImplicitMethod", new Type[0]);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_does_not_implement_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IExplicitInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitMethod(interfaceType, "NonExistentMethod", new Type[0]);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_explicitly_implement_a_method_from_an_unimplemented_interface_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IDummyInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitMethod(interfaceType, "NonExistentMethod", new Type[0]);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface" +
+                        ", but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_have_explicit_method_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitMethod(
+                        typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
+                        ", but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_method_inherited_from_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitMethod(null, "ExplicitMethod", new Type[0]);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("interfaceType");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_method_with_a_null_parameter_type_list_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitMethod(typeof(IExplicitInterface), "ExplicitMethod", null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("parameterTypes");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_method_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitMethod(typeof(IExplicitInterface), null, new Type[0]);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_method_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitMethod(typeof(IExplicitInterface), string.Empty, new Type[0]);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_method_which_it_does_not_implement_it_fails()
+        public class NotHaveExplicitMethodOfT
         {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
+            [Fact]
+            public void When_asserting_a_type_does_not_explicitly_implementOfT_a_method_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
 
-            var interfaceType = typeof(IExplicitInterface);
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitMethod<IExplicitInterface>("ExplicitMethod", new Type[0]);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitMethod(interfaceType, "NonExistentMethod", new Type[0]);
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
+                        "*.IExplicitInterface.ExplicitMethod(), but it does.");
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected *.ClassExplicitlyImplementingInterface to explicitly implement " +
-                    "*.IExplicitInterface.NonExistentMethod(), but it does not.");
+            [Fact]
+            public void When_subject_is_null_not_have_explicit_methodOfT_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitMethod<IExplicitInterface>(
+                        "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
+                        ", but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_methodOfT_with_a_null_parameter_type_list_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitMethod<IExplicitInterface>("ExplicitMethod", null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("parameterTypes");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_methodOfT_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitMethod<IExplicitInterface>(null, new Type[0]);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_methodOfT_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitMethod<IExplicitInterface>(string.Empty, new Type[0]);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_method_from_an_unimplemented_interface_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            var interfaceType = typeof(IDummyInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitMethod(interfaceType, "NonExistentProperty", new Type[0]);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassExplicitlyImplementingInterface to implement interface " +
-                    "*.IDummyInterface, but it does not.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_have_explicit_method_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitMethod(
-                    typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_method_with_a_null_interface_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitMethod(null, "ExplicitMethod", new Type[0]);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("interfaceType");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_method_with_a_null_parameter_type_list_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitMethod(typeof(IExplicitInterface), "ExplicitMethod", null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("parameterTypes");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_method_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitMethod(typeof(IExplicitInterface), null, new Type[0]);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_method_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitMethod(typeof(IExplicitInterface), string.Empty, new Type[0]);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        #endregion
-
-        #region HaveExplicitMethodOfT
-
-        [Fact]
-        public void When_asserting_a_type_explicitly_implementsOfT_a_method_which_it_does_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitMethod<IExplicitInterface>("ExplicitMethod", new Type[0]);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_subject_is_null_have_explicit_methodOfT_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitMethod<IExplicitInterface>(
-                    "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_methodOfT_with_a_null_parameter_type_list_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitMethod<IExplicitInterface>("ExplicitMethod", null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("parameterTypes");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_methodOfT_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitMethod<IExplicitInterface>(null, new Type[0]);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_methodOfT_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitMethod<IExplicitInterface>(string.Empty, new Type[0]);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        #endregion
-
-        #region NotHaveExplicitMethod
-
-        [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            var interfaceType = typeof(IExplicitInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitMethod(interfaceType, "ExplicitMethod", new Type[0]);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "*.IExplicitInterface.ExplicitMethod(), but it does.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_implements_implicitly_and_explicitly_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            var interfaceType = typeof(IExplicitInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitMethod(interfaceType, "ExplicitImplicitMethod", new Type[0]);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "*.IExplicitInterface.ExplicitImplicitMethod(), but it does.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_implements_implicitly_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            var interfaceType = typeof(IExplicitInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitMethod(interfaceType, "ImplicitMethod", new Type[0]);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_does_not_implement_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            var interfaceType = typeof(IExplicitInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitMethod(interfaceType, "NonExistentMethod", new Type[0]);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_method_from_an_unimplemented_interface_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            var interfaceType = typeof(IDummyInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitMethod(interfaceType, "NonExistentMethod", new Type[0]);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface" +
-                    ", but it does not.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_explicit_method_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitMethod(
-                    typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_method_inherited_from_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitMethod(null, "ExplicitMethod", new Type[0]);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("interfaceType");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_method_with_a_null_parameter_type_list_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitMethod(typeof(IExplicitInterface), "ExplicitMethod", null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("parameterTypes");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_method_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitMethod(typeof(IExplicitInterface), null, new Type[0]);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_method_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitMethod(typeof(IExplicitInterface), string.Empty, new Type[0]);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        #endregion
-
-        #region NotHaveExplicitMethodOfT
-
-        [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implementOfT_a_method_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitMethod<IExplicitInterface>("ExplicitMethod", new Type[0]);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "*.IExplicitInterface.ExplicitMethod(), but it does.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_explicit_methodOfT_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitMethod<IExplicitInterface>(
-                    "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_methodOfT_with_a_null_parameter_type_list_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitMethod<IExplicitInterface>("ExplicitMethod", null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("parameterTypes");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_methodOfT_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitMethod<IExplicitInterface>(null, new Type[0]);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_methodOfT_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitMethod<IExplicitInterface>(string.Empty, new Type[0]);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitProperty.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitProperty.cs
@@ -9,463 +9,459 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region HaveExplicitProperty
-
-        [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_property_which_it_does_it_succeeds()
+        public class HaveExplicitProperty
         {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
+            [Fact]
+            public void When_asserting_a_type_explicitly_implements_a_property_which_it_does_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
 
-            var interfaceType = typeof(IExplicitInterface);
+                var interfaceType = typeof(IExplicitInterface);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitProperty(interfaceType, "ExplicitStringProperty");
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitProperty(interfaceType, "ExplicitStringProperty");
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_explicitly_implements_a_property_which_it_implements_implicitly_and_explicitly_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IExplicitInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitProperty(interfaceType, "ExplicitImplicitStringProperty");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_explicitly_implements_a_property_which_it_implements_implicitly_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IExplicitInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitProperty(interfaceType, "ImplicitStringProperty");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected *.ClassExplicitlyImplementingInterface to explicitly implement " +
+                        "*.IExplicitInterface.ImplicitStringProperty, but it does not.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_explicitly_implements_a_property_which_it_does_not_implement_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IExplicitInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitProperty(interfaceType, "NonExistentProperty");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected *.ClassExplicitlyImplementingInterface to explicitly implement " +
+                        "*.IExplicitInterface.NonExistentProperty, but it does not.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_explicitly_implements_a_property_from_an_unimplemented_interface_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IDummyInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitProperty(interfaceType, "NonExistentProperty");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface" +
+                        ", but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_explicit_property_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitProperty(
+                        typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*" +
+                        ", but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_property_inherited_by_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitProperty(null, "ExplicitStringProperty");
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("interfaceType");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_property_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitProperty(typeof(IExplicitInterface), null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicit_property_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitProperty(typeof(IExplicitInterface), string.Empty);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_property_which_it_implements_implicitly_and_explicitly_it_succeeds()
+        public class HaveExplicitPropertyOfT
         {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
+            [Fact]
+            public void When_asserting_a_type_explicitlyOfT_implements_a_property_which_it_does_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
 
-            var interfaceType = typeof(IExplicitInterface);
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveExplicitProperty<IExplicitInterface>("ExplicitStringProperty");
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitProperty(interfaceType, "ExplicitImplicitStringProperty");
+                // Assert
+                act.Should().NotThrow();
+            }
 
-            // Assert
-            act.Should().NotThrow();
+            [Fact]
+            public void When_asserting_a_type_has_an_explicitlyOfT_property_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitProperty<IExplicitInterface>(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_explicitlyOfT_property_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitProperty<IExplicitInterface>(string.Empty);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_explicit_propertyOfT_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveExplicitProperty<IExplicitInterface>(
+                        "ExplicitStringProperty", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*" +
+                        ", but type is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_property_which_it_implements_implicitly_it_fails()
+        public class NotHaveExplicitProperty
         {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
+            [Fact]
+            public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
 
-            var interfaceType = typeof(IExplicitInterface);
+                var interfaceType = typeof(IExplicitInterface);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitProperty(interfaceType, "ImplicitStringProperty");
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitProperty(interfaceType, "ExplicitStringProperty");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected *.ClassExplicitlyImplementingInterface to explicitly implement " +
-                    "*.IExplicitInterface.ImplicitStringProperty, but it does not.");
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
+                        "*.IExplicitInterface.ExplicitStringProperty, but it does.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_implements_implicitly_and_explicitly_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IExplicitInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitProperty(interfaceType, "ExplicitImplicitStringProperty");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
+                        "*.IExplicitInterface.ExplicitImplicitStringProperty, but it does.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_implements_implicitly_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IExplicitInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitProperty(interfaceType, "ImplicitStringProperty");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_does_not_implement_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IExplicitInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitProperty(interfaceType, "NonExistentProperty");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_explicitly_implement_a_property_from_an_unimplemented_interface_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                var interfaceType = typeof(IDummyInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitProperty(interfaceType, "NonExistentProperty");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface" +
+                        ", but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_have_explicit_property_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitProperty(
+                        typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type to not explicitly implement *IExplicitInterface.ExplicitStringProperty *failure message*" +
+                        ", but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_property_inherited_from_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitProperty(null, "ExplicitStringProperty");
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("interfaceType");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_property_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitProperty(typeof(IExplicitInterface), null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicit_property_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitProperty(typeof(IExplicitInterface), string.Empty);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_property_which_it_does_not_implement_it_fails()
+        public class NotHaveExplicitPropertyOfT
         {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
+            [Fact]
+            public void When_asserting_a_type_does_not_explicitlyOfT_implement_a_property_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
 
-            var interfaceType = typeof(IExplicitInterface);
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveExplicitProperty<IExplicitInterface>("ExplicitStringProperty");
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitProperty(interfaceType, "NonExistentProperty");
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
+                        "*.IExplicitInterface.ExplicitStringProperty, but it does.");
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected *.ClassExplicitlyImplementingInterface to explicitly implement " +
-                    "*.IExplicitInterface.NonExistentProperty, but it does not.");
+            [Fact]
+            public void When_subject_is_null_not_have_explicit_propertyOfT_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitProperty<IExplicitInterface>(
+                        "ExplicitStringProperty", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type to not explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*" +
+                        ", but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicitlyOfT_property_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitProperty<IExplicitInterface>(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_explicitlyOfT_property_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassExplicitlyImplementingInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveExplicitProperty<IExplicitInterface>(string.Empty);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_property_from_an_unimplemented_interface_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            var interfaceType = typeof(IDummyInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitProperty(interfaceType, "NonExistentProperty");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface" +
-                    ", but it does not.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_have_explicit_property_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitProperty(
-                    typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_property_inherited_by_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitProperty(null, "ExplicitStringProperty");
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("interfaceType");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_property_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitProperty(typeof(IExplicitInterface), null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicit_property_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitProperty(typeof(IExplicitInterface), string.Empty);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        #endregion
-
-        #region HaveExplicitPropertyOfT
-
-        [Fact]
-        public void When_asserting_a_type_explicitlyOfT_implements_a_property_which_it_does_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveExplicitProperty<IExplicitInterface>("ExplicitStringProperty");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicitlyOfT_property_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitProperty<IExplicitInterface>(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_explicitlyOfT_property_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitProperty<IExplicitInterface>(string.Empty);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_subject_is_null_have_explicit_propertyOfT_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveExplicitProperty<IExplicitInterface>(
-                    "ExplicitStringProperty", "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        #endregion
-
-        #region NotHaveExplicitProperty
-
-        [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            var interfaceType = typeof(IExplicitInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitProperty(interfaceType, "ExplicitStringProperty");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "*.IExplicitInterface.ExplicitStringProperty, but it does.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_implements_implicitly_and_explicitly_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            var interfaceType = typeof(IExplicitInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitProperty(interfaceType, "ExplicitImplicitStringProperty");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "*.IExplicitInterface.ExplicitImplicitStringProperty, but it does.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_implements_implicitly_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            var interfaceType = typeof(IExplicitInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitProperty(interfaceType, "ImplicitStringProperty");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_does_not_implement_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            var interfaceType = typeof(IExplicitInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitProperty(interfaceType, "NonExistentProperty");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_property_from_an_unimplemented_interface_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            var interfaceType = typeof(IDummyInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitProperty(interfaceType, "NonExistentProperty");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface" +
-                    ", but it does not.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_explicit_property_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitProperty(
-                    typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to not explicitly implement *IExplicitInterface.ExplicitStringProperty *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_property_inherited_from_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitProperty(null, "ExplicitStringProperty");
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("interfaceType");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_property_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitProperty(typeof(IExplicitInterface), null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_property_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitProperty(typeof(IExplicitInterface), string.Empty);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        #endregion
-
-        #region NotHaveExplicitPropertyOfT
-
-        [Fact]
-        public void When_asserting_a_type_does_not_explicitlyOfT_implement_a_property_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveExplicitProperty<IExplicitInterface>("ExplicitStringProperty");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "*.IExplicitInterface.ExplicitStringProperty, but it does.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_explicit_propertyOfT_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitProperty<IExplicitInterface>(
-                    "ExplicitStringProperty", "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to not explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicitlyOfT_property_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitProperty<IExplicitInterface>(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicitlyOfT_property_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassExplicitlyImplementingInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitProperty<IExplicitInterface>(string.Empty);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveImplicitConversionOperator.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveImplicitConversionOperator.cs
@@ -9,296 +9,292 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region HaveImplicitConversionOperator
-
-        [Fact]
-        public void When_asserting_a_type_has_an_implicit_conversion_operator_which_it_does_it_succeeds()
+        public class HaveImplicitConversionOperator
         {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-            var sourceType = typeof(TypeWithConversionOperators);
-            var targetType = typeof(int);
+            [Fact]
+            public void When_asserting_a_type_has_an_implicit_conversion_operator_which_it_does_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+                var sourceType = typeof(TypeWithConversionOperators);
+                var targetType = typeof(int);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveImplicitConversionOperator(sourceType, targetType)
-                    .Which.Should()
-                        .NotBeNull();
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveImplicitConversionOperator(sourceType, targetType)
+                        .Which.Should()
+                            .NotBeNull();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_implicit_conversion_operator_which_it_does_not_it_fails()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+                var sourceType = typeof(TypeWithConversionOperators);
+                var targetType = typeof(string);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveImplicitConversionOperator(
+                        sourceType, targetType, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static implicit *.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                        ", but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_implicit_conversion_operator_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveImplicitConversionOperator(
+                        typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static implicit *.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                        ", but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_implicit_conversion_operator_from_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveImplicitConversionOperator(null, typeof(string));
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("sourceType");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_implicit_conversion_operator_to_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveImplicitConversionOperator(typeof(TypeWithConversionOperators), null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("targetType");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_has_an_implicit_conversion_operator_which_it_does_not_it_fails()
+        public class HaveImplicitConversionOperatorOfT
         {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-            var sourceType = typeof(TypeWithConversionOperators);
-            var targetType = typeof(string);
+            [Fact]
+            public void When_asserting_a_type_has_an_implicit_conversion_operatorOfT_which_it_does_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
 
-            // Act
-            Action act = () =>
-                type.Should().HaveImplicitConversionOperator(
-                    sourceType, targetType, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveImplicitConversionOperator<TypeWithConversionOperators, int>()
+                        .Which.Should()
+                            .NotBeNull();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit *.String(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but it does not.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_implicit_conversion_operatorOfT_which_it_does_not_it_fails()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>(
+                        "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static implicit *.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                        ", but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_implicit_conversion_operatorOfT_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>(
+                        "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static implicit *.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                        ", but type is <null>.");
+            }
         }
 
-        [Fact]
-        public void When_subject_is_null_have_implicit_conversion_operator_should_fail()
+        public class NotHaveImplicitConversionOperator
         {
-            // Arrange
-            Type type = null;
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_which_it_does_not_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+                var sourceType = typeof(TypeWithConversionOperators);
+                var targetType = typeof(string);
 
-            // Act
-            Action act = () =>
-                type.Should().HaveImplicitConversionOperator(
-                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveImplicitConversionOperator(sourceType, targetType);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit *.String(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but type is <null>.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+                var sourceType = typeof(TypeWithConversionOperators);
+                var targetType = typeof(int);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveImplicitConversionOperator(
+                        sourceType, targetType, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static implicit *.Int32(*.TypeWithConversionOperators) to not exist *failure message*" +
+                        ", but it does.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_have_implicit_conversion_operator_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveImplicitConversionOperator(
+                        typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static implicit *.String(*.TypeWithConversionOperators) to not exist *failure message*" +
+                        ", but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_from_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveImplicitConversionOperator(null, typeof(string));
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("sourceType");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_to_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveImplicitConversionOperator(typeof(TypeWithConversionOperators), null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("targetType");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_has_an_implicit_conversion_operator_from_null_it_should_throw()
+        public class NotHaveImplicitConversionOperatorOfT
         {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_implicit_conversion_operatorOfT_which_it_does_not_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
 
-            // Act
-            Action act = () =>
-                type.Should().HaveImplicitConversionOperator(null, typeof(string));
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .NotHaveImplicitConversionOperator<TypeWithConversionOperators, string>();
 
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("sourceType");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_implicit_conversion_operatorOfT_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(TypeWithConversionOperators);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, int>(
+                        "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static implicit *.Int32(*.TypeWithConversionOperators) to not exist *failure message*" +
+                        ", but it does.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_have_implicit_conversion_operatorOfT_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, string>(
+                        "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected public static implicit *.String(*.TypeWithConversionOperators) to not exist *failure message*" +
+                        ", but type is <null>.");
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_implicit_conversion_operator_to_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveImplicitConversionOperator(typeof(TypeWithConversionOperators), null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("targetType");
-        }
-
-        #endregion
-
-        #region HaveImplicitConversionOperatorOfT
-
-        [Fact]
-        public void When_asserting_a_type_has_an_implicit_conversion_operatorOfT_which_it_does_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveImplicitConversionOperator<TypeWithConversionOperators, int>()
-                    .Which.Should()
-                        .NotBeNull();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_implicit_conversion_operatorOfT_which_it_does_not_it_fails()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>(
-                    "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit *.String(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but it does not.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_have_implicit_conversion_operatorOfT_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>(
-                    "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit *.String(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        #endregion
-
-        #region NotHaveImplicitConversionOperator
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_which_it_does_not_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-            var sourceType = typeof(TypeWithConversionOperators);
-            var targetType = typeof(string);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveImplicitConversionOperator(sourceType, targetType);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-            var sourceType = typeof(TypeWithConversionOperators);
-            var targetType = typeof(int);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator(
-                    sourceType, targetType, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit *.Int32(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but it does.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_implicit_conversion_operator_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator(
-                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit *.String(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_from_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator(null, typeof(string));
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("sourceType");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_to_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator(typeof(TypeWithConversionOperators), null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("targetType");
-        }
-
-        #endregion
-
-        #region NotHaveImplicitConversionOperatorOfT
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operatorOfT_which_it_does_not_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveImplicitConversionOperator<TypeWithConversionOperators, string>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operatorOfT_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(TypeWithConversionOperators);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, int>(
-                    "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit *.Int32(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but it does.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_implicit_conversion_operatorOfT_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, string>(
-                    "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit *.String(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but type is <null>.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveIndexer.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveIndexer.cs
@@ -10,169 +10,167 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region HaveIndexer
-
-        [Fact]
-        public void When_asserting_a_type_has_an_indexer_which_it_does_then_it_succeeds()
+        public class HaveIndexer
         {
-            // Arrange
-            var type = typeof(ClassWithMembers);
+            [Fact]
+            public void When_asserting_a_type_has_an_indexer_which_it_does_then_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveIndexer(typeof(string), new[] { typeof(string) })
-                    .Which.Should()
-                        .BeWritable(CSharpAccessModifier.Internal)
-                        .And.BeReadable(CSharpAccessModifier.Private);
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveIndexer(typeof(string), new[] { typeof(string) })
+                        .Which.Should()
+                            .BeWritable(CSharpAccessModifier.Internal)
+                            .And.BeReadable(CSharpAccessModifier.Private);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_indexer_which_it_does_not_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithNoMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveIndexer(
+                        typeof(string), new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected String *ClassWithNoMembers[System.Int32, System.Type] to exist *failure message*" +
+                        ", but it does not.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_indexer_with_different_parameters_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveIndexer(
+                        typeof(string), new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected String *.ClassWithMembers[System.Int32, System.Type] to exist *failure message*, but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_indexer_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveIndexer(typeof(string), new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected String type[System.String] to exist *failure message*, but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_indexer_for_null_it_should_throw()
+            {
+                // Arrange
+                Type type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveIndexer(null, new[] { typeof(string) });
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("indexerType");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_an_indexer_with_a_null_parameter_type_list_it_should_throw()
+            {
+                // Arrange
+                Type type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveIndexer(typeof(string), null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("parameterTypes");
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_indexer_which_it_does_not_it_fails()
+        
+        public class NotHaveIndexer
         {
-            // Arrange
-            var type = typeof(ClassWithNoMembers);
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_indexer_which_it_does_not_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithoutMembers);
 
-            // Act
-            Action act = () =>
-                type.Should().HaveIndexer(
-                    typeof(string), new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveIndexer(new[] { typeof(string) });
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected String *ClassWithNoMembers[System.Int32, System.Type] to exist *failure message*" +
-                    ", but it does not.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_indexer_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveIndexer(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected indexer *.ClassWithMembers[System.String] to not exist *failure message*, but it does.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_have_indexer_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveIndexer(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected indexer type[System.String] to not exist *failure message*, but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_an_indexer_for_null_it_should_throw()
+            {
+                // Arrange
+                Type type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveIndexer(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("parameterTypes");
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_indexer_with_different_parameters_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveIndexer(
-                    typeof(string), new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected String *.ClassWithMembers[System.Int32, System.Type] to exist *failure message*, but it does not.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_have_indexer_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveIndexer(typeof(string), new[] { typeof(string) }, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected String type[System.String] to exist *failure message*, but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_indexer_for_null_it_should_throw()
-        {
-            // Arrange
-            Type type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveIndexer(null, new[] { typeof(string) });
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("indexerType");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_an_indexer_with_a_null_parameter_type_list_it_should_throw()
-        {
-            // Arrange
-            Type type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveIndexer(typeof(string), null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("parameterTypes");
-        }
-
-        #endregion
-
-        #region NotHaveIndexer
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_indexer_which_it_does_not_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassWithoutMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveIndexer(new[] { typeof(string) });
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_indexer_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveIndexer(new[] { typeof(string) }, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected indexer *.ClassWithMembers[System.String] to not exist *failure message*, but it does.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_indexer_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveIndexer(new[] { typeof(string) }, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected indexer type[System.String] to not exist *failure message*, but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_an_indexer_for_null_it_should_throw()
-        {
-            // Arrange
-            Type type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveIndexer(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("parameterTypes");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveMethod.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveMethod.cs
@@ -10,229 +10,227 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region HaveMethod
-
-        [Fact]
-        public void When_asserting_a_type_has_a_method_which_it_does_it_succeeds()
+        public class HaveMethod
         {
-            // Arrange
-            var type = typeof(ClassWithMembers);
+            [Fact]
+            public void When_asserting_a_type_has_a_method_which_it_does_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveMethod("VoidMethod", new Type[] { })
-                    .Which.Should()
-                        .HaveAccessModifier(CSharpAccessModifier.Private)
-                        .And.ReturnVoid();
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveMethod("VoidMethod", new Type[] { })
+                        .Which.Should()
+                            .HaveAccessModifier(CSharpAccessModifier.Private)
+                            .And.ReturnVoid();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_method_which_it_does_not_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithNoMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveMethod(
+                            "NonExistentMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected method *ClassWithNoMembers.NonExistentMethod(*.Int32, *.Type) to exist *failure message*" +
+                        ", but it does not.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_method_with_different_parameter_types_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveMethod(
+                        "VoidMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected method *.ClassWithMembers.VoidMethod(*.Int32, *.Type) to exist *failure message*" +
+                        ", but it does not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_method_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveMethod("Name", new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method type.Name(System.String) to exist *failure message*, but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_method_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveMethod(null, new[] { typeof(string) });
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_method_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveMethod(string.Empty, new[] { typeof(string) });
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_method_with_a_null_parameter_type_list_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveMethod("Name", null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("parameterTypes");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_has_a_method_which_it_does_not_it_fails()
+        public class NotHaveMethod
         {
-            // Arrange
-            var type = typeof(ClassWithNoMembers);
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_method_which_it_does_not_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithoutMembers);
 
-            // Act
-            Action act = () =>
-                type.Should().HaveMethod(
-                        "NonExistentMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveMethod("NonExistentMethod", new Type[] { });
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method *ClassWithNoMembers.NonExistentMethod(*.Int32, *.Type) to exist *failure message*" +
-                    ", but it does not.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_method_which_it_has_with_different_parameter_types_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveMethod("VoidMethod", new[] { typeof(int) });
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_that_method_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveMethod("VoidMethod", new Type[] { }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method Void *.ClassWithMembers.VoidMethod() to not exist *failure message*, but it does.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_have_method_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveMethod("Name", new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected method type.Name(System.String) to not exist *failure message*, but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_method_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveMethod(null, new[] { typeof(string) });
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_method_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveMethod(string.Empty, new[] { typeof(string) });
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_method_with_a_null_parameter_type_list_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveMethod("Name", null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("parameterTypes");
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_type_has_a_method_with_different_parameter_types_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveMethod(
-                    "VoidMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method *.ClassWithMembers.VoidMethod(*.Int32, *.Type) to exist *failure message*" +
-                    ", but it does not.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_have_method_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveMethod("Name", new[] { typeof(string) }, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method type.Name(System.String) to exist *failure message*, but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_a_method_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveMethod(null, new[] { typeof(string) });
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_a_method_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveMethod(string.Empty, new[] { typeof(string) });
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_a_method_with_a_null_parameter_type_list_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveMethod("Name", null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("parameterTypes");
-        }
-
-        #endregion
-
-        #region NotHaveMethod
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_method_which_it_does_not_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassWithoutMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveMethod("NonExistentMethod", new Type[] { });
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_method_which_it_has_with_different_parameter_types_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveMethod("VoidMethod", new[] { typeof(int) });
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_that_method_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveMethod("VoidMethod", new Type[] { }, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method Void *.ClassWithMembers.VoidMethod() to not exist *failure message*, but it does.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_method_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveMethod("Name", new[] { typeof(string) }, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method type.Name(System.String) to not exist *failure message*, but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_method_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveMethod(null, new[] { typeof(string) });
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_method_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveMethod(string.Empty, new[] { typeof(string) });
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_method_with_a_null_parameter_type_list_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveMethod("Name", null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("parameterTypes");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveProperty.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveProperty.cs
@@ -10,251 +10,248 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region HaveProperty
-
-        [Fact]
-        public void When_asserting_a_type_has_a_property_which_it_does_then_it_succeeds()
+        public class HaveProperty
         {
-            // Arrange
-            var type = typeof(ClassWithMembers);
+            [Fact]
+            public void When_asserting_a_type_has_a_property_which_it_does_then_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveProperty(typeof(string), "PrivateWriteProtectedReadProperty")
-                    .Which.Should()
-                        .BeWritable(CSharpAccessModifier.Private)
-                        .And.BeReadable(CSharpAccessModifier.Protected);
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveProperty(typeof(string), "PrivateWriteProtectedReadProperty")
+                        .Which.Should()
+                            .BeWritable(CSharpAccessModifier.Private)
+                            .And.BeReadable(CSharpAccessModifier.Protected);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_property_which_it_does_not_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithNoMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveProperty(typeof(string), "PublicProperty", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected String *ClassWithNoMembers.PublicProperty to exist *failure message*, but it does not.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_property_which_it_has_with_a_different_type_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveProperty(typeof(int), "PrivateWriteProtectedReadProperty", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected String *.ClassWithMembers.PrivateWriteProtectedReadProperty to be of type System.Int32 " +
+                        "*failure message*, but it is not.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_have_property_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveProperty(typeof(string), "PublicProperty", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected String type.PublicProperty to exist *failure message*, but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_property_of_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveProperty(null, "PublicProperty");
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("propertyType");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_property_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveProperty(typeof(string), null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_property_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveProperty(typeof(string), string.Empty);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_has_a_property_which_it_does_not_it_fails()
+        public class HavePropertyOfT
         {
-            // Arrange
-            var type = typeof(ClassWithNoMembers);
+            [Fact]
+            public void When_asserting_a_type_has_a_propertyOfT_which_it_does_then_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
 
-            // Act
-            Action act = () =>
-                type.Should().HaveProperty(typeof(string), "PublicProperty", "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should()
+                        .HaveProperty<string>("PrivateWriteProtectedReadProperty")
+                        .Which.Should()
+                            .BeWritable(CSharpAccessModifier.Private)
+                            .And.BeReadable(CSharpAccessModifier.Protected);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected String *ClassWithNoMembers.PublicProperty to exist *failure message*, but it does not.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_propertyOfT_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveProperty<string>(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_has_a_propertyOfT_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().HaveProperty<string>(string.Empty);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_has_a_property_which_it_has_with_a_different_type_it_fails()
+        public class NotHaveProperty
         {
-            // Arrange
-            var type = typeof(ClassWithMembers);
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_property_which_it_does_not_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassWithoutMembers);
 
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveProperty(typeof(int), "PrivateWriteProtectedReadProperty", "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveProperty("Property");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected String *.ClassWithMembers.PrivateWriteProtectedReadProperty to be of type System.Int32 " +
-                    "*failure message*, but it is not.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_property_which_it_does_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveProperty("PrivateWriteProtectedReadProperty", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected String *.ClassWithMembers.PrivateWriteProtectedReadProperty to not exist *failure message*" +
+                        ", but it does.");
+            }
+
+            [Fact]
+            public void When_subject_is_null_not_have_property_should_fail()
+            {
+                // Arrange
+                Type type = null;
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveProperty("PublicProperty", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected type.PublicProperty to not exist *failure message*, but type is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_property_with_a_null_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveProperty(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_have_a_property_with_an_empty_name_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassWithMembers);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotHaveProperty(string.Empty);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("name");
+            }
         }
-
-        [Fact]
-        public void When_subject_is_null_have_property_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().HaveProperty(typeof(string), "PublicProperty", "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected String type.PublicProperty to exist *failure message*, but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_a_property_of_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveProperty(null, "PublicProperty");
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("propertyType");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_a_property_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveProperty(typeof(string), null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_a_property_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveProperty(typeof(string), string.Empty);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        #endregion
-
-        #region HavePropertyOfT
-
-        [Fact]
-        public void When_asserting_a_type_has_a_propertyOfT_which_it_does_then_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should()
-                    .HaveProperty<string>("PrivateWriteProtectedReadProperty")
-                    .Which.Should()
-                        .BeWritable(CSharpAccessModifier.Private)
-                        .And.BeReadable(CSharpAccessModifier.Protected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_a_propertyOfT_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveProperty<string>(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_has_a_propertyOfT_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().HaveProperty<string>(string.Empty);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        #endregion
-
-        #region NotHaveProperty
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_property_which_it_does_not_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassWithoutMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveProperty("Property");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_property_which_it_does_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveProperty("PrivateWriteProtectedReadProperty", "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected String *.ClassWithMembers.PrivateWriteProtectedReadProperty to not exist *failure message*" +
-                    ", but it does.");
-        }
-
-        [Fact]
-        public void When_subject_is_null_not_have_property_should_fail()
-        {
-            // Arrange
-            Type type = null;
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveProperty("PublicProperty", "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type.PublicProperty to not exist *failure message*, but type is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_property_with_a_null_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveProperty(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_have_a_property_with_an_empty_name_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassWithMembers);
-
-            // Act
-            Action act = () =>
-                type.Should().NotHaveProperty(string.Empty);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("name");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.Implement.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.Implement.cs
@@ -9,174 +9,170 @@ namespace FluentAssertions.Specs.Types
     /// </content>
     public partial class TypeAssertionSpecs
     {
-        #region Implement
-
-        [Fact]
-        public void When_asserting_a_type_implements_an_interface_which_it_does_then_it_succeeds()
+        public class Implement
         {
-            // Arrange
-            var type = typeof(ClassThatImplementsInterface);
+            [Fact]
+            public void When_asserting_a_type_implements_an_interface_which_it_does_then_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassThatImplementsInterface);
 
-            // Act
-            Action act = () =>
-                type.Should().Implement(typeof(IDummyInterface));
+                // Act
+                Action act = () =>
+                    type.Should().Implement(typeof(IDummyInterface));
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_implement_an_interface_which_it_does_then_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassThatDoesNotImplementInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().Implement(typeof(IDummyInterface), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassThatDoesNotImplementInterface to implement interface *.IDummyInterface " +
+                        "*failure message*, but it does not.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_implements_a_NonInterface_type_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassThatDoesNotImplementInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().Implement(typeof(DateTime), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassThatDoesNotImplementInterface to implement interface *.DateTime *failure message*" +
+                        ", but *.DateTime is not an interface.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_to_implement_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(DummyBaseType<>);
+
+                // Act
+                Action act = () =>
+                    type.Should().Implement(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("interfaceType");
+            }
+        }
+        
+        public class ImplementOfT
+        {
+            [Fact]
+            public void When_asserting_a_type_implementsOfT_an_interface_which_it_does_then_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassThatImplementsInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().Implement<IDummyInterface>();
+
+                // Assert
+                act.Should().NotThrow();
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_does_not_implement_an_interface_which_it_does_then_it_fails()
+        public class NotImplement
         {
-            // Arrange
-            var type = typeof(ClassThatDoesNotImplementInterface);
+            [Fact]
+            public void When_asserting_a_type_does_not_implement_an_interface_which_it_does_not_then_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassThatDoesNotImplementInterface);
 
-            // Act
-            Action act = () =>
-                type.Should().Implement(typeof(IDummyInterface), "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should().NotImplement(typeof(IDummyInterface));
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassThatDoesNotImplementInterface to implement interface *.IDummyInterface " +
-                    "*failure message*, but it does not.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_type_implements_an_interface_which_it_does_not_then_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassThatImplementsInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotImplement(typeof(IDummyInterface), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassThatImplementsInterface to not implement interface *.IDummyInterface " +
+                        "*failure message*, but it does.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_does_not_implement_a_NonInterface_type_it_fails()
+            {
+                // Arrange
+                var type = typeof(ClassThatDoesNotImplementInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotImplement(typeof(DateTime), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected type *.ClassThatDoesNotImplementInterface to not implement interface *.DateTime *failure message*" +
+                        ", but *.DateTime is not an interface.");
+            }
+
+            [Fact]
+            public void When_asserting_a_type_not_to_implement_null_it_should_throw()
+            {
+                // Arrange
+                var type = typeof(ClassThatDoesNotImplementInterface);
+
+                // Act
+                Action act = () =>
+                    type.Should().NotImplement(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("interfaceType");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_type_implements_a_NonInterface_type_it_fails()
+        public class NotImplementOfT
         {
-            // Arrange
-            var type = typeof(ClassThatDoesNotImplementInterface);
+            [Fact]
+            public void When_asserting_a_type_does_not_implementOfT_an_interface_which_it_does_not_then_it_succeeds()
+            {
+                // Arrange
+                var type = typeof(ClassThatDoesNotImplementInterface);
 
-            // Act
-            Action act = () =>
-                type.Should().Implement(typeof(DateTime), "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    type.Should().NotImplement<IDummyInterface>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassThatDoesNotImplementInterface to implement interface *.DateTime *failure message*" +
-                    ", but *.DateTime is not an interface.");
+                // Assert
+                act.Should().NotThrow();
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_type_to_implement_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(DummyBaseType<>);
-
-            // Act
-            Action act = () =>
-                type.Should().Implement(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("interfaceType");
-        }
-
-        #endregion
-
-        #region ImplementOfT
-
-        [Fact]
-        public void When_asserting_a_type_implementsOfT_an_interface_which_it_does_then_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassThatImplementsInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().Implement<IDummyInterface>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        #endregion
-
-        #region NotImplement
-
-        [Fact]
-        public void When_asserting_a_type_does_not_implement_an_interface_which_it_does_not_then_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassThatDoesNotImplementInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotImplement(typeof(IDummyInterface));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_type_implements_an_interface_which_it_does_not_then_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassThatImplementsInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotImplement(typeof(IDummyInterface), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassThatImplementsInterface to not implement interface *.IDummyInterface " +
-                    "*failure message*, but it does.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_does_not_implement_a_NonInterface_type_it_fails()
-        {
-            // Arrange
-            var type = typeof(ClassThatDoesNotImplementInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotImplement(typeof(DateTime), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassThatDoesNotImplementInterface to not implement interface *.DateTime *failure message*" +
-                    ", but *.DateTime is not an interface.");
-        }
-
-        [Fact]
-        public void When_asserting_a_type_not_to_implement_null_it_should_throw()
-        {
-            // Arrange
-            var type = typeof(ClassThatDoesNotImplementInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotImplement(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("interfaceType");
-        }
-
-        #endregion
-
-        #region NotImplementOfT
-
-        [Fact]
-        public void When_asserting_a_type_does_not_implementOfT_an_interface_which_it_does_not_then_it_succeeds()
-        {
-            // Arrange
-            var type = typeof(ClassThatDoesNotImplementInterface);
-
-            // Act
-            Action act = () =>
-                type.Should().NotImplement<IDummyInterface>();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorAssertionSpecs.cs
@@ -10,794 +10,784 @@ namespace FluentAssertions.Specs.Types
 {
     public class TypeSelectorAssertionSpecs
     {
-        #region BeSealed
-
-        [Fact]
-        public void When_all_types_are_sealed_it_succeeds()
+        public class BeSealed
         {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_all_types_are_sealed_it_succeeds()
             {
-                typeof(Sealed)
-            });
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(Sealed)
+                });
 
-            // Act / Assert
-            types.Should().BeSealed();
+                // Act / Assert
+                types.Should().BeSealed();
+            }
+
+            [Fact]
+            public void When_any_type_is_not_sealed_it_fails_with_a_meaningful_message()
+            {
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(Sealed),
+                    typeof(Abstract)
+                });
+
+                // Act
+                Action act = () => types.Should().BeSealed("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all types to be sealed *failure message*, but the following types are not:*\"*.Abstract\".");
+            }
         }
 
-        [Fact]
-        public void When_any_type_is_not_sealed_it_fails_with_a_meaningful_message()
+        public class NotBeSealed
         {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_all_types_are_not_sealed_it_succeeds()
             {
-                typeof(Sealed),
-                typeof(Abstract)
-            });
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(Abstract)
+                });
 
-            // Act
-            Action act = () => types.Should().BeSealed("we want to test the failure {0}", "message");
+                // Act / Assert
+                types.Should().NotBeSealed();
+            }
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be sealed *failure message*, but the following types are not:*\"*.Abstract\".");
+            [Fact]
+            public void When_any_type_is_sealed_it_fails_with_a_meaningful_message()
+            {
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(Abstract),
+                    typeof(Sealed)
+                });
+
+                // Act
+                Action act = () => types.Should().NotBeSealed("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected all types not to be sealed *failure message*, but the following types are:*\"*.Sealed\".");
+            }
         }
 
-        #endregion
-
-        #region NotBeSealed
-
-        [Fact]
-        public void When_all_types_are_not_sealed_it_succeeds()
+        public class BeDecoratedWith
         {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_asserting_a_selection_of_decorated_types_is_decorated_with_an_attribute_it_succeeds()
             {
-                typeof(Abstract)
-            });
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassWithAttribute)
+                });
 
-            // Act / Assert
-            types.Should().NotBeSealed();
+                // Act
+                Action act = () =>
+                    types.Should().BeDecoratedWith<DummyClassAttribute>();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_selection_of_non_decorated_types_is_decorated_with_an_attribute_it_fails()
+            {
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassWithAttribute),
+                    typeof(ClassWithoutAttribute),
+                    typeof(OtherClassWithoutAttribute)
+                });
+
+                // Act
+                Action act = () =>
+                    types.Should().BeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all types to be decorated with *.DummyClassAttribute *failure message*" +
+                        ", but the attribute was not found on the following types:" +
+                        "*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_predicate_into_TypeSelector_BeDecoratedWith_it_should_throw()
+            {
+                // Arrange
+                var types = new TypeSelector(typeof(ClassWithAttribute));
+
+                // Act
+                Action act = () => types.Should()
+                    .BeDecoratedWith<DummyClassAttribute>(isMatchingAttributePredicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
+
+            [Fact]
+            public void When_asserting_a_selection_of_types_with_unexpected_attribute_property_it_fails()
+            {
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassWithAttribute),
+                    typeof(ClassWithoutAttribute),
+                    typeof(OtherClassWithoutAttribute)
+                });
+
+                // Act
+                Action act = () =>
+                    types.Should()
+                        .BeDecoratedWith<DummyClassAttribute>(
+                            a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all types to be decorated with *.DummyClassAttribute that matches " +
+                        "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but no matching attribute was found on " +
+                        "the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+            }
         }
 
-        [Fact]
-        public void When_any_type_is_sealed_it_fails_with_a_meaningful_message()
+        public class BeDecoratedWithOrInherit
         {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_asserting_a_selection_of_decorated_types_inheriting_an_attribute_it_succeeds()
             {
-                typeof(Abstract),
-                typeof(Sealed)
-            });
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassWithInheritedAttribute)
+                });
 
-            // Act
-            Action act = () => types.Should().NotBeSealed("we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    types.Should().BeDecoratedWithOrInherit<DummyClassAttribute>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types not to be sealed *failure message*, but the following types are:*\"*.Sealed\".");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_selection_of_non_decorated_types_inheriting_an_attribute_it_fails()
+            {
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassWithAttribute),
+                    typeof(ClassWithoutAttribute),
+                    typeof(OtherClassWithoutAttribute)
+                });
+
+                // Act
+                Action act = () =>
+                    types.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all types to be decorated with or inherit *.DummyClassAttribute *failure message*" +
+                        ", but the attribute was not found on the following types:" +
+                        "*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_predicate_into_TypeSelector_BeDecoratedWithOrInherit_it_should_throw()
+            {
+                // Arrange
+                var types = new TypeSelector(typeof(ClassWithAttribute));
+
+                // Act
+                Action act = () => types.Should()
+                    .BeDecoratedWithOrInherit<DummyClassAttribute>(isMatchingAttributePredicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
+
+            [Fact]
+            public void When_asserting_a_selection_of_types_with_some_inheriting_attributes_with_unexpected_attribute_property_it_fails()
+            {
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassWithAttribute),
+                    typeof(ClassWithInheritedAttribute),
+                    typeof(ClassWithoutAttribute),
+                    typeof(OtherClassWithoutAttribute)
+                });
+
+                // Act
+                Action act = () =>
+                    types.Should()
+                        .BeDecoratedWithOrInherit<DummyClassAttribute>(
+                            a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all types to be decorated with or inherit *.DummyClassAttribute that matches " +
+                        "(a.Name == \"Expected\")*a.IsEnabled *failure message*, but no matching attribute was found " +
+                        "on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+            }
         }
 
-        #endregion
-
-        #region BeDecoratedWith
-
-        [Fact]
-        public void When_asserting_a_selection_of_decorated_types_is_decorated_with_an_attribute_it_succeeds()
+        public class NotBeDecoratedWith
         {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_asserting_a_selection_of_non_decorated_types_is_not_decorated_with_an_attribute_it_succeeds()
             {
-                typeof(ClassWithAttribute)
-            });
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassWithoutAttribute),
+                    typeof(OtherClassWithoutAttribute)
+                });
 
-            // Act
-            Action act = () =>
-                types.Should().BeDecoratedWith<DummyClassAttribute>();
+                // Act
+                Action act = () =>
+                    types.Should().NotBeDecoratedWith<DummyClassAttribute>();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_selection_of_decorated_types_is_not_decorated_with_an_attribute_it_fails()
+            {
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassWithoutAttribute),
+                    typeof(ClassWithAttribute)
+                });
+
+                // Act
+                Action act = () =>
+                    types.Should().NotBeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all types to not be decorated *.DummyClassAttribute *failure message*" +
+                        ", but the attribute was found on the following types:*\"*.ClassWithAttribute\".");
+            }
+
+            [Fact]
+            public void When_injecting_a_null_predicate_into_TypeSelector_NotBeDecoratedWith_it_should_throw()
+            {
+                // Arrange
+                var types = new TypeSelector(typeof(ClassWithAttribute));
+
+                // Act
+                Action act = () => types.Should()
+                    .NotBeDecoratedWith<DummyClassAttribute>(isMatchingAttributePredicate: null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
+
+            [Fact]
+            public void When_asserting_a_selection_of_types_with_unexpected_attribute_and_unexpected_attribute_property_it_fails()
+            {
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassWithoutAttribute),
+                    typeof(ClassWithAttribute)
+                });
+
+                // Act
+                Action act = () =>
+                    types.Should()
+                        .NotBeDecoratedWith<DummyClassAttribute>(
+                            a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all types to not be decorated with *.DummyClassAttribute that matches " +
+                        "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but a matching attribute was found " +
+                        "on the following types:*\"*.ClassWithAttribute\".");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_selection_of_non_decorated_types_is_decorated_with_an_attribute_it_fails()
+        public class NotBeDecoratedWithOrInherit
         {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_asserting_a_selection_of_non_decorated_types_does_not_inherit_an_attribute_it_succeeds()
             {
-                typeof(ClassWithAttribute),
-                typeof(ClassWithoutAttribute),
-                typeof(OtherClassWithoutAttribute)
-            });
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassWithoutAttribute),
+                    typeof(OtherClassWithoutAttribute)
+                });
 
-            // Act
-            Action act = () =>
-                types.Should().BeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    types.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be decorated with *.DummyClassAttribute *failure message*" +
-                    ", but the attribute was not found on the following types:" +
-                    "*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_injecting_a_null_predicate_into_TypeSelector_BeDecoratedWith_it_should_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassWithAttribute));
-
-            // Act
-            Action act = () => types.Should()
-                .BeDecoratedWith<DummyClassAttribute>(isMatchingAttributePredicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
-        }
-
-        [Fact]
-        public void When_asserting_a_selection_of_types_with_unexpected_attribute_property_it_fails()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_asserting_a_selection_of_decorated_types_does_not_inherit_an_attribute_it_fails()
             {
-                typeof(ClassWithAttribute),
-                typeof(ClassWithoutAttribute),
-                typeof(OtherClassWithoutAttribute)
-            });
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassWithoutAttribute),
+                    typeof(ClassWithInheritedAttribute)
+                });
 
-            // Act
-            Action act = () =>
-                types.Should()
-                    .BeDecoratedWith<DummyClassAttribute>(
+                // Act
+                Action act = () =>
+                    types.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all types to not be decorated with or inherit *.DummyClassAttribute *failure message*" +
+                        ", but the attribute was found on the following types:*\"*.ClassWithInheritedAttribute\".");
+            }
+
+            [Fact]
+            public void When_a_selection_of_types_do_inherit_unexpected_attribute_with_the_expected_properties_it_succeeds()
+            {
+                // Arrange
+                var types = new TypeSelector(typeof(ClassWithInheritedAttribute));
+
+                // Act
+                Action act = () => types.Should()
+                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>(
                         a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be decorated with *.DummyClassAttribute that matches " +
-                    "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but no matching attribute was found on " +
-                    "the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
-        }
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all types to not be decorated with or inherit *.DummyClassAttribute that matches " +
+                        "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but a matching attribute was found " +
+                        "on the following types:*\"*.ClassWithInheritedAttribute\".");
+            }
 
-        #endregion
-
-        #region BeDecoratedWithOrInherit
-
-        [Fact]
-        public void When_asserting_a_selection_of_decorated_types_inheriting_an_attribute_it_succeeds()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_selection_of_types_do_not_inherit_unexpected_attribute_with_the_expected_properties_it_succeeds()
             {
-                typeof(ClassWithInheritedAttribute)
-            });
+                // Arrange
+                var types = new TypeSelector(typeof(ClassWithoutAttribute));
 
-            // Act
-            Action act = () =>
-                types.Should().BeDecoratedWithOrInherit<DummyClassAttribute>();
+                // Act
+                Action act = () => types.Should()
+                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_asserting_a_selection_of_non_decorated_types_inheriting_an_attribute_it_fails()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_injecting_a_null_predicate_into_TypeSelector_NotBeDecoratedWithOrInherit_it_should_throw()
             {
-                typeof(ClassWithAttribute),
-                typeof(ClassWithoutAttribute),
-                typeof(OtherClassWithoutAttribute)
-            });
+                // Arrange
+                var types = new TypeSelector(typeof(ClassWithAttribute));
 
-            // Act
-            Action act = () =>
-                types.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
+                // Act
+                Action act = () => types.Should()
+                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>(isMatchingAttributePredicate: null);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be decorated with or inherit *.DummyClassAttribute *failure message*" +
-                    ", but the attribute was not found on the following types:" +
-                    "*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("isMatchingAttributePredicate");
+            }
         }
 
-        [Fact]
-        public void When_injecting_a_null_predicate_into_TypeSelector_BeDecoratedWithOrInherit_it_should_throw()
+        public class BeInNamespace
         {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassWithAttribute));
-
-            // Act
-            Action act = () => types.Should()
-                .BeDecoratedWithOrInherit<DummyClassAttribute>(isMatchingAttributePredicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
-        }
-
-        [Fact]
-        public void When_asserting_a_selection_of_types_with_some_inheriting_attributes_with_unexpected_attribute_property_it_fails()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_is_in_the_expected_namespace_it_should_not_throw()
             {
-                typeof(ClassWithAttribute),
-                typeof(ClassWithInheritedAttribute),
-                typeof(ClassWithoutAttribute),
-                typeof(OtherClassWithoutAttribute)
-            });
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInDummyNamespace));
 
-            // Act
-            Action act = () =>
-                types.Should()
-                    .BeDecoratedWithOrInherit<DummyClassAttribute>(
-                        a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () => types.Should().BeInNamespace(nameof(DummyNamespace));
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be decorated with or inherit *.DummyClassAttribute that matches " +
-                    "(a.Name == \"Expected\")*a.IsEnabled *failure message*, but no matching attribute was found " +
-                    "on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        #endregion
-
-        #region NotBeDecoratedWith
-
-        [Fact]
-        public void When_asserting_a_selection_of_non_decorated_types_is_not_decorated_with_an_attribute_it_succeeds()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_is_not_in_the_expected_namespace_it_should_throw()
             {
-                typeof(ClassWithoutAttribute),
-                typeof(OtherClassWithoutAttribute)
-            });
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassInDummyNamespace),
+                    typeof(ClassNotInDummyNamespace),
+                    typeof(OtherClassNotInDummyNamespace)
+                });
 
-            // Act
-            Action act = () =>
-                types.Should().NotBeDecoratedWith<DummyClassAttribute>();
+                // Act
+                Action act = () =>
+                    types.Should().BeInNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all types to be in namespace \"DummyNamespace\" *failure message*, but the following types " +
+                        "are in a different namespace:*\"*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
+            }
 
-        [Fact]
-        public void When_asserting_a_selection_of_decorated_types_is_not_decorated_with_an_attribute_it_fails()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_is_in_the_expected_global_namespace_it_should_not_throw()
             {
-                typeof(ClassWithoutAttribute),
-                typeof(ClassWithAttribute)
-            });
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInGlobalNamespace));
 
-            // Act
-            Action act = () =>
-                types.Should().NotBeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
+                // Act
+                Action act = () => types.Should().BeInNamespace(null);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to not be decorated *.DummyClassAttribute *failure message*" +
-                    ", but the attribute was found on the following types:*\"*.ClassWithAttribute\".");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_injecting_a_null_predicate_into_TypeSelector_NotBeDecoratedWith_it_should_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassWithAttribute));
-
-            // Act
-            Action act = () => types.Should()
-                .NotBeDecoratedWith<DummyClassAttribute>(isMatchingAttributePredicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
-        }
-
-        [Fact]
-        public void When_asserting_a_selection_of_types_with_unexpected_attribute_and_unexpected_attribute_property_it_fails()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_in_the_global_namespace_is_not_in_the_expected_namespace_it_should_throw()
             {
-                typeof(ClassWithoutAttribute),
-                typeof(ClassWithAttribute)
-            });
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInGlobalNamespace));
 
-            // Act
-            Action act = () =>
-                types.Should()
-                    .NotBeDecoratedWith<DummyClassAttribute>(
-                        a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () => types.Should().BeInNamespace(nameof(DummyNamespace));
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to not be decorated with *.DummyClassAttribute that matches " +
-                    "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but a matching attribute was found " +
-                    "on the following types:*\"*.ClassWithAttribute\".");
-        }
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all types to be in namespace \"DummyNamespace\", but the following types " +
+                        "are in a different namespace:*\"ClassInGlobalNamespace\".");
+            }
 
-        #endregion
-
-        #region NotBeDecoratedWithOrInherit
-
-        [Fact]
-        public void When_asserting_a_selection_of_non_decorated_types_does_not_inherit_an_attribute_it_succeeds()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_is_not_in_the_expected_global_namespace_it_should_throw()
             {
-                typeof(ClassWithoutAttribute),
-                typeof(OtherClassWithoutAttribute)
-            });
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassInDummyNamespace),
+                    typeof(ClassNotInDummyNamespace),
+                    typeof(OtherClassNotInDummyNamespace)
+                });
 
-            // Act
-            Action act = () =>
-                types.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>();
+                // Act
+                Action act = () => types.Should().BeInNamespace(null);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected all types to be in namespace <null>, but the following types are in a different namespace:" +
+                        "*\"*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_selection_of_decorated_types_does_not_inherit_an_attribute_it_fails()
+        public class NotBeInNamespace
         {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_is_not_in_the_unexpected_namespace_it_should_not_throw()
             {
-                typeof(ClassWithoutAttribute),
-                typeof(ClassWithInheritedAttribute)
-            });
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInDummyNamespace));
 
-            // Act
-            Action act = () =>
-                types.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    types.Should().NotBeInNamespace($"{nameof(DummyNamespace)}.{nameof(DummyNamespace.InnerDummyNamespace)}");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to not be decorated with or inherit *.DummyClassAttribute *failure message*" +
-                    ", but the attribute was found on the following types:*\"*.ClassWithInheritedAttribute\".");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_a_selection_of_types_do_inherit_unexpected_attribute_with_the_expected_properties_it_succeeds()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassWithInheritedAttribute));
-
-            // Act
-            Action act = () => types.Should()
-                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(
-                    a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to not be decorated with or inherit *.DummyClassAttribute that matches " +
-                    "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but a matching attribute was found " +
-                    "on the following types:*\"*.ClassWithInheritedAttribute\".");
-        }
-
-        [Fact]
-        public void When_a_selection_of_types_do_not_inherit_unexpected_attribute_with_the_expected_properties_it_succeeds()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassWithoutAttribute));
-
-            // Act
-            Action act = () => types.Should()
-                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_injecting_a_null_predicate_into_TypeSelector_NotBeDecoratedWithOrInherit_it_should_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassWithAttribute));
-
-            // Act
-            Action act = () => types.Should()
-                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(isMatchingAttributePredicate: null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("isMatchingAttributePredicate");
-        }
-
-        #endregion
-
-        #region BeInNamespace
-
-        [Fact]
-        public void When_a_type_is_in_the_expected_namespace_it_should_not_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInDummyNamespace));
-
-            // Act
-            Action act = () => types.Should().BeInNamespace(nameof(DummyNamespace));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_type_is_not_in_the_expected_namespace_it_should_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_is_not_in_the_unexpected_parent_namespace_it_should_not_throw()
             {
-                typeof(ClassInDummyNamespace),
-                typeof(ClassNotInDummyNamespace),
-                typeof(OtherClassNotInDummyNamespace)
-            });
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInInnerDummyNamespace));
 
-            // Act
-            Action act = () =>
-                types.Should().BeInNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
+                // Act
+                Action act = () => types.Should().NotBeInNamespace(nameof(DummyNamespace));
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be in namespace \"DummyNamespace\" *failure message*, but the following types " +
-                    "are in a different namespace:*\"*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_a_type_is_in_the_expected_global_namespace_it_should_not_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInGlobalNamespace));
-
-            // Act
-            Action act = () => types.Should().BeInNamespace(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_type_in_the_global_namespace_is_not_in_the_expected_namespace_it_should_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInGlobalNamespace));
-
-            // Act
-            Action act = () => types.Should().BeInNamespace(nameof(DummyNamespace));
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be in namespace \"DummyNamespace\", but the following types " +
-                    "are in a different namespace:*\"ClassInGlobalNamespace\".");
-        }
-
-        [Fact]
-        public void When_a_type_is_not_in_the_expected_global_namespace_it_should_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_is_in_the_unexpected_namespace_it_should_throw()
             {
-                typeof(ClassInDummyNamespace),
-                typeof(ClassNotInDummyNamespace),
-                typeof(OtherClassNotInDummyNamespace)
-            });
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassInDummyNamespace),
+                    typeof(ClassNotInDummyNamespace),
+                    typeof(OtherClassNotInDummyNamespace)
+                });
 
-            // Act
-            Action act = () => types.Should().BeInNamespace(null);
+                // Act
+                Action act = () =>
+                    types.Should().NotBeInNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be in namespace <null>, but the following types are in a different namespace:" +
-                    "*\"*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected no types to be in namespace \"DummyNamespace\" *failure message*" +
+                        ", but the following types are in the namespace:*\"DummyNamespace.ClassInDummyNamespace\".");
+            }
         }
 
-        #endregion
-
-        #region NotBeInNamespace
-
-        [Fact]
-        public void When_a_type_is_not_in_the_unexpected_namespace_it_should_not_throw()
+        public class BeUnderNamespace
         {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInDummyNamespace));
-
-            // Act
-            Action act = () =>
-                types.Should().NotBeInNamespace($"{nameof(DummyNamespace)}.{nameof(DummyNamespace.InnerDummyNamespace)}");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_type_is_not_in_the_unexpected_parent_namespace_it_should_not_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInInnerDummyNamespace));
-
-            // Act
-            Action act = () => types.Should().NotBeInNamespace(nameof(DummyNamespace));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_type_is_in_the_unexpected_namespace_it_should_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_is_under_the_expected_namespace_it_should_not_throw()
             {
-                typeof(ClassInDummyNamespace),
-                typeof(ClassNotInDummyNamespace),
-                typeof(OtherClassNotInDummyNamespace)
-            });
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInDummyNamespace));
 
-            // Act
-            Action act = () =>
-                types.Should().NotBeInNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
+                // Act
+                Action act = () => types.Should().BeUnderNamespace(nameof(DummyNamespace));
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected no types to be in namespace \"DummyNamespace\" *failure message*" +
-                    ", but the following types are in the namespace:*\"DummyNamespace.ClassInDummyNamespace\".");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        #endregion
-
-        #region BeUnderNamespace
-
-        [Fact]
-        public void When_a_type_is_under_the_expected_namespace_it_should_not_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInDummyNamespace));
-
-            // Act
-            Action act = () => types.Should().BeUnderNamespace(nameof(DummyNamespace));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_type_is_under_the_expected_nested_namespace_it_should_not_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInInnerDummyNamespace));
-
-            // Act
-            Action act = () =>
-                types.Should().BeUnderNamespace($"{nameof(DummyNamespace)}.{nameof(DummyNamespace.InnerDummyNamespace)}");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_type_is_under_the_expected_parent_namespace_it_should_not_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInInnerDummyNamespace));
-
-            // Act
-            Action act = () => types.Should().BeUnderNamespace(nameof(DummyNamespace));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_type_is_exactly_under_the_expected_global_namespace_it_should_not_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInGlobalNamespace));
-
-            // Act
-            Action act = () => types.Should().BeUnderNamespace(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_type_is_under_the_expected_global_namespace_it_should_not_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_is_under_the_expected_nested_namespace_it_should_not_throw()
             {
-                typeof(ClassInDummyNamespace),
-                typeof(ClassNotInDummyNamespace),
-                typeof(OtherClassNotInDummyNamespace)
-            });
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInInnerDummyNamespace));
 
-            // Act
-            Action act = () => types.Should().BeUnderNamespace(null);
+                // Act
+                Action act = () =>
+                    types.Should().BeUnderNamespace($"{nameof(DummyNamespace)}.{nameof(DummyNamespace.InnerDummyNamespace)}");
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_a_type_only_shares_a_prefix_with_the_expected_namespace_it_should_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInDummyNamespaceTwo));
-
-            // Act
-            Action act = () =>
-                types.Should().BeUnderNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                    .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace\" *failure message*" +
-                    ", but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespaceTwo\".");
-        }
-
-        [Fact]
-        public void When_asserting_a_selection_of_types_not_under_a_namespace_is_under_that_namespace_it_fails()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_is_under_the_expected_parent_namespace_it_should_not_throw()
             {
-                typeof(ClassInDummyNamespace),
-                typeof(ClassInInnerDummyNamespace)
-            });
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInInnerDummyNamespace));
 
-            // Act
-            Action act = () =>
-                types.Should().BeUnderNamespace($"{nameof(DummyNamespace)}.{nameof(DummyNamespace.InnerDummyNamespace)}");
+                // Act
+                Action act = () => types.Should().BeUnderNamespace(nameof(DummyNamespace));
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected the namespaces of all types to start with \"DummyNamespace.InnerDummyNamespace\"" +
-                    ", but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespace\".");
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        #endregion
-
-        #region NotBeUnderNamespace
-
-        [Fact]
-        public void When_a_types_is_not_under_the_unexpected_namespace_it_should_not_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_is_exactly_under_the_expected_global_namespace_it_should_not_throw()
             {
-                typeof(ClassInDummyNamespace),
-                typeof(ClassNotInDummyNamespace),
-                typeof(OtherClassNotInDummyNamespace)
-            });
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInGlobalNamespace));
 
-            // Act
-            Action act = () =>
-                types.Should().NotBeUnderNamespace($"{nameof(DummyNamespace)}.{nameof(DummyNamespace.InnerDummyNamespace)}");
+                // Act
+                Action act = () => types.Should().BeUnderNamespace(null);
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_a_type_is_under_the_unexpected_namespace_it_shold_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInDummyNamespace));
-
-            // Act
-            Action act = () =>
-                types.Should().NotBeUnderNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected the namespaces of all types to not start with \"DummyNamespace\" *failure message*" +
-                    ", but the namespaces of the following types start with it:*\"*.ClassInDummyNamespace\".");
-        }
-
-        [Fact]
-        public void When_a_type_is_under_the_unexpected_nested_namespace_it_should_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInInnerDummyNamespace));
-
-            // Act
-            Action act = () =>
-                types.Should().NotBeUnderNamespace($"{nameof(DummyNamespace)}.{nameof(DummyNamespace.InnerDummyNamespace)}");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected the namespaces of all types to not start with \"DummyNamespace.InnerDummyNamespace\"" +
-                    ", but the namespaces of the following types start with it:*\"*.ClassInInnerDummyNamespace\".");
-        }
-
-        [Fact]
-        public void When_a_type_is_under_the_unexpected_parent_namespace_it_should_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInInnerDummyNamespace));
-
-            // Act
-            Action act = () => types.Should().NotBeUnderNamespace(nameof(DummyNamespace));
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected the namespaces of all types to not start with \"DummyNamespace\"" +
-                    ", but the namespaces of the following types start with it:*\"*.ClassInInnerDummyNamespace\".");
-        }
-
-        [Fact]
-        public void When_a_type_is_under_the_unexpected_global_namespace_it_should_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInGlobalNamespace));
-
-            // Act
-            Action act = () => types.Should().NotBeUnderNamespace(null);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected the namespaces of all types to not start with <null>" +
-                    ", but the namespaces of the following types start with it:*\"ClassInGlobalNamespace\".");
-        }
-
-        [Fact]
-        public void When_a_type_is_under_the_unexpected_parent_global_namespace_it_should_throw()
-        {
-            // Arrange
-            var types = new TypeSelector(new[]
+            [Fact]
+            public void When_a_type_is_under_the_expected_global_namespace_it_should_not_throw()
             {
-                typeof(ClassInDummyNamespace),
-                typeof(ClassNotInDummyNamespace),
-                typeof(OtherClassNotInDummyNamespace)
-            });
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassInDummyNamespace),
+                    typeof(ClassNotInDummyNamespace),
+                    typeof(OtherClassNotInDummyNamespace)
+                });
 
-            // Act
-            Action act = () => types.Should().NotBeUnderNamespace(null);
+                // Act
+                Action act = () => types.Should().BeUnderNamespace(null);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected the namespaces of all types to not start with <null>, but the namespaces of the following types " +
-                    "start with it:*\"*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_type_only_shares_a_prefix_with_the_expected_namespace_it_should_throw()
+            {
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInDummyNamespaceTwo));
+
+                // Act
+                Action act = () =>
+                    types.Should().BeUnderNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                        .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace\" *failure message*" +
+                        ", but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespaceTwo\".");
+            }
+
+            [Fact]
+            public void When_asserting_a_selection_of_types_not_under_a_namespace_is_under_that_namespace_it_fails()
+            {
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassInDummyNamespace),
+                    typeof(ClassInInnerDummyNamespace)
+                });
+
+                // Act
+                Action act = () =>
+                    types.Should().BeUnderNamespace($"{nameof(DummyNamespace)}.{nameof(DummyNamespace.InnerDummyNamespace)}");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected the namespaces of all types to start with \"DummyNamespace.InnerDummyNamespace\"" +
+                        ", but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespace\".");
+            }
         }
 
-        [Fact]
-        public void When_a_type_only_shares_a_prefix_with_the_unexpected_namespace_it_should_not_throw()
+        public class NotBeUnderNamespace
         {
-            // Arrange
-            var types = new TypeSelector(typeof(ClassInDummyNamespaceTwo));
+            [Fact]
+            public void When_a_types_is_not_under_the_unexpected_namespace_it_should_not_throw()
+            {
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassInDummyNamespace),
+                    typeof(ClassNotInDummyNamespace),
+                    typeof(OtherClassNotInDummyNamespace)
+                });
 
-            // Act
-            Action act = () => types.Should().NotBeUnderNamespace(nameof(DummyNamespace));
+                // Act
+                Action act = () =>
+                    types.Should().NotBeUnderNamespace($"{nameof(DummyNamespace)}.{nameof(DummyNamespace.InnerDummyNamespace)}");
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_type_is_under_the_unexpected_namespace_it_shold_throw()
+            {
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInDummyNamespace));
+
+                // Act
+                Action act = () =>
+                    types.Should().NotBeUnderNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected the namespaces of all types to not start with \"DummyNamespace\" *failure message*" +
+                        ", but the namespaces of the following types start with it:*\"*.ClassInDummyNamespace\".");
+            }
+
+            [Fact]
+            public void When_a_type_is_under_the_unexpected_nested_namespace_it_should_throw()
+            {
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInInnerDummyNamespace));
+
+                // Act
+                Action act = () =>
+                    types.Should().NotBeUnderNamespace($"{nameof(DummyNamespace)}.{nameof(DummyNamespace.InnerDummyNamespace)}");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected the namespaces of all types to not start with \"DummyNamespace.InnerDummyNamespace\"" +
+                        ", but the namespaces of the following types start with it:*\"*.ClassInInnerDummyNamespace\".");
+            }
+
+            [Fact]
+            public void When_a_type_is_under_the_unexpected_parent_namespace_it_should_throw()
+            {
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInInnerDummyNamespace));
+
+                // Act
+                Action act = () => types.Should().NotBeUnderNamespace(nameof(DummyNamespace));
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected the namespaces of all types to not start with \"DummyNamespace\"" +
+                        ", but the namespaces of the following types start with it:*\"*.ClassInInnerDummyNamespace\".");
+            }
+
+            [Fact]
+            public void When_a_type_is_under_the_unexpected_global_namespace_it_should_throw()
+            {
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInGlobalNamespace));
+
+                // Act
+                Action act = () => types.Should().NotBeUnderNamespace(null);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected the namespaces of all types to not start with <null>" +
+                        ", but the namespaces of the following types start with it:*\"ClassInGlobalNamespace\".");
+            }
+
+            [Fact]
+            public void When_a_type_is_under_the_unexpected_parent_global_namespace_it_should_throw()
+            {
+                // Arrange
+                var types = new TypeSelector(new[]
+                {
+                    typeof(ClassInDummyNamespace),
+                    typeof(ClassNotInDummyNamespace),
+                    typeof(OtherClassNotInDummyNamespace)
+                });
+
+                // Act
+                Action act = () => types.Should().NotBeUnderNamespace(null);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected the namespaces of all types to not start with <null>, but the namespaces of the following types " +
+                        "start with it:*\"*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
+            }
+
+            [Fact]
+            public void When_a_type_only_shares_a_prefix_with_the_unexpected_namespace_it_should_not_throw()
+            {
+                // Arrange
+                var types = new TypeSelector(typeof(ClassInDummyNamespaceTwo));
+
+                // Act
+                Action act = () => types.Should().NotBeUnderNamespace(nameof(DummyNamespace));
+
+                // Assert
+                act.Should().NotThrow();
+            }
         }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Xml/XAttributeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XAttributeAssertionSpecs.cs
@@ -7,319 +7,322 @@ namespace FluentAssertions.Specs.Xml
 {
     public class XAttributeAssertionSpecs
     {
-        #region Be / NotBe
-
-        [Fact]
-        public void When_asserting_an_xml_attribute_is_equal_to_the_same_xml_attribute_it_should_succeed()
+        public class Be
         {
-            // Arrange
-            var attribute = new XAttribute("name", "value");
-            var sameXAttribute = new XAttribute("name", "value");
+            [Fact]
+            public void When_asserting_an_xml_attribute_is_equal_to_the_same_xml_attribute_it_should_succeed()
+            {
+                // Arrange
+                var attribute = new XAttribute("name", "value");
+                var sameXAttribute = new XAttribute("name", "value");
 
-            // Act
-            Action act = () =>
-                attribute.Should().Be(sameXAttribute);
+                // Act
+                Action act = () =>
+                    attribute.Should().Be(sameXAttribute);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_attribute_is_equal_to_a_different_xml_attribute_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theAttribute = new XAttribute("name", "value");
+                var otherAttribute = new XAttribute("name2", "value");
+
+                // Act
+                Action act = () =>
+                    theAttribute.Should().Be(otherAttribute, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    $"Expected theAttribute to be {otherAttribute} because we want to test the failure message, but found {theAttribute}.");
+            }
+
+            [Fact]
+            public void When_both_subject_and_expected_are_null_it_succeeds()
+            {
+                XAttribute theAttribute = null;
+
+                // Act
+                Action act = () => theAttribute.Should().Be(null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_the_expected_attribute_is_null_then_it_fails()
+            {
+                XAttribute theAttribute = null;
+
+                // Act
+                Action act = () =>
+                    theAttribute.Should().Be(new XAttribute("name", "value"), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected theAttribute to be name=\"value\" *failure message*, but found <null>.");
+            }
+
+            [Fact]
+            public void When_the_attribute_is_expected_to_equal_null_it_fails()
+            {
+                XAttribute theAttribute = new XAttribute("name", "value");
+
+                // Act
+                Action act = () => theAttribute.Should().Be(null, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected theAttribute to be <null> *failure message*, but found name=\"value\".");
+            }
         }
 
-        [Fact]
-        public void When_asserting_an_xml_attribute_is_equal_to_a_different_xml_attribute_it_should_fail_with_descriptive_message()
+        public class NotBe
         {
-            // Arrange
-            var theAttribute = new XAttribute("name", "value");
-            var otherAttribute = new XAttribute("name2", "value");
+            [Fact]
+            public void When_asserting_an_xml_attribute_is_not_equal_to_a_different_xml_attribute_it_should_succeed()
+            {
+                // Arrange
+                var attribute = new XAttribute("name", "value");
+                var otherXAttribute = new XAttribute("name2", "value");
 
-            // Act
-            Action act = () =>
-                theAttribute.Should().Be(otherAttribute, "because we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    attribute.Should().NotBe(otherXAttribute);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                $"Expected theAttribute to be {otherAttribute} because we want to test the failure message, but found {theAttribute}.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_attribute_is_not_equal_to_the_same_xml_attribute_it_should_throw()
+            {
+                // Arrange
+                var theAttribute = new XAttribute("name", "value");
+                var sameXAttribute = theAttribute;
+
+                // Act
+                Action act = () =>
+                    theAttribute.Should().NotBe(sameXAttribute);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theAttribute to be name=\"value\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_attribute_is_not_equal_to_the_same_xml_attribute_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var theAttribute = new XAttribute("name", "value");
+                var sameAttribute = theAttribute;
+
+                // Act
+                Action act = () =>
+                    theAttribute.Should().NotBe(sameAttribute, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    $"Did not expect theAttribute to be {sameAttribute} because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void When_a_null_attribute_is_not_supposed_to_be_an_attribute_it_succeeds()
+            {
+                // Arrange
+                XAttribute theAttribute = null;
+
+                // Act
+                Action act = () => theAttribute.Should().NotBe(new XAttribute("name", "value"));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_an_attribute_is_not_supposed_to_be_null_it_succeeds()
+            {
+                // Arrange
+                XAttribute theAttribute = new XAttribute("name", "value");
+
+                // Act
+                Action act = () => theAttribute.Should().NotBe(null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_null_attribute_is_not_supposed_to_be_null_it_fails()
+            {
+                // Arrange
+                XAttribute theAttribute = null;
+
+                // Act
+                Action act = () => theAttribute.Should().NotBe(null, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect theAttribute to be <null> *failure message*.");
+            }
         }
 
-        [Fact]
-        public void When_both_subject_and_expected_are_null_it_succeeds()
+        public class BeNull
         {
-            XAttribute theAttribute = null;
+            [Fact]
+            public void When_asserting_a_null_xml_attribute_is_null_it_should_succeed()
+            {
+                // Arrange
+                XAttribute attribute = null;
 
-            // Act
-            Action act = () => theAttribute.Should().Be(null);
+                // Act
+                Action act = () =>
+                    attribute.Should().BeNull();
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_non_null_xml_attribute_is_null_it_should_fail()
+            {
+                // Arrange
+                var theAttribute = new XAttribute("name", "value");
+
+                // Act
+                Action act = () =>
+                    theAttribute.Should().BeNull();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theAttribute to be <null>, but found name=\"value\".");
+            }
+
+            [Fact]
+            public void When_asserting_a_non_null_xml_attribute_is_null_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theAttribute = new XAttribute("name", "value");
+
+                // Act
+                Action act = () =>
+                    theAttribute.Should().BeNull("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    $"Expected theAttribute to be <null> because we want to test the failure message, but found {theAttribute}.");
+            }
         }
 
-        [Fact]
-        public void When_the_expected_attribute_is_null_then_it_fails()
+        public class NotBeNull
         {
-            XAttribute theAttribute = null;
+            [Fact]
+            public void When_asserting_a_non_null_xml_attribute_is_not_null_it_should_succeed()
+            {
+                // Arrange
+                var attribute = new XAttribute("name", "value");
 
-            // Act
-            Action act = () =>
-                theAttribute.Should().Be(new XAttribute("name", "value"), "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    attribute.Should().NotBeNull();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected theAttribute to be name=\"value\" *failure message*, but found <null>.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_null_xml_attribute_is_not_null_it_should_fail()
+            {
+                // Arrange
+                XAttribute theAttribute = null;
+
+                // Act
+                Action act = () =>
+                    theAttribute.Should().NotBeNull();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theAttribute not to be <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_null_xml_attribute_is_not_null_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                XAttribute theAttribute = null;
+
+                // Act
+                Action act = () =>
+                    theAttribute.Should().NotBeNull("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theAttribute not to be <null> because we want to test the failure message.");
+            }
         }
 
-        [Fact]
-        public void When_the_attribute_is_expected_to_equal_null_it_fails()
+        public class HaveValue
         {
-            XAttribute theAttribute = new XAttribute("name", "value");
+            [Fact]
+            public void When_asserting_attribute_has_a_specific_value_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var attribute = new XAttribute("age", "36");
 
-            // Act
-            Action act = () => theAttribute.Should().Be(null, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    attribute.Should().HaveValue("36");
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected theAttribute to be <null> *failure message*, but found name=\"value\".");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_attribute_has_a_specific_value_but_it_has_a_different_value_it_should_throw()
+            {
+                // Arrange
+                var theAttribute = new XAttribute("age", "36");
+
+                // Act
+                Action act = () =>
+                    theAttribute.Should().HaveValue("16");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theAttribute \"age\" to have value \"16\", but found \"36\".");
+            }
+
+            [Fact]
+            public void When_asserting_attribute_has_a_specific_value_but_it_has_a_different_value_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var theAttribute = new XAttribute("age", "36");
+
+                // Act
+                Action act = () =>
+                    theAttribute.Should().HaveValue("16", "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theAttribute \"age\" to have value \"16\" because we want to test the failure message, but found \"36\".");
+            }
+
+            [Fact]
+            public void When_an_attribute_is_null_then_have_value_should_fail()
+            {
+                XAttribute theAttribute = null;
+
+                // Act
+                Action act = () =>
+                    theAttribute.Should().HaveValue("value", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the attribute to have value \"value\" *failure message*, but theAttribute is <null>.");
+            }
         }
-
-        [Fact]
-        public void When_asserting_an_xml_attribute_is_not_equal_to_a_different_xml_attribute_it_should_succeed()
-        {
-            // Arrange
-            var attribute = new XAttribute("name", "value");
-            var otherXAttribute = new XAttribute("name2", "value");
-
-            // Act
-            Action act = () =>
-                attribute.Should().NotBe(otherXAttribute);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_attribute_is_not_equal_to_the_same_xml_attribute_it_should_throw()
-        {
-            // Arrange
-            var theAttribute = new XAttribute("name", "value");
-            var sameXAttribute = theAttribute;
-
-            // Act
-            Action act = () =>
-                theAttribute.Should().NotBe(sameXAttribute);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theAttribute to be name=\"value\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_attribute_is_not_equal_to_the_same_xml_attribute_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var theAttribute = new XAttribute("name", "value");
-            var sameAttribute = theAttribute;
-
-            // Act
-            Action act = () =>
-                theAttribute.Should().NotBe(sameAttribute, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                $"Did not expect theAttribute to be {sameAttribute} because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void When_a_null_attribute_is_not_supposed_to_be_an_attribute_it_succeeds()
-        {
-            // Arrange
-            XAttribute theAttribute = null;
-
-            // Act
-            Action act = () => theAttribute.Should().NotBe(new XAttribute("name", "value"));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_an_attribute_is_not_supposed_to_be_null_it_succeeds()
-        {
-            // Arrange
-            XAttribute theAttribute = new XAttribute("name", "value");
-
-            // Act
-            Action act = () => theAttribute.Should().NotBe(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_null_attribute_is_not_supposed_to_be_null_it_fails()
-        {
-            // Arrange
-            XAttribute theAttribute = null;
-
-            // Act
-            Action act = () => theAttribute.Should().NotBe(null, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect theAttribute to be <null> *failure message*.");
-        }
-
-        #endregion
-
-        #region BeNull / NotBeNull
-
-        [Fact]
-        public void When_asserting_a_null_xml_attribute_is_null_it_should_succeed()
-        {
-            // Arrange
-            XAttribute attribute = null;
-
-            // Act
-            Action act = () =>
-                attribute.Should().BeNull();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_non_null_xml_attribute_is_null_it_should_fail()
-        {
-            // Arrange
-            var theAttribute = new XAttribute("name", "value");
-
-            // Act
-            Action act = () =>
-                theAttribute.Should().BeNull();
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theAttribute to be <null>, but found name=\"value\".");
-        }
-
-        [Fact]
-        public void When_asserting_a_non_null_xml_attribute_is_null_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theAttribute = new XAttribute("name", "value");
-
-            // Act
-            Action act = () =>
-                theAttribute.Should().BeNull("because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                $"Expected theAttribute to be <null> because we want to test the failure message, but found {theAttribute}.");
-        }
-
-        [Fact]
-        public void When_asserting_a_non_null_xml_attribute_is_not_null_it_should_succeed()
-        {
-            // Arrange
-            var attribute = new XAttribute("name", "value");
-
-            // Act
-            Action act = () =>
-                attribute.Should().NotBeNull();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_null_xml_attribute_is_not_null_it_should_fail()
-        {
-            // Arrange
-            XAttribute theAttribute = null;
-
-            // Act
-            Action act = () =>
-                theAttribute.Should().NotBeNull();
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theAttribute not to be <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_null_xml_attribute_is_not_null_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            XAttribute theAttribute = null;
-
-            // Act
-            Action act = () =>
-                theAttribute.Should().NotBeNull("because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theAttribute not to be <null> because we want to test the failure message.");
-        }
-
-        #endregion
-
-        #region HaveValue
-
-        [Fact]
-        public void When_asserting_attribute_has_a_specific_value_and_it_does_it_should_succeed()
-        {
-            // Arrange
-            var attribute = new XAttribute("age", "36");
-
-            // Act
-            Action act = () =>
-                attribute.Should().HaveValue("36");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_attribute_has_a_specific_value_but_it_has_a_different_value_it_should_throw()
-        {
-            // Arrange
-            var theAttribute = new XAttribute("age", "36");
-
-            // Act
-            Action act = () =>
-                theAttribute.Should().HaveValue("16");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theAttribute \"age\" to have value \"16\", but found \"36\".");
-        }
-
-        [Fact]
-        public void When_asserting_attribute_has_a_specific_value_but_it_has_a_different_value_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var theAttribute = new XAttribute("age", "36");
-
-            // Act
-            Action act = () =>
-                theAttribute.Should().HaveValue("16", "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theAttribute \"age\" to have value \"16\" because we want to test the failure message, but found \"36\".");
-        }
-
-        [Fact]
-        public void When_an_attribute_is_null_then_have_value_should_fail()
-        {
-            XAttribute theAttribute = null;
-
-            // Act
-            Action act = () =>
-                theAttribute.Should().HaveValue("value", "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the attribute to have value \"value\" *failure message*, but theAttribute is <null>.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -9,1320 +9,1323 @@ namespace FluentAssertions.Specs.Xml
 {
     public class XDocumentAssertionSpecs
     {
-        #region Be / NotBe
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_equal_to_the_same_xml_document_it_should_succeed()
+        public class Be
         {
-            // Arrange
-            var document = new XDocument();
-            var sameXDocument = document;
+            [Fact]
+            public void When_asserting_a_xml_document_is_equal_to_the_same_xml_document_it_should_succeed()
+            {
+                // Arrange
+                var document = new XDocument();
+                var sameXDocument = document;
 
-            // Act
-            Action act = () =>
-                document.Should().Be(sameXDocument);
+                // Act
+                Action act = () =>
+                    document.Should().Be(sameXDocument);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_equal_to_a_different_xml_document_it_should_fail()
+            {
+                // Arrange
+                var theDocument = new XDocument();
+                var otherXDocument = new XDocument();
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().Be(otherXDocument);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theDocument to be [XML document without root element], but found [XML document without root element].");
+            }
+
+            [Fact]
+            public void When_the_expected_element_is_null_it_fails()
+            {
+                // Arrange
+                XDocument theDocument = null;
+
+                // Act
+                Action act = () => theDocument.Should().Be(new XDocument(), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theDocument to be [XML document without root element] *failure message*, but found <null>.");
+            }
+
+            [Fact]
+            public void When_both_subject_and_expected_documents_are_null_it_succeeds()
+            {
+                // Arrange
+                XDocument theDocument = null;
+
+                // Act
+                Action act = () => theDocument.Should().Be(null);
+
+                // Assert
+                act.Should().NotThrow<XunitException>();
+            }
+
+            [Fact]
+            public void When_a_document_is_expected_to_equal_null_it_fails()
+            {
+                // Arrange
+                XDocument theDocument = new XDocument();
+
+                // Act
+                Action act = () => theDocument.Should().Be(null, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theDocument to be <null> *failure message*, but found [XML document without root element].");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_equal_to_a_different_xml_document_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<configuration></configuration>");
+                var otherXDocument = XDocument.Parse("<data></data>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().Be(otherXDocument, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theDocument to be <data*> because we want to test the failure message, but found <configuration*>.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_xml_document_is_equal_to_a_different_xml_document_it_should_fail()
+        public class NotBe
         {
-            // Arrange
-            var theDocument = new XDocument();
-            var otherXDocument = new XDocument();
+            [Fact]
+            public void When_asserting_a_xml_document_is_not_equal_to_a_different_xml_document_it_should_succeed()
+            {
+                // Arrange
+                var document = new XDocument();
+                var otherXDocument = new XDocument();
 
-            // Act
-            Action act = () =>
-                theDocument.Should().Be(otherXDocument);
+                // Act
+                Action act = () =>
+                    document.Should().NotBe(otherXDocument);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to be [XML document without root element], but found [XML document without root element].");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_not_equal_to_the_same_xml_document_it_should_fail()
+            {
+                // Arrange
+                var theDocument = new XDocument();
+                var sameXDocument = theDocument;
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().NotBe(sameXDocument);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theDocument to be [XML document without root element].");
+            }
+
+            [Fact]
+            public void When_a_null_document_is_not_supposed_to_be_a_document_it_succeeds()
+            {
+                // Arrange
+                XDocument theDocument = null;
+
+                // Act
+                Action act = () => theDocument.Should().NotBe(new XDocument());
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_document_is_not_supposed_to_be_null_it_succeeds()
+            {
+                // Arrange
+                XDocument theDocument = new XDocument();
+
+                // Act
+                Action act = () => theDocument.Should().NotBe(null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_null_document_is_not_supposed_to_be_equal_to_null_it_fails()
+            {
+                // Arrange
+                XDocument theDocument = null;
+
+                // Act
+                Action act = () => theDocument.Should().NotBe(null, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect theDocument to be <null> *failure message*.");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_not_equal_to_the_same_xml_document_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<configuration></configuration>");
+                var sameXDocument = theDocument;
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().NotBe(sameXDocument, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theDocument to be <configuration*> because we want to test the failure message.");
+            }
         }
 
-        [Fact]
-        public void When_the_expected_element_is_null_it_fails()
+        public class BeEquivalentTo
         {
-            // Arrange
-            XDocument theDocument = null;
+            [Fact]
+            public void When_asserting_a_xml_document_is_equivalent_to_the_same_xml_document_it_should_succeed()
+            {
+                // Arrange
+                var document = new XDocument();
+                var sameXDocument = document;
 
-            // Act
-            Action act = () => theDocument.Should().Be(new XDocument(), "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    document.Should().BeEquivalentTo(sameXDocument);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to be [XML document without root element] *failure message*, but found <null>.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_selfclosing_document_is_equivalent_to_a_different_xml_document_with_same_structure_it_should_succeed()
+            {
+                // Arrange
+                var document = XDocument.Parse("<parent><child /></parent>");
+                var otherXDocument = XDocument.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    document.Should().BeEquivalentTo(otherXDocument);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_same_structure_it_should_succeed()
+            {
+                // Arrange
+                var document = XDocument.Parse("<parent><child></child></parent>");
+                var otherXDocument = XDocument.Parse("<parent><child></child></parent>");
+
+                // Act
+                Action act = () =>
+                    document.Should().BeEquivalentTo(otherXDocument);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_equivalent_to_a_xml_document_with_elements_missing_it_should_fail()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<parent><child /><child2 /></parent>");
+                var otherXDocument = XDocument.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(otherXDocument);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected EndElement \"parent\" in theDocument at \"/parent\", but found Element \"child2\".");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_extra_elements_it_should_fail()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<parent><child /></parent>");
+                var expected = XDocument.Parse("<parent><child /><child2 /></parent>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected Element \"child2\" in theDocument at \"/parent\", but found EndElement \"parent\".");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_with_selfclosing_child_is_equivalent_to_a_different_xml_document_with_subchild_child_it_should_fail()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<parent><child /></parent>");
+                var otherXDocument = XDocument.Parse("<parent><child><child /></child></parent>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(otherXDocument);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected Element \"child\" in theDocument at \"/parent/child\", but found EndElement \"parent\".");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_elements_missing_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<parent><child /><child2 /></parent>");
+                var expected = XDocument.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected EndElement \"parent\" in theDocument at \"/parent\" because we want to test the failure message,"
+                    + " but found Element \"child2\".");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_extra_elements_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<parent><child /></parent>");
+                var expected = XDocument.Parse("<parent><child /><child2 /></parent>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected Element \"child2\" in theDocument at \"/parent\" because we want to test the failure message,"
+                    + " but found EndElement \"parent\".");
+            }
+
+            [Fact]
+            public void When_a_document_is_null_then_be_equivalent_to_null_succeeds()
+            {
+                XDocument theDocument = null;
+
+                // Act
+                Action act = () => theDocument.Should().BeEquivalentTo(null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_document_is_null_then_be_equivalent_to_a_document_fails()
+            {
+                XDocument theDocument = null;
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(
+                        XDocument.Parse("<parent><child /></parent>"), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected theDocument to be equivalent to <null> *failure message*" +
+                        ", but found \"<parent><child /></parent>\".");
+            }
+
+            [Fact]
+            public void When_a_document_is_equivalent_to_null_it_fails()
+            {
+                XDocument theDocument = XDocument.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(null, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected theDocument to be equivalent to \"<parent><child /></parent>\" *failure message*" +
+                        ", but found <null>.");
+            }
+            
+            [Fact]
+            public void When_assertion_an_xml_document_is_equivalent_to_a_different_xml_document_with_different_namespace_prefix_it_should_succeed()
+            {
+                // Arrange
+                var subject = XDocument.Parse("<xml xmlns=\"urn:a\"/>");
+                var expected = XDocument.Parse("<a:xml xmlns:a=\"urn:a\"/>");
+
+                // Act
+                Action act = () =>
+                    subject.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_document_is_equivalent_to_a_different_xml_document_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
+            {
+                // Arrange
+                var subject = XDocument.Parse("<xml xmlns:a=\"urn:a\"/>");
+                var expected = XDocument.Parse("<xml/>");
+
+                // Act
+                Action act = () =>
+                    subject.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_lacks_attributes_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<xml><element b=\"1\"/></xml>");
+                var expected = XDocument.Parse("<xml><element a=\"b\" b=\"1\"/></xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message, but found none.");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_extra_attributes_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<xml><element a=\"b\"/></xml>");
+                var expected = XDocument.Parse("<xml><element/></xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect to find attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<xml><element a=\"b\"/></xml>");
+                var expected = XDocument.Parse("<xml><element a=\"c\"/></xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected attribute \"a\" in theDocument at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
+                var expected = XDocument.Parse("<xml><element a=\"b\"/></xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect to find attribute \"ns:a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_different_text_contents_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<xml>a</xml>");
+                var expected = XDocument.Parse("<xml>b</xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected content to be \"b\" in theDocument at \"/xml\" because we want to test the failure message, but found \"a\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_with_different_comments_it_should_succeed()
+            {
+                // Arrange
+                var subject = XDocument.Parse("<xml><!--Comment--><a/></xml>");
+                var expected = XDocument.Parse("<xml><a/><!--Comment--></xml>");
+
+                // Act
+                Action act = () => subject.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_equivalence_of_an_xml_document_but_has_different_attribute_value_it_should_fail_with_xpath_to_difference()
+            {
+                // Arrange
+                XDocument actual = XDocument.Parse("<xml><a attr=\"x\"/><b id=\"foo\"/></xml>");
+                XDocument expected = XDocument.Parse("<xml><a attr=\"x\"/><b id=\"bar\"/></xml>");
+
+                // Act
+                Action act = () => actual.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*\"/xml/b\"*");
+            }
+
+            [Fact]
+            public void When_asserting_equivalence_of_document_with_repeating_element_names_but_differs_it_should_fail_with_index_xpath_to_difference()
+            {
+                // Arrange
+                XDocument actual = XDocument.Parse(
+                    "<xml><xml2 /><xml2 /><xml2><a x=\"y\"/><b><sub /></b><a x=\"y\"/></xml2></xml>");
+                XDocument expected = XDocument.Parse(
+                    "<xml><xml2 /><xml2 /><xml2><a x=\"y\"/><b><sub /></b><a x=\"z\"/></xml2></xml>");
+
+                // Act
+                Action act = () => actual.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*\"/xml/xml2[3]/a[2]\"*");
+            }
+
+            [Fact]
+            public void When_asserting_equivalence_of_document_with_repeating_element_names_on_different_levels_but_differs_it_should_fail_with_index_xpath_to_difference()
+            {
+                // Arrange
+                XDocument actual = XDocument.Parse(
+                    "<xml><xml /><xml /><xml><xml x=\"y\"/><xml2><xml /></xml2><xml x=\"y\"/></xml></xml>");
+                XDocument expected = XDocument.Parse(
+                    "<xml><xml /><xml /><xml><xml x=\"y\"/><xml2><xml /></xml2><xml x=\"z\"/></xml></xml>");
+
+                // Act
+                Action act = () => actual.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*\"/xml/xml[3]/xml[2]\"*");
+            }
+
+            [Fact]
+            public void When_asserting_equivalence_of_document_with_repeating_element_names_with_different_parents_but_differs_it_should_fail_with_index_xpath_to_difference()
+            {
+                // Arrange
+                XDocument actual = XDocument.Parse(
+                    "<root><xml1 /><xml1><xml2 /><xml2 a=\"x\" /></xml1><xml1><xml2 /><xml2 a=\"x\" /></xml1></root>");
+                XDocument expected = XDocument.Parse(
+                    "<root><xml1 /><xml1><xml2 /><xml2 a=\"x\" /></xml1><xml1><xml2 /><xml2 a=\"y\" /></xml1></root>");
+
+                // Act
+                Action act = () => actual.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("*\"/root/xml1[3]/xml2[2]\"*");
+            }
         }
 
-        [Fact]
-        public void When_both_subject_and_expected_documents_are_null_it_succeeds()
+        public class NotBeEquivalentTo
         {
-            // Arrange
-            XDocument theDocument = null;
+            [Fact]
+            public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_elements_missing_it_should_succeed()
+            {
+                // Arrange
+                var document = XDocument.Parse("<parent><child /><child2 /></parent>");
+                var otherXDocument = XDocument.Parse("<parent><child /></parent>");
 
-            // Act
-            Action act = () => theDocument.Should().Be(null);
+                // Act
+                Action act = () =>
+                    document.Should().NotBeEquivalentTo(otherXDocument);
 
-            // Assert
-            act.Should().NotThrow<XunitException>();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_extra_elements_it_should_succeed()
+            {
+                // Arrange
+                var document = XDocument.Parse("<parent><child /></parent>");
+                var otherXDocument = XDocument.Parse("<parent><child /><child2 /></parent>");
+
+                // Act
+                Action act = () =>
+                    document.Should().NotBeEquivalentTo(otherXDocument);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_structure_it_should_fail()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<parent><child /></parent>");
+                var otherXDocument = XDocument.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().NotBeEquivalentTo(otherXDocument);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theDocument to be equivalent, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_not_equivalent_to_the_same_xml_document_it_should_fail()
+            {
+                // Arrange
+                var theDocument = new XDocument();
+                var sameXDocument = theDocument;
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().NotBeEquivalentTo(sameXDocument);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theDocument to be equivalent, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_structure_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<parent><child /></parent>");
+                var otherDocument = XDocument.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().NotBeEquivalentTo(otherDocument, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_contents_but_different_ns_prefixes_it_should_fail()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse(@"<parent xmlns:ns1=""a""><ns1:child /></parent>");
+                var otherXDocument = XDocument.Parse(@"<parent xmlns:ns2=""a""><ns2:child /></parent>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().NotBeEquivalentTo(otherXDocument, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_contents_but_extra_unused_xmlns_declaration_it_should_fail()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse(@"<xml xmlns:ns1=""a"" />");
+                var otherDocument = XDocument.Parse("<xml />");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().NotBeEquivalentTo(otherDocument);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theDocument to be equivalent, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_document_is_not_equivalent_to_the_same_xml_document_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<parent><child /></parent>");
+                var sameXDocument = theDocument;
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().NotBeEquivalentTo(sameXDocument, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
+            }
+
+            [Fact]
+            public void When_a_null_document_is_unexpected_equivalent_to_null_it_fails()
+            {
+                XDocument theDocument = null;
+
+                // Act
+                Action act = () => theDocument.Should().NotBeEquivalentTo(null, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect theDocument to be equivalent *failure message*, but it is.");
+            }
+
+            [Fact]
+            public void When_a_null_document_is_not_equivalent_to_a_document_it_succeeds()
+            {
+                XDocument theDocument = null;
+
+                // Act
+                Action act = () => theDocument.Should().NotBeEquivalentTo(XDocument.Parse("<parent><child /></parent>"));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_document_is_not_equivalent_to_null_it_succeeds()
+            {
+                XDocument theDocument = XDocument.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () => theDocument.Should().NotBeEquivalentTo(null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
         }
 
-        [Fact]
-        public void When_a_document_is_expected_to_equal_null_it_fails()
+        public class BeNull
         {
-            // Arrange
-            XDocument theDocument = new XDocument();
+            [Fact]
+            public void When_asserting_a_null_xml_document_is_null_it_should_succeed()
+            {
+                // Arrange
+                XDocument document = null;
 
-            // Act
-            Action act = () => theDocument.Should().Be(null, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    document.Should().BeNull();
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to be <null> *failure message*, but found [XML document without root element].");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_non_null_xml_document_is_null_it_should_fail()
+            {
+                // Arrange
+                var theDocument = new XDocument();
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeNull();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theDocument to be <null>, but found [XML document without root element].");
+            }
+
+            [Fact]
+            public void When_asserting_a_non_null_xml_document_is_null_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse("<configuration></configuration>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeNull("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theDocument to be <null> because we want to test the failure message, but found <configuration*>.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_xml_document_is_equal_to_a_different_xml_document_it_should_fail_with_descriptive_message()
+        public class NotBeNull
         {
-            // Arrange
-            var theDocument = XDocument.Parse("<configuration></configuration>");
-            var otherXDocument = XDocument.Parse("<data></data>");
+            [Fact]
+            public void When_asserting_a_non_null_xml_document_is_not_null_it_should_succeed()
+            {
+                // Arrange
+                var document = new XDocument();
 
-            // Act
-            Action act = () =>
-                theDocument.Should().Be(otherXDocument, "because we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    document.Should().NotBeNull();
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to be <data*> because we want to test the failure message, but found <configuration*>.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_null_xml_document_is_not_null_it_should_fail()
+            {
+                // Arrange
+                XDocument theDocument = null;
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().NotBeNull();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected theDocument not to be <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_null_xml_document_is_not_null_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                XDocument theDocument = null;
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().NotBeNull("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theDocument not to be <null> because we want to test the failure message.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_a_xml_document_is_not_equal_to_a_different_xml_document_it_should_succeed()
+        public class HaveRoot
         {
-            // Arrange
-            var document = new XDocument();
-            var otherXDocument = new XDocument();
-
-            // Act
-            Action act = () =>
-                document.Should().NotBe(otherXDocument);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_not_equal_to_the_same_xml_document_it_should_fail()
-        {
-            // Arrange
-            var theDocument = new XDocument();
-            var sameXDocument = theDocument;
-
-            // Act
-            Action act = () =>
-                theDocument.Should().NotBe(sameXDocument);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theDocument to be [XML document without root element].");
-        }
-
-        [Fact]
-        public void When_a_null_document_is_not_supposed_to_be_a_document_it_succeeds()
-        {
-            // Arrange
-            XDocument theDocument = null;
-
-            // Act
-            Action act = () => theDocument.Should().NotBe(new XDocument());
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_document_is_not_supposed_to_be_null_it_succeeds()
-        {
-            // Arrange
-            XDocument theDocument = new XDocument();
-
-            // Act
-            Action act = () => theDocument.Should().NotBe(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_null_document_is_not_supposed_to_be_equal_to_null_it_fails()
-        {
-            // Arrange
-            XDocument theDocument = null;
-
-            // Act
-            Action act = () => theDocument.Should().NotBe(null, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect theDocument to be <null> *failure message*.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_not_equal_to_the_same_xml_document_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<configuration></configuration>");
-            var sameXDocument = theDocument;
-
-            // Act
-            Action act = () =>
-                theDocument.Should().NotBe(sameXDocument, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theDocument to be <configuration*> because we want to test the failure message.");
-        }
-
-        #endregion
-
-        #region BeEquivalentTo / NotBeEquivalentTo
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_equivalent_to_the_same_xml_document_it_should_succeed()
-        {
-            // Arrange
-            var document = new XDocument();
-            var sameXDocument = document;
-
-            // Act
-            Action act = () =>
-                document.Should().BeEquivalentTo(sameXDocument);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_selfclosing_document_is_equivalent_to_a_different_xml_document_with_same_structure_it_should_succeed()
-        {
-            // Arrange
-            var document = XDocument.Parse("<parent><child /></parent>");
-            var otherXDocument = XDocument.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                document.Should().BeEquivalentTo(otherXDocument);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_same_structure_it_should_succeed()
-        {
-            // Arrange
-            var document = XDocument.Parse("<parent><child></child></parent>");
-            var otherXDocument = XDocument.Parse("<parent><child></child></parent>");
-
-            // Act
-            Action act = () =>
-                document.Should().BeEquivalentTo(otherXDocument);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_equivalent_to_a_xml_document_with_elements_missing_it_should_fail()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<parent><child /><child2 /></parent>");
-            var otherXDocument = XDocument.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(otherXDocument);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected EndElement \"parent\" in theDocument at \"/parent\", but found Element \"child2\".");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_extra_elements_it_should_fail()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<parent><child /></parent>");
-            var expected = XDocument.Parse("<parent><child /><child2 /></parent>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected Element \"child2\" in theDocument at \"/parent\", but found EndElement \"parent\".");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_with_selfclosing_child_is_equivalent_to_a_different_xml_document_with_subchild_child_it_should_fail()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<parent><child /></parent>");
-            var otherXDocument = XDocument.Parse("<parent><child><child /></child></parent>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(otherXDocument);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected Element \"child\" in theDocument at \"/parent/child\", but found EndElement \"parent\".");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_elements_missing_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<parent><child /><child2 /></parent>");
-            var expected = XDocument.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected EndElement \"parent\" in theDocument at \"/parent\" because we want to test the failure message,"
-                + " but found Element \"child2\".");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_extra_elements_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<parent><child /></parent>");
-            var expected = XDocument.Parse("<parent><child /><child2 /></parent>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected Element \"child2\" in theDocument at \"/parent\" because we want to test the failure message,"
-                + " but found EndElement \"parent\".");
-        }
-
-        [Fact]
-        public void When_a_document_is_null_then_be_equivalent_to_null_succeeds()
-        {
-            XDocument theDocument = null;
-
-            // Act
-            Action act = () => theDocument.Should().BeEquivalentTo(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_document_is_null_then_be_equivalent_to_a_document_fails()
-        {
-            XDocument theDocument = null;
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(
-                    XDocument.Parse("<parent><child /></parent>"), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected theDocument to be equivalent to <null> *failure message*" +
-                    ", but found \"<parent><child /></parent>\".");
-        }
-
-        [Fact]
-        public void When_a_document_is_equivalent_to_null_it_fails()
-        {
-            XDocument theDocument = XDocument.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(null, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected theDocument to be equivalent to \"<parent><child /></parent>\" *failure message*" +
-                    ", but found <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_elements_missing_it_should_succeed()
-        {
-            // Arrange
-            var document = XDocument.Parse("<parent><child /><child2 /></parent>");
-            var otherXDocument = XDocument.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                document.Should().NotBeEquivalentTo(otherXDocument);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_extra_elements_it_should_succeed()
-        {
-            // Arrange
-            var document = XDocument.Parse("<parent><child /></parent>");
-            var otherXDocument = XDocument.Parse("<parent><child /><child2 /></parent>");
-
-            // Act
-            Action act = () =>
-                document.Should().NotBeEquivalentTo(otherXDocument);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_structure_it_should_fail()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<parent><child /></parent>");
-            var otherXDocument = XDocument.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().NotBeEquivalentTo(otherXDocument);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theDocument to be equivalent, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_the_same_xml_document_it_should_fail()
-        {
-            // Arrange
-            var theDocument = new XDocument();
-            var sameXDocument = theDocument;
-
-            // Act
-            Action act = () =>
-                theDocument.Should().NotBeEquivalentTo(sameXDocument);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theDocument to be equivalent, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_structure_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<parent><child /></parent>");
-            var otherDocument = XDocument.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().NotBeEquivalentTo(otherDocument, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_contents_but_different_ns_prefixes_it_should_fail()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse(@"<parent xmlns:ns1=""a""><ns1:child /></parent>");
-            var otherXDocument = XDocument.Parse(@"<parent xmlns:ns2=""a""><ns2:child /></parent>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().NotBeEquivalentTo(otherXDocument, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_contents_but_extra_unused_xmlns_declaration_it_should_fail()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse(@"<xml xmlns:ns1=""a"" />");
-            var otherDocument = XDocument.Parse("<xml />");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().NotBeEquivalentTo(otherDocument);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theDocument to be equivalent, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_the_same_xml_document_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<parent><child /></parent>");
-            var sameXDocument = theDocument;
-
-            // Act
-            Action act = () =>
-                theDocument.Should().NotBeEquivalentTo(sameXDocument, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
-        }
-
-        [Fact]
-        public void When_assertion_an_xml_document_is_equivalent_to_a_different_xml_document_with_different_namespace_prefix_it_should_succeed()
-        {
-            // Arrange
-            var subject = XDocument.Parse("<xml xmlns=\"urn:a\"/>");
-            var expected = XDocument.Parse("<a:xml xmlns:a=\"urn:a\"/>");
-
-            // Act
-            Action act = () =>
-                subject.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_a_different_xml_document_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
-        {
-            // Arrange
-            var subject = XDocument.Parse("<xml xmlns:a=\"urn:a\"/>");
-            var expected = XDocument.Parse("<xml/>");
-
-            // Act
-            Action act = () =>
-                subject.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_lacks_attributes_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<xml><element b=\"1\"/></xml>");
-            var expected = XDocument.Parse("<xml><element a=\"b\" b=\"1\"/></xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message, but found none.");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_extra_attributes_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<xml><element a=\"b\"/></xml>");
-            var expected = XDocument.Parse("<xml><element/></xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect to find attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<xml><element a=\"b\"/></xml>");
-            var expected = XDocument.Parse("<xml><element a=\"c\"/></xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected attribute \"a\" in theDocument at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
-            var expected = XDocument.Parse("<xml><element a=\"b\"/></xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect to find attribute \"ns:a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_different_text_contents_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<xml>a</xml>");
-            var expected = XDocument.Parse("<xml>b</xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected content to be \"b\" in theDocument at \"/xml\" because we want to test the failure message, but found \"a\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_with_different_comments_it_should_succeed()
-        {
-            // Arrange
-            var subject = XDocument.Parse("<xml><!--Comment--><a/></xml>");
-            var expected = XDocument.Parse("<xml><a/><!--Comment--></xml>");
-
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_equivalence_of_an_xml_document_but_has_different_attribute_value_it_should_fail_with_xpath_to_difference()
-        {
-            // Arrange
-            XDocument actual = XDocument.Parse("<xml><a attr=\"x\"/><b id=\"foo\"/></xml>");
-            XDocument expected = XDocument.Parse("<xml><a attr=\"x\"/><b id=\"bar\"/></xml>");
-
-            // Act
-            Action act = () => actual.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*\"/xml/b\"*");
-        }
-
-        [Fact]
-        public void When_asserting_equivalence_of_document_with_repeating_element_names_but_differs_it_should_fail_with_index_xpath_to_difference()
-        {
-            // Arrange
-            XDocument actual = XDocument.Parse(
-                "<xml><xml2 /><xml2 /><xml2><a x=\"y\"/><b><sub /></b><a x=\"y\"/></xml2></xml>");
-            XDocument expected = XDocument.Parse(
-                "<xml><xml2 /><xml2 /><xml2><a x=\"y\"/><b><sub /></b><a x=\"z\"/></xml2></xml>");
-
-            // Act
-            Action act = () => actual.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*\"/xml/xml2[3]/a[2]\"*");
-        }
-
-        [Fact]
-        public void When_asserting_equivalence_of_document_with_repeating_element_names_on_different_levels_but_differs_it_should_fail_with_index_xpath_to_difference()
-        {
-            // Arrange
-            XDocument actual = XDocument.Parse(
-                "<xml><xml /><xml /><xml><xml x=\"y\"/><xml2><xml /></xml2><xml x=\"y\"/></xml></xml>");
-            XDocument expected = XDocument.Parse(
-                "<xml><xml /><xml /><xml><xml x=\"y\"/><xml2><xml /></xml2><xml x=\"z\"/></xml></xml>");
-
-            // Act
-            Action act = () => actual.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*\"/xml/xml[3]/xml[2]\"*");
-        }
-
-        [Fact]
-        public void When_asserting_equivalence_of_document_with_repeating_element_names_with_different_parents_but_differs_it_should_fail_with_index_xpath_to_difference()
-        {
-            // Arrange
-            XDocument actual = XDocument.Parse(
-                "<root><xml1 /><xml1><xml2 /><xml2 a=\"x\" /></xml1><xml1><xml2 /><xml2 a=\"x\" /></xml1></root>");
-            XDocument expected = XDocument.Parse(
-                "<root><xml1 /><xml1><xml2 /><xml2 a=\"x\" /></xml1><xml1><xml2 /><xml2 a=\"y\" /></xml1></root>");
-
-            // Act
-            Action act = () => actual.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("*\"/root/xml1[3]/xml2[2]\"*");
-        }
-
-        [Fact]
-        public void When_a_null_document_is_unexpected_equivalent_to_null_it_fails()
-        {
-            XDocument theDocument = null;
-
-            // Act
-            Action act = () => theDocument.Should().NotBeEquivalentTo(null, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect theDocument to be equivalent *failure message*, but it is.");
-        }
-
-        [Fact]
-        public void When_a_null_document_is_not_equivalent_to_a_document_it_succeeds()
-        {
-            XDocument theDocument = null;
-
-            // Act
-            Action act = () => theDocument.Should().NotBeEquivalentTo(XDocument.Parse("<parent><child /></parent>"));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_document_is_not_equivalent_to_null_it_succeeds()
-        {
-            XDocument theDocument = XDocument.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () => theDocument.Should().NotBeEquivalentTo(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        #endregion
-
-        #region BeNull / NotBeNull
-
-        [Fact]
-        public void When_asserting_a_null_xml_document_is_null_it_should_succeed()
-        {
-            // Arrange
-            XDocument document = null;
-
-            // Act
-            Action act = () =>
-                document.Should().BeNull();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_non_null_xml_document_is_null_it_should_fail()
-        {
-            // Arrange
-            var theDocument = new XDocument();
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeNull();
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to be <null>, but found [XML document without root element].");
-        }
-
-        [Fact]
-        public void When_asserting_a_non_null_xml_document_is_null_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse("<configuration></configuration>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeNull("because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to be <null> because we want to test the failure message, but found <configuration*>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_non_null_xml_document_is_not_null_it_should_succeed()
-        {
-            // Arrange
-            var document = new XDocument();
-
-            // Act
-            Action act = () =>
-                document.Should().NotBeNull();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_null_xml_document_is_not_null_it_should_fail()
-        {
-            // Arrange
-            XDocument theDocument = null;
-
-            // Act
-            Action act = () =>
-                theDocument.Should().NotBeNull();
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected theDocument not to be <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_null_xml_document_is_not_null_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            XDocument theDocument = null;
-
-            // Act
-            Action act = () =>
-                theDocument.Should().NotBeNull("because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument not to be <null> because we want to test the failure message.");
-        }
-
-        #endregion
-
-        #region HaveRoot
-
-        [Fact]
-        public void When_asserting_document_has_root_element_and_it_does_it_should_succeed_and_return_it_for_chaining()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_document_has_root_element_and_it_does_it_should_succeed_and_return_it_for_chaining()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            XElement root = document.Should().HaveRoot("parent").Subject;
+                // Act
+                XElement root = document.Should().HaveRoot("parent").Subject;
 
-            // Assert
-            root.Should().BeSameAs(document.Root);
-        }
+                // Assert
+                root.Should().BeSameAs(document.Root);
+            }
 
-        [Fact]
-        public void When_asserting_document_has_root_element_but_it_does_not_it_should_fail()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_document_has_root_element_but_it_does_not_it_should_fail()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () => theDocument.Should().HaveRoot("unknown");
+                // Act
+                Action act = () => theDocument.Should().HaveRoot("unknown");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to have root element \"unknown\", but found <parent>…</parent>.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theDocument to have root element \"unknown\", but found <parent>…</parent>.");
+            }
 
-        [Fact]
-        public void When_asserting_document_has_root_element_but_it_does_not_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_document_has_root_element_but_it_does_not_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                theDocument.Should().HaveRoot("unknown", "because we want to test the failure message");
+                // Act
+                Action act = () =>
+                    theDocument.Should().HaveRoot("unknown", "because we want to test the failure message");
 
-            // Assert
-            string expectedMessage = "Expected theDocument to have root element \"unknown\"" +
-                                     " because we want to test the failure message" +
-                                    $", but found {Formatter.ToString(theDocument)}.";
+                // Assert
+                string expectedMessage = "Expected theDocument to have root element \"unknown\"" +
+                                         " because we want to test the failure message" +
+                                        $", but found {Formatter.ToString(theDocument)}.";
 
-            act.Should().Throw<XunitException>().WithMessage(expectedMessage);
-        }
+                act.Should().Throw<XunitException>().WithMessage(expectedMessage);
+            }
 
-        [Fact]
-        public void When_asserting_a_null_document_has_root_element_it_should_fail()
-        {
-            // Arrange
-            XDocument theDocument = null;
+            [Fact]
+            public void When_asserting_a_null_document_has_root_element_it_should_fail()
+            {
+                // Arrange
+                XDocument theDocument = null;
 
-            // Act
-            Action act = () => theDocument.Should().HaveRoot("unknown");
+                // Act
+                Action act = () => theDocument.Should().HaveRoot("unknown");
 
-            // Assert
-            act.Should().Throw<InvalidOperationException>().WithMessage(
-                "Cannot assert the document has a root element if the document itself is <null>.");
-        }
+                // Assert
+                act.Should().Throw<InvalidOperationException>().WithMessage(
+                    "Cannot assert the document has a root element if the document itself is <null>.");
+            }
 
-        [Fact]
-        public void When_asserting_a_document_has_a_root_element_with_a_null_name_it_should_fail()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_a_document_has_a_root_element_with_a_null_name_it_should_fail()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () => theDocument.Should().HaveRoot(null);
+                // Act
+                Action act = () => theDocument.Should().HaveRoot(null);
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot assert the document has a root element if the expected name is <null>*");
-        }
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot assert the document has a root element if the expected name is <null>*");
+            }
 
-        [Fact]
-        public void When_asserting_a_document_has_a_root_element_with_a_null_xname_it_should_fail()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_a_document_has_a_root_element_with_a_null_xname_it_should_fail()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () => theDocument.Should().HaveRoot((XName)null);
+                // Act
+                Action act = () => theDocument.Should().HaveRoot((XName)null);
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot assert the document has a root element if the expected name is <null>*");
-        }
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot assert the document has a root element if the expected name is <null>*");
+            }
 
-        [Fact]
-        public void When_asserting_document_has_root_element_with_ns_and_it_does_it_should_succeed()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent xmlns='http://www.example.com/2012/test'>
+            [Fact]
+            public void When_asserting_document_has_root_element_with_ns_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent xmlns='http://www.example.com/2012/test'>
                     <child/>
                   </parent>");
 
-            // Act
-            Action act = () =>
-                document.Should().HaveRoot(XName.Get("parent", "http://www.example.com/2012/test"));
+                // Act
+                Action act = () =>
+                    document.Should().HaveRoot(XName.Get("parent", "http://www.example.com/2012/test"));
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_asserting_document_has_root_element_with_ns_but_it_does_not_it_should_fail()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_document_has_root_element_with_ns_but_it_does_not_it_should_fail()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                theDocument.Should().HaveRoot(XName.Get("unknown", "http://www.example.com/2012/test"));
+                // Act
+                Action act = () =>
+                    theDocument.Should().HaveRoot(XName.Get("unknown", "http://www.example.com/2012/test"));
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to have root element \"{http://www.example.com/2012/test}unknown\", but found <parent>…</parent>.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theDocument to have root element \"{http://www.example.com/2012/test}unknown\", but found <parent>…</parent>.");
+            }
 
-        [Fact]
-        public void When_asserting_document_has_root_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_document_has_root_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                theDocument.Should().HaveRoot(XName.Get("unknown", "http://www.example.com/2012/test"),
-                    "because we want to test the failure message");
+                // Act
+                Action act = () =>
+                    theDocument.Should().HaveRoot(XName.Get("unknown", "http://www.example.com/2012/test"),
+                        "because we want to test the failure message");
 
-            // Assert
-            string expectedMessage =
-                "Expected theDocument to have root element \"{http://www.example.com/2012/test}unknown\"" +
-                " because we want to test the failure message" +
-               $", but found {Formatter.ToString(theDocument)}.";
+                // Assert
+                string expectedMessage =
+                    "Expected theDocument to have root element \"{http://www.example.com/2012/test}unknown\"" +
+                    " because we want to test the failure message" +
+                   $", but found {Formatter.ToString(theDocument)}.";
 
-            act.Should().Throw<XunitException>().WithMessage(expectedMessage);
+                act.Should().Throw<XunitException>().WithMessage(expectedMessage);
+            }
         }
 
-        #endregion
-
-        #region HaveElement
-
-        [Fact]
-        public void When_document_has_the_expected_child_element_it_should_not_throw_and_return_the_element_for_chaining()
+        public class HaveElement
         {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_document_has_the_expected_child_element_it_should_not_throw_and_return_the_element_for_chaining()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            XElement element = document.Should().HaveElement("child").Subject;
+                // Act
+                XElement element = document.Should().HaveElement("child").Subject;
 
-            // Assert
-            element.Should().BeSameAs(document.Element("parent").Element("child"));
-        }
+                // Assert
+                element.Should().BeSameAs(document.Element("parent").Element("child"));
+            }
 
-        [Fact]
-        public void When_asserting_document_has_root_with_child_element_but_it_does_not_it_should_fail()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_document_has_root_with_child_element_but_it_does_not_it_should_fail()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                theDocument.Should().HaveElement("unknown");
+                // Act
+                Action act = () =>
+                    theDocument.Should().HaveElement("unknown");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to have root element with child \"unknown\", but no such child element was found.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theDocument to have root element with child \"unknown\", but no such child element was found.");
+            }
 
-        [Fact]
-        public void When_asserting_document_has_root_with_child_element_but_it_does_not_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_document_has_root_with_child_element_but_it_does_not_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                theDocument.Should().HaveElement("unknown", "because we want to test the failure message");
+                // Act
+                Action act = () =>
+                    theDocument.Should().HaveElement("unknown", "because we want to test the failure message");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to have root element with child \"unknown\" because we want to test the failure message,"
-                + " but no such child element was found.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theDocument to have root element with child \"unknown\" because we want to test the failure message,"
+                    + " but no such child element was found.");
+            }
 
-        [Fact]
-        public void When_asserting_document_has_root_with_child_element_with_ns_and_it_does_it_should_succeed()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent xmlns:test='http://www.example.org/2012/test'>
+            [Fact]
+            public void When_asserting_document_has_root_with_child_element_with_ns_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent xmlns:test='http://www.example.org/2012/test'>
                     <test:child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                document.Should().HaveElement(XName.Get("child", "http://www.example.org/2012/test"));
+                // Act
+                Action act = () =>
+                    document.Should().HaveElement(XName.Get("child", "http://www.example.org/2012/test"));
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_asserting_document_has_root_with_child_element_with_ns_but_it_does_not_it_should_fail()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_document_has_root_with_child_element_with_ns_but_it_does_not_it_should_fail()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                document.Should().HaveElement(XName.Get("unknown", "http://www.example.org/2012/test"));
+                // Act
+                Action act = () =>
+                    document.Should().HaveElement(XName.Get("unknown", "http://www.example.org/2012/test"));
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected document to have root element with child \"{http://www.example.org/2012/test}unknown\","
-                + " but no such child element was found.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected document to have root element with child \"{http://www.example.org/2012/test}unknown\","
+                    + " but no such child element was found.");
+            }
 
-        [Fact]
-        public void When_asserting_document_has_root_with_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_document_has_root_with_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = XDocument.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                theDocument.Should().HaveElement(XName.Get("unknown", "http://www.example.org/2012/test"),
-                    "because we want to test the failure message");
+                // Act
+                Action act = () =>
+                    theDocument.Should().HaveElement(XName.Get("unknown", "http://www.example.org/2012/test"),
+                        "because we want to test the failure message");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to have root element with child \"{http://www.example.org/2012/test}unknown\""
-                + " because we want to test the failure message, but no such child element was found.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theDocument to have root element with child \"{http://www.example.org/2012/test}unknown\""
+                    + " because we want to test the failure message, but no such child element was found.");
+            }
 
-        [Fact]
-        public void When_asserting_document_has_root_with_child_element_with_attributes_it_should_be_possible_to_use_which_to_assert_on_the_element()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_document_has_root_with_child_element_with_attributes_it_should_be_possible_to_use_which_to_assert_on_the_element()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent>
                     <child attr='1' />
                   </parent>");
 
-            // Act
-            XElement matchedElement = document.Should().HaveElement("child").Subject;
+                // Act
+                XElement matchedElement = document.Should().HaveElement("child").Subject;
 
-            // Assert
-            matchedElement.Should().BeOfType<XElement>().And.HaveAttribute("attr", "1");
-            matchedElement.Name.Should().Be(XName.Get("child"));
-        }
+                // Assert
+                matchedElement.Should().BeOfType<XElement>().And.HaveAttribute("attr", "1");
+                matchedElement.Name.Should().Be(XName.Get("child"));
+            }
 
-        [Fact]
-        public void When_asserting_a_null_document_has_an_element_it_should_fail()
-        {
-            // Arrange
-            XDocument document = null;
-
-            // Act
-            Action act = () => document.Should().HaveElement("unknown");
-
-            // Assert
-            act.Should().Throw<InvalidOperationException>().WithMessage(
-                "Cannot assert the document has an element if the document itself is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_document_without_root_element_has_an_element_it_should_fail()
-        {
-            // Arrange
-            XDocument document = new();
-
-            // Act
-            Action act = () => document.Should().HaveElement("unknown");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected document to have root element with child \"unknown\", but it has no root element.");
-        }
-
-        [Fact]
-        public void When_asserting_a_document_has_an_element_with_a_null_name_it_should_fail()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent>
-                    <child />
-                  </parent>");
-
-            // Act
-            Action act = () => document.Should().HaveElement(null);
-
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot assert the document has an element if the expected name is <null>*");
-        }
-
-        [Fact]
-        public void When_asserting_a_document_has_an_element_with_a_null_xname_it_should_fail()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent>
-                    <child />
-                  </parent>");
-
-            // Act
-            Action act = () => document.Should().HaveElement((XName)null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>().WithMessage(
-                "Cannot assert the document has an element if the expected name is <null>*");
-        }
-
-        #endregion
-
-        #region HaveElement (with occurrence)
-
-        [Fact]
-        public void When_asserting_document_has_two_child_elements_and_it_does_it_succeeds()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent>
-                    <child />
-                    <child />
-                  </parent>");
-
-            // Act / Assert
-            document.Should().HaveElement("child", Exactly.Twice());
-        }
-
-        [Fact]
-        public void Asserting_document_null_inside_an_assertion_scope_it_checks_the_whole_assertion_scope_before_failing()
-        {
-            // Arrange
-            XDocument document = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_asserting_a_null_document_has_an_element_it_should_fail()
             {
-                using (new AssertionScope())
-                {
-                    document.Should().HaveElement("child", Exactly.Twice());
-                    document.Should().HaveElement("child", Exactly.Twice());
-                }
-            };
+                // Arrange
+                XDocument document = null;
 
-            // Assert
-            act.Should().NotThrow<NullReferenceException>();
-        }
+                // Act
+                Action act = () => document.Should().HaveElement("unknown");
 
-        [Fact]
-        public void Asserting_with_document_root_null_inside_an_assertion_scope_it_checks_the_whole_assertion_scope_before_failing()
-        {
-            // Arrange
-            XDocument document = new();
+                // Assert
+                act.Should().Throw<InvalidOperationException>().WithMessage(
+                    "Cannot assert the document has an element if the document itself is <null>.");
+            }
 
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_asserting_a_document_without_root_element_has_an_element_it_should_fail()
             {
-                using (new AssertionScope())
+                // Arrange
+                XDocument document = new();
+
+                // Act
+                Action act = () => document.Should().HaveElement("unknown");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected document to have root element with child \"unknown\", but it has no root element.");
+            }
+
+            [Fact]
+            public void When_asserting_a_document_has_an_element_with_a_null_name_it_should_fail()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent>
+                    <child />
+                  </parent>");
+
+                // Act
+                Action act = () => document.Should().HaveElement(null);
+
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot assert the document has an element if the expected name is <null>*");
+            }
+
+            [Fact]
+            public void When_asserting_a_document_has_an_element_with_a_null_xname_it_should_fail()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent>
+                    <child />
+                  </parent>");
+
+                // Act
+                Action act = () => document.Should().HaveElement((XName)null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>().WithMessage(
+                    "Cannot assert the document has an element if the expected name is <null>*");
+            }
+        }
+
+        public class HaveElementWithOccurrence
+        {
+            [Fact]
+            public void When_asserting_document_has_two_child_elements_and_it_does_it_succeeds()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent>
+                    <child />
+                    <child />
+                  </parent>");
+
+                // Act / Assert
+                document.Should().HaveElement("child", Exactly.Twice());
+            }
+
+            [Fact]
+            public void Asserting_document_null_inside_an_assertion_scope_it_checks_the_whole_assertion_scope_before_failing()
+            {
+                // Arrange
+                XDocument document = null;
+
+                // Act
+                Action act = () =>
                 {
-                    document.Should().HaveElement("child", Exactly.Twice());
-                    document.Should().HaveElement("child", Exactly.Twice());
-                }
-            };
+                    using (new AssertionScope())
+                    {
+                        document.Should().HaveElement("child", Exactly.Twice());
+                        document.Should().HaveElement("child", Exactly.Twice());
+                    }
+                };
 
-            // Assert
-            act.Should().NotThrow<NullReferenceException>();
-        }
+                // Assert
+                act.Should().NotThrow<NullReferenceException>();
+            }
 
-        [Fact]
-        public void When_asserting_document_has_two_child_elements_but_it_does_have_three_it_fails()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void Asserting_with_document_root_null_inside_an_assertion_scope_it_checks_the_whole_assertion_scope_before_failing()
+            {
+                // Arrange
+                XDocument document = new();
+
+                // Act
+                Action act = () =>
+                {
+                    using (new AssertionScope())
+                    {
+                        document.Should().HaveElement("child", Exactly.Twice());
+                        document.Should().HaveElement("child", Exactly.Twice());
+                    }
+                };
+
+                // Assert
+                act.Should().NotThrow<NullReferenceException>();
+            }
+
+            [Fact]
+            public void When_asserting_document_has_two_child_elements_but_it_does_have_three_it_fails()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent>
                     <child />
                     <child />
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () => document.Should().HaveElement("child", Exactly.Twice());
+                // Act
+                Action act = () => document.Should().HaveElement("child", Exactly.Twice());
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected document to have a root element containing a child \"child\"*exactly*2 times, but found it 3 times*");
-        }
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected document to have a root element containing a child \"child\"*exactly*2 times, but found it 3 times*");
+            }
 
-        [Fact]
-        public void Document_is_valid_and_expected_null_with_string_overload_it_fails()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void Document_is_valid_and_expected_null_with_string_overload_it_fails()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent>
                     <child />
                     <child />
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () => document.Should().HaveElement(null, Exactly.Twice());
+                // Act
+                Action act = () => document.Should().HaveElement(null, Exactly.Twice());
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot assert the document has an element if the expected name is <null>.*");
-        }
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot assert the document has an element if the expected name is <null>.*");
+            }
 
-        [Fact]
-        public void Document_is_valid_and_expected_null_with_x_name_overload_it_fails()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void Document_is_valid_and_expected_null_with_x_name_overload_it_fails()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent>
                     <child />
                     <child />
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () => document.Should().HaveElement((XName)null, Exactly.Twice());
+                // Act
+                Action act = () => document.Should().HaveElement((XName)null, Exactly.Twice());
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot assert the document has an element count if the element name is <null>.*");
-        }
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot assert the document has an element count if the element name is <null>.*");
+            }
 
-        [Fact]
-        public void Chaining_after_a_successful_occurrence_check_does_continue_the_assertion()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                @"<parent>
+            [Fact]
+            public void Chaining_after_a_successful_occurrence_check_does_continue_the_assertion()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                    @"<parent>
                     <child />
                     <child />
                     <child />
                   </parent>");
 
-            // Act / Assert
-            document.Should().HaveElement("child", AtLeast.Twice())
-                .Which.Should().NotBeNull();
-        }
+                // Act / Assert
+                document.Should().HaveElement("child", AtLeast.Twice())
+                    .Which.Should().NotBeNull();
+            }
 
-        [Fact]
-        public void Chaining_after_a_non_successful_occurrence_check_does_not_continue_the_assertion()
-        {
-            // Arrange
-            var document = XDocument.Parse(
-                 @"<parent>
+            [Fact]
+            public void Chaining_after_a_non_successful_occurrence_check_does_not_continue_the_assertion()
+            {
+                // Arrange
+                var document = XDocument.Parse(
+                     @"<parent>
                     <child />
                     <child />
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () => document.Should().HaveElement("child", Exactly.Once())
-                .Which.Should().NotBeNull();
+                // Act
+                Action act = () => document.Should().HaveElement("child", Exactly.Once())
+                    .Which.Should().NotBeNull();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected document to have a root element containing a child \"child\"*exactly*1 time, but found it 3 times.");
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected document to have a root element containing a child \"child\"*exactly*1 time, but found it 3 times.");
+            }
+
+            [Fact]
+            public void When_asserting_a_null_document_to_have_an_element_count_it_should_fail()
+            {
+                // Arrange
+                XDocument xDocument = null;
+
+                // Act
+                Action act = () => xDocument.Should().HaveElement("child", AtLeast.Once());
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Cannot assert the count if the document itself is <null>.");
+            }
         }
-
-        [Fact]
-        public void When_asserting_a_null_document_to_have_an_element_count_it_should_fail()
-        {
-            // Arrange
-            XDocument xDocument = null;
-
-            // Act
-            Action act = () => xDocument.Should().HaveElement("child", AtLeast.Once());
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Cannot assert the count if the document itself is <null>.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -8,1371 +8,1373 @@ namespace FluentAssertions.Specs.Xml
 {
     public class XElementAssertionSpecs
     {
-        #region Be / NotBe
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_equal_to_the_same_xml_element_it_should_succeed()
-        {
-            // Arrange
-            var theElement = new XElement("element");
-            var sameElement = new XElement("element");
-
-            // Act
-            Action act = () =>
-                theElement.Should().Be(sameElement);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_equal_to_a_different_xml_element_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = new XElement("element");
-            var otherElement = new XElement("other");
-
-            // Act
-            Action act = () =>
-                theElement.Should().Be(otherElement, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to be*other*because we want to test the failure message, but found *element*");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_equal_to_an_xml_element_with_a_deep_difference_it_should_fail()
-        {
-            // Arrange
-            var theElement =
-                new XElement("parent",
-                    new XElement("child",
-                        new XElement("grandChild2")));
-            var expected =
-                new XElement("parent",
-                    new XElement("child",
-                        new XElement("grandChild")));
-
-            // Act
-            Action act = () => theElement.Should().Be(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to be <parent>…</parent>, but found <parent>…</parent>.");
-        }
-
-        [Fact]
-        public void When_the_expected_element_is_null_it_fails()
-        {
-            // Arrange
-            XElement theElement = null;
-
-            // Act
-            Action act = () =>
-                theElement.Should().Be(new XElement("other"), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected theElement to be <other /> *failure message*, but found <null>.");
-        }
-
-        [Fact]
-        public void When_element_is_expected_to_equal_null_it_fails()
-        {
-            // Arrange
-            XElement theElement = new XElement("element");
-
-            // Act
-            Action act = () => theElement.Should().Be(null, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected theElement to be <null> *failure message*, but found <element />.");
-        }
-
-        [Fact]
-        public void When_both_subject_and_expected_are_null_it_succeeds()
-        {
-            // Arrange
-            XElement theElement = null;
-
-            // Act
-            Action act = () => theElement.Should().Be(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_not_equal_to_a_different_xml_element_it_should_succeed()
-        {
-            // Arrange
-            var element = new XElement("element");
-            var otherElement = new XElement("other");
-
-            // Act
-            Action act = () =>
-                element.Should().NotBe(otherElement);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_deep_xml_element_is_not_equal_to_a_different_xml_element_it_should_succeed()
-        {
-            // Arrange
-            var differentElement =
-                new XElement("parent",
-                    new XElement("child",
-                        new XElement("grandChild")));
-            var element =
-                new XElement("parent",
-                    new XElement("child",
-                        new XElement("grandChild2")));
-
-            // Act
-            Action act = () => element.Should().NotBe(differentElement);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_not_equal_to_the_same_xml_element_it_should_fail()
-        {
-            // Arrange
-            var theElement = new XElement("element");
-            var sameElement = theElement;
-
-            // Act
-            Action act = () =>
-                theElement.Should().NotBe(sameElement, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect theElement to be <element /> because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void When_an_element_is_not_supposed_to_be_null_it_succeeds()
-        {
-            // Arrange
-            XElement theElement = new XElement("element");
-
-            // Act
-            Action act = () => theElement.Should().NotBe(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_null_element_is_not_supposed_to_be_an_element_it_succeeds()
-        {
-            // Arrange
-            XElement theElement = null;
-
-            // Act
-            Action act = () => theElement.Should().NotBe(new XElement("other"));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_null_element_is_not_supposed_to_be_null_it_fails()
-        {
-            // Arrange
-            XElement theElement = null;
-
-            // Act
-            Action act = () => theElement.Should().NotBe(null, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect theElement to be <null> *failure message*.");
-        }
-
-        #endregion
-
-        #region BeNull / NotBeNull
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_null_and_it_is_it_should_succeed()
-        {
-            // Arrange
-            XElement element = null;
-
-            // Act
-            Action act = () =>
-                element.Should().BeNull();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_null_but_it_is_not_it_should_fail()
-        {
-            // Arrange
-            var theElement = new XElement("element");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeNull();
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to be <null>, but found <element />.");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_null_but_it_is_not_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = new XElement("element");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeNull("because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to be <null> because we want to test the failure message, but found <element />.");
-        }
-
-        [Fact]
-        public void When_asserting_a_non_null_xml_element_is_not_null_it_should_succeed()
-        {
-            // Arrange
-            var element = new XElement("element");
-
-            // Act
-            Action act = () =>
-                element.Should().NotBeNull();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_null_xml_element_is_not_null_it_should_fail()
-        {
-            // Arrange
-            XElement theElement = null;
-
-            // Act
-            Action act = () =>
-                theElement.Should().NotBeNull();
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected theElement not to be <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_null_xml_element_is_not_null_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            XElement theElement = null;
-
-            // Act
-            Action act = () =>
-                theElement.Should().NotBeNull("because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement not to be <null> because we want to test the failure message.");
-        }
-
-        #endregion
-
-        #region BeEquivalentTo / NotBeEquivalentTo
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_equivalent_to_the_same_xml_element_it_should_succeed()
-        {
-            // Arrange
-            var element = new XElement("element");
-            var sameXElement = element;
-
-            // Act
-            Action act = () =>
-                element.Should().BeEquivalentTo(sameXElement);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_with_same_structure_it_should_succeed()
-        {
-            // Arrange
-            var element = XElement.Parse("<parent><child /></parent>");
-            var otherXElement = XElement.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                element.Should().BeEquivalentTo(otherXElement);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_empty_xml_element_is_equivalent_to_a_different_selfclosing_xml_element_it_should_succeed()
-        {
-            // Arrange
-            var element = XElement.Parse("<parent><child></child></parent>");
-            var otherElement = XElement.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                element.Should().BeEquivalentTo(otherElement);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_selfclosing_xml_element_is_equivalent_to_a_different_empty_xml_element_it_should_succeed()
-        {
-            // Arrange
-            var element = XElement.Parse("<parent><child /></parent>");
-            var otherElement = XElement.Parse("<parent><child></child></parent>");
-
-            // Act
-            Action act = () =>
-                element.Should().BeEquivalentTo(otherElement);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_equivalent_to_a_xml_element_with_elements_missing_it_should_fail()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<parent><child /><child2 /></parent>");
-            var otherXElement = XElement.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeEquivalentTo(otherXElement);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected EndElement \"parent\" in theElement at \"/parent\", but found Element \"child2\".");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_with_extra_elements_it_should_fail()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<parent><child /></parent>");
-            var otherXElement = XElement.Parse("<parent><child /><child2 /></parent>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeEquivalentTo(otherXElement);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected Element \"child2\" in theElement at \"/parent\", but found EndElement \"parent\".");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_elements_missing_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<parent><child /><child2 /></parent>");
-            var otherXElement = XElement.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected EndElement \"parent\" in theElement at \"/parent\" because we want to test the failure message, but found Element \"child2\".");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_with_extra_elements_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<parent><child /></parent>");
-            var otherXElement = XElement.Parse("<parent><child /><child2 /></parent>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected Element \"child2\" in theElement at \"/parent\" because we want to test the failure message, but found EndElement \"parent\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_empty_xml_element_is_equivalent_to_a_different_xml_element_with_text_content_it_should_fail()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<parent><child /></parent>");
-            var otherXElement = XElement.Parse("<parent><child>text</child></parent>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected content \"text\" in theElement at \"/parent/child\" because we want to test the failure message, but found EndElement \"parent\".");
-        }
-
-        [Fact]
-        public void When_an_element_is_null_then_be_equivalent_to_null_succeeds()
-        {
-            XElement theElement = null;
-
-            // Act
-            Action act = () => theElement.Should().BeEquivalentTo(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_an_element_is_null_then_be_equivalent_to_an_element_fails()
-        {
-            XElement theElement = null;
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeEquivalentTo(new XElement("element"), "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected theElement to be equivalent to <null> *failure message*, but found \"<element />\".");
-        }
-
-        [Fact]
-        public void When_an_element_is_equivalent_to_null_it_fails()
-        {
-            XElement theElement = new XElement("element");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeEquivalentTo(null, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected theElement to be equivalent to \"<element />\" *failure message*, but found <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_elements_missing_it_should_succeed()
-        {
-            // Arrange
-            var element = XElement.Parse("<parent><child /><child2 /></parent>");
-            var otherXElement = XElement.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                element.Should().NotBeEquivalentTo(otherXElement);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_extra_elements_it_should_succeed()
-        {
-            // Arrange
-            var element = XElement.Parse("<parent><child /></parent>");
-            var otherXElement = XElement.Parse("<parent><child /><child2 /></parent>");
-
-            // Act
-            Action act = () =>
-                element.Should().NotBeEquivalentTo(otherXElement);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_structure_it_should_fail()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<parent><child /></parent>");
-            var otherXElement = XElement.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().NotBeEquivalentTo(otherXElement);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theElement to be equivalent, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_contents_but_different_ns_prefixes_it_should_fail()
-        {
-            // Arrange
-            var theElement = XElement.Parse(@"<parent xmlns:ns1=""a""><ns1:child /></parent>");
-            var otherXElement = XElement.Parse(@"<parent xmlns:ns2=""a""><ns2:child /></parent>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().NotBeEquivalentTo(otherXElement);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theElement to be equivalent, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_contents_but_extra_unused_xmlns_declaration_it_should_fail()
-        {
-            // Arrange
-            var theElement = XElement.Parse(@"<xml xmlns:ns1=""a"" />");
-            var otherXElement = XElement.Parse("<xml />");
-
-            // Act
-            Action act = () =>
-                theElement.Should().NotBeEquivalentTo(otherXElement);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theElement to be equivalent, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_the_same_xml_element_it_should_fail()
-        {
-            // Arrange
-            var theElement = new XElement("element");
-            var sameXElement = theElement;
-
-            // Act
-            Action act = () =>
-                theElement.Should().NotBeEquivalentTo(sameXElement);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theElement to be equivalent, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_structure_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<parent><child /></parent>");
-            var otherXElement = XElement.Parse("<parent><child /></parent>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().NotBeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theElement to be equivalent because we want to test the failure message, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_the_same_xml_element_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<parent><child /></parent>");
-            var sameXElement = theElement;
-
-            // Act
-            Action act = () =>
-                theElement.Should().NotBeEquivalentTo(sameXElement, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theElement to be equivalent because we want to test the failure message, but it is.");
-        }
-
-        [Fact]
-        public void
-            When_asserting_an_xml_element_is_equivalent_to_a_different_xml_element_with_different_namespace_prefix_it_should_succeed()
-        {
-            // Arrange
-            var subject = XElement.Parse("<xml xmlns=\"urn:a\"/>");
-            var expected = XElement.Parse("<a:xml xmlns:a=\"urn:a\"/>");
-
-            // Act
-            Action act = () =>
-                subject.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_a_different_xml_element_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
-        {
-            // Arrange
-            var subject = XElement.Parse("<xml xmlns:a=\"urn:a\"/>");
-            var expected = XElement.Parse("<xml/>");
-
-            // Act
-            Action act = () =>
-                subject.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_lacks_attributes_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<xml><element b=\"1\"/></xml>");
-            var expected = XElement.Parse("<xml><element a=\"b\" b=\"1\"/></xml>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected attribute \"a\" in theElement at \"/xml/element\" because we want to test the failure message, but found none.");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_extra_attributes_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<xml><element a=\"b\"/></xml>");
-            var expected = XElement.Parse("<xml><element/></xml>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect to find attribute \"a\" in theElement at \"/xml/element\" because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void
-            When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<xml><element a=\"b\"/></xml>");
-            var expected = XElement.Parse("<xml><element a=\"c\"/></xml>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected attribute \"a\" in theElement at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
-            var expected = XElement.Parse("<xml><element a=\"b\"/></xml>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect to find attribute \"ns:a\" in theElement at \"/xml/element\" because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_different_text_contents_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<xml>a</xml>");
-            var expected = XElement.Parse("<xml>b</xml>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected content to be \"b\" in theElement at \"/xml\" because we want to test the failure message, but found \"a\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_with_different_comments_it_should_succeed()
-        {
-            // Arrange
-            var subject = XElement.Parse("<xml><!--Comment--><a/></xml>");
-            var expected = XElement.Parse("<xml><a/><!--Comment--></xml>");
-
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_a_null_element_is_unexpected_equivalent_to_null_it_fails()
-        {
-            XElement theElement = null;
-
-            // Act
-            Action act = () => theElement.Should().NotBeEquivalentTo(null, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect theElement to be equivalent *failure message*, but it is.");
-        }
-
-        [Fact]
-        public void When_a_null_element_is_not_equivalent_to_an_element_it_succeeds()
-        {
-            XElement theElement = null;
-
-            // Act
-            Action act = () => theElement.Should().NotBeEquivalentTo(new XElement("element"));
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_an_element_is_not_equivalent_to_null_it_succeeds()
-        {
-            XElement theElement = new XElement("element");
-
-            // Act
-            Action act = () => theElement.Should().NotBeEquivalentTo(null);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        #endregion
-
-        #region HaveValue
-
-        [Fact]
-        public void When_asserting_element_has_a_specific_value_and_it_does_it_should_succeed()
-        {
-            // Arrange
-            var element = XElement.Parse("<user>grega</user>");
-
-            // Act
-            Action act = () =>
-                element.Should().HaveValue("grega");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_element_has_a_specific_value_but_it_has_a_different_value_it_should_throw()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<user>grega</user>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveValue("stamac");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement 'user' to have value \"stamac\", but found \"grega\".");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_a_specific_value_but_it_has_a_different_value_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse("<user>grega</user>");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveValue("stamac", "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement 'user' to have value \"stamac\" because we want to test the failure message, but found \"grega\".");
-        }
-
-        [Fact]
-        public void When_xml_element_is_null_then_have_value_should_fail()
-        {
-            XElement theElement = null;
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveValue("value", "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the element to have value \"value\" *failure message*, but theElement is <null>.");
-        }
-
-        #endregion
-
-        #region HaveAttribute
-
-        [Fact]
-        public void When_asserting_element_has_attribute_with_specific_value_and_it_does_it_should_succeed()
-        {
-            // Arrange
-            var element = XElement.Parse(@"<user name=""martin"" />");
-
-            // Act
-            Action act = () =>
-                element.Should().HaveAttribute("name", "martin");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_element_has_attribute_with_ns_and_specific_value_and_it_does_it_should_succeed()
-        {
-            // Arrange
-            var element = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-
-            // Act
-            Action act = () =>
-                element.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "martin");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail()
-        {
-            // Arrange
-            var theElement = XElement.Parse(@"<user name=""martin"" />");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute("age", "36");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to have attribute \"age\" with value \"36\", but found no such attribute in <user name=\"martin\" />");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail()
-        {
-            // Arrange
-            var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute(XName.Get("age", "http://www.example.com/2012/test"), "36");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to have attribute \"{http://www.example.com/2012/test}age\" with value \"36\","
-                + " but found no such attribute in <user xmlns:a=\"http://www.example.com/2012/test\" a:name=\"martin\" />");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse(@"<user name=""martin"" />");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute("age", "36", "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to have attribute \"age\" with value \"36\" because we want to test the failure message,"
-                + " but found no such attribute in <user name=\"martin\" />");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute(XName.Get("age", "http://www.example.com/2012/test"), "36",
-                    "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to have attribute \"{http://www.example.com/2012/test}age\" with value \"36\""
-                + " because we want to test the failure message,"
-                + " but found no such attribute in <user xmlns:a=\"http://www.example.com/2012/test\" a:name=\"martin\" />");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail()
-        {
-            // Arrange
-            var theElement = XElement.Parse(@"<user name=""martin"" />");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute("name", "dennis");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected attribute \"name\" in theElement to have value \"dennis\", but found \"martin\".");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
-        {
-            // Arrange
-            var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "dennis");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected attribute \"{http://www.example.com/2012/test}name\" in theElement to have value \"dennis\", but found \"martin\".");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse(@"<user name=""martin"" />");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute("name", "dennis", "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected attribute \"name\" in theElement to have value \"dennis\""
-                + " because we want to test the failure message, but found \"martin\".");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-
-            // Act
-            Action act = () =>
-                 theElement.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "dennis",
-                    "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected attribute \"{http://www.example.com/2012/test}name\" in theElement to have value \"dennis\""
-                + " because we want to test the failure message, but found \"martin\".");
-        }
-
-        [Fact]
-        public void When_xml_element_is_null_then_have_attribute_should_fail()
-        {
-            XElement theElement = null;
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute("name", "value", "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected attribute \"name\" in element to have value \"value\" *failure message*" +
-                    ", but theElement is <null>.");
-        }
-
-        [Fact]
-        public void When_xml_element_is_null_then_have_attribute_with_XName_should_fail()
-        {
-            XElement theElement = null;
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute((XName)"name", "value", "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected attribute \"name\" in element to have value \"value\" *failure message*" +
-                    ", but theElement is <null>.");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_an_attribute_with_a_null_name_it_should_throw()
-        {
-            XElement theElement = new XElement("element");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute(null, "value");
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("expectedName");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_an_attribute_with_a_null_XName_it_should_throw()
-        {
-            XElement theElement = new XElement("element");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute((XName)null, "value");
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("expectedName");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_an_attribute_with_an_empty_name_it_should_throw()
-        {
-            XElement theElement = new XElement("element");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute(string.Empty, "value");
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("expectedName");
-        }
-
-        #endregion
-
-        #region HaveElement
-
-        [Fact]
-        public void When_asserting_element_has_child_element_and_it_does_it_should_succeed()
-        {
-            // Arrange
-            var element = XElement.Parse(
-                @"<parent>
+        public class Be
+        {
+            [Fact]
+            public void When_asserting_an_xml_element_is_equal_to_the_same_xml_element_it_should_succeed()
+            {
+                // Arrange
+                var theElement = new XElement("element");
+                var sameElement = new XElement("element");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().Be(sameElement);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_element_is_equal_to_a_different_xml_element_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = new XElement("element");
+                var otherElement = new XElement("other");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().Be(otherElement, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to be*other*because we want to test the failure message, but found *element*");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_element_is_equal_to_an_xml_element_with_a_deep_difference_it_should_fail()
+            {
+                // Arrange
+                var theElement =
+                    new XElement("parent",
+                        new XElement("child",
+                            new XElement("grandChild2")));
+                var expected =
+                    new XElement("parent",
+                        new XElement("child",
+                            new XElement("grandChild")));
+
+                // Act
+                Action act = () => theElement.Should().Be(expected);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to be <parent>…</parent>, but found <parent>…</parent>.");
+            }
+
+            [Fact]
+            public void When_the_expected_element_is_null_it_fails()
+            {
+                // Arrange
+                XElement theElement = null;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().Be(new XElement("other"), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected theElement to be <other /> *failure message*, but found <null>.");
+            }
+
+            [Fact]
+            public void When_element_is_expected_to_equal_null_it_fails()
+            {
+                // Arrange
+                XElement theElement = new XElement("element");
+
+                // Act
+                Action act = () => theElement.Should().Be(null, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected theElement to be <null> *failure message*, but found <element />.");
+            }
+
+            [Fact]
+            public void When_both_subject_and_expected_are_null_it_succeeds()
+            {
+                // Arrange
+                XElement theElement = null;
+
+                // Act
+                Action act = () => theElement.Should().Be(null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+        }
+
+        public class NotBe
+        {
+            [Fact]
+            public void When_asserting_an_xml_element_is_not_equal_to_a_different_xml_element_it_should_succeed()
+            {
+                // Arrange
+                var element = new XElement("element");
+                var otherElement = new XElement("other");
+
+                // Act
+                Action act = () =>
+                    element.Should().NotBe(otherElement);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_deep_xml_element_is_not_equal_to_a_different_xml_element_it_should_succeed()
+            {
+                // Arrange
+                var differentElement =
+                    new XElement("parent",
+                        new XElement("child",
+                            new XElement("grandChild")));
+                var element =
+                    new XElement("parent",
+                        new XElement("child",
+                            new XElement("grandChild2")));
+
+                // Act
+                Action act = () => element.Should().NotBe(differentElement);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_element_is_not_equal_to_the_same_xml_element_it_should_fail()
+            {
+                // Arrange
+                var theElement = new XElement("element");
+                var sameElement = theElement;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().NotBe(sameElement, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect theElement to be <element /> because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void When_an_element_is_not_supposed_to_be_null_it_succeeds()
+            {
+                // Arrange
+                XElement theElement = new XElement("element");
+
+                // Act
+                Action act = () => theElement.Should().NotBe(null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_null_element_is_not_supposed_to_be_an_element_it_succeeds()
+            {
+                // Arrange
+                XElement theElement = null;
+
+                // Act
+                Action act = () => theElement.Should().NotBe(new XElement("other"));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_a_null_element_is_not_supposed_to_be_null_it_fails()
+            {
+                // Arrange
+                XElement theElement = null;
+
+                // Act
+                Action act = () => theElement.Should().NotBe(null, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect theElement to be <null> *failure message*.");
+            }
+        }
+
+        public class BeNull
+        {
+            [Fact]
+            public void When_asserting_an_xml_element_is_null_and_it_is_it_should_succeed()
+            {
+                // Arrange
+                XElement element = null;
+
+                // Act
+                Action act = () =>
+                    element.Should().BeNull();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_element_is_null_but_it_is_not_it_should_fail()
+            {
+                // Arrange
+                var theElement = new XElement("element");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeNull();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to be <null>, but found <element />.");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_element_is_null_but_it_is_not_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = new XElement("element");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeNull("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to be <null> because we want to test the failure message, but found <element />.");
+            }
+        }
+
+        public class NotBeNull
+        {
+            [Fact]
+            public void When_asserting_a_non_null_xml_element_is_not_null_it_should_succeed()
+            {
+                // Arrange
+                var element = new XElement("element");
+
+                // Act
+                Action act = () =>
+                    element.Should().NotBeNull();
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_null_xml_element_is_not_null_it_should_fail()
+            {
+                // Arrange
+                XElement theElement = null;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().NotBeNull();
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage("Expected theElement not to be <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_a_null_xml_element_is_not_null_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                XElement theElement = null;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().NotBeNull("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement not to be <null> because we want to test the failure message.");
+            }
+        }
+
+        public class BeEquivalentTo
+        {
+            [Fact]
+            public void When_asserting_a_xml_element_is_equivalent_to_the_same_xml_element_it_should_succeed()
+            {
+                // Arrange
+                var element = new XElement("element");
+                var sameXElement = element;
+
+                // Act
+                Action act = () =>
+                    element.Should().BeEquivalentTo(sameXElement);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_with_same_structure_it_should_succeed()
+            {
+                // Arrange
+                var element = XElement.Parse("<parent><child /></parent>");
+                var otherXElement = XElement.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    element.Should().BeEquivalentTo(otherXElement);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_empty_xml_element_is_equivalent_to_a_different_selfclosing_xml_element_it_should_succeed()
+            {
+                // Arrange
+                var element = XElement.Parse("<parent><child></child></parent>");
+                var otherElement = XElement.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    element.Should().BeEquivalentTo(otherElement);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_selfclosing_xml_element_is_equivalent_to_a_different_empty_xml_element_it_should_succeed()
+            {
+                // Arrange
+                var element = XElement.Parse("<parent><child /></parent>");
+                var otherElement = XElement.Parse("<parent><child></child></parent>");
+
+                // Act
+                Action act = () =>
+                    element.Should().BeEquivalentTo(otherElement);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_element_is_equivalent_to_a_xml_element_with_elements_missing_it_should_fail()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<parent><child /><child2 /></parent>");
+                var otherXElement = XElement.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeEquivalentTo(otherXElement);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected EndElement \"parent\" in theElement at \"/parent\", but found Element \"child2\".");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_with_extra_elements_it_should_fail()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<parent><child /></parent>");
+                var otherXElement = XElement.Parse("<parent><child /><child2 /></parent>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeEquivalentTo(otherXElement);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected Element \"child2\" in theElement at \"/parent\", but found EndElement \"parent\".");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_elements_missing_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<parent><child /><child2 /></parent>");
+                var otherXElement = XElement.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected EndElement \"parent\" in theElement at \"/parent\" because we want to test the failure message, but found Element \"child2\".");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_with_extra_elements_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<parent><child /></parent>");
+                var otherXElement = XElement.Parse("<parent><child /><child2 /></parent>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected Element \"child2\" in theElement at \"/parent\" because we want to test the failure message, but found EndElement \"parent\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_empty_xml_element_is_equivalent_to_a_different_xml_element_with_text_content_it_should_fail()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<parent><child /></parent>");
+                var otherXElement = XElement.Parse("<parent><child>text</child></parent>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected content \"text\" in theElement at \"/parent/child\" because we want to test the failure message, but found EndElement \"parent\".");
+            }
+
+            [Fact]
+            public void When_an_element_is_null_then_be_equivalent_to_null_succeeds()
+            {
+                XElement theElement = null;
+
+                // Act
+                Action act = () => theElement.Should().BeEquivalentTo(null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_an_element_is_null_then_be_equivalent_to_an_element_fails()
+            {
+                XElement theElement = null;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeEquivalentTo(new XElement("element"), "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected theElement to be equivalent to <null> *failure message*, but found \"<element />\".");
+            }
+
+            [Fact]
+            public void When_an_element_is_equivalent_to_null_it_fails()
+            {
+                XElement theElement = new XElement("element");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeEquivalentTo(null, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected theElement to be equivalent to \"<element />\" *failure message*, but found <null>.");
+            }
+
+            [Fact]
+            public void
+               When_asserting_an_xml_element_is_equivalent_to_a_different_xml_element_with_different_namespace_prefix_it_should_succeed()
+            {
+                // Arrange
+                var subject = XElement.Parse("<xml xmlns=\"urn:a\"/>");
+                var expected = XElement.Parse("<a:xml xmlns:a=\"urn:a\"/>");
+
+                // Act
+                Action act = () =>
+                    subject.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_element_is_equivalent_to_a_different_xml_element_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
+            {
+                // Arrange
+                var subject = XElement.Parse("<xml xmlns:a=\"urn:a\"/>");
+                var expected = XElement.Parse("<xml/>");
+
+                // Act
+                Action act = () =>
+                    subject.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_lacks_attributes_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<xml><element b=\"1\"/></xml>");
+                var expected = XElement.Parse("<xml><element a=\"b\" b=\"1\"/></xml>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected attribute \"a\" in theElement at \"/xml/element\" because we want to test the failure message, but found none.");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_extra_attributes_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<xml><element a=\"b\"/></xml>");
+                var expected = XElement.Parse("<xml><element/></xml>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect to find attribute \"a\" in theElement at \"/xml/element\" because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void
+                When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<xml><element a=\"b\"/></xml>");
+                var expected = XElement.Parse("<xml><element a=\"c\"/></xml>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected attribute \"a\" in theElement at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
+                var expected = XElement.Parse("<xml><element a=\"b\"/></xml>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect to find attribute \"ns:a\" in theElement at \"/xml/element\" because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_different_text_contents_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<xml>a</xml>");
+                var expected = XElement.Parse("<xml>b</xml>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected content to be \"b\" in theElement at \"/xml\" because we want to test the failure message, but found \"a\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_with_different_comments_it_should_succeed()
+            {
+                // Arrange
+                var subject = XElement.Parse("<xml><!--Comment--><a/></xml>");
+                var expected = XElement.Parse("<xml><a/><!--Comment--></xml>");
+
+                // Act
+                Action act = () => subject.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+        }
+
+        public class NotBeEquivalentTo
+        {
+            [Fact]
+            public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_elements_missing_it_should_succeed()
+            {
+                // Arrange
+                var element = XElement.Parse("<parent><child /><child2 /></parent>");
+                var otherXElement = XElement.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    element.Should().NotBeEquivalentTo(otherXElement);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_extra_elements_it_should_succeed()
+            {
+                // Arrange
+                var element = XElement.Parse("<parent><child /></parent>");
+                var otherXElement = XElement.Parse("<parent><child /><child2 /></parent>");
+
+                // Act
+                Action act = () =>
+                    element.Should().NotBeEquivalentTo(otherXElement);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_structure_it_should_fail()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<parent><child /></parent>");
+                var otherXElement = XElement.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().NotBeEquivalentTo(otherXElement);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theElement to be equivalent, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_contents_but_different_ns_prefixes_it_should_fail()
+            {
+                // Arrange
+                var theElement = XElement.Parse(@"<parent xmlns:ns1=""a""><ns1:child /></parent>");
+                var otherXElement = XElement.Parse(@"<parent xmlns:ns2=""a""><ns2:child /></parent>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().NotBeEquivalentTo(otherXElement);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theElement to be equivalent, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_contents_but_extra_unused_xmlns_declaration_it_should_fail()
+            {
+                // Arrange
+                var theElement = XElement.Parse(@"<xml xmlns:ns1=""a"" />");
+                var otherXElement = XElement.Parse("<xml />");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().NotBeEquivalentTo(otherXElement);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theElement to be equivalent, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_element_is_not_equivalent_to_the_same_xml_element_it_should_fail()
+            {
+                // Arrange
+                var theElement = new XElement("element");
+                var sameXElement = theElement;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().NotBeEquivalentTo(sameXElement);
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theElement to be equivalent, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_structure_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<parent><child /></parent>");
+                var otherXElement = XElement.Parse("<parent><child /></parent>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().NotBeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theElement to be equivalent because we want to test the failure message, but it is.");
+            }
+
+            [Fact]
+            public void When_asserting_a_xml_element_is_not_equivalent_to_the_same_xml_element_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<parent><child /></parent>");
+                var sameXElement = theElement;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().NotBeEquivalentTo(sameXElement, "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Did not expect theElement to be equivalent because we want to test the failure message, but it is.");
+            }
+
+            [Fact]
+            public void When_a_null_element_is_unexpected_equivalent_to_null_it_fails()
+            {
+                XElement theElement = null;
+
+                // Act
+                Action act = () => theElement.Should().NotBeEquivalentTo(null, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Did not expect theElement to be equivalent *failure message*, but it is.");
+            }
+
+            [Fact]
+            public void When_a_null_element_is_not_equivalent_to_an_element_it_succeeds()
+            {
+                XElement theElement = null;
+
+                // Act
+                Action act = () => theElement.Should().NotBeEquivalentTo(new XElement("element"));
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_an_element_is_not_equivalent_to_null_it_succeeds()
+            {
+                XElement theElement = new XElement("element");
+
+                // Act
+                Action act = () => theElement.Should().NotBeEquivalentTo(null);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+        }
+
+        public class HaveValue
+        {
+            [Fact]
+            public void When_asserting_element_has_a_specific_value_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var element = XElement.Parse("<user>grega</user>");
+
+                // Act
+                Action act = () =>
+                    element.Should().HaveValue("grega");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_element_has_a_specific_value_but_it_has_a_different_value_it_should_throw()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<user>grega</user>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveValue("stamac");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement 'user' to have value \"stamac\", but found \"grega\".");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_a_specific_value_but_it_has_a_different_value_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse("<user>grega</user>");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveValue("stamac", "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement 'user' to have value \"stamac\" because we want to test the failure message, but found \"grega\".");
+            }
+
+            [Fact]
+            public void When_xml_element_is_null_then_have_value_should_fail()
+            {
+                XElement theElement = null;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveValue("value", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected the element to have value \"value\" *failure message*, but theElement is <null>.");
+            }
+        }
+
+        public class HaveAttribute
+        {
+            [Fact]
+            public void When_asserting_element_has_attribute_with_specific_value_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var element = XElement.Parse(@"<user name=""martin"" />");
+
+                // Act
+                Action act = () =>
+                    element.Should().HaveAttribute("name", "martin");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_element_has_attribute_with_ns_and_specific_value_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var element = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+
+                // Act
+                Action act = () =>
+                    element.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "martin");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail()
+            {
+                // Arrange
+                var theElement = XElement.Parse(@"<user name=""martin"" />");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute("age", "36");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to have attribute \"age\" with value \"36\", but found no such attribute in <user name=\"martin\" />");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail()
+            {
+                // Arrange
+                var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute(XName.Get("age", "http://www.example.com/2012/test"), "36");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to have attribute \"{http://www.example.com/2012/test}age\" with value \"36\","
+                    + " but found no such attribute in <user xmlns:a=\"http://www.example.com/2012/test\" a:name=\"martin\" />");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse(@"<user name=""martin"" />");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute("age", "36", "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to have attribute \"age\" with value \"36\" because we want to test the failure message,"
+                    + " but found no such attribute in <user name=\"martin\" />");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute(XName.Get("age", "http://www.example.com/2012/test"), "36",
+                        "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to have attribute \"{http://www.example.com/2012/test}age\" with value \"36\""
+                    + " because we want to test the failure message,"
+                    + " but found no such attribute in <user xmlns:a=\"http://www.example.com/2012/test\" a:name=\"martin\" />");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail()
+            {
+                // Arrange
+                var theElement = XElement.Parse(@"<user name=""martin"" />");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute("name", "dennis");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected attribute \"name\" in theElement to have value \"dennis\", but found \"martin\".");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
+            {
+                // Arrange
+                var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "dennis");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected attribute \"{http://www.example.com/2012/test}name\" in theElement to have value \"dennis\", but found \"martin\".");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse(@"<user name=""martin"" />");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute("name", "dennis", "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected attribute \"name\" in theElement to have value \"dennis\""
+                    + " because we want to test the failure message, but found \"martin\".");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+
+                // Act
+                Action act = () =>
+                     theElement.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "dennis",
+                        "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected attribute \"{http://www.example.com/2012/test}name\" in theElement to have value \"dennis\""
+                    + " because we want to test the failure message, but found \"martin\".");
+            }
+
+            [Fact]
+            public void When_xml_element_is_null_then_have_attribute_should_fail()
+            {
+                XElement theElement = null;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute("name", "value", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected attribute \"name\" in element to have value \"value\" *failure message*" +
+                        ", but theElement is <null>.");
+            }
+
+            [Fact]
+            public void When_xml_element_is_null_then_have_attribute_with_XName_should_fail()
+            {
+                XElement theElement = null;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute((XName)"name", "value", "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected attribute \"name\" in element to have value \"value\" *failure message*" +
+                        ", but theElement is <null>.");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_an_attribute_with_a_null_name_it_should_throw()
+            {
+                XElement theElement = new XElement("element");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute(null, "value");
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("expectedName");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_an_attribute_with_a_null_XName_it_should_throw()
+            {
+                XElement theElement = new XElement("element");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute((XName)null, "value");
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("expectedName");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_an_attribute_with_an_empty_name_it_should_throw()
+            {
+                XElement theElement = new XElement("element");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute(string.Empty, "value");
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("expectedName");
+            }
+        }
+
+        public class HaveElement
+        {
+            [Fact]
+            public void When_asserting_element_has_child_element_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var element = XElement.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                element.Should().HaveElement("child");
+                // Act
+                Action act = () =>
+                    element.Should().HaveElement("child");
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_asserting_element_has_child_element_with_ns_and_it_does_it_should_succeed()
-        {
-            // Arrange
-            var element = XElement.Parse(
-                @"<parent xmlns:c='http://www.example.com/2012/test'>
+            [Fact]
+            public void When_asserting_element_has_child_element_with_ns_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var element = XElement.Parse(
+                    @"<parent xmlns:c='http://www.example.com/2012/test'>
                     <c:child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                element.Should().HaveElement(XName.Get("child", "http://www.example.com/2012/test"));
+                // Act
+                Action act = () =>
+                    element.Should().HaveElement(XName.Get("child", "http://www.example.com/2012/test"));
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_asserting_element_has_child_element_but_it_does_not_it_should_fail()
-        {
-            // Arrange
-            var theElement = XElement.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_element_has_child_element_but_it_does_not_it_should_fail()
+            {
+                // Arrange
+                var theElement = XElement.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                theElement.Should().HaveElement("unknown");
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveElement("unknown");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to have child element \"unknown\", but no such child element was found.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to have child element \"unknown\", but no such child element was found.");
+            }
 
-        [Fact]
-        public void When_asserting_element_has_child_element_with_ns_but_it_does_not_it_should_fail()
-        {
-            // Arrange
-            var theElement = XElement.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_element_has_child_element_with_ns_but_it_does_not_it_should_fail()
+            {
+                // Arrange
+                var theElement = XElement.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                theElement.Should().HaveElement(XName.Get("unknown", "http://www.example.com/2012/test"));
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveElement(XName.Get("unknown", "http://www.example.com/2012/test"));
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to have child element \"{{http://www.example.com/2012/test}}unknown\", but no such child element was found.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to have child element \"{{http://www.example.com/2012/test}}unknown\", but no such child element was found.");
+            }
 
-        [Fact]
-        public void When_asserting_element_has_child_element_but_it_does_not_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_element_has_child_element_but_it_does_not_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                theElement.Should().HaveElement("unknown", "because we want to test the failure message");
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveElement("unknown", "because we want to test the failure message");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to have child element \"unknown\" because we want to test the failure message,"
-                + " but no such child element was found.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to have child element \"unknown\" because we want to test the failure message,"
+                    + " but no such child element was found.");
+            }
 
-        [Fact]
-        public void When_asserting_element_has_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = XElement.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_element_has_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theElement = XElement.Parse(
+                    @"<parent>
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () =>
-                theElement.Should().HaveElement(XName.Get("unknown", "http://www.example.com/2012/test"),
-                    "because we want to test the failure message");
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveElement(XName.Get("unknown", "http://www.example.com/2012/test"),
+                        "because we want to test the failure message");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to have child element \"{{http://www.example.com/2012/test}}unknown\""
-                + " because we want to test the failure message, but no such child element was found.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to have child element \"{{http://www.example.com/2012/test}}unknown\""
+                    + " because we want to test the failure message, but no such child element was found.");
+            }
 
-        [Fact]
-        public void When_asserting_element_has_child_element_it_should_return_the_matched_element_in_the_which_property()
-        {
-            // Arrange
-            var element = XElement.Parse(
-                @"<parent>
+            [Fact]
+            public void When_asserting_element_has_child_element_it_should_return_the_matched_element_in_the_which_property()
+            {
+                // Arrange
+                var element = XElement.Parse(
+                    @"<parent>
                     <child attr='1' />
                   </parent>");
 
-            // Act
-            var matchedElement = element.Should().HaveElement("child").Subject;
+                // Act
+                var matchedElement = element.Should().HaveElement("child").Subject;
 
-            // Assert
-            matchedElement.Should().BeOfType<XElement>()
-                .And.HaveAttribute("attr", "1");
-            matchedElement.Name.Should().Be(XName.Get("child"));
-        }
+                // Assert
+                matchedElement.Should().BeOfType<XElement>()
+                    .And.HaveAttribute("attr", "1");
+                matchedElement.Name.Should().Be(XName.Get("child"));
+            }
 
-        [Fact]
-        public void When_asserting_element_has_a_child_element_with_a_null_name_it_should_throw()
-        {
-            XElement theElement = new XElement("element");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveElement(null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("expected");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_a_child_element_with_a_null_XName_it_should_throw()
-        {
-            XElement theElement = new XElement("element");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveElement((XName)null);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("expected");
-        }
-
-        [Fact]
-        public void When_asserting_element_has_a_child_element_with_an_empty_name_it_should_throw()
-        {
-            XElement theElement = new XElement("element");
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveElement(string.Empty);
-
-            // Assert
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("expected");
-        }
-
-        #endregion
-
-        #region HaveElement (with occurrence)
-
-        [Fact]
-        public void Element_has_two_child_elements_and_it_expected_does_it_succeeds()
-        {
-            // Arrange
-            var element = XElement.Parse(
-                @"<parent>
-                    <child />
-                    <child />
-                  </parent>");
-
-            // Act / Assert
-            element.Should().HaveElement("child", Exactly.Twice());
-        }
-
-        [Fact]
-        public void Asserting_element_inside_an_assertion_scope_it_checks_the_whole_assertion_scope_before_failing()
-        {
-            // Arrange
-            XElement element = null;
-
-            // Act
-            Action act = () =>
+            [Fact]
+            public void When_asserting_element_has_a_child_element_with_a_null_name_it_should_throw()
             {
-                using (new AssertionScope())
+                XElement theElement = new XElement("element");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveElement(null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("expected");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_a_child_element_with_a_null_XName_it_should_throw()
+            {
+                XElement theElement = new XElement("element");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveElement((XName)null);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("expected");
+            }
+
+            [Fact]
+            public void When_asserting_element_has_a_child_element_with_an_empty_name_it_should_throw()
+            {
+                XElement theElement = new XElement("element");
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveElement(string.Empty);
+
+                // Assert
+                act.Should().ThrowExactly<ArgumentNullException>()
+                    .WithParameterName("expected");
+            }
+        }
+
+        public class HaveElementWithOccurrence
+        {
+            [Fact]
+            public void Element_has_two_child_elements_and_it_expected_does_it_succeeds()
+            {
+                // Arrange
+                var element = XElement.Parse(
+                    @"<parent>
+                    <child />
+                    <child />
+                  </parent>");
+
+                // Act / Assert
+                element.Should().HaveElement("child", Exactly.Twice());
+            }
+
+            [Fact]
+            public void Asserting_element_inside_an_assertion_scope_it_checks_the_whole_assertion_scope_before_failing()
+            {
+                // Arrange
+                XElement element = null;
+
+                // Act
+                Action act = () =>
                 {
-                    element.Should().HaveElement("child", Exactly.Twice());
-                    element.Should().HaveElement("child", Exactly.Twice());
-                }
-            };
+                    using (new AssertionScope())
+                    {
+                        element.Should().HaveElement("child", Exactly.Twice());
+                        element.Should().HaveElement("child", Exactly.Twice());
+                    }
+                };
 
-            // Assert
-            act.Should().NotThrow<NullReferenceException>();
-        }
+                // Assert
+                act.Should().NotThrow<NullReferenceException>();
+            }
 
-        [Fact]
-        public void Element_has_two_child_elements_and_three_expected_it_fails()
-        {
-            // Arrange
-            var element = XElement.Parse(
-                @"<parent>
+            [Fact]
+            public void Element_has_two_child_elements_and_three_expected_it_fails()
+            {
+                // Arrange
+                var element = XElement.Parse(
+                    @"<parent>
                     <child />
                     <child />
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () => element.Should().HaveElement("child", Exactly.Twice());
+                // Act
+                Action act = () => element.Should().HaveElement("child", Exactly.Twice());
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected element to have an element \"child\"*exactly*2 times, but found it 3 times.");
-        }
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected element to have an element \"child\"*exactly*2 times, but found it 3 times.");
+            }
 
-        [Fact]
-        public void Element_is_valid_and_expected_null_with_string_overload_it_fails()
-        {
-            // Arrange
-            var element = XElement.Parse(
-                @"<parent>
+            [Fact]
+            public void Element_is_valid_and_expected_null_with_string_overload_it_fails()
+            {
+                // Arrange
+                var element = XElement.Parse(
+                    @"<parent>
                     <child />
                     <child />
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () => element.Should().HaveElement(null, Exactly.Twice());
+                // Act
+                Action act = () => element.Should().HaveElement(null, Exactly.Twice());
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot assert the element has an element if the expected name is <null>.*");
-        }
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot assert the element has an element if the expected name is <null>.*");
+            }
 
-        [Fact]
-        public void Element_is_valid_and_expected_null_with_x_name_overload_it_fails()
-        {
-            // Arrange
-            var element = XElement.Parse(
-                @"<parent>
+            [Fact]
+            public void Element_is_valid_and_expected_null_with_x_name_overload_it_fails()
+            {
+                // Arrange
+                var element = XElement.Parse(
+                    @"<parent>
                     <child />
                     <child />
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () => element.Should().HaveElement((XName)null, Exactly.Twice());
+                // Act
+                Action act = () => element.Should().HaveElement((XName)null, Exactly.Twice());
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot assert the element has an element count if the element name is <null>.*");
-        }
+                // Assert
+                act.Should().Throw<ArgumentNullException>().WithMessage(
+                    "Cannot assert the element has an element count if the element name is <null>.*");
+            }
 
-        [Fact]
-        public void Chaining_after_a_successful_occurrence_check_does_continue_the_assertion()
-        {
-            // Arrange
-            var element = XElement.Parse(
-                @"<parent>
+            [Fact]
+            public void Chaining_after_a_successful_occurrence_check_does_continue_the_assertion()
+            {
+                // Arrange
+                var element = XElement.Parse(
+                    @"<parent>
                     <child />
                     <child />
                     <child />
                   </parent>");
 
-            // Act / Assert
-            element.Should().HaveElement("child", AtLeast.Twice())
-                .Which.Should().NotBeNull();
-        }
+                // Act / Assert
+                element.Should().HaveElement("child", AtLeast.Twice())
+                    .Which.Should().NotBeNull();
+            }
 
-        [Fact]
-        public void Chaining_after_a_non_successful_occurrence_check_does_not_continue_the_assertion()
-        {
-            // Arrange
-            var element = XElement.Parse(
-                @"<parent>
+            [Fact]
+            public void Chaining_after_a_non_successful_occurrence_check_does_not_continue_the_assertion()
+            {
+                // Arrange
+                var element = XElement.Parse(
+                    @"<parent>
                     <child />
                     <child />
                     <child />
                   </parent>");
 
-            // Act
-            Action act = () => element.Should().HaveElement("child", Exactly.Once())
-                .Which.Should().NotBeNull();
+                // Act
+                Action act = () => element.Should().HaveElement("child", Exactly.Once())
+                    .Which.Should().NotBeNull();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected element to have an element \"child\"*exactly*1 time, but found it 3 times.");
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected element to have an element \"child\"*exactly*1 time, but found it 3 times.");
+            }
+
+            [Fact]
+            public void Null_element_is_expected_to_have_an_element_count_it_should_fail()
+            {
+                // Arrange
+                XElement xElement = null;
+
+                // Act
+                Action act = () => xElement.Should().HaveElement("child", AtLeast.Once());
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected* to have an element with count of *, but the element itself is <null>.");
+            }
         }
-
-        [Fact]
-        public void Null_element_is_expected_to_have_an_element_count_it_should_fail()
-        {
-            // Arrange
-            XElement xElement = null;
-
-            // Act
-            Action act = () => xElement.Should().HaveElement("child", AtLeast.Once());
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected* to have an element with count of *, but the element itself is <null>.");
-        }
-
-        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
@@ -7,455 +7,457 @@ namespace FluentAssertions.Specs.Xml
 {
     public class XmlElementAssertionSpecs
     {
-        #region BeEquivalent
-
-        [Fact]
-        public void When_asserting_xml_element_is_equivalent_to_another_xml_element_with_same_contents_it_should_succeed()
+        public class BeEquivalent
         {
-            // This test is basically just a check that the BeEquivalent method
-            // is available on XmlElementAssertions, which it should be if
-            // XmlElementAssertions inherits XmlNodeAssertions.
+            [Fact]
+            public void When_asserting_xml_element_is_equivalent_to_another_xml_element_with_same_contents_it_should_succeed()
+            {
+                // This test is basically just a check that the BeEquivalent method
+                // is available on XmlElementAssertions, which it should be if
+                // XmlElementAssertions inherits XmlNodeAssertions.
 
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml("<user>grega</user>");
-            var element = xmlDoc.DocumentElement;
-            var expectedDoc = new XmlDocument();
-            expectedDoc.LoadXml("<user>grega</user>");
-            var expected = expectedDoc.DocumentElement;
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml("<user>grega</user>");
+                var element = xmlDoc.DocumentElement;
+                var expectedDoc = new XmlDocument();
+                expectedDoc.LoadXml("<user>grega</user>");
+                var expected = expectedDoc.DocumentElement;
 
-            // Act
-            Action act = () =>
-                element.Should().BeEquivalentTo(expected);
+                // Act
+                Action act = () =>
+                    element.Should().BeEquivalentTo(expected);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
         }
 
-        #endregion
-
-        #region HaveValue
-
-        [Fact]
-        public void When_asserting_xml_element_has_a_specific_inner_text_and_it_does_it_should_succeed()
+        public class HaveInnerText
         {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml("<user>grega</user>");
-            var element = xmlDoc.DocumentElement;
+            [Fact]
+            public void When_asserting_xml_element_has_a_specific_inner_text_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml("<user>grega</user>");
+                var element = xmlDoc.DocumentElement;
 
-            // Act
-            Action act = () =>
-                element.Should().HaveInnerText("grega");
+                // Act
+                Action act = () =>
+                    element.Should().HaveInnerText("grega");
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_xml_element_has_a_specific_inner_text_but_it_has_a_different_inner_text_it_should_throw()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml("<user>grega</user>");
+                var element = xmlDoc.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    element.Should().HaveInnerText("stamac");
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void
+                When_asserting_xml_element_has_a_specific_inner_text_but_it_has_a_different_inner_text_it_should_throw_with_descriptive_message()
+            {
+                // Arrange
+                var document = new XmlDocument();
+                document.LoadXml("<user>grega</user>");
+                var theElement = document.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveInnerText("stamac", "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to have value \"stamac\" because we want to test the failure message, but found \"grega\".");
+            }
         }
 
-        [Fact]
-        public void When_asserting_xml_element_has_a_specific_inner_text_but_it_has_a_different_inner_text_it_should_throw()
+        public class HaveAttribute
         {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml("<user>grega</user>");
-            var element = xmlDoc.DocumentElement;
+            [Fact]
+            public void When_asserting_xml_element_has_attribute_with_specific_value_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(@"<user name=""martin"" />");
+                var element = xmlDoc.DocumentElement;
 
-            // Act
-            Action act = () =>
-                element.Should().HaveInnerText("stamac");
+                // Act
+                Action act = () =>
+                    element.Should().HaveAttribute("name", "martin");
 
-            // Assert
-            act.Should().Throw<XunitException>();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(@"<user name=""martin"" />");
+                var element = xmlDoc.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    element.Should().HaveAttribute("age", "36");
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void
+                When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var document = new XmlDocument();
+                document.LoadXml(@"<user name=""martin"" />");
+                var theElement = document.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute("age", "36", "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected theElement to have attribute \"age\" with value \"36\"" +
+                                 " because we want to test the failure message" +
+                                 ", but found no such attribute in <user name=\"martin\"*");
+            }
+
+            [Fact]
+            public void
+                When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(@"<user name=""martin"" />");
+                var element = xmlDoc.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    element.Should().HaveAttribute("name", "dennis");
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void
+                When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var document = new XmlDocument();
+                document.LoadXml(@"<user name=""martin"" />");
+                var theElement = document.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttribute("name", "dennis", "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected attribute \"name\" in theElement to have value \"dennis\"" +
+                                 " because we want to test the failure message" +
+                                 ", but found \"martin\".");
+            }
         }
 
-        [Fact]
-        public void
-            When_asserting_xml_element_has_a_specific_inner_text_but_it_has_a_different_inner_text_it_should_throw_with_descriptive_message()
+        public class HaveAttributeWithNamespace
         {
-            // Arrange
-            var document = new XmlDocument();
-            document.LoadXml("<user>grega</user>");
-            var theElement = document.DocumentElement;
+            [Fact]
+            public void When_asserting_xml_element_has_attribute_with_ns_and_specific_value_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+                var element = xmlDoc.DocumentElement;
 
-            // Act
-            Action act = () =>
-                theElement.Should().HaveInnerText("stamac", "because we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    element.Should().HaveAttributeWithNamespace("name", "http://www.example.com/2012/test", "martin");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to have value \"stamac\" because we want to test the failure message, but found \"grega\".");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void
+                    When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+                var element = xmlDoc.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    element.Should().HaveAttributeWithNamespace("age", "http://www.example.com/2012/test", "36");
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void
+                    When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var document = new XmlDocument();
+                document.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+                var theElement = document.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttributeWithNamespace("age", "http://www.example.com/2012/test", "36",
+                        "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected theElement to have attribute \"{http://www.example.com/2012/test}age\" with value \"36\"" +
+                        " because we want to test the failure message" +
+                        ", but found no such attribute in <user xmlns:a=\"http:…");
+            }
+
+            [Fact]
+            public void
+                    When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+                var element = xmlDoc.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    element.Should().HaveAttributeWithNamespace("name", "http://www.example.com/2012/test", "dennis");
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void
+                        When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var document = new XmlDocument();
+                document.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+                var theElement = document.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveAttributeWithNamespace("name", "http://www.example.com/2012/test", "dennis",
+                        "because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected attribute \"{http://www.example.com/2012/test}name\" in theElement to have value \"dennis\"" +
+                        " because we want to test the failure message" +
+                        ", but found \"martin\".");
+            }
         }
 
-        #endregion
-
-        #region HaveAttribute
-
-        [Fact]
-        public void When_asserting_xml_element_has_attribute_with_specific_value_and_it_does_it_should_succeed()
+        public class HaveElement
         {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
-
-            // Act
-            Action act = () =>
-                element.Should().HaveAttribute("name", "martin");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_xml_element_has_attribute_with_ns_and_specific_value_and_it_does_it_should_succeed()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
-
-            // Act
-            Action act = () =>
-                element.Should().HaveAttributeWithNamespace("name", "http://www.example.com/2012/test", "martin");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
-
-            // Act
-            Action act = () =>
-                element.Should().HaveAttribute("age", "36");
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void
-            When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
-
-            // Act
-            Action act = () =>
-                element.Should().HaveAttributeWithNamespace("age", "http://www.example.com/2012/test", "36");
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void
-            When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var document = new XmlDocument();
-            document.LoadXml(@"<user name=""martin"" />");
-            var theElement = document.DocumentElement;
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute("age", "36", "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected theElement to have attribute \"age\" with value \"36\"" +
-                             " because we want to test the failure message" +
-                             ", but found no such attribute in <user name=\"martin\"*");
-        }
-
-        [Fact]
-        public void
-            When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var document = new XmlDocument();
-            document.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-            var theElement = document.DocumentElement;
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttributeWithNamespace("age", "http://www.example.com/2012/test", "36",
-                    "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected theElement to have attribute \"{http://www.example.com/2012/test}age\" with value \"36\"" +
-                    " because we want to test the failure message" +
-                    ", but found no such attribute in <user xmlns:a=\"http:…");
-        }
-
-        [Fact]
-        public void
-            When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
-
-            // Act
-            Action act = () =>
-                element.Should().HaveAttribute("name", "dennis");
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void
-            When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
-
-            // Act
-            Action act = () =>
-                element.Should().HaveAttributeWithNamespace("name", "http://www.example.com/2012/test", "dennis");
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void
-            When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var document = new XmlDocument();
-            document.LoadXml(@"<user name=""martin"" />");
-            var theElement = document.DocumentElement;
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute("name", "dennis", "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected attribute \"name\" in theElement to have value \"dennis\"" +
-                             " because we want to test the failure message" +
-                             ", but found \"martin\".");
-        }
-
-        [Fact]
-        public void
-            When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var document = new XmlDocument();
-            document.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-            var theElement = document.DocumentElement;
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveAttributeWithNamespace("name", "http://www.example.com/2012/test", "dennis",
-                    "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected attribute \"{http://www.example.com/2012/test}name\" in theElement to have value \"dennis\"" +
-                    " because we want to test the failure message" +
-                    ", but found \"martin\".");
-        }
-
-        #endregion
-
-        #region HaveElement
-
-        [Fact]
-        public void When_asserting_xml_element_has_child_element_and_it_does_it_should_succeed()
-        {
-            // Arrange
-            var xml = new XmlDocument();
-            xml.LoadXml(
-                @"<parent>
+            [Fact]
+            public void When_asserting_xml_element_has_child_element_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var xml = new XmlDocument();
+                xml.LoadXml(
+                    @"<parent>
                     <child />
                   </parent>");
-            var element = xml.DocumentElement;
+                var element = xml.DocumentElement;
 
-            // Act
-            Action act = () =>
-                element.Should().HaveElement("child");
+                // Act
+                Action act = () =>
+                    element.Should().HaveElement("child");
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_asserting_xml_element_has_child_element_with_ns_and_it_does_it_should_succeed()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
-                @"<parent xmlns:c='http://www.example.com/2012/test'>
-                    <c:child />
-                  </parent>");
-            var element = xmlDoc.DocumentElement;
-
-            // Act
-            Action act = () =>
-                element.Should().HaveElementWithNamespace("child", "http://www.example.com/2012/test");
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_xml_element_has_child_element_but_it_does_not_it_should_fail()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
-                @"<parent>
+            [Fact]
+            public void When_asserting_xml_element_has_child_element_but_it_does_not_it_should_fail()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(
+                    @"<parent>
                     <child />
                   </parent>");
-            var element = xmlDoc.DocumentElement;
+                var element = xmlDoc.DocumentElement;
 
-            // Act
-            Action act = () =>
-                element.Should().HaveElement("unknown");
+                // Act
+                Action act = () =>
+                    element.Should().HaveElement("unknown");
 
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
 
-        [Fact]
-        public void When_asserting_xml_element_has_child_element_with_ns_but_it_does_not_it_should_fail()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
-                @"<parent>
+            [Fact]
+            public void When_asserting_xml_element_has_child_element_but_it_does_not_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var document = new XmlDocument();
+                document.LoadXml(
+                    @"<parent>
                     <child />
                   </parent>");
-            var element = xmlDoc.DocumentElement;
+                var theElement = document.DocumentElement;
 
-            // Act
-            Action act = () =>
-                element.Should().HaveElementWithNamespace("unknown", "http://www.example.com/2012/test");
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveElement("unknown", "because we want to test the failure message");
 
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to have child element \"unknown\""
+                    + " because we want to test the failure message"
+                    + ", but no such child element was found.");
+            }
 
-        [Fact]
-        public void When_asserting_xml_element_has_child_element_but_it_does_not_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var document = new XmlDocument();
-            document.LoadXml(
-                @"<parent>
-                    <child />
-                  </parent>");
-            var theElement = document.DocumentElement;
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveElement("unknown", "because we want to test the failure message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to have child element \"unknown\""
-                + " because we want to test the failure message"
-                + ", but no such child element was found.");
-        }
-
-        [Fact]
-        public void When_asserting_xml_element_has_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var document = new XmlDocument();
-            document.LoadXml(
-                @"<parent>
-                    <child />
-                  </parent>");
-            var theElement = document.DocumentElement;
-
-            // Act
-            Action act = () =>
-                theElement.Should().HaveElementWithNamespace("unknown", "http://www.example.com/2012/test",
-                    "because we want to test the failure message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to have child element \"{{http://www.example.com/2012/test}}unknown\""
-                + " because we want to test the failure message"
-                + ", but no such child element was found.");
-        }
-
-        [Fact]
-        public void When_asserting_xml_element_has_child_element_it_should_return_the_matched_element_in_the_which_property()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
-                @"<parent>
+            [Fact]
+            public void When_asserting_xml_element_has_child_element_it_should_return_the_matched_element_in_the_which_property()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(
+                    @"<parent>
                     <child attr='1' />
                   </parent>");
-            var element = xmlDoc.DocumentElement;
+                var element = xmlDoc.DocumentElement;
 
-            // Act
-            var matchedElement = element.Should().HaveElement("child").Subject;
+                // Act
+                var matchedElement = element.Should().HaveElement("child").Subject;
 
-            // Assert
-            matchedElement.Should().BeOfType<XmlElement>()
-                .And.HaveAttribute("attr", "1");
-            matchedElement.Name.Should().Be("child");
-        }
+                // Assert
+                matchedElement.Should().BeOfType<XmlElement>()
+                    .And.HaveAttribute("attr", "1");
+                matchedElement.Name.Should().Be("child");
+            }
 
-        [Fact]
-        public void When_asserting_xml_element_with_ns_has_child_element_and_it_does_it_should_succeed()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
-                @"<parent xmlns=""test"">
+            [Fact]
+            public void When_asserting_xml_element_with_ns_has_child_element_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(
+                    @"<parent xmlns=""test"">
                     <child>value</child>
                 </parent>");
-            var element = xmlDoc.DocumentElement;
+                var element = xmlDoc.DocumentElement;
 
-            // Act
-            Action act = () =>
-                element.Should().HaveElement("child");
+                // Act
+                Action act = () =>
+                    element.Should().HaveElement("child");
 
-            // Assert
-            act.Should().NotThrow();
-        }
+                // Assert
+                act.Should().NotThrow();
+            }
 
-        [Fact]
-        public void When_asserting_xml_element_has_child_element_and_it_does_with_ns_it_should_succeed2()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
-                @"<parent>
+            [Fact]
+            public void When_asserting_xml_element_has_child_element_and_it_does_with_ns_it_should_succeed2()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(
+                    @"<parent>
                     <child xmlns=""test"">value</child>
                 </parent>");
-            var element = xmlDoc.DocumentElement;
+                var element = xmlDoc.DocumentElement;
 
-            // Act
-            Action act = () =>
-                element.Should().HaveElement("child");
+                // Act
+                Action act = () =>
+                    element.Should().HaveElement("child");
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
         }
 
-        #endregion
+        public class HaveElementWithNamespace
+        {
+            [Fact]
+            public void When_asserting_xml_element_has_child_element_with_ns_and_it_does_it_should_succeed()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(
+                    @"<parent xmlns:c='http://www.example.com/2012/test'>
+                    <c:child />
+                  </parent>");
+                var element = xmlDoc.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    element.Should().HaveElementWithNamespace("child", "http://www.example.com/2012/test");
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_xml_element_has_child_element_with_ns_but_it_does_not_it_should_fail()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(
+                    @"<parent>
+                    <child />
+                  </parent>");
+                var element = xmlDoc.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    element.Should().HaveElementWithNamespace("unknown", "http://www.example.com/2012/test");
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_xml_element_has_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var document = new XmlDocument();
+                document.LoadXml(
+                    @"<parent>
+                    <child />
+                  </parent>");
+                var theElement = document.DocumentElement;
+
+                // Act
+                Action act = () =>
+                    theElement.Should().HaveElementWithNamespace("unknown", "http://www.example.com/2012/test",
+                        "because we want to test the failure message");
+
+                // Assert
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected theElement to have child element \"{{http://www.example.com/2012/test}}unknown\""
+                    + " because we want to test the failure message"
+                    + ", but no such child element was found.");
+            }
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Xml/XmlNodeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlNodeAssertionSpecs.cs
@@ -7,549 +7,552 @@ namespace FluentAssertions.Specs.Xml
 {
     public class XmlNodeAssertionSpecs
     {
-        #region BeSameAs / NotBeSameAs
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_the_same_as_the_same_xml_node_it_should_succeed()
+        public class BeSameAs
         {
-            // Arrange
-            var doc = new XmlDocument();
+            [Fact]
+            public void When_asserting_an_xml_node_is_the_same_as_the_same_xml_node_it_should_succeed()
+            {
+                // Arrange
+                var doc = new XmlDocument();
 
-            // Act
-            Action act = () =>
-                doc.Should().BeSameAs(doc);
+                // Act
+                Action act = () =>
+                    doc.Should().BeSameAs(doc);
 
-            // Assert
-            act.Should().NotThrow();
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_same_as_a_different_xml_node_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<doc/>");
+                var otherNode = new XmlDocument();
+                otherNode.LoadXml("<otherDoc/>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeSameAs(otherNode, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected theDocument to refer to <otherDoc /> because we want to test the failure message, but found <doc />.");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_same_as_a_different_xml_node_it_should_fail_with_descriptive_message_and_truncate_xml()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<doc>Some very long text that should be truncated.</doc>");
+                var otherNode = new XmlDocument();
+                otherNode.LoadXml("<otherDoc/>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeSameAs(otherNode, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected theDocument to refer to <otherDoc /> because we want to test the failure message, but found <doc>Some very long….");
+            }
+
+            [Fact]
+            public void When_asserting_the_equality_of_an_xml_node_but_is_null_it_should_throw_appropriately()
+            {
+                // Arrange
+                XmlDocument theDocument = null;
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml/>");
+
+                // Act
+                Action act = () => theDocument.Should().BeSameAs(expected);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected theDocument to refer to *xml*, but found <null>.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_an_xml_node_is_same_as_a_different_xml_node_it_should_fail_with_descriptive_message()
+        public class BeNull
         {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<doc/>");
-            var otherNode = new XmlDocument();
-            otherNode.LoadXml("<otherDoc/>");
+            [Fact]
+            public void When_asserting_an_xml_node_is_null_and_it_is_it_should_succeed()
+            {
+                // Arrange
+                XmlNode node = null;
 
-            // Act
-            Action act = () =>
-                theDocument.Should().BeSameAs(otherNode, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    node.Should().BeNull();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected theDocument to refer to <otherDoc /> because we want to test the failure message, but found <doc />.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_null_but_it_is_not_it_should_fail()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml("<xml/>");
+
+                // Act
+                Action act = () =>
+                    xmlDoc.Should().BeNull();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_null_but_it_is_not_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml/>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeNull("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected theDocument to be <null> because we want to test the failure message," +
+                                 " but found <xml />.");
+            }
         }
 
-        [Fact]
-        public void When_asserting_an_xml_node_is_same_as_a_different_xml_node_it_should_fail_with_descriptive_message_and_truncate_xml()
+        public class NotBeNull
         {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<doc>Some very long text that should be truncated.</doc>");
-            var otherNode = new XmlDocument();
-            otherNode.LoadXml("<otherDoc/>");
+            [Fact]
+            public void When_asserting_a_non_null_xml_node_is_not_null_it_should_succeed()
+            {
+                // Arrange
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml("<xml/>");
 
-            // Act
-            Action act = () =>
-                theDocument.Should().BeSameAs(otherNode, "we want to test the failure {0}", "message");
+                // Act
+                Action act = () =>
+                    xmlDoc.Should().NotBeNull();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected theDocument to refer to <otherDoc /> because we want to test the failure message, but found <doc>Some very long….");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_a_null_xml_node_is_not_null_it_should_fail()
+            {
+                // Arrange
+                XmlDocument xmlDoc = null;
+
+                // Act
+                Action act = () =>
+                    xmlDoc.Should().NotBeNull();
+
+                // Assert
+                act.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_asserting_a_null_xml_node_is_not_null_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                XmlDocument theDocument = null;
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().NotBeNull("because we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected theDocument not to be <null> because we want to test the failure message.");
+            }
+        }
+        
+        public class BeEquivalentTo
+        {
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_the_same_xml_node_it_should_succeed()
+            {
+                // Arrange
+                var doc = new XmlDocument();
+
+                // Act
+                Action act = () =>
+                    doc.Should().BeEquivalentTo(doc);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_with_other_contents_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<subject/>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<expected/>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected local name of element in theDocument at \"/\" to be \"expected\" because we want to test the failure message, but found \"subject\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_with_same_contents_it_should_succeed()
+            {
+                // Arrange
+                var xml = "<root><a xmlns=\"urn:a\"><data>data</data></a><ns:b xmlns:ns=\"urn:b\"><data>data</data></ns:b></root>";
+
+                var subject = new XmlDocument();
+                subject.LoadXml(xml);
+                var expected = new XmlDocument();
+                expected.LoadXml(xml);
+
+                // Act
+                Action act = () =>
+                    subject.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_assertion_an_xml_node_is_equivalent_to_a_different_xml_node_with_different_namespace_prefix_it_should_succeed()
+            {
+                // Arrange
+                var subject = new XmlDocument();
+                subject.LoadXml("<xml xmlns=\"urn:a\"/>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<a:xml xmlns:a=\"urn:a\"/>");
+
+                // Act
+                Action act = () =>
+                    subject.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
+            {
+                // Arrange
+                var subject = new XmlDocument();
+                subject.LoadXml("<xml xmlns:a=\"urn:a\"/>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml/>");
+
+                // Act
+                Action act = () =>
+                    subject.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_a_different_XmlDocument_which_differs_on_a_child_element_name_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml><child><subject/></child></xml>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml><child><expected/></child></xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected local name of element in theDocument at \"/xml/child\" to be \"expected\" because we want to test the failure message, but found \"subject\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_on_a_child_element_namespace_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<a:xml xmlns:a=\"urn:a\"><a:child><a:data/></a:child></a:xml>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml xmlns=\"urn:a\"><child><data xmlns=\"urn:b\"/></child></xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected namespace of element \"data\" in theDocument at \"/xml/child\" to be \"urn:b\" because we want to test the failure message, but found \"urn:a\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_an_unexpected_node_type_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml>data</xml>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml><data/></xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected Element \"data\" in theDocument at \"/xml\" because we want to test the failure message, but found content \"data\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_extra_elements_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml><data/></xml>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml/>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected end of document in theDocument because we want to test the failure message, but found \"data\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_elements_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml/>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml><data/></xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected \"data\" in theDocument because we want to test the failure message, but found end of document.");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_attributes_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml><element b=\"1\"/></xml>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml><element a=\"b\" b=\"1\"/></xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message, but found none.");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_extra_attributes_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml><element a=\"b\"/></xml>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml><element/></xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Did not expect to find attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml><element a=\"b\"/></xml>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml><element a=\"c\"/></xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected attribute \"a\" in theDocument at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml><element a=\"b\"/></xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Did not expect to find attribute \"ns:a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_text_contents_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml>a</xml>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml>b</xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Expected content to be \"b\" in theDocument at \"/xml\" because we want to test the failure message, but found \"a\".");
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_with_different_comments_it_should_succeed()
+            {
+                // Arrange
+                var subject = new XmlDocument();
+                subject.LoadXml("<xml><!--Comment--><a/></xml>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml><a/><!--Comment--></xml>");
+
+                // Act
+                Action act = () => subject.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_with_different_insignificant_whitespace_it_should_succeed()
+            {
+                // Arrange
+                var subject = new XmlDocument() { PreserveWhitespace = true };
+                subject.LoadXml("<xml><a><b/></a></xml>");
+                var expected = new XmlDocument() { PreserveWhitespace = true };
+                expected.LoadXml("<xml>\n<a>   \n   <b/></a>\r\n</xml>");
+
+                // Act
+                Action act = () => subject.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_equivalent_that_contains_an_unsupported_node_it_should_throw_a_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml><![CDATA[Text]]></xml>");
+
+                // Act
+                Action act = () => theDocument.Should().BeEquivalentTo(theDocument);
+
+                // Assert
+                act.Should().Throw<NotSupportedException>()
+                    .WithMessage("CDATA found at /xml is not supported for equivalency comparison.");
+            }
+
+            [Fact]
+            public void
+                When_asserting_an_xml_node_is_equivalent_that_isnt_it_should_include_the_right_location_in_the_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml><a/><b c=\"d\"/></xml>");
+                var expected = new XmlDocument();
+                expected.LoadXml("<xml><a/><b c=\"e\"/></xml>");
+
+                // Act
+                Action act = () => theDocument.Should().BeEquivalentTo(expected);
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage("Expected attribute \"c\" in theDocument at \"/xml/b\" to have value \"e\", but found \"d\".");
+            }
         }
 
-        [Fact]
-        public void When_asserting_the_equality_of_an_xml_node_but_is_null_it_should_throw_appropriately()
+        public class NotBeEquivalentTo
         {
-            // Arrange
-            XmlDocument theDocument = null;
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml/>");
+            [Fact]
+            public void When_asserting_an_xml_node_is_not_equivalent_to_som_other_xml_node_it_should_succeed()
+            {
+                // Arrange
+                var subject = new XmlDocument();
+                subject.LoadXml("<xml>a</xml>");
+                var unexpected = new XmlDocument();
+                unexpected.LoadXml("<xml>b</xml>");
 
-            // Act
-            Action act = () => theDocument.Should().BeSameAs(expected);
+                // Act
+                Action act = () =>
+                    subject.Should().NotBeEquivalentTo(unexpected);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected theDocument to refer to *xml*, but found <null>.");
+                // Assert
+                act.Should().NotThrow();
+            }
+
+            [Fact]
+            public void When_asserting_an_xml_node_is_not_equivalent_to_same_xml_node_it_should_fail_with_descriptive_message()
+            {
+                // Arrange
+                var theDocument = new XmlDocument();
+                theDocument.LoadXml("<xml>a</xml>");
+
+                // Act
+                Action act = () =>
+                    theDocument.Should().NotBeEquivalentTo(theDocument, "we want to test the failure {0}", "message");
+
+                // Assert
+                act.Should().Throw<XunitException>()
+                    .WithMessage(
+                        "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
+            }
         }
-
-        #endregion
-
-        #region BeNull / NotBeNull
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_null_and_it_is_it_should_succeed()
-        {
-            // Arrange
-            XmlNode node = null;
-
-            // Act
-            Action act = () =>
-                node.Should().BeNull();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_null_but_it_is_not_it_should_fail()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml("<xml/>");
-
-            // Act
-            Action act = () =>
-                xmlDoc.Should().BeNull();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_null_but_it_is_not_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml/>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeNull("because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected theDocument to be <null> because we want to test the failure message," +
-                             " but found <xml />.");
-        }
-
-        [Fact]
-        public void When_asserting_a_non_null_xml_node_is_not_null_it_should_succeed()
-        {
-            // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml("<xml/>");
-
-            // Act
-            Action act = () =>
-                xmlDoc.Should().NotBeNull();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_a_null_xml_node_is_not_null_it_should_fail()
-        {
-            // Arrange
-            XmlDocument xmlDoc = null;
-
-            // Act
-            Action act = () =>
-                xmlDoc.Should().NotBeNull();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_asserting_a_null_xml_node_is_not_null_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            XmlDocument theDocument = null;
-
-            // Act
-            Action act = () =>
-                theDocument.Should().NotBeNull("because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected theDocument not to be <null> because we want to test the failure message.");
-        }
-
-        #endregion
-
-        #region BeEquivalentTo / NotBeEquivalentTo
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_the_same_xml_node_it_should_succeed()
-        {
-            // Arrange
-            var doc = new XmlDocument();
-
-            // Act
-            Action act = () =>
-                doc.Should().BeEquivalentTo(doc);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_not_equivalent_to_som_other_xml_node_it_should_succeed()
-        {
-            // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml>a</xml>");
-            var unexpected = new XmlDocument();
-            unexpected.LoadXml("<xml>b</xml>");
-
-            // Act
-            Action act = () =>
-                subject.Should().NotBeEquivalentTo(unexpected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_not_equivalent_to_same_xml_node_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml>a</xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().NotBeEquivalentTo(theDocument, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_with_other_contents_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<subject/>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<expected/>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected local name of element in theDocument at \"/\" to be \"expected\" because we want to test the failure message, but found \"subject\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_with_same_contents_it_should_succeed()
-        {
-            // Arrange
-            var xml = "<root><a xmlns=\"urn:a\"><data>data</data></a><ns:b xmlns:ns=\"urn:b\"><data>data</data></ns:b></root>";
-
-            var subject = new XmlDocument();
-            subject.LoadXml(xml);
-            var expected = new XmlDocument();
-            expected.LoadXml(xml);
-
-            // Act
-            Action act = () =>
-                subject.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_assertion_an_xml_node_is_equivalent_to_a_different_xml_node_with_different_namespace_prefix_it_should_succeed()
-        {
-            // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml xmlns=\"urn:a\"/>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<a:xml xmlns:a=\"urn:a\"/>");
-
-            // Act
-            Action act = () =>
-                subject.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
-        {
-            // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml xmlns:a=\"urn:a\"/>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml/>");
-
-            // Act
-            Action act = () =>
-                subject.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_a_different_XmlDocument_which_differs_on_a_child_element_name_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><child><subject/></child></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><child><expected/></child></xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected local name of element in theDocument at \"/xml/child\" to be \"expected\" because we want to test the failure message, but found \"subject\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_on_a_child_element_namespace_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<a:xml xmlns:a=\"urn:a\"><a:child><a:data/></a:child></a:xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml xmlns=\"urn:a\"><child><data xmlns=\"urn:b\"/></child></xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected namespace of element \"data\" in theDocument at \"/xml/child\" to be \"urn:b\" because we want to test the failure message, but found \"urn:a\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_an_unexpected_node_type_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml>data</xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><data/></xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected Element \"data\" in theDocument at \"/xml\" because we want to test the failure message, but found content \"data\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_extra_elements_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><data/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml/>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected end of document in theDocument because we want to test the failure message, but found \"data\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_elements_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml/>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><data/></xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected \"data\" in theDocument because we want to test the failure message, but found end of document.");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_attributes_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><element b=\"1\"/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><element a=\"b\" b=\"1\"/></xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message, but found none.");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_extra_attributes_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><element a=\"b\"/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><element/></xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Did not expect to find attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><element a=\"b\"/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><element a=\"c\"/></xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected attribute \"a\" in theDocument at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><element a=\"b\"/></xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Did not expect to find attribute \"ns:a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_text_contents_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml>a</xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml>b</xml>");
-
-            // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected content to be \"b\" in theDocument at \"/xml\" because we want to test the failure message, but found \"a\".");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_with_different_comments_it_should_succeed()
-        {
-            // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml><!--Comment--><a/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><a/><!--Comment--></xml>");
-
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_with_different_insignificant_whitespace_it_should_succeed()
-        {
-            // Arrange
-            var subject = new XmlDocument() { PreserveWhitespace = true };
-            subject.LoadXml("<xml><a><b/></a></xml>");
-            var expected = new XmlDocument() { PreserveWhitespace = true };
-            expected.LoadXml("<xml>\n<a>   \n   <b/></a>\r\n</xml>");
-
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_that_contains_an_unsupported_node_it_should_throw_a_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><![CDATA[Text]]></xml>");
-
-            // Act
-            Action act = () => theDocument.Should().BeEquivalentTo(theDocument);
-
-            // Assert
-            act.Should().Throw<NotSupportedException>()
-                .WithMessage("CDATA found at /xml is not supported for equivalency comparison.");
-        }
-
-        [Fact]
-        public void
-            When_asserting_an_xml_node_is_equivalent_that_isnt_it_should_include_the_right_location_in_the_descriptive_message()
-        {
-            // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><a/><b c=\"d\"/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><a/><b c=\"e\"/></xml>");
-
-            // Act
-            Action act = () => theDocument.Should().BeEquivalentTo(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected attribute \"c\" in theDocument at \"/xml/b\" to have value \"e\", but found \"d\".");
-        }
-
-        #endregion
     }
 }


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).