### PR TITLE
Extend IObjectInfo with info about DeclaringType

### DIFF
--- a/Src/FluentAssertions/Equivalency/Execution/ObjectInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/ObjectInfo.cs
@@ -7,12 +7,15 @@ internal class ObjectInfo : IObjectInfo
     public ObjectInfo(Comparands comparands, INode currentNode)
     {
         Type = currentNode.Type;
+        ParentType = currentNode.ParentType;
         Path = currentNode.PathAndName;
         CompileTimeType = comparands.CompileTimeType;
         RuntimeType = comparands.RuntimeType;
     }
 
     public Type Type { get; }
+
+    public Type ParentType { get; }
 
     public string Path { get; set; }
 

--- a/Src/FluentAssertions/Equivalency/Field.cs
+++ b/Src/FluentAssertions/Equivalency/Field.cs
@@ -27,6 +27,7 @@ public class Field : Node, IMember
         GetSubjectId = parent.GetSubjectId;
         Name = fieldInfo.Name;
         Type = fieldInfo.FieldType;
+        ParentType = fieldInfo.DeclaringType;
         RootIsCollection = parent.RootIsCollection;
     }
 

--- a/Src/FluentAssertions/Equivalency/INode.cs
+++ b/Src/FluentAssertions/Equivalency/INode.cs
@@ -1,9 +1,11 @@
 using System;
+using JetBrains.Annotations;
 
 namespace FluentAssertions.Equivalency;
 
 /// <summary>
-/// Represents a node in the object graph as it is expected in a structural equivalency check.
+/// Represents a node in the object graph that is being compared as part of a structural equivalency check.
+/// This can be the root object, a collection item, a dictionary element, a property or a field.
 /// </summary>
 public interface INode
 {
@@ -22,9 +24,18 @@ public interface INode
     string Name { get; set; }
 
     /// <summary>
-    /// Gets the type of this node.
+    /// Gets the type of this node, e.g. the type of the field or property, or the type of the collection item. 
     /// </summary>
     Type Type { get; }
+
+    /// <summary>
+    /// Gets the type of the parent node, e.g. the type that declares a property or field.
+    /// </summary>
+    /// <value>
+    /// Is <c>null</c> for the root object.
+    /// </value>
+    [CanBeNull]
+    Type ParentType { get; }
 
     /// <summary>
     /// Gets the path from the root object UNTIL the current node, separated by dots or index/key brackets.

--- a/Src/FluentAssertions/Equivalency/IObjectInfo.cs
+++ b/Src/FluentAssertions/Equivalency/IObjectInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using JetBrains.Annotations;
 
 namespace FluentAssertions.Equivalency;
 
@@ -8,9 +9,19 @@ namespace FluentAssertions.Equivalency;
 public interface IObjectInfo
 {
     /// <summary>
-    /// Gets the type of this node.
+    /// Gets the type of the object 
     /// </summary>
+    [Obsolete("Use CompileTimeType or RuntimeType instead")]
     Type Type { get; }
+
+    /// <summary>
+    /// Gets the type of the parent, e.g. the type that declares a property or field.
+    /// </summary>
+    /// <value>
+    /// Is <c>null</c> for the root object.
+    /// </value>
+    [CanBeNull]
+    Type ParentType { get; }
 
     /// <summary>
     /// Gets the full path from the root object until the current node separated by dots.

--- a/Src/FluentAssertions/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Equivalency/Node.cs
@@ -1,15 +1,11 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency;
 
-/// <summary>
-/// Represents a node in the object graph that is being compared as part of a structural equivalency check.
-/// </summary>
 public class Node : INode
 {
     private static readonly Regex MatchFirstIndex = new(@"^\[\d+\]$");
@@ -21,6 +17,8 @@ public class Node : INode
     public GetSubjectId GetSubjectId { get; protected set; } = () => string.Empty;
 
     public Type Type { get; protected set; }
+
+    public Type ParentType { get; protected set; }
 
     public string Path
     {
@@ -82,6 +80,7 @@ public class Node : INode
             Name = string.Empty,
             Path = string.Empty,
             Type = typeof(T),
+            ParentType = null,
             RootIsCollection = IsCollection(typeof(T))
         };
     }
@@ -91,6 +90,7 @@ public class Node : INode
         return new Node
         {
             Type = typeof(T),
+            ParentType = parent.Type,
             Name = "[" + index + "]",
             Path = parent.PathAndName,
             GetSubjectId = parent.GetSubjectId,
@@ -103,6 +103,7 @@ public class Node : INode
         return new Node
         {
             Type = typeof(T),
+            ParentType = parent.Type,
             Name = "[" + key + "]",
             Path = parent.PathAndName,
             GetSubjectId = parent.GetSubjectId,

--- a/Src/FluentAssertions/Equivalency/Ordering/CollectionMemberObjectInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/CollectionMemberObjectInfo.cs
@@ -7,7 +7,12 @@ internal class CollectionMemberObjectInfo : IObjectInfo
     public CollectionMemberObjectInfo(IObjectInfo context)
     {
         Path = GetAdjustedPropertyPath(context.Path);
+        
+#pragma warning disable CS0618
         Type = context.Type;
+#pragma warning restore CS0618
+        
+        ParentType = context.ParentType;
         RuntimeType = context.RuntimeType;
         CompileTimeType = context.CompileTimeType;
     }
@@ -18,6 +23,8 @@ internal class CollectionMemberObjectInfo : IObjectInfo
     }
 
     public Type Type { get; }
+    
+    public Type ParentType { get; }
 
     public string Path { get; set; }
 

--- a/Src/FluentAssertions/Equivalency/Property.cs
+++ b/Src/FluentAssertions/Equivalency/Property.cs
@@ -26,6 +26,7 @@ public class Property : Node, IMember
         DeclaringType = propertyInfo.DeclaringType;
         Name = propertyInfo.Name;
         Type = propertyInfo.PropertyType;
+        ParentType = propertyInfo.DeclaringType;
         Path = parent.PathAndName;
         GetSubjectId = parent.GetSubjectId;
         RootIsCollection = parent.RootIsCollection;
@@ -36,7 +37,7 @@ public class Property : Node, IMember
         return propertyInfo.GetValue(obj);
     }
 
-    public Type DeclaringType { get; private set; }
+    public Type DeclaringType { get; }
 
     public Type ReflectedType { get; }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -935,6 +935,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
         string Name { get; set; }
+        System.Type ParentType { get; }
         string Path { get; }
         string PathAndName { get; }
         bool RootIsCollection { get; }
@@ -943,8 +944,10 @@ namespace FluentAssertions.Equivalency
     public interface IObjectInfo
     {
         System.Type CompileTimeType { get; }
+        System.Type ParentType { get; }
         string Path { get; set; }
         System.Type RuntimeType { get; }
+        [System.Obsolete("Use CompileTimeType or RuntimeType instead")]
         System.Type Type { get; }
     }
     public interface IOrderingRule
@@ -982,6 +985,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; set; }
         public bool IsRoot { get; }
         public string Name { get; set; }
+        public System.Type ParentType { get; set; }
         public string Path { get; set; }
         public string PathAndName { get; }
         public bool RootIsCollection { get; set; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -947,6 +947,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
         string Name { get; set; }
+        System.Type ParentType { get; }
         string Path { get; }
         string PathAndName { get; }
         bool RootIsCollection { get; }
@@ -955,8 +956,10 @@ namespace FluentAssertions.Equivalency
     public interface IObjectInfo
     {
         System.Type CompileTimeType { get; }
+        System.Type ParentType { get; }
         string Path { get; set; }
         System.Type RuntimeType { get; }
+        [System.Obsolete("Use CompileTimeType or RuntimeType instead")]
         System.Type Type { get; }
     }
     public interface IOrderingRule
@@ -994,6 +997,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; set; }
         public bool IsRoot { get; }
         public string Name { get; set; }
+        public System.Type ParentType { get; set; }
         public string Path { get; set; }
         public string PathAndName { get; }
         public bool RootIsCollection { get; set; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -935,6 +935,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
         string Name { get; set; }
+        System.Type ParentType { get; }
         string Path { get; }
         string PathAndName { get; }
         bool RootIsCollection { get; }
@@ -943,8 +944,10 @@ namespace FluentAssertions.Equivalency
     public interface IObjectInfo
     {
         System.Type CompileTimeType { get; }
+        System.Type ParentType { get; }
         string Path { get; set; }
         System.Type RuntimeType { get; }
+        [System.Obsolete("Use CompileTimeType or RuntimeType instead")]
         System.Type Type { get; }
     }
     public interface IOrderingRule
@@ -982,6 +985,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; set; }
         public bool IsRoot { get; }
         public string Name { get; set; }
+        public System.Type ParentType { get; set; }
         public string Path { get; set; }
         public string PathAndName { get; }
         public bool RootIsCollection { get; set; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -935,6 +935,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
         string Name { get; set; }
+        System.Type ParentType { get; }
         string Path { get; }
         string PathAndName { get; }
         bool RootIsCollection { get; }
@@ -943,8 +944,10 @@ namespace FluentAssertions.Equivalency
     public interface IObjectInfo
     {
         System.Type CompileTimeType { get; }
+        System.Type ParentType { get; }
         string Path { get; set; }
         System.Type RuntimeType { get; }
+        [System.Obsolete("Use CompileTimeType or RuntimeType instead")]
         System.Type Type { get; }
     }
     public interface IOrderingRule
@@ -982,6 +985,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; set; }
         public bool IsRoot { get; }
         public string Name { get; set; }
+        public System.Type ParentType { get; set; }
         public string Path { get; set; }
         public string PathAndName { get; }
         public bool RootIsCollection { get; set; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -928,6 +928,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
         string Name { get; set; }
+        System.Type ParentType { get; }
         string Path { get; }
         string PathAndName { get; }
         bool RootIsCollection { get; }
@@ -936,8 +937,10 @@ namespace FluentAssertions.Equivalency
     public interface IObjectInfo
     {
         System.Type CompileTimeType { get; }
+        System.Type ParentType { get; }
         string Path { get; set; }
         System.Type RuntimeType { get; }
+        [System.Obsolete("Use CompileTimeType or RuntimeType instead")]
         System.Type Type { get; }
     }
     public interface IOrderingRule
@@ -975,6 +978,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; set; }
         public bool IsRoot { get; }
         public string Name { get; set; }
+        public System.Type ParentType { get; set; }
         public string Path { get; set; }
         public string PathAndName { get; }
         public bool RootIsCollection { get; set; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -935,6 +935,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
         string Name { get; set; }
+        System.Type ParentType { get; }
         string Path { get; }
         string PathAndName { get; }
         bool RootIsCollection { get; }
@@ -943,8 +944,10 @@ namespace FluentAssertions.Equivalency
     public interface IObjectInfo
     {
         System.Type CompileTimeType { get; }
+        System.Type ParentType { get; }
         string Path { get; set; }
         System.Type RuntimeType { get; }
+        [System.Obsolete("Use CompileTimeType or RuntimeType instead")]
         System.Type Type { get; }
     }
     public interface IOrderingRule
@@ -982,6 +985,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; set; }
         public bool IsRoot { get; }
         public string Name { get; set; }
+        public System.Type ParentType { get; set; }
         public string Path { get; set; }
         public string PathAndName { get; }
         public bool RootIsCollection { get; set; }

--- a/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
@@ -227,6 +227,27 @@ public class ExtensibilitySpecs
     }
 
     [Fact]
+    public void Can_exclude_all_properties_of_the_parent_type()
+    {
+        // Arrange
+        var subject = new
+        {
+            Id = "foo",
+        };
+
+        var expectation = new
+        {
+            Id = "bar",
+        };
+
+        // Act
+        subject.Should().BeEquivalentTo(expectation,
+            o => o
+                .Using<string>(c => c.Subject.Should().HaveLength(c.Expectation.Length))
+                .When(si => si.ParentType == expectation.GetType() && si.Path.EndsWith("Id", StringComparison.InvariantCulture)));
+    }
+
+    [Fact]
     public void When_property_of_subject_is_incompatible_with_generic_type_the_message_should_include_generic_type()
     {
         // Arrange

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's new
 * Added `ContainInConsecutiveOrder` and `NotContainInConsecutiveOrder` assertions to check if a collection contains items in a specific order and to be consecutive - [#1963](https://github.com/fluentassertions/fluentassertions/pull/1963)
 * Added `NotCompleteWithinAsync` for assertions on `Task` - [#1967](https://github.com/fluentassertions/fluentassertions/pull/1967)
+* Added a `ParentType` to `IObjectInfo` to help determining the parent in a call to `Using`/`When` constructs - [#1950](https://github.com/fluentassertions/fluentassertions/pull/1950)
 
 ### Fixes
 * Fix `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)


### PR DESCRIPTION
Adds `IObjectInfo.ParentType` to help determining the declaring type in a call to `Using`/`When` constructs.

Also marks `IObjectInfo.Type` as obsolete since its purpose is so confusing.

Fixes #1949

