### PR TITLE
Make For/Excluding work with nested paths

### DIFF
--- a/Src/FluentAssertions/Common/MemberPath.cs
+++ b/Src/FluentAssertions/Common/MemberPath.cs
@@ -81,7 +81,7 @@ internal class MemberPath
     public MemberPath AsParentCollectionOf(MemberPath nextPath)
     {
         var extendedDottedPath = dottedPath.Combine(nextPath.dottedPath, "[]");
-        return new MemberPath(declaringType, nextPath.reflectedType, extendedDottedPath);
+        return new MemberPath(nextPath.reflectedType, nextPath.declaringType, extendedDottedPath);
     }
 
     /// <summary>

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -766,6 +766,105 @@ public class CollectionSpecs
         }
 
         [Fact]
+        public void When_property_in_object_in_collection_is_excluded_it_should_not_throw()
+        {
+            // Arrange
+            var subject = new
+            {
+                Collection = new[]
+                {
+                    new
+                    {
+                        Level = new
+                        {
+                            Text = "Actual"
+                        }
+                    }
+                }
+            };
+
+            var expected = new
+            {
+                Collection = new[]
+                {
+                    new
+                    {
+                        Level = new
+                        {
+                            Text = "Expected"
+                        }
+                    }
+                }
+            };
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expected,
+                options => options
+                    .For(x => x.Collection)
+                    .Exclude(x => x.Level.Text)
+            );
+        }
+
+        [Fact]
+        public void When_property_in_object_in_collection_in_object_in_collection_is_excluded_it_should_not_throw()
+        {
+            // Arrange
+            var subject = new
+            {
+                Collection = new[]
+                {
+                    new
+                    {
+                        Level = new
+                        {
+                            Collection = new[]
+                            {
+                                new
+                                {
+                                    Level = new
+                                    {
+                                        Text = "Actual"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var expected = new
+            {
+                Collection = new[]
+                {
+                    new
+                    {
+                        Level = new
+                        {
+                            Collection = new[]
+                            {
+                                new
+                                {
+                                    Level = new
+                                    {
+                                        Text = "Expected"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expected,
+                options => options
+                    .For(x => x.Collection)
+                    .For(x => x.Level.Collection)
+                    .Exclude(x => x.Level)
+            );
+        }
+
+        [Fact]
         public void A_nested_exclusion_can_be_followed_by_a_root_level_exclusion()
         {
             // Arrange

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -7,6 +7,13 @@ sidebar:
   nav: "sidebar"
 ---
 
+## Unreleased
+
+### What's new
+
+### Fixes
+* Fix `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)
+
 ## 6.7.0
 
 ### What's new


### PR DESCRIPTION
Fixed #1952

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).