### PR TITLE
Optimize `BeEquivalentTo`

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -845,7 +845,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
 
             using (var scope = new AssertionScope())
             {
-                scope.AddReportable("configuration", options.ToString());
+                scope.AddReportable("configuration", () => options.ToString());
 
                 foreach (T actualItem in Subject)
                 {
@@ -2199,7 +2199,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
                         .WithExpectation("Expected {context:collection} {0} not to contain equivalent of {1}{reason}, ", Subject, unexpected)
-                        .AddReportable("configuration", options.ToString());
+                        .AddReportable("configuration", () => options.ToString());
 
                     if (foundIndices.Count == 1)
                     {

--- a/Src/FluentAssertions/Equivalency/ConversionSelector.cs
+++ b/Src/FluentAssertions/Equivalency/ConversionSelector.cs
@@ -27,8 +27,19 @@ public class ConversionSelector
         }
     }
 
-    private List<ConversionSelectorRule> inclusions = new();
-    private List<ConversionSelectorRule> exclusions = new();
+    private readonly List<ConversionSelectorRule> inclusions;
+    private readonly List<ConversionSelectorRule> exclusions;
+
+    public ConversionSelector()
+        : this(new List<ConversionSelectorRule>(), new List<ConversionSelectorRule>())
+    {
+    }
+
+    private ConversionSelector(List<ConversionSelectorRule> inclusions, List<ConversionSelectorRule> exclusions)
+    {
+        this.inclusions = inclusions;
+        this.exclusions = exclusions;
+    }
 
     public void IncludeAll()
     {
@@ -55,6 +66,11 @@ public class ConversionSelector
 
     public bool RequiresConversion(Comparands comparands, INode currentNode)
     {
+        if (inclusions.Count == 0)
+        {
+            return false;
+        }
+
         var objectInfo = new ObjectInfo(comparands, currentNode);
 
         return inclusions.Any(p => p.Predicate(objectInfo)) && !exclusions.Any(p => p.Predicate(objectInfo));
@@ -84,10 +100,6 @@ public class ConversionSelector
 
     public ConversionSelector Clone()
     {
-        return new ConversionSelector
-        {
-            inclusions = new List<ConversionSelectorRule>(inclusions),
-            exclusions = new List<ConversionSelectorRule>(exclusions),
-        };
+        return new ConversionSelector(new List<ConversionSelectorRule>(inclusions), new List<ConversionSelectorRule>(exclusions));
     }
 }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -1,4 +1,5 @@
 using System;
+using FluentAssertions.Equivalency.Tracing;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency;
@@ -15,7 +16,7 @@ public class EquivalencyValidator : IEquivalencyValidator
         using var scope = new AssertionScope();
 
         scope.AssumeSingleCaller();
-        scope.AddReportable("configuration", context.Options.ToString());
+        scope.AddReportable("configuration", () => context.Options.ToString());
         scope.BecauseOf(context.Reason);
 
         RecursivelyAssertEquality(comparands, context);

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -65,12 +65,13 @@ public class EquivalencyValidator : IEquivalencyValidator
     {
         using var _ = context.Tracer.WriteBlock(node => node.Description);
 
+        Func<IEquivalencyStep, GetTraceMessage> getMessage = step => _ => $"Equivalency was proven by {step.GetType().Name}";
         foreach (IEquivalencyStep step in AssertionOptions.EquivalencyPlan)
         {
             var result = step.Handle(comparands, context, this);
             if (result == EquivalencyResult.AssertionCompleted)
             {
-                context.Tracer.WriteLine(_ => $"Equivalency was proven by {step.GetType().Name}");
+                context.Tracer.WriteLine(getMessage(step));
                 return;
             }
         }

--- a/Src/FluentAssertions/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Equivalency/Node.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using FluentAssertions.Common;
@@ -13,15 +14,35 @@ public class Node : INode
 {
     private static readonly Regex MatchFirstIndex = new(@"^\[\d+\]$");
 
+    private string path;
+    private string name;
+    private string pathAndName;
+
     public GetSubjectId GetSubjectId { get; protected set; } = () => string.Empty;
 
     public Type Type { get; protected set; }
 
-    public string Path { get; protected set; }
+    public string Path
+    {
+        get => path;
+        protected set
+        {
+            path = value;
+            pathAndName = null;
+        }
+    }
 
-    public string PathAndName => Path.Combine(Name);
+    public string PathAndName => pathAndName ??= Path.Combine(Name);
 
-    public string Name { get; set; }
+    public string Name
+    {
+        get => name;
+        set
+        {
+            name = value;
+            pathAndName = null;
+        }
+    }
 
     public virtual string Description => $"{GetSubjectId().Combine(PathAndName)}";
 
@@ -109,14 +130,17 @@ public class Node : INode
         return Equals((Node)obj);
     }
 
-    private bool Equals(Node other) => Type == other.Type && PathAndName == other.PathAndName;
+    private bool Equals(Node other) => (Type, Name, Path) == (other.Type, other.Name, other.Path);
 
     public override int GetHashCode()
     {
         unchecked
         {
 #pragma warning disable CA1307
-            return (Type.GetHashCode() * 397) ^ PathAndName.GetHashCode();
+            int hashCode = Type.GetHashCode();
+            hashCode = (hashCode * 397) + Path.GetHashCode();
+            hashCode = (hashCode * 397) + Name.GetHashCode();
+            return hashCode;
         }
     }
 

--- a/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
@@ -15,22 +15,24 @@ public class StructuralEqualityEquivalencyStep : IEquivalencyStep
             return EquivalencyResult.ContinueWithNext;
         }
 
-        bool expectationIsNotNull = AssertionScope.Current
-            .ForCondition(comparands.Expectation is not null)
+        if (comparands.Expectation is null)
+        {
+            AssertionScope.Current
             .BecauseOf(context.Reason)
             .FailWith(
                 "Expected {context:subject} to be <null>{reason}, but found {0}.",
                 comparands.Subject);
-
-        bool subjectIsNotNull = AssertionScope.Current
-            .ForCondition(comparands.Subject is not null)
+        }
+        else if (comparands.Subject is null)
+        {
+            AssertionScope.Current
             .BecauseOf(context.Reason)
             .FailWith(
                 "Expected {context:object} to be {0}{reason}, but found {1}.",
                 comparands.Expectation,
                 comparands.Subject);
-
-        if (expectationIsNotNull && subjectIsNotNull)
+        }
+        else
         {
             IMember[] selectedMembers = GetMembersFromExpectation(context.CurrentNode, comparands, context.Options).ToArray();
             if (context.CurrentNode.IsRoot && !selectedMembers.Any())

--- a/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
@@ -159,6 +159,22 @@ public class CyclicReferencesSpecs
     }
 
     [Fact]
+    public void Allowing_infinite_recursion_is_described_in_the_failure_message()
+    {
+        // Arrange
+        var recursiveClass1 = new ClassWithFiniteRecursiveProperty(1);
+        var recursiveClass2 = new ClassWithFiniteRecursiveProperty(2);
+
+        // Act
+        Action act = () => recursiveClass1.Should().BeEquivalentTo(recursiveClass2,
+            options => options.AllowingInfiniteRecursion());
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("*Recurse indefinitely*");
+    }
+
+    [Fact]
     public void When_injecting_a_null_config_to_BeEquivalentTo_it_should_throw()
     {
         // Arrange

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -52,6 +52,102 @@ public class SelectionRulesSpecs
     }
 
     [Fact]
+    public void A_member_included_by_path_is_described_in_the_failure_message()
+    {
+        // Arrange
+        var subject = new
+        {
+            Name = "John"
+        };
+
+        var customer = new
+        {
+            Name = "Jack"
+        };
+
+        // Act
+        Action act = () => subject.Should().BeEquivalentTo(customer, options => options
+            .Including(d => d.Name));
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("*Include*Name*");
+    }
+
+    [Fact]
+    public void A_member_included_by_predicate_is_described_in_the_failure_message()
+    {
+        // Arrange
+        var subject = new
+        {
+            Name = "John"
+        };
+
+        var customer = new
+        {
+            Name = "Jack"
+        };
+
+        // Act
+        Action act = () => subject.Should().BeEquivalentTo(customer, options => options
+            .Including(ctx => ctx.Path == "Name"));
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("*Include member when*Name*");
+    }
+
+    [Fact]
+    public void A_member_excluded_by_path_is_described_in_the_failure_message()
+    {
+        // Arrange
+        var subject = new
+        {
+            Name = "John",
+            Age = 13
+        };
+
+        var customer = new
+        {
+            Name = "Jack",
+            Age = 37
+        };
+
+        // Act
+        Action act = () => subject.Should().BeEquivalentTo(customer, options => options
+            .Excluding(d => d.Age));
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("*Exclude*Age*");
+    }
+
+    [Fact]
+    public void A_member_excluded_by_predicate_is_described_in_the_failure_message()
+    {
+        // Arrange
+        var subject = new
+        {
+            Name = "John",
+            Age = 13
+        };
+
+        var customer = new
+        {
+            Name = "Jack",
+            Age = 37
+        };
+
+        // Act
+        Action act = () => subject.Should().BeEquivalentTo(customer, options => options
+            .Excluding(ctx => ctx.Path == "Age"));
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("*Exclude member when*Age*");
+    }
+
+    [Fact]
     public void When_a_predicate_for_properties_to_include_has_been_specified_it_should_ignore_the_other_properties()
     {
         // Arrange


### PR DESCRIPTION
In #1932 I noticed that we generate the equivalency summary even when a test does not fail.
That didn't look right to me.

### Benchmark 1: Comparing two simple objects
<details>

```cs
[MemoryDiagnoser]
[SimpleJob(RuntimeMoniker.Net472)]
[SimpleJob(RuntimeMoniker.Net60)]
public class BeEquivalentToBenchmarks
{
    public class MyClass
    {
        public int MyProperty { get; set; }
    }

    private readonly MyClass a = new();
    private readonly MyClass b = new();

    [Benchmark]
    public AndConstraint<ObjectAssertions> BeEquivalentTo() => a.Should().BeEquivalentTo(b);
}
```
</details>

develop
|         Method |              Runtime |      Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
|--------------- |--------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
| BeEquivalentTo |             .NET 6.0 |  8.888 us | 0.1760 us | 0.2524 us | 2.0447 | 0.0153 |     13 KB |
| BeEquivalentTo | .NET Framework 4.7.2 | 11.181 us | 0.1033 us | 0.0915 us | 2.1820 | 0.0153 |     13 KB |


373a6add033fec1baf7870fcd10ba4ce61be2e44
|         Method |              Runtime |      Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
|--------------- |--------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
| BeEquivalentTo |             .NET 6.0 |  7.830 us | 0.0923 us | 0.0863 us | 1.7090 | 0.0153 |     11 KB |
| BeEquivalentTo | .NET Framework 4.7.2 | 10.427 us | 0.1348 us | 0.1195 us | 1.8463 | 0.0153 |     11 KB |


6c5db114828617e2047588bea7750705d18e3893
|         Method |              Runtime |      Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
|--------------- |--------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
| BeEquivalentTo |             .NET 6.0 |  6.972 us | 0.0881 us | 0.0824 us | 1.5564 | 0.0153 |     10 KB |
| BeEquivalentTo | .NET Framework 4.7.2 | 10.023 us | 0.1090 us | 0.1020 us | 1.6785 | 0.0153 |     10 KB |


72c2e256ce1d8e630e049f410d5aa02f8af56abd
|         Method |              Runtime |     Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
|--------------- |--------------------- |---------:|----------:|----------:|-------:|-------:|----------:|
| BeEquivalentTo |             .NET 6.0 | 7.239 us | 0.0411 us | 0.0385 us | 1.4954 | 0.0153 |      9 KB |
| BeEquivalentTo | .NET Framework 4.7.2 | 9.646 us | 0.0978 us | 0.0915 us | 1.6785 | 0.0153 |     10 KB |


a50e07a0da331f4e047205a54cd63e9100fa1ce6
|         Method |              Runtime |     Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
|--------------- |--------------------- |---------:|----------:|----------:|-------:|-------:|----------:|
| BeEquivalentTo |             .NET 6.0 | 6.732 us | 0.0667 us | 0.0624 us | 1.3809 | 0.0153 |      8 KB |
| BeEquivalentTo | .NET Framework 4.7.2 | 9.559 us | 0.1534 us | 0.1435 us | 1.5717 | 0.0153 |     10 KB |


8eeb20c6744eea033ed732d3125ce37501045433
|         Method |              Runtime |     Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
|--------------- |--------------------- |---------:|----------:|----------:|-------:|-------:|----------:|
| BeEquivalentTo |             .NET 6.0 | 6.833 us | 0.0264 us | 0.0247 us | 1.3199 | 0.0153 |      8 KB |
| BeEquivalentTo | .NET Framework 4.7.2 | 9.518 us | 0.1333 us | 0.1247 us | 1.5106 | 0.0153 |      9 KB |

### Benchmark 2: Comparing lists of complex objects
<details>

`BeEquivalentToWithDeeplyNestedStructures` with these modifications

```cs
[Params(5)]
public int N { get; set; }

[Params(4)]
public int Depth { get; set; }

[GlobalSetup]
public void GlobalSetup()
{
	subject = Enumerable.Range(0, N).Select(_ => CreateComplex(Depth)).ToList();
	expectation = Enumerable.Range(0, N).Select(_ => CreateComplex(Depth)).ToList();

	AssertionOptions.AssertEquivalencyUsing(e => e.WithoutStrictOrdering());
}
```
</details>

develop
|         Method |              Runtime | N | Depth |     Mean |   Error |  StdDev |   Gen 0 |  Gen 1 | Allocated |
|--------------- |--------------------- |-- |------ |---------:|--------:|--------:|--------:|-------:|----------:|
| BeEquivalentTo |             .NET 6.0 | 5 |     4 | 243.9 us | 1.60 us | 1.49 us | 44.9219 | 1.9531 |    278 KB |
| BeEquivalentTo | .NET Framework 4.7.2 | 5 |     4 | 345.5 us | 3.87 us | 3.62 us | 49.3164 | 1.9531 |    303 KB |


8eeb20c6744eea033ed732d3125ce37501045433 - `RequiresConversion`
|         Method |              Runtime | N | Depth |     Mean |   Error |  StdDev |   Gen 0 |  Gen 1 | Allocated |
|--------------- |--------------------- |-- |------ |---------:|--------:|--------:|--------:|-------:|----------:|
| BeEquivalentTo |             .NET 6.0 | 5 |     4 | 222.2 us | 1.87 us | 1.46 us | 34.6680 | 0.9766 |    215 KB |
| BeEquivalentTo | .NET Framework 4.7.2 | 5 |     4 | 323.7 us | 5.21 us | 4.88 us | 40.0391 | 1.4648 |    247 KB |


55c79b340bc85f87c144351804cf9e6ae8975f61 `Node.GetHashCode`
|         Method |              Runtime | N | Depth |     Mean |   Error |  StdDev |   Gen 0 |  Gen 1 | Allocated |
|--------------- |--------------------- |-- |------ |---------:|--------:|--------:|--------:|-------:|----------:|
| BeEquivalentTo |             .NET 6.0 | 5 |     4 | 216.6 us | 1.21 us | 1.08 us | 33.2031 | 1.2207 |    205 KB |
| BeEquivalentTo | .NET Framework 4.7.2 | 5 |     4 | 305.7 us | 3.23 us | 3.03 us | 38.0859 | 1.4648 |    235 KB |

55c79b340bc85f87c144351804cf9e6ae8975f61 `Node.Equals`
|         Method |              Runtime | N | Depth |     Mean |   Error |  StdDev |   Gen 0 |  Gen 1 | Allocated |
|--------------- |--------------------- |-- |------ |---------:|--------:|--------:|--------:|-------:|----------:|
| BeEquivalentTo |             .NET 6.0 | 5 |     4 | 216.5 us | 1.17 us | 1.10 us | 32.7148 | 1.2207 |    201 KB |
| BeEquivalentTo | .NET Framework 4.7.2 | 5 |     4 | 306.4 us | 4.11 us | 3.64 us | 37.1094 | 0.9766 |    231 KB |


55c79b340bc85f87c144351804cf9e6ae8975f61 Cache `PathName`
|         Method |              Runtime | N | Depth |     Mean |   Error |  StdDev |   Gen 0 |  Gen 1 | Allocated |
|--------------- |--------------------- |-- |------ |---------:|--------:|--------:|--------:|-------:|----------:|
| BeEquivalentTo |             .NET 6.0 | 5 |     4 | 209.4 us | 0.99 us | 0.92 us | 31.2500 | 1.2207 |    192 KB |
| BeEquivalentTo | .NET Framework 4.7.2 | 5 |     4 | 288.2 us | 2.05 us | 1.92 us | 35.6445 | 0.9766 |    221 KB |