### PR TITLE
Do not add all arguments of type `T` to the matching events, if one is found

### DIFF
--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -62,35 +62,27 @@ namespace FluentAssertions
 
             Func<T, bool> compiledPredicate = predicate.Compile();
 
-            bool hasArgumentOfRightType = false;
-            var eventsMatchingPredicate = new List<OccurredEvent>();
+            var eventsWithMatchingPredicate = new List<OccurredEvent>();
 
             foreach (OccurredEvent @event in eventRecording)
             {
                 var typedParameters = @event.Parameters.OfType<T>().ToArray();
-                if (typedParameters.Any())
-                {
-                    hasArgumentOfRightType = true;
-                }
 
                 if (typedParameters.Any(parameter => compiledPredicate(parameter)))
                 {
-                    eventsMatchingPredicate.Add(@event);
+                    eventsWithMatchingPredicate.Add(@event);
                 }
             }
 
-            if (!hasArgumentOfRightType)
-            {
-                throw new ArgumentException("No argument of event " + eventRecording.EventName + " is of type <" + typeof(T) + ">.");
-            }
+            bool foundMatchingEvent = eventsWithMatchingPredicate.Any();
 
-            if (!eventsMatchingPredicate.Any())
-            {
-                Execute.Assertion
-                    .FailWith("Expected at least one event with arguments matching {0}, but found none.", predicate.Body);
-            }
+            Execute.Assertion
+                .ForCondition(foundMatchingEvent)
+                .FailWith("Expected at least one event which arguments are of type <{0}> and matches {1}, but found none.",
+                    typeof(T),
+                    predicate.Body);
 
-            return new FilteredEventRecording(eventRecording, eventsMatchingPredicate);
+            return new FilteredEventRecording(eventRecording, eventsWithMatchingPredicate);
         }
 
         /// <summary>
@@ -104,16 +96,12 @@ namespace FluentAssertions
         {
             Func<T, bool>[] compiledPredicates = predicates.Select(p => p?.Compile()).ToArray();
 
-            bool hasArgumentOfRightType = false;
-            var eventsMatchingPredicate = new List<OccurredEvent>();
+            var eventsWithMatchingPredicate = new List<OccurredEvent>();
 
             foreach (OccurredEvent @event in eventRecording)
             {
                 var typedParameters = @event.Parameters.OfType<T>().ToArray();
-                if (typedParameters.Any())
-                {
-                    hasArgumentOfRightType = true;
-                }
+                bool hasArgumentOfRightType = typedParameters.Any();
 
                 if (predicates.Length > typedParameters.Length)
                 {
@@ -121,7 +109,7 @@ namespace FluentAssertions
                         $"Expected the event to have at least {predicates.Length} parameters of type {typeof(T)}, but only found {typedParameters.Length}.");
                 }
 
-                bool isMatch = true;
+                bool isMatch = hasArgumentOfRightType;
                 for (int index = 0; index < predicates.Length && isMatch; index++)
                 {
                     isMatch = compiledPredicates[index]?.Invoke(typedParameters[index]) ?? true;
@@ -129,24 +117,21 @@ namespace FluentAssertions
 
                 if (isMatch)
                 {
-                    eventsMatchingPredicate.Add(@event);
+                    eventsWithMatchingPredicate.Add(@event);
                 }
             }
 
-            if (!hasArgumentOfRightType)
+            bool foundMatchingEvent = eventsWithMatchingPredicate.Any();
+
+            if (!foundMatchingEvent)
             {
-                throw new ArgumentException("No argument of event " + eventRecording.EventName + " is of type <" + typeof(T) + ">.");
+                Execute.Assertion
+                    .FailWith("Expected at least one event which arguments are of type <{0}> and matches {1}, but found none.",
+                        typeof(T),
+                        string.Join(" | ", predicates.Where(p => p is not null).Select(p => p.Body.ToString())));
             }
 
-            if (!eventsMatchingPredicate.Any())
-            {
-                Execute
-                    .Assertion
-                    .FailWith("Expected at least one event with arguments matching {0}, but found none.",
-                    string.Join(" | ", predicates.Where(p => p is not null).Select(p => p.Body.ToString())));
-            }
-
-            return new FilteredEventRecording(eventRecording, eventsMatchingPredicate);
+            return new FilteredEventRecording(eventRecording, eventsWithMatchingPredicate);
         }
     }
 }

--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -53,8 +53,9 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        /// Asserts that at least one occurrence of the events had at least one of the arguments matching a predicate. Returns
-        /// only the events that matched that predicate.
+        ///  Asserts that at least one occurence of the events had one or more arguments of the expected
+        ///  type <typeparamref name="T"/> which matched the given predicate.
+        ///  Returns only the events that matched both type and optionally a predicate.
         /// </summary>
         public static IEventRecording WithArgs<T>(this IEventRecording eventRecording, Expression<Func<T, bool>> predicate)
         {
@@ -86,8 +87,9 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        /// Asserts that at least one of the occurred events has arguments the match the predicates in the same order. Returns
-        /// only the events that matched those predicates.
+        /// Asserts that at least one occurence of the events had one or more arguments of the expected
+        /// type <typeparamref name="T"/> which matched the predicates in the same order.
+        /// Returns only the events that matched both type and optionally predicates.
         /// </summary>
         /// <remarks>
         /// If a <c>null</c> is provided as predicate argument, the corresponding event parameter value is ignored.

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,6 +18,7 @@ sidebar:
 
 ### Fixes
 * Fix the failure message for regex matches (occurrence overload) to include the missing subject - [#1913](https://github.com/fluentassertions/fluentassertions/pull/1913)
+* Fixed `WithArgs` matching too many events when at least one argument matched the expected type - [#1920](https://github.com/fluentassertions/fluentassertions/pull/1920)
 
 ## 6.6.0
 


### PR DESCRIPTION
This closes #1915

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).