### PR TITLE
Filter dynamic methods from stack trace

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -44,7 +44,7 @@ public static class CallerIdentifier
                 allStackFrames,
                 startIndex: 0,
                 count: searchStart + 1,
-                frame => !IsCurrentAssembly(frame) && !IsDotNet(frame));
+                frame => !IsCurrentAssembly(frame) && !IsDynamic(frame) && !IsDotNet(frame));
 
             for (int i = lastUserStackFrameBeforeFluentAssertionsCodeIndex; i < allStackFrames.Length; i++)
             {


### PR DESCRIPTION
.NET 7 Preview 5 includes https://github.com/dotnet/runtime/pull/67917 which might change the looks of the stack trace when using reflection to create dynamic methods like we do for `GenericEnumerableEquivalencyStep.HandleMethod`.

The stack trace for some tests changed from
```
at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
```

to
```
at InvokeStub_GenericEnumerableEquivalencyStep.HandleImpl(Object, Object, IntPtr*)
at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
```

which prevented `CallerIdentifier.IsDotNet` from excluding the stack frame.

As this is only reproducible with the latest preview I haven't added a new test, but these tests consistently fails without the fix.
```
When_testing_for_equivalence_against_empty_collection_it_should_throw
When_collections_with_duplicates_are_not_equivalent_it_should_throw
When_testing_for_equivalence_against_empty_collection_it_should_throw
When_collections_with_duplicates_are_not_equivalent_it_should_throw
```

This fixes #1942