### PR TITLE
More use of pattern matching and lifted operators

### DIFF
--- a/Src/FluentAssertions/CallerIdentification/AddNonEmptySymbolParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/AddNonEmptySymbolParsingStrategy.cs
@@ -16,7 +16,7 @@ internal class AddNonEmptySymbolParsingStrategy : IParsingStrategy
         }
         else if (mode is Mode.RemoveSuperfluousWhitespace)
         {
-            if (precedingSymbol.HasValue && !char.IsWhiteSpace(precedingSymbol.Value))
+            if (precedingSymbol is char value && !char.IsWhiteSpace(value))
             {
                 statement.Append(symbol);
             }

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -238,7 +238,7 @@ internal static class TypeExtensions
             return type
                 .GetProperties(AllInstanceMembersFlag | BindingFlags.DeclaredOnly)
                 .Where(property => property.GetMethod?.IsPrivate == false)
-                .Where(property => includeInternals || (property.GetMethod?.IsAssembly == false && property.GetMethod?.IsFamilyOrAssembly == false))
+                .Where(property => includeInternals || (property.GetMethod is { IsAssembly: false, IsFamilyOrAssembly: false }))
                 .ToArray();
         });
     }
@@ -344,7 +344,7 @@ internal static class TypeExtensions
     private static bool HasNonPrivateGetter(PropertyInfo propertyInfo)
     {
         MethodInfo getMethod = propertyInfo.GetGetMethod(nonPublic: true);
-        return getMethod is not null && !getMethod.IsPrivate && !getMethod.IsFamily;
+        return getMethod is { IsPrivate: false, IsFamily: false };
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
+++ b/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
@@ -15,7 +15,7 @@ public class MultidimensionalArrayFormatter : IValueFormatter
     /// </returns>
     public bool CanHandle(object value)
     {
-        return value is Array arr && arr.Rank >= 2;
+        return value is Array { Rank: >= 2 };
     }
 
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)

--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -18,7 +18,7 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
 
         var reducedExpression = ReduceConstantSubExpressions(lambdaExpression.Body);
 
-        if (reducedExpression is BinaryExpression binaryExpression && binaryExpression.NodeType == ExpressionType.AndAlso)
+        if (reducedExpression is BinaryExpression { NodeType: ExpressionType.AndAlso } binaryExpression)
         {
             var subExpressions = ExtractChainOfExpressionsJoinedWithAndOperator(binaryExpression);
             formattedGraph.AddFragment(string.Join(" AndAlso ", subExpressions.Select(e => e.ToString())));

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -58,7 +58,7 @@ public class NumericAssertions<T, TAssertions>
     public AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) == 0)
+            .ForCondition(Subject?.CompareTo(expected) == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected, Subject);
 
@@ -79,9 +79,7 @@ public class NumericAssertions<T, TAssertions>
     public AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(
-                (!Subject.HasValue && !expected.HasValue)
-                || (Subject.HasValue && expected.HasValue && Subject.Value.CompareTo(expected.Value) == 0))
+            .ForCondition(expected is T value ? Subject?.CompareTo(value) == 0 : !Subject.HasValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected, Subject);
 
@@ -102,7 +100,7 @@ public class NumericAssertions<T, TAssertions>
     public AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(!Subject.HasValue || Subject.Value.CompareTo(unexpected) != 0)
+            .ForCondition(Subject?.CompareTo(unexpected) != 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:value} to be {0}{reason}.", unexpected);
 
@@ -123,9 +121,7 @@ public class NumericAssertions<T, TAssertions>
     public AndConstraint<TAssertions> NotBe(T? unexpected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(
-                (!Subject.HasValue == unexpected.HasValue)
-                || (Subject.HasValue && unexpected.HasValue && Subject.Value.CompareTo(unexpected.Value) != 0))
+            .ForCondition(unexpected is T value ? Subject?.CompareTo(value) != 0 : Subject.HasValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:value} to be {0}{reason}.", unexpected);
 
@@ -145,7 +141,7 @@ public class NumericAssertions<T, TAssertions>
     public AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(default(T)) > 0)
+            .ForCondition(Subject?.CompareTo(default(T)) > 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be positive{reason}, but found {0}.", Subject);
 
@@ -165,7 +161,7 @@ public class NumericAssertions<T, TAssertions>
     public AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && !IsNaN(Subject.Value) && Subject.Value.CompareTo(default(T)) < 0)
+            .ForCondition(Subject is T value && !IsNaN(value) && value.CompareTo(default(T)) < 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be negative{reason}, but found {0}.", Subject);
 
@@ -191,7 +187,7 @@ public class NumericAssertions<T, TAssertions>
         }
 
         Execute.Assertion
-            .ForCondition(Subject.HasValue && !IsNaN(Subject.Value) && Subject.Value.CompareTo(expected) < 0)
+            .ForCondition(Subject is T value && !IsNaN(value) && value.CompareTo(expected) < 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be less than {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected, Subject);
 
@@ -218,7 +214,7 @@ public class NumericAssertions<T, TAssertions>
         }
 
         Execute.Assertion
-            .ForCondition(Subject.HasValue && !IsNaN(Subject.Value) && Subject.Value.CompareTo(expected) <= 0)
+            .ForCondition(Subject is T value && !IsNaN(value) && value.CompareTo(expected) <= 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be less than or equal to {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected, Subject);
 
@@ -248,7 +244,7 @@ public class NumericAssertions<T, TAssertions>
         }
 
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
+            .ForCondition(Subject?.CompareTo(expected) > 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be greater than {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected, Subject);
 
@@ -275,7 +271,7 @@ public class NumericAssertions<T, TAssertions>
         }
 
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
+            .ForCondition(Subject?.CompareTo(expected) >= 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be greater than or equal to {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected, Subject);
 
@@ -313,7 +309,7 @@ public class NumericAssertions<T, TAssertions>
         }
 
         Execute.Assertion
-            .ForCondition(Subject.HasValue && (Subject.Value.CompareTo(minimumValue) >= 0) && (Subject.Value.CompareTo(maximumValue) <= 0))
+            .ForCondition(Subject is T value && (value.CompareTo(minimumValue) >= 0) && (value.CompareTo(maximumValue) <= 0))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be between {0} and {1}{reason}, but found {2}.",
                 minimumValue, maximumValue, Subject);
@@ -349,7 +345,7 @@ public class NumericAssertions<T, TAssertions>
         }
 
         Execute.Assertion
-            .ForCondition(Subject.HasValue && !((Subject.Value.CompareTo(minimumValue) >= 0) && (Subject.Value.CompareTo(maximumValue) <= 0)))
+            .ForCondition(Subject is T value && !((value.CompareTo(minimumValue) >= 0) && (value.CompareTo(maximumValue) <= 0)))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to not be between {0} and {1}{reason}, but found {2}.",
                 minimumValue, maximumValue, Subject);
@@ -385,7 +381,7 @@ public class NumericAssertions<T, TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && validValues.Contains((T)Subject))
+            .ForCondition(Subject is T value && validValues.Contains(value))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be one of {0}{reason}, but found {1}.", validValues, Subject);
 

--- a/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
@@ -142,7 +142,7 @@ public class DateOnlyAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
+            .ForCondition(Subject < expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} to be before {0}{reason}, but found {1}.", expected,
                 Subject);
@@ -182,7 +182,7 @@ public class DateOnlyAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
+            .ForCondition(Subject <= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} to be on or before {0}{reason}, but found {1}.", expected,
                 Subject);
@@ -222,7 +222,7 @@ public class DateOnlyAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
+            .ForCondition(Subject > expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} to be after {0}{reason}, but found {1}.", expected,
                 Subject);
@@ -262,7 +262,7 @@ public class DateOnlyAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
+            .ForCondition(Subject >= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} to be on or after {0}{reason}, but found {1}.", expected,
                 Subject);

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -239,7 +239,7 @@ public class DateTimeAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
+            .ForCondition(Subject < expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be before {0}{reason}, but found {1}.", expected,
                 Subject);
@@ -279,7 +279,7 @@ public class DateTimeAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
+            .ForCondition(Subject <= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be on or before {0}{reason}, but found {1}.", expected,
                 Subject);
@@ -319,7 +319,7 @@ public class DateTimeAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
+            .ForCondition(Subject > expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be after {0}{reason}, but found {1}.", expected,
                 Subject);
@@ -359,7 +359,7 @@ public class DateTimeAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
+            .ForCondition(Subject >= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be on or after {0}{reason}, but found {1}.", expected,
                 Subject);

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -375,7 +375,7 @@ public class DateTimeOffsetAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
+            .ForCondition(Subject < expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be before {0}{reason}, but it was {1}.", expected,
                 Subject);
@@ -415,7 +415,7 @@ public class DateTimeOffsetAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
+            .ForCondition(Subject <= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be on or before {0}{reason}, but it was {1}.", expected,
                 Subject);
@@ -455,7 +455,7 @@ public class DateTimeOffsetAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
+            .ForCondition(Subject > expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be after {0}{reason}, but it was {1}.", expected,
                 Subject);
@@ -495,7 +495,7 @@ public class DateTimeOffsetAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
+            .ForCondition(Subject >= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be on or after {0}{reason}, but it was {1}.", expected,
                 Subject);

--- a/Src/FluentAssertions/Primitives/EnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/EnumAssertions.cs
@@ -195,7 +195,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> HaveValue(decimal expected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && (GetValue(Subject.Value) == expected))
+            .ForCondition(Subject is TEnum value && (GetValue(value) == expected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to have value {0}{reason}, but found {1}.",
                 expected, Subject);
@@ -217,7 +217,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> NotHaveValue(decimal unexpected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(!(Subject.HasValue && (GetValue(Subject.Value) == unexpected)))
+            .ForCondition(!(Subject is TEnum value && (GetValue(value) == unexpected)))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to not have value {0}{reason}, but found {1}.",
                 unexpected, Subject);
@@ -240,7 +240,7 @@ public class EnumAssertions<TEnum, TAssertions>
         where T : struct, Enum
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && (GetValue(Subject.Value) == GetValue(expected)))
+            .ForCondition(Subject is TEnum value && (GetValue(value) == GetValue(expected)))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to have same value as {0}{reason}, but found {1}.",
                 expected, Subject);
@@ -263,7 +263,7 @@ public class EnumAssertions<TEnum, TAssertions>
         where T : struct, Enum
     {
         Execute.Assertion
-            .ForCondition(!(Subject.HasValue && (GetValue(Subject.Value) == GetValue(unexpected))))
+            .ForCondition(!(Subject is TEnum value && (GetValue(value) == GetValue(unexpected))))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to not have same value as {0}{reason}, but found {1}.",
                 unexpected, Subject);
@@ -286,7 +286,7 @@ public class EnumAssertions<TEnum, TAssertions>
         where T : struct, Enum
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && (GetName(Subject.Value) == GetName(expected)))
+            .ForCondition(Subject is TEnum value && (GetName(value) == GetName(expected)))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to have same name as {0}{reason}, but found {1}.",
                 expected, Subject);
@@ -309,7 +309,7 @@ public class EnumAssertions<TEnum, TAssertions>
         where T : struct, Enum
     {
         Execute.Assertion
-            .ForCondition(!(Subject.HasValue && (GetName(Subject.Value) == GetName(unexpected))))
+            .ForCondition(!(Subject is TEnum value && (GetName(value) == GetName(unexpected))))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to not have same name as {0}{reason}, but found {1}.",
                 unexpected, Subject);

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -70,7 +70,7 @@ public class GuidAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && (Subject.Value != Guid.Empty))
+            .ForCondition(Subject is Guid value && value != Guid.Empty)
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:Guid} to be empty{reason}.");
 

--- a/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
@@ -152,7 +152,7 @@ public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAsserti
     public AndConstraint<TAssertions> NotBeFalse(string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(!Subject.HasValue || Subject.Value)
+            .ForCondition(Subject is not false)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:nullable boolean} not to be {0}{reason}, but found {1}.", false, Subject);
 
@@ -172,7 +172,7 @@ public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAsserti
     public AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(!Subject.HasValue || !Subject.Value)
+            .ForCondition(Subject is not true)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:nullable boolean} not to be {0}{reason}, but found {1}.", true, Subject);
 

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -50,14 +50,8 @@ public class SimpleTimeSpanAssertions<TAssertions>
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {context:time} to be positive{reason}, ")
-            .ForCondition(Subject.HasValue)
-            .FailWith("but found <null>.")
-            .Then
-            .ForCondition(Subject.Value.CompareTo(TimeSpan.Zero) > 0)
-            .FailWith("but found {0}.", Subject.Value)
-            .Then
-            .ClearExpectation();
+            .ForCondition(Subject > TimeSpan.Zero)
+            .FailWith("Expected {context:time} to be positive{reason}, but found {0}.", Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -76,14 +70,8 @@ public class SimpleTimeSpanAssertions<TAssertions>
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {context:time} to be negative{reason}, ")
-            .ForCondition(Subject.HasValue)
-            .FailWith("but found <null>.")
-            .Then
-            .ForCondition(Subject.Value.CompareTo(TimeSpan.Zero) < 0)
-            .FailWith("but found {0}.", Subject.Value)
-            .Then
-            .ClearExpectation();
+            .ForCondition(Subject < TimeSpan.Zero)
+            .FailWith("Expected {context:time} to be negative{reason}, but found {0}.", Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -104,14 +92,8 @@ public class SimpleTimeSpanAssertions<TAssertions>
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {0}{reason}, ", expected)
-            .ForCondition(Subject.HasValue)
-            .FailWith("but found <null>.")
-            .Then
-            .ForCondition(Subject.Value.CompareTo(expected) == 0)
-            .FailWith("but found {0}.", Subject.Value)
-            .Then
-            .ClearExpectation();
+            .ForCondition(expected == Subject)
+            .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -131,7 +113,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBe(TimeSpan unexpected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(!Subject.HasValue || Subject.Value.CompareTo(unexpected) != 0)
+            .ForCondition(unexpected != Subject)
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {0}{reason}.", unexpected);
 
@@ -154,14 +136,8 @@ public class SimpleTimeSpanAssertions<TAssertions>
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {context:time} to be less than {0}{reason}, ", expected)
-            .ForCondition(Subject.HasValue)
-            .FailWith("but found <null>.")
-            .Then
-            .ForCondition(Subject.Value.CompareTo(expected) < 0)
-            .FailWith("but found {0}.", Subject.Value)
-            .Then
-            .ClearExpectation();
+            .ForCondition(Subject < expected)
+            .FailWith("Expected {context:time} to be less than {0}{reason}, but found {1}.", expected, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -182,14 +158,8 @@ public class SimpleTimeSpanAssertions<TAssertions>
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {context:time} to be less than or equal to {0}{reason}, ", expected)
-            .ForCondition(Subject.HasValue)
-            .FailWith("but found <null>.")
-            .Then
-            .ForCondition(Subject.Value.CompareTo(expected) <= 0)
-            .FailWith("but found {0}.", Subject.Value)
-            .Then
-            .ClearExpectation();
+            .ForCondition(Subject <= expected)
+            .FailWith("Expected {context:time} to be less than or equal to {0}{reason}, but found {1}.", expected, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -213,14 +183,8 @@ public class SimpleTimeSpanAssertions<TAssertions>
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {context:time} to be greater than {0}{reason}, ", expected)
-            .ForCondition(Subject.HasValue)
-            .FailWith("but found <null>.")
-            .Then
-            .ForCondition(Subject.Value.CompareTo(expected) > 0)
-            .FailWith("but found {0}.", Subject.Value)
-            .Then
-            .ClearExpectation();
+            .ForCondition(Subject > expected)
+            .FailWith("Expected {context:time} to be greater than {0}{reason}, but found {1}.", expected, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -242,14 +206,8 @@ public class SimpleTimeSpanAssertions<TAssertions>
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {context:time} to be greater than or equal to {0}{reason}, ", expected)
-            .ForCondition(Subject.HasValue)
-            .FailWith("but found <null>.")
-            .Then
-            .ForCondition(Subject.Value.CompareTo(expected) >= 0)
-            .FailWith("but found {0}.", Subject.Value)
-            .Then
-            .ClearExpectation();
+            .ForCondition(Subject >= expected)
+            .FailWith("Expected {context:time} to be greater than or equal to {0}{reason}, but found {1}.", expected, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
@@ -142,7 +142,7 @@ public class TimeOnlyAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
+            .ForCondition(Subject < expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be before {0}{reason}, but found {1}.", expected,
                 Subject);
@@ -182,7 +182,7 @@ public class TimeOnlyAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
+            .ForCondition(Subject <= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be on or before {0}{reason}, but found {1}.", expected,
                 Subject);
@@ -222,7 +222,7 @@ public class TimeOnlyAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
+            .ForCondition(Subject > expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be after {0}{reason}, but found {1}.", expected,
                 Subject);
@@ -262,7 +262,7 @@ public class TimeOnlyAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
+            .ForCondition(Subject >= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be on or after {0}{reason}, but found {1}.", expected,
                 Subject);

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -70,7 +70,7 @@ public class ExecutionTimeAssertions
     /// </param>
     public AndConstraint<ExecutionTimeAssertions> BeLessThanOrEqualTo(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
     {
-        bool Condition(TimeSpan duration) => duration.CompareTo(maxDuration) <= 0;
+        bool Condition(TimeSpan duration) => duration <= maxDuration;
         (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: false, rate: maxDuration);
 
         Execute.Assertion
@@ -103,7 +103,7 @@ public class ExecutionTimeAssertions
     /// </param>
     public AndConstraint<ExecutionTimeAssertions> BeLessThan(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
     {
-        bool Condition(TimeSpan duration) => duration.CompareTo(maxDuration) < 0;
+        bool Condition(TimeSpan duration) => duration < maxDuration;
         (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: false, rate: maxDuration);
 
         Execute.Assertion
@@ -133,7 +133,7 @@ public class ExecutionTimeAssertions
     /// </param>
     public AndConstraint<ExecutionTimeAssertions> BeGreaterThanOrEqualTo(TimeSpan minDuration, string because = "", params object[] becauseArgs)
     {
-        bool Condition(TimeSpan duration) => duration.CompareTo(minDuration) >= 0;
+        bool Condition(TimeSpan duration) => duration >= minDuration;
         (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: true, rate: minDuration);
 
         Execute.Assertion
@@ -166,7 +166,7 @@ public class ExecutionTimeAssertions
     /// </param>
     public AndConstraint<ExecutionTimeAssertions> BeGreaterThan(TimeSpan minDuration, string because = "", params object[] becauseArgs)
     {
-        bool Condition(TimeSpan duration) => duration.CompareTo(minDuration) > 0;
+        bool Condition(TimeSpan duration) => duration > minDuration;
         (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: true, rate: minDuration);
 
         Execute.Assertion

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -202,35 +202,18 @@ public class NumericAssertionSpecs
     public class Be
     {
         [Fact]
-        public void When_a_value_is_equal_to_same_value_it_should_not_throw()
+        public void A_value_is_equal_to_the_same_value()
         {
             // Arrange
             int value = 1;
             int sameValue = 1;
 
             // Act
-            Action act = () => value.Should().Be(sameValue);
-
-            // Assert
-            act.Should().NotThrow();
+            value.Should().Be(sameValue);
         }
 
         [Fact]
-        public void When_a_value_is_equal_to_different_value_it_should_throw()
-        {
-            // Arrange
-            int value = 1;
-            int differentValue = 2;
-
-            // Act
-            Action act = () => value.Should().Be(differentValue);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_a_value_is_equal_to_different_value_it_should_throw_with_descriptive_message()
+        public void A_value_is_not_equal_to_another_value()
         {
             // Arrange
             int value = 1;
@@ -246,21 +229,18 @@ public class NumericAssertionSpecs
         }
 
         [Fact]
-        public void When_a_nullable_value_is_equal_it_should_not_throw()
+        public void A_value_is_equal_to_the_same_nullable_value()
         {
             // Arrange
             int value = 2;
             int? nullableValue = 2;
 
             // Act
-            Action act = () => value.Should().Be(nullableValue);
-
-            // Assert
-            act.Should().NotThrow();
+            value.Should().Be(nullableValue);
         }
 
         [Fact]
-        public void When_a_nullable_value_is_null_but_the_subject_isnt_it_should_throw()
+        public void A_value_is_not_equal_to_null()
         {
             // Arrange
             int value = 2;
@@ -276,7 +256,7 @@ public class NumericAssertionSpecs
         }
 
         [Fact]
-        public void When_a_nullable_value_has_value_but_the_subject_is_null_should_throw()
+        public void Null_is_not_equal_to_another_nullable_value()
         {
             // Arrange
             int? value = 2;
@@ -290,36 +270,17 @@ public class NumericAssertionSpecs
                 .WithMessage("Expected*2, but found <null>.");
         }
 
-        [Fact]
-        public void When_a_value_is_not_equal_to_a_different_value_it_should_not_throw()
+        [InlineData(1, 2)]
+        [InlineData(null, 2)]
+        [Theory]
+        public void A_nullable_value_is_not_equal_to_another_value(int? subject, int unexpected)
         {
-            // Arrange
-            int value = 1;
-            int differentValue = 2;
-
             // Act
-            Action act = () => value.Should().NotBe(differentValue);
-
-            // Assert
-            act.Should().NotThrow();
+            subject.Should().NotBe(unexpected);
         }
 
         [Fact]
-        public void When_a_value_is_not_equal_to_the_same_value_it_should_throw()
-        {
-            // Arrange
-            int value = 1;
-            int sameValue = 1;
-
-            // Act
-            Action act = () => value.Should().NotBe(sameValue);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_a_value_is_not_equal_to_the_same_value_it_should_throw_with_descriptive_message()
+        public void A_value_is_not_different_from_the_same_value()
         {
             // Arrange
             int value = 1;
@@ -334,101 +295,59 @@ public class NumericAssertionSpecs
                 .WithMessage("Did not expect value to be 1 because we want to test the failure message.");
         }
 
-        [Fact]
-        public void When_a_nullable_numeric_null_value_not_equals_null_it_should_throw()
+        [InlineData(null, null)]
+        [InlineData(0, 0)]
+        [Theory]
+        public void A_nullable_value_is_not_different_from_the_same_value(int? subject, int? unexpected)
         {
-            // Arrange
-            int? nullableIntegerA = null;
-            int? nullableIntegerB = null;
-
             // Act
-            Action act = () => nullableIntegerA.Should().NotBe(nullableIntegerB);
+            Action act = () => subject.Should().NotBe(unexpected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [InlineData(0, 1)]
+        [InlineData(0, null)]
+        [InlineData(null, 0)]
+        [Theory]
+        public void A_nullable_value_is_different_from_another_value(int? subject, int? unexpected)
+        {
+            // Act / Assert
+            subject.Should().NotBe(unexpected);
+        }
+
+        [InlineData(0, 0)]
+        [InlineData(null, null)]
+        [Theory]
+        public void A_nullable_value_is_equal_to_the_same_nullable_value(int? subject, int? expected)
+        {
+            // Act / Assert
+            subject.Should().Be(expected);
+        }
+
+        [InlineData(0, 1)]
+        [InlineData(0, null)]
+        [InlineData(null, 0)]
+        [Theory]
+        public void A_nullable_value_is_not_equal_to_another_nullable_value(int? subject, int? expected)
+        {
+            // Act
+            Action act = () => subject.Should().Be(expected);
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void When_a_nullable_numeric_value_not_equals_null_it_should_succeed()
+        public void Null_is_not_equal_to_another_value()
         {
             // Arrange
-            int? nullableIntegerA = 1;
-            int? nullableIntegerB = null;
-
-            // Act / Assert
-            nullableIntegerA.Should().NotBe(nullableIntegerB);
-        }
-
-        [Fact]
-        public void When_a_nullable_numeric_null_value_not_equals_nullable_value_it_should_succeed()
-        {
-            // Arrange
-            int? nullableIntegerA = null;
-            int? nullableIntegerB = 1;
-
-            // Act / Assert
-            nullableIntegerA.Should().NotBe(nullableIntegerB);
-        }
-
-        [Fact]
-        public void When_a_nullable_numeric_null_value_not_equals_value_it_should_succeed()
-        {
-            // Arrange
-            int? nullableIntegerA = null;
-            int nullableIntegerB = 1;
-
-            // Act / Assert
-            nullableIntegerA.Should().NotBe(nullableIntegerB);
-        }
-
-        [Fact]
-        public void When_a_nullable_numeric_null_value_equals_null_it_should_succeed()
-        {
-            // Arrange
-            int? nullableIntegerA = null;
-            int? nullableIntegerB = null;
-
-            // Act / Assert
-            nullableIntegerA.Should().Be(nullableIntegerB);
-        }
-
-        [Fact]
-        public void When_a_nullable_numeric_value_equals_null_it_should_throw()
-        {
-            // Arrange
-            int? nullableIntegerA = 1;
-            int? nullableIntegerB = null;
+            int? subject = null;
+            int expected = 1;
 
             // Act
-            Action act = () => nullableIntegerA.Should().Be(nullableIntegerB);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_a_nullable_numeric_null_value_equals_nullable_value_it_should_throw()
-        {
-            // Arrange
-            int? nullableIntegerA = null;
-            int? nullableIntegerB = 1;
-
-            // Act
-            Action act = () => nullableIntegerA.Should().Be(nullableIntegerB);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_a_nullable_numeric_null_value_equals_value_it_should_throw()
-        {
-            // Arrange
-            int? nullableIntegerA = null;
-            int nullableIntegerB = 1;
-
-            // Act
-            Action act = () => nullableIntegerA.Should().Be(nullableIntegerB);
+            Action act = () => subject.Should().Be(expected);
 
             // Assert
             act.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions.Extensions;
+using FluentAssertions.Primitives;
 using Xunit;
 using Xunit.Sdk;
 
@@ -155,6 +156,20 @@ public class SimpleTimeSpanAssertionSpecs
 
         // Act
         Action act = () => actual.Should().Be(expected);
+
+        // Assert
+        act.Should().Throw<XunitException>();
+    }
+
+    [Fact]
+    public void A_null_is_not_equal_to_another_value()
+    {
+        // Arrange
+        var subject = new SimpleTimeSpanAssertions(null);
+        TimeSpan expected = 2.Seconds();
+
+        // Act
+        Action act = () => subject.Be(expected);
 
         // Assert
         act.Should().Throw<XunitException>();


### PR DESCRIPTION
Many primitive types have overloaded comparison operators so developers don't have to use the `IComparable<T>.CompareTo(T)` method.

With the increasingly improved pattern matching in C# I often feel the combined use of `HasValue` and `Value` is similar to using `ContainsKey` + `[key]` instead of `TryGetValue`.