### PR TITLE
Avoid allocating sub-arrays in ContainInOrder

### DIFF
--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInOrder.cs
@@ -101,6 +101,20 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
+        public void Collections_contain_the_empty_sequence()
+        {
+            // Assert
+            new[] { 1 }.Should().ContainInOrder(new int[0]);
+        }
+
+        [Fact]
+        public void Collections_do_not_not_contain_the_empty_sequence()
+        {
+            // Assert
+            new[] { 1 }.Should().NotContainInOrder(new int[0]);
+        }
+
+        [Fact]
         public void When_asserting_collection_contains_some_values_in_order_but_collection_is_null_it_should_throw()
         {
             // Arrange


### PR DESCRIPTION
There's no need to repeatedly allocating sub-arrays.
In the worst case, when subject and expected are identical, we will allocate N sub-arrays of a total length of O(N^2).

Instead we simply keep an index of how far we have scanned the subject.

The added tests are not meant as authoritative but only to ensure behavior has not changed.