### PR TITLE
Fix the failure message for occurrence regex

### DIFF
--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -507,8 +507,9 @@ namespace FluentAssertions.Primitives
                     .ForConstraint(occurrenceConstraint, actual)
                     .UsingLineBreaks
                     .BecauseOf(because, becauseArgs)
-                    .FailWith($"Expected {{context:string}} to match regex {{0}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
-                        regexStr);
+                    .FailWith($"Expected {{context:string}} {{0}} to match regex {{1}} {{expectedOccurrence}}{{reason}}, " +
+                        $"but found it {actual.Times()}.",
+                        Subject, regexStr);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
@@ -225,7 +225,7 @@ namespace FluentAssertions.Specs.Primitives
 
                 // Assert
                 act.Should().Throw<XunitException>()
-                    .WithMessage($"Expected subject to match regex*\"Lorem.*\" exactly 2 times, but found it 1 time.");
+                    .WithMessage($"Expected subject*Lorem*to match regex*\"Lorem.*\" exactly 2 times, but found it 1 time*");
             }
 
             [Fact]
@@ -252,7 +252,7 @@ namespace FluentAssertions.Specs.Primitives
 
                 // Assert
                 act.Should().Throw<XunitException>()
-                    .WithMessage($"Expected subject to match regex*\"a\" exactly 0 times, but found it 1 time.");
+                    .WithMessage($"Expected subject*a*to match regex*\"a\" exactly 0 times, but found it 1 time*");
             }
 
             [Fact]
@@ -305,7 +305,7 @@ namespace FluentAssertions.Specs.Primitives
 
                 // Assert
                 act.Should().Throw<XunitException>()
-                    .WithMessage($"Expected subject to match regex* at least 1 time, but found it 0 times.*");
+                    .WithMessage($"Expected subject*to match regex* at least 1 time, but found it 0 times*");
             }
 
             [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,6 +16,9 @@ sidebar:
 * Add `For`/`Exclude` to allow exclusion of members inside a collection - [#1782](https://github.com/fluentassertions/fluentassertions/pull/1782)
 * Added overload for `HaveElement` for `XDocument` and `XElement` to assert on number of XML nodes - [#1880](https://github.com/fluentassertions/fluentassertions/pull/1880)
 
+### Fixes
+* Fix the failure message for regex matches (occurrence overload) to include the missing subject - [#1913](https://github.com/fluentassertions/fluentassertions/pull/1913)
+
 ## 6.6.0
 
 ### What's New
@@ -31,8 +34,6 @@ sidebar:
 * Ensure `ExcludingMissingMembers` doesn't undo usage of `WithMapping` in `BeEquivalentTo` - [#1838](https://github.com/fluentassertions/fluentassertions/pull/1838)
 * Better handling of NaN in various numeric assertions - [#1822](https://github.com/fluentassertions/fluentassertions/pull/1822) & [#1867](https://github.com/fluentassertions/fluentassertions/pull/1867)
 * `WithMapping` in `BeEquivalentTo` now also works when the root is a collection - [#1858](https://github.com/fluentassertions/fluentassertions/pull/1858)
-
-### Fixes (Extensibility)
 
 ## 6.5.1
 


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

In my daily work, I was really pissed about the fact, that I have forgotten to include the actual subject in the failure message.
This PR fixes my own fault. :)