### PR TITLE
Print commas at the end of the line

### DIFF
--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -42,7 +42,7 @@ public class DefaultValueFormatter : IValueFormatter
         {
             if (context.UseLineBreaks)
             {
-                formattedGraph.AddLine(value.ToString());
+                formattedGraph.AddFragmentOnNewLine(value.ToString());
             }
             else
             {

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -653,6 +653,20 @@ public class FormatterSpecs
         result.Should().Match("*…18 more…*");
     }
 
+    [Fact]
+    public void When_formatting_multiple_items_with_a_custom_string_representation_using_line_breaks_it_should_end_lines_with_a_comma()
+    {
+        // Arrange
+        var subject = new[] { typeof(A), typeof(B) };
+
+        // Act
+        string result = Formatter.ToString(subject, new FormattingOptions { UseLineBreaks = true } );
+
+        // Assert
+        result.Should().Contain($"FluentAssertions.Specs.Formatting.FormatterSpecs+A, {Environment.NewLine}");
+        result.Should().Contain($"FluentAssertions.Specs.Formatting.FormatterSpecs+B{Environment.NewLine}");
+    }
+
     public class BaseStuff
     {
         public int StuffId { get; set; }


### PR DESCRIPTION
When using line breaks, print commas behind the listed items, instead of on a new line.

Before:
```
Expected someCollection {
    item1
    ,
    item2
    ,
```
After:
```
Expected someCollection {
    item1,
    item2,
```

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).