### PR TITLE
More specifically clarify the intentions of `WithArgs`

### DIFF
--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -14,9 +14,11 @@ namespace FluentAssertions
     public static class EventRaisingExtensions
     {
         /// <summary>
-        /// Asserts that all occurrences of the event originated from the <param name="expectedSender"/> and
-        /// returns only the events that came from that sender.
+        /// Asserts that all occurrences of the event originates from the <param name="expectedSender"/>.
         /// </summary>
+        /// <returns>
+        /// Returns only the events that comes from that sender.
+        /// </returns>
         public static IEventRecording WithSender(this IEventRecording eventRecording, object expectedSender)
         {
             var eventsForSender = new List<OccurredEvent>();
@@ -53,10 +55,12 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        ///  Asserts that at least one occurence of the events had one or more arguments of the expected
-        ///  type <typeparamref name="T"/> which matched the given predicate.
-        ///  Returns only the events that matched both type and optionally a predicate.
+        /// Asserts that at least one occurrence of the events has some argument of the expected
+        /// type <typeparamref name="T"/> that matches the given predicate.
         /// </summary>
+        /// <returns>
+        /// Returns only the events having some argument matching both type and predicate.
+        /// </returns>
         public static IEventRecording WithArgs<T>(this IEventRecording eventRecording, Expression<Func<T, bool>> predicate)
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
@@ -79,7 +83,7 @@ namespace FluentAssertions
 
             Execute.Assertion
                 .ForCondition(foundMatchingEvent)
-                .FailWith("Expected at least one event which arguments are of type <{0}> and matches {1}, but found none.",
+                .FailWith("Expected at least one event with some argument of type <{0}> that matches {1}, but found none.",
                     typeof(T),
                     predicate.Body);
 
@@ -87,10 +91,12 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        /// Asserts that at least one occurence of the events had one or more arguments of the expected
-        /// type <typeparamref name="T"/> which matched the predicates in the same order.
-        /// Returns only the events that matched both type and optionally predicates.
+        /// Asserts that at least one occurrence of the events has arguments of the expected
+        /// type <typeparamref name="T"/> that pairwise match all the given predicates.
         /// </summary>
+        /// <returns>
+        /// Returns only the events having arguments matching both type and all predicates.
+        /// </returns>
         /// <remarks>
         /// If a <c>null</c> is provided as predicate argument, the corresponding event parameter value is ignored.
         /// </remarks>
@@ -128,7 +134,7 @@ namespace FluentAssertions
             if (!foundMatchingEvent)
             {
                 Execute.Assertion
-                    .FailWith("Expected at least one event which arguments are of type <{0}> and matches {1}, but found none.",
+                    .FailWith("Expected at least one event with some arguments of type <{0}> that pairwise match {1}, but found none.",
                         typeof(T),
                         string.Join(" | ", predicates.Where(p => p is not null).Select(p => p.Body.ToString())));
             }

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -179,7 +179,7 @@ namespace FluentAssertions.Specs.Events
                 act
                     .Should().Throw<XunitException>()
                     .WithMessage(
-                        "Expected at least one event which arguments are of type*PropertyChangedEventArgs*matches*(args.PropertyName == \"SomeProperty\"), but found none.");
+                        "Expected at least one event with some argument of type*PropertyChangedEventArgs*matches*(args.PropertyName == \"SomeProperty\"), but found none.");
             }
 
             [Fact]
@@ -321,7 +321,7 @@ namespace FluentAssertions.Specs.Events
 
                 // Assert
                 act.Should().Throw<XunitException>().WithMessage(
-                    "Expected at least one event which arguments*type*Int32*matches*(args == " + wrongArgument + "), but found none.");
+                    "Expected at least one event with some argument*type*Int32*matches*(args == " + wrongArgument + "), but found none.");
             }
 
             [Fact]
@@ -340,7 +340,7 @@ namespace FluentAssertions.Specs.Events
 
                 // Assert
                 act.Should().Throw<XunitException>().WithMessage(
-                    "Expected at least one event which arguments*matches*\"(args == \"" + wrongArgument +
+                    "Expected at least one event with some arguments*match*\"(args == \"" + wrongArgument +
                     "\")\", but found none.");
             }
 


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

Adjust the XML summaries of `WithArgs` to more closely clarify the implementation.
* For the overload taking a single predicate only a single argument of type `T` has to match the predicate.
  * So for three arguments of type `T` it's enough for e.g. the second argument to match.
* I found "some argument" preferable to "an argument" to signal that the event can have other arguments besides the matching one(s).
* Be explicit about that it's the arguments and not the event that have to match the predicate.

I also discovered that the summaries for the entire type was in past tense where all others (as far as I could see) are written in present tense.