### PR TITLE
Upgrade to C# 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <LangVersion>10.0</LangVersion>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -771,12 +771,12 @@ namespace FluentAssertions.Equivalency
 
             foreach (Type valueType in valueTypes)
             {
-                builder.AppendLine($"- Compare {valueType} by value");
+                builder.AppendLine(CultureInfo.InvariantCulture, $"- Compare {valueType} by value");
             }
 
             foreach (Type type in referenceTypes)
             {
-                builder.AppendLine($"- Compare {type} by its members");
+                builder.AppendLine(CultureInfo.InvariantCulture, $"- Compare {type} by its members");
             }
 
             if (excludeNonBrowsableOnExpectation)

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -6,8 +6,6 @@
     <AssemblyOriginatorKeyFile>FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591;1573</NoWarn>
-    <CheckEolTargetFramework>false</CheckEolTargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <CodeAnalysisRuleSet>..\..\Rules.ruleset</CodeAnalysisRuleSet>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -29,7 +27,6 @@
     <PackageIcon>FluentAssertions.png</PackageIcon>
     <PackageReleaseNotes>See https://fluentassertions.com/releases/</PackageReleaseNotes>
     <Copyright>Copyright Dennis Doomen 2010-2020</Copyright>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
@@ -64,6 +61,9 @@
   </ItemGroup>
   <ItemGroup Condition=" !('$(TargetFramework)' == 'net47' Or '$(TargetFramework)' == 'netstandard2.0') ">
     <Compile Remove="SystemExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <Compile Remove="StringBuilderExtensions.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0' Or '$(TargetFramework)' == 'net6.0' ">
     <Compile Remove="Common/NullConfigurationStore.cs" />

--- a/Src/FluentAssertions/StringBuilderExtensions.cs
+++ b/Src/FluentAssertions/StringBuilderExtensions.cs
@@ -1,0 +1,14 @@
+﻿namespace System.Text
+{
+    /// <summary>
+    /// Since net6.0 StringBuilder has additional overloads taking an AppendInterpolatedStringHandler
+    /// and optionally an IFormatProvider.
+    /// The overload here is polyfill for older target frameworks to avoid littering the code base with #ifs 
+    /// in order to silence analyzers about dependending on the current culture instead of an invariant culture.
+    /// </summary>
+    internal static class StringBuilderExtensions
+    {
+        public static StringBuilder AppendLine(this StringBuilder stringBuilder, IFormatProvider _, string value) =>
+            stringBuilder.AppendLine(value);
+    }
+}

--- a/Tests/AssemblyA/AssemblyA.csproj
+++ b/Tests/AssemblyA/AssemblyA.csproj
@@ -4,7 +4,6 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <CodeAnalysisRuleSet>..\..\Rules.ruleset</CodeAnalysisRuleSet>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AssemblyB\AssemblyB.csproj" />

--- a/Tests/AssemblyB/AssemblyB.csproj
+++ b/Tests/AssemblyB/AssemblyB.csproj
@@ -4,6 +4,5 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <CodeAnalysisRuleSet>..\..\Rules.ruleset</CodeAnalysisRuleSet>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/Tests/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6;net472</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <OutputType>Exe</OutputType>

--- a/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
+++ b/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
@@ -3,14 +3,11 @@
   <!-- To reduce build times, we only enable analyzers for the newest TFM -->
   <PropertyGroup>
     <TargetFrameworks>net47;net6.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
     <NoWarn>$(NoWarn),IDE0052,1573,1591,1712</NoWarn>
-    <CheckEolTargetFramework>false</CheckEolTargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>full</DebugType>
   </PropertyGroup>
 

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -3,14 +3,11 @@
   <!-- To reduce build times, we only enable analyzers for the newest TFM -->
   <PropertyGroup>
     <TargetFrameworks>net47;net6.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
     <NoWarn>$(NoWarn),IDE0052,1573,1591,1712</NoWarn>
-    <CheckEolTargetFramework>false</CheckEolTargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>full</DebugType>
   </PropertyGroup>
 

--- a/Tests/UWP.Specs/UWP.Specs.csproj
+++ b/Tests/UWP.Specs/UWP.Specs.csproj
@@ -8,7 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UWP.Specs</RootNamespace>
     <AssemblyName>UWP.Specs</AssemblyName>
-    <LangVersion>9.0</LangVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>


### PR DESCRIPTION
Upgrade all our projects to C# 10 and centralize it in `Directory.Build.props`.

This triggered an analyzer since `StringBuilder.AppendLine()` now may resolve to `StringBuilder.AppendLine(ref AppendInterpolatedStringHandler)`

For more information about string interpolation handlers.
https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/interpolated-string-handler
https://devblogs.microsoft.com/dotnet/string-interpolation-in-c-10-and-net-6/