### PR TITLE
Fix `CA1062`

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -3035,6 +3035,7 @@ namespace FluentAssertions.Collections
         protected void AssertCollectionEndsWith<TActual, TExpectation>(IEnumerable<TActual> actual, ICollection<TExpectation> expected, Func<TActual, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(equalityComparison, nameof(equalityComparison));
+            Guard.ThrowIfArgumentIsNull(expected, nameof(expected));
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -3057,6 +3058,7 @@ namespace FluentAssertions.Collections
         protected void AssertCollectionStartsWith<TActual, TExpectation>(IEnumerable<TActual> actualItems, ICollection<TExpectation> expected, Func<TActual, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(equalityComparison, nameof(equalityComparison));
+            Guard.ThrowIfArgumentIsNull(expected, nameof(expected));
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -1,4 +1,5 @@
 using System;
+using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency
@@ -12,6 +13,8 @@ namespace FluentAssertions.Equivalency
 
         public void AssertEquality(Comparands comparands, EquivalencyValidationContext context)
         {
+            Guard.ThrowIfArgumentIsNull(context, nameof(context));
+
             using var scope = new AssertionScope();
 
             scope.AssumeSingleCaller();
@@ -28,6 +31,9 @@ namespace FluentAssertions.Equivalency
 
         public void RecursivelyAssertEquality(Comparands comparands, IEquivalencyValidationContext context)
         {
+            Guard.ThrowIfArgumentIsNull(comparands, nameof(comparands));
+            Guard.ThrowIfArgumentIsNull(context, nameof(context));
+
             var scope = AssertionScope.Current;
 
             if (ShouldCompareMembersThisDeep(context.CurrentNode, context.Options, scope))

--- a/Src/FluentAssertions/Equivalency/Tracing/Tracer.cs
+++ b/Src/FluentAssertions/Equivalency/Tracing/Tracer.cs
@@ -1,4 +1,5 @@
 using System;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency.Tracing
 {
@@ -37,6 +38,8 @@ namespace FluentAssertions.Equivalency.Tracing
         /// </remarks>
         public IDisposable WriteBlock(GetTraceMessage getTraceMessage)
         {
+            Guard.ThrowIfArgumentIsNull(getTraceMessage, nameof(getTraceMessage));
+
             if (traceWriter is not null)
             {
                 return traceWriter.AddBlock(getTraceMessage(currentNode));

--- a/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions.Common;
 using static System.FormattableString;
 
 namespace FluentAssertions.Formatting
@@ -19,6 +20,10 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+            Guard.ThrowIfArgumentIsNull(formatChild, nameof(formatChild));
+
             var exception = (AggregateException)value;
             if (exception.InnerExceptions.Count == 1)
             {

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -35,6 +35,8 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+
             MethodInfo method = GetFormatter(value);
 
             object[] parameters = new[] { value, formattedGraph };

--- a/Src/FluentAssertions/Formatting/ByteValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ByteValueFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
@@ -18,6 +19,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             formattedGraph.AddFragment("0x" + ((byte)value).ToString("X2", CultureInfo.InvariantCulture));
         }
     }

--- a/Src/FluentAssertions/Formatting/DateOnlyValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateOnlyValueFormatter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using FluentAssertions.Common;
 
 #if NET6_0_OR_GREATER
 
@@ -21,6 +22,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             var dateOnly = (DateOnly)value;
             formattedGraph.AddFragment(dateOnly.ToString("<yyyy-MM-dd>", CultureInfo.InvariantCulture));
         }

--- a/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
@@ -20,6 +20,10 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+            Guard.ThrowIfArgumentIsNull(formatChild, nameof(formatChild));
+
             DateTimeOffset dateTimeOffset;
             bool significantOffset = false;
 

--- a/Src/FluentAssertions/Formatting/DecimalValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DecimalValueFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
@@ -18,6 +19,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             formattedGraph.AddFragment(((decimal)value).ToString(CultureInfo.InvariantCulture) + "M");
         }
     }

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -28,6 +28,11 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+            Guard.ThrowIfArgumentIsNull(context, nameof(context));
+            Guard.ThrowIfArgumentIsNull(formatChild, nameof(formatChild));
+
             if (value.GetType() == typeof(object))
             {
                 formattedGraph.AddFragment($"System.Object (HashCode={value.GetHashCode()})");
@@ -96,7 +101,12 @@ namespace FluentAssertions.Formatting
         /// <param name="type">The <see cref="System.Type"/> of the object being formatted.</param>
         /// <returns>The name to be displayed for <paramref name="type"/>.</returns>
         /// <remarks>The default is <see cref="System.Type.FullName"/>.</remarks>
-        protected virtual string TypeDisplayName(Type type) => type.FullName;
+        protected virtual string TypeDisplayName(Type type)
+        {
+            Guard.ThrowIfArgumentIsNull(type, nameof(type));
+
+            return type.FullName;
+        }
 
         private static void WriteMemberValueTextFor(object value, MemberInfo member, FormattedObjectGraph formattedGraph, FormatChild formatChild)
         {

--- a/Src/FluentAssertions/Formatting/DictionaryValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DictionaryValueFormatter.cs
@@ -29,6 +29,11 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+            Guard.ThrowIfArgumentIsNull(context, nameof(context));
+            Guard.ThrowIfArgumentIsNull(formatChild, nameof(formatChild));
+
             int startCount = formattedGraph.LineCount;
             IEnumerable<KeyValuePair<object, object>> collection = AsEnumerable((IDictionary)value);
 

--- a/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
@@ -19,6 +20,8 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             formattedGraph.AddFragment(Format(value));
         }
 

--- a/Src/FluentAssertions/Formatting/EnumValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumValueFormatter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
@@ -20,6 +21,9 @@ namespace FluentAssertions.Formatting
         /// <inheritdoc />
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             string typePart = value.GetType().Name;
             string namePart = value.ToString().Replace(", ", "|", StringComparison.Ordinal);
             string valuePart = Convert.ToDecimal(value, CultureInfo.InvariantCulture)

--- a/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
@@ -29,6 +29,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+            Guard.ThrowIfArgumentIsNull(formatChild, nameof(formatChild));
+
             int startCount = formattedGraph.LineCount;
             IEnumerable<object> collection = ((IEnumerable)value).Cast<object>();
 

--- a/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions.Common;
 using static System.FormattableString;
 
 namespace FluentAssertions.Formatting
@@ -19,6 +20,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             var exception = (Exception)value;
 
             formattedGraph.AddFragment(Invariant($"{exception.GetType().FullName} with message \"{exception.Message}\""));

--- a/Src/FluentAssertions/Formatting/ExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExpressionValueFormatter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
@@ -19,6 +20,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             formattedGraph.AddFragment(value.ToString().Replace(" = ", " == ", StringComparison.Ordinal));
         }
     }

--- a/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
@@ -21,6 +22,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             var timeSpan = (TimeSpan)value;
 
             if (timeSpan == TimeSpan.MinValue)

--- a/Src/FluentAssertions/Formatting/UInt16ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/UInt16ValueFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
@@ -18,6 +19,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             formattedGraph.AddFragment(((ushort)value).ToString(CultureInfo.InvariantCulture) + "us");
         }
     }

--- a/Src/FluentAssertions/Formatting/UInt32ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/UInt32ValueFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
@@ -18,6 +19,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             formattedGraph.AddFragment(((uint)value).ToString(CultureInfo.InvariantCulture) + "u");
         }
     }

--- a/Src/FluentAssertions/Formatting/UInt64ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/UInt64ValueFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
@@ -18,6 +19,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             formattedGraph.AddFragment(((ulong)value).ToString(CultureInfo.InvariantCulture) + "UL");
         }
     }

--- a/Src/FluentAssertions/Formatting/XAttributeValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XAttributeValueFormatter.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
@@ -18,6 +19,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             formattedGraph.AddFragment(((XAttribute)value).ToString());
         }
     }

--- a/Src/FluentAssertions/Formatting/XDocumentValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XDocumentValueFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Xml.Linq;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
@@ -11,6 +12,10 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+            Guard.ThrowIfArgumentIsNull(formatChild, nameof(formatChild));
+
             var document = (XDocument)value;
 
             if (document.Root is not null)

--- a/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
@@ -21,6 +21,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             var element = (XElement)value;
 
             formattedGraph.AddFragment(element.HasElements

--- a/Src/FluentAssertions/Formatting/XmlReaderValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XmlReaderValueFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Xml;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
@@ -18,6 +19,9 @@ namespace FluentAssertions.Formatting
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             var reader = (XmlReader)value;
 
             if (reader.ReadState == ReadState.Initial)

--- a/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
@@ -13,6 +13,9 @@ namespace FluentAssertions.Xml
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
+            Guard.ThrowIfArgumentIsNull(value, nameof(value));
+            Guard.ThrowIfArgumentIsNull(formattedGraph, nameof(formattedGraph));
+
             string outerXml = ((XmlNode)value).OuterXml;
 
             const int maxLength = 20;


### PR DESCRIPTION
https://docs.microsoft.com/de-de/dotnet/fundamentals/code-analysis/quality-rules/ca1062

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

Fix some VS informations..

Maybe better to disable globally (because there are 2560 more 🙈 )?