### PR TITLE
Added assertions for non-generic TaskCompletionSource

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -921,6 +921,20 @@ public static class AssertionExtensions
 
 #endif
 
+#if NET6_0_OR_GREATER
+
+    /// <summary>
+    /// Returns a <see cref="TaskCompletionSourceAssertions"/> object that can be used to assert the
+    /// current <see cref="TaskCompletionSource"/>.
+    /// </summary>
+    [Pure]
+    public static TaskCompletionSourceAssertions Should(this TaskCompletionSource tcs)
+    {
+        return new TaskCompletionSourceAssertions(tcs);
+    }
+
+#endif
+
     /// <summary>
     /// Safely casts the specified object to the type specified through <typeparamref name="TTo"/>.
     /// </summary>
@@ -1038,7 +1052,7 @@ public static class AssertionExtensions
 
     /// <inheritdoc cref="Should(ExecutionTimeAssertions)" />
     [Obsolete("You are asserting the 'AndConstraint' itself. Remove the 'Should()' method directly following 'And'", error: true)]
-    public static void Should<TSubject>(this TaskCompletionSourceAssertions<TSubject> _)
+    public static void Should(this TaskCompletionSourceAssertionsBase _)
     {
         InvalidShouldCall();
     }

--- a/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
+++ b/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
@@ -8,7 +8,89 @@ namespace FluentAssertions.Specialized;
 
 #pragma warning disable CS0659 // Ignore not overriding Object.GetHashCode()
 #pragma warning disable CA1065 // Ignore throwing NotSupportedException from Equals
-public class TaskCompletionSourceAssertions<T>
+
+#if NET6_0_OR_GREATER
+public class TaskCompletionSourceAssertions : TaskCompletionSourceAssertionsBase
+{
+    private readonly TaskCompletionSource subject;
+
+    public TaskCompletionSourceAssertions(TaskCompletionSource tcs)
+        : this(tcs, new Clock())
+    {
+    }
+
+    public TaskCompletionSourceAssertions(TaskCompletionSource tcs, IClock clock)
+        : base(clock)
+    {
+        subject = tcs;
+    }
+
+    /// <summary>
+    /// Asserts that the <see cref="Task"/> of the current <see cref="TaskCompletionSource"/> will complete within the specified time.
+    /// </summary>
+    /// <param name="timeSpan">The allowed time span for the operation.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public async Task<AndConstraint<TaskCompletionSourceAssertions>> CompleteWithinAsync(
+        TimeSpan timeSpan, string because = "", params object[] becauseArgs)
+    {
+        var success = Execute.Assertion
+            .ForCondition(subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context} to complete within {0}{reason}, but found <null>.", timeSpan);
+
+        if (success)
+        {
+            bool completesWithinTimeout = await CompletesWithinTimeoutAsync(subject.Task, timeSpan);
+            Execute.Assertion
+                .ForCondition(completesWithinTimeout)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
+        }
+
+        return new AndConstraint<TaskCompletionSourceAssertions>(this);
+    }
+
+    /// <summary>
+    /// Asserts that the <see cref="Task"/> of the current <see cref="TaskCompletionSource"/> will not complete within the specified time.
+    /// </summary>
+    /// <param name="timeSpan">The time span to wait for the operation.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public async Task<AndConstraint<TaskCompletionSourceAssertions>> NotCompleteWithinAsync(
+        TimeSpan timeSpan, string because = "", params object[] becauseArgs)
+    {
+        var success = Execute.Assertion
+            .ForCondition(subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context} to not complete within {0}{reason}, but found <null>.", timeSpan);
+
+        if (success)
+        {
+            bool completesWithinTimeout = await CompletesWithinTimeoutAsync(subject.Task, timeSpan);
+            Execute.Assertion
+                .ForCondition(!completesWithinTimeout)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:task} to not complete within {0}{reason}.", timeSpan);
+        }
+
+        return new AndConstraint<TaskCompletionSourceAssertions>(this);
+    }
+}
+
+#endif
+
+public class TaskCompletionSourceAssertions<T> : TaskCompletionSourceAssertionsBase
 {
     private readonly TaskCompletionSource<T> subject;
 
@@ -18,12 +100,10 @@ public class TaskCompletionSourceAssertions<T>
     }
 
     public TaskCompletionSourceAssertions(TaskCompletionSource<T> tcs, IClock clock)
+        : base(clock)
     {
         subject = tcs;
-        Clock = clock ?? throw new ArgumentNullException(nameof(clock));
     }
-
-    private protected IClock Clock { get; }
 
     /// <summary>
     /// Asserts that the <see cref="Task"/> of the current <see cref="TaskCompletionSource{T}"/> will complete within the specified time.
@@ -39,27 +119,23 @@ public class TaskCompletionSourceAssertions<T>
     public async Task<AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(
         TimeSpan timeSpan, string because = "", params object[] becauseArgs)
     {
-        Execute.Assertion
+        var success = Execute.Assertion
             .ForCondition(subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} to complete within {0}{reason}, but found <null>.", timeSpan);
 
-        using var timeoutCancellationTokenSource = new CancellationTokenSource();
-        Task completedTask = await Task.WhenAny(
-            subject.Task,
-            Clock.DelayAsync(timeSpan, timeoutCancellationTokenSource.Token));
-
-        if (completedTask == subject.Task)
+        if (!success)
         {
-            timeoutCancellationTokenSource.Cancel();
-            await completedTask;
+            return new AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>(this, default(T));
         }
 
+        bool completesWithinTimeout = await CompletesWithinTimeoutAsync(subject.Task, timeSpan);
         Execute.Assertion
-            .ForCondition(completedTask == subject.Task)
+            .ForCondition(completesWithinTimeout)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
-        return new AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>(this, subject.Task.Result);
+        T result = subject.Task.IsCompleted ? subject.Task.Result : default;
+        return new AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>(this, result);
     }
 
     /// <summary>
@@ -73,32 +149,60 @@ public class TaskCompletionSourceAssertions<T>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public async Task NotCompleteWithinAsync(
+    public async Task<AndConstraint<TaskCompletionSourceAssertions<T>>> NotCompleteWithinAsync(
         TimeSpan timeSpan, string because = "", params object[] becauseArgs)
     {
-        Execute.Assertion
+        var success = Execute.Assertion
             .ForCondition(subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context} to complete within {0}{reason}, but found <null>.", timeSpan);
 
-        using var timeoutCancellationTokenSource = new CancellationTokenSource();
-        Task completedTask = await Task.WhenAny(
-            subject.Task,
-            Clock.DelayAsync(timeSpan, timeoutCancellationTokenSource.Token));
-
-        if (completedTask == subject.Task)
+        if (success)
         {
-            timeoutCancellationTokenSource.Cancel();
-            await completedTask;
+            bool completesWithinTimeout = await CompletesWithinTimeoutAsync(subject.Task, timeSpan);
+            Execute.Assertion
+                .ForCondition(!completesWithinTimeout)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Did not expect {context:task} to complete within {0}{reason}.", timeSpan);
         }
 
-        Execute.Assertion
-            .ForCondition(completedTask != subject.Task)
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Did not expect {context:task} to complete within {0}{reason}.", timeSpan);
+        return new AndConstraint<TaskCompletionSourceAssertions<T>>(this);
     }
+}
+
+/// <summary>
+/// Implements base functionality for assertions on TaskCompletionSource.
+/// </summary>
+public class TaskCompletionSourceAssertionsBase
+{
+    protected TaskCompletionSourceAssertionsBase(IClock clock)
+    {
+        Clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    private protected IClock Clock { get; }
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
         throw new NotSupportedException("Calling Equals on Assertion classes is not supported.");
+
+    /// <summary>
+    ///     Monitors the specified task whether it completes withing the remaining time span.
+    /// </summary>
+    private protected async Task<bool> CompletesWithinTimeoutAsync(Task target, TimeSpan remainingTime)
+    {
+        using var timeoutCancellationTokenSource = new CancellationTokenSource();
+
+        Task completedTask =
+            await Task.WhenAny(target, Clock.DelayAsync(remainingTime, timeoutCancellationTokenSource.Token));
+
+        if (completedTask != target)
+        {
+            return false;
+        }
+
+        // cancel the clock
+        timeoutCancellationTokenSource.Cancel();
+        return true;
+    }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -43,6 +43,9 @@ namespace FluentAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this FluentAssertions.Specialized.ExecutionTimeAssertions _) { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should(this FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase _) { }
         public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
@@ -135,9 +138,6 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
-        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
-            "ly following \'And\'", true)]
-        public static void Should<TSubject>(this FluentAssertions.Specialized.TaskCompletionSourceAssertions<TSubject> _) { }
         public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
@@ -2348,13 +2348,17 @@ namespace FluentAssertions.Specialized
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
     }
-    public class TaskCompletionSourceAssertions<T>
+    public class TaskCompletionSourceAssertionsBase
+    {
+        protected TaskCompletionSourceAssertionsBase(FluentAssertions.Common.IClock clock) { }
+        public override bool Equals(object obj) { }
+    }
+    public class TaskCompletionSourceAssertions<T> : FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase
     {
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public override bool Equals(object obj) { }
-        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Streams

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -43,6 +43,9 @@ namespace FluentAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this FluentAssertions.Specialized.ExecutionTimeAssertions _) { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should(this FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase _) { }
         public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
@@ -77,6 +80,7 @@ namespace FluentAssertions
         public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
         public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Specialized.TaskCompletionSourceAssertions Should(this System.Threading.Tasks.TaskCompletionSource tcs) { }
         public static FluentAssertions.Primitives.TimeOnlyAssertions Should(this System.TimeOnly actualValue) { }
         public static FluentAssertions.Primitives.NullableTimeOnlyAssertions Should(this System.TimeOnly? actualValue) { }
         public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
@@ -147,9 +151,6 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions> { }
-        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
-            "ly following \'And\'", true)]
-        public static void Should<TSubject>(this FluentAssertions.Specialized.TaskCompletionSourceAssertions<TSubject> _) { }
         public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
@@ -2466,13 +2467,24 @@ namespace FluentAssertions.Specialized
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
     }
-    public class TaskCompletionSourceAssertions<T>
+    public class TaskCompletionSourceAssertions : FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase
+    {
+        public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource tcs) { }
+        public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource tcs, FluentAssertions.Common.IClock clock) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+    public class TaskCompletionSourceAssertionsBase
+    {
+        protected TaskCompletionSourceAssertionsBase(FluentAssertions.Common.IClock clock) { }
+        public override bool Equals(object obj) { }
+    }
+    public class TaskCompletionSourceAssertions<T> : FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase
     {
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public override bool Equals(object obj) { }
-        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Streams

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -43,6 +43,9 @@ namespace FluentAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this FluentAssertions.Specialized.ExecutionTimeAssertions _) { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should(this FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase _) { }
         public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
@@ -135,9 +138,6 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
-        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
-            "ly following \'And\'", true)]
-        public static void Should<TSubject>(this FluentAssertions.Specialized.TaskCompletionSourceAssertions<TSubject> _) { }
         public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
@@ -2348,13 +2348,17 @@ namespace FluentAssertions.Specialized
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
     }
-    public class TaskCompletionSourceAssertions<T>
+    public class TaskCompletionSourceAssertionsBase
+    {
+        protected TaskCompletionSourceAssertionsBase(FluentAssertions.Common.IClock clock) { }
+        public override bool Equals(object obj) { }
+    }
+    public class TaskCompletionSourceAssertions<T> : FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase
     {
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public override bool Equals(object obj) { }
-        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Streams

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -43,6 +43,9 @@ namespace FluentAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this FluentAssertions.Specialized.ExecutionTimeAssertions _) { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should(this FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase _) { }
         public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
@@ -135,9 +138,6 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
-        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
-            "ly following \'And\'", true)]
-        public static void Should<TSubject>(this FluentAssertions.Specialized.TaskCompletionSourceAssertions<TSubject> _) { }
         public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
@@ -2348,13 +2348,17 @@ namespace FluentAssertions.Specialized
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
     }
-    public class TaskCompletionSourceAssertions<T>
+    public class TaskCompletionSourceAssertionsBase
+    {
+        protected TaskCompletionSourceAssertionsBase(FluentAssertions.Common.IClock clock) { }
+        public override bool Equals(object obj) { }
+    }
+    public class TaskCompletionSourceAssertions<T> : FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase
     {
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public override bool Equals(object obj) { }
-        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Streams

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -42,6 +42,9 @@ namespace FluentAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this FluentAssertions.Specialized.ExecutionTimeAssertions _) { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should(this FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase _) { }
         public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
@@ -134,9 +137,6 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
-        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
-            "ly following \'And\'", true)]
-        public static void Should<TSubject>(this FluentAssertions.Specialized.TaskCompletionSourceAssertions<TSubject> _) { }
         public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
@@ -2300,13 +2300,17 @@ namespace FluentAssertions.Specialized
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
     }
-    public class TaskCompletionSourceAssertions<T>
+    public class TaskCompletionSourceAssertionsBase
+    {
+        protected TaskCompletionSourceAssertionsBase(FluentAssertions.Common.IClock clock) { }
+        public override bool Equals(object obj) { }
+    }
+    public class TaskCompletionSourceAssertions<T> : FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase
     {
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public override bool Equals(object obj) { }
-        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Streams

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -43,6 +43,9 @@ namespace FluentAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this FluentAssertions.Specialized.ExecutionTimeAssertions _) { }
+        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
+            "ly following \'And\'", true)]
+        public static void Should(this FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase _) { }
         public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
@@ -135,9 +138,6 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
-        [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
-            "ly following \'And\'", true)]
-        public static void Should<TSubject>(this FluentAssertions.Specialized.TaskCompletionSourceAssertions<TSubject> _) { }
         public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
@@ -2348,13 +2348,17 @@ namespace FluentAssertions.Specialized
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
     }
-    public class TaskCompletionSourceAssertions<T>
+    public class TaskCompletionSourceAssertionsBase
+    {
+        protected TaskCompletionSourceAssertionsBase(FluentAssertions.Common.IClock clock) { }
+        public override bool Equals(object obj) { }
+    }
+    public class TaskCompletionSourceAssertions<T> : FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase
     {
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public override bool Equals(object obj) { }
-        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Streams

--- a/Tests/FluentAssertions.Specs/AssertionExtensions.cs
+++ b/Tests/FluentAssertions.Specs/AssertionExtensions.cs
@@ -33,4 +33,13 @@ internal static class AssertionExtensions
     {
         return new TaskCompletionSourceAssertions<T>(tcs, clock);
     }
+
+#if NET6_0_OR_GREATER
+
+    public static TaskCompletionSourceAssertions Should(this TaskCompletionSource tcs, IClock clock)
+    {
+        return new TaskCompletionSourceAssertions(tcs, clock);
+    }
+
+#endif
 }

--- a/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
@@ -44,10 +44,6 @@ public class AssertionExtensionsSpecs
         new object[] { new DateTimeRangeAssertions<DateTimeAssertions>(default, default, default, default) },
         new object[] { new DateTimeOffsetAssertions<DateTimeOffsetAssertions>(default) },
         new object[] { new DateTimeOffsetRangeAssertions<DateTimeOffsetAssertions>(default, default, default, default) },
-#if NET6_0_OR_GREATER
-        new object[] { new DateOnlyAssertions<DateOnlyAssertions>(default) },
-        new object[] { new TimeOnlyAssertions<TimeOnlyAssertions>(default) },
-#endif
         new object[] { new ExecutionTimeAssertions(new ExecutionTime(() => { }, () => new StopwatchTimer())) },
         new object[] { new GuidAssertions<GuidAssertions>(default) },
         new object[] { new MethodInfoSelectorAssertions() },
@@ -56,7 +52,11 @@ public class AssertionExtensionsSpecs
         new object[] { new SimpleTimeSpanAssertions<SimpleTimeSpanAssertions>(default) },
         new object[] { new TaskCompletionSourceAssertions<int>(default) },
         new object[] { new TypeSelectorAssertions() },
-        new object[] { new EnumAssertions<StringComparison, EnumAssertions<StringComparison>>(default) }
+        new object[] { new EnumAssertions<StringComparison, EnumAssertions<StringComparison>>(default) },
+#if NET6_0_OR_GREATER
+        new object[] { new DateOnlyAssertions<DateOnlyAssertions>(default) },
+        new object[] { new TimeOnlyAssertions<TimeOnlyAssertions>(default) },
+#endif
     };
 
     [Theory]
@@ -77,19 +77,19 @@ public class AssertionExtensionsSpecs
     [InlineData(typeof(DateTimeRangeAssertions<DateTimeAssertions>))]
     [InlineData(typeof(DateTimeOffsetAssertions<DateTimeOffsetAssertions>))]
     [InlineData(typeof(DateTimeOffsetRangeAssertions<DateTimeOffsetAssertions>))]
-#if NET6_0_OR_GREATER
-    [InlineData(typeof(DateOnlyAssertions<DateOnlyAssertions>))]
-    [InlineData(typeof(TimeOnlyAssertions<TimeOnlyAssertions>))]
-#endif
     [InlineData(typeof(ExecutionTimeAssertions))]
     [InlineData(typeof(GuidAssertions<GuidAssertions>))]
     [InlineData(typeof(MethodInfoSelectorAssertions))]
     [InlineData(typeof(NumericAssertions<int, NumericAssertions<int>>))]
     [InlineData(typeof(PropertyInfoSelectorAssertions))]
     [InlineData(typeof(SimpleTimeSpanAssertions<SimpleTimeSpanAssertions>))]
-    [InlineData(typeof(TaskCompletionSourceAssertions<int>))]
+    [InlineData(typeof(TaskCompletionSourceAssertionsBase))]
     [InlineData(typeof(TypeSelectorAssertions))]
     [InlineData(typeof(EnumAssertions<StringComparison, EnumAssertions<StringComparison>>))]
+#if NET6_0_OR_GREATER
+    [InlineData(typeof(DateOnlyAssertions<DateOnlyAssertions>))]
+    [InlineData(typeof(TimeOnlyAssertions<TimeOnlyAssertions>))]
+#endif
     public void Fake_should_method_throws(Type type)
     {
         // Arrange
@@ -134,8 +134,13 @@ public class AssertionExtensionsSpecs
             .Distinct()
             .Concat(new[]
             {
+                // @jnyrup: DateTimeRangeAssertions and DateTimeOffsetRangeAssertions are manually added here,
+                // because they expose AndConstraints,
+                // and hence should have a guarding Should(DateTimeRangeAssertions _) overloads,
+                // but they do not have a regular Should() overload,
+                // as they are always constructed through the fluent API.
                 typeof(DateTimeRangeAssertions<>),
-                typeof(DateTimeOffsetRangeAssertions<>)
+                typeof(DateTimeOffsetRangeAssertions<>),
             })
             .ToList();
 

--- a/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using FluentAssertions.Extensions;
 using Xunit;
@@ -9,160 +8,261 @@ namespace FluentAssertions.Specs.Specialized;
 
 public class TaskCompletionSourceAssertionSpecs
 {
-    [Fact]
-    public async Task When_TCS_completes_in_time_it_should_succeed()
+#if NET6_0_OR_GREATER
+
+    public class NonGeneric
     {
-        // Arrange
-        var subject = new TaskCompletionSource<bool>();
-        var timer = new FakeClock();
+        [Fact]
+        public async Task When_it_completes_in_time_it_should_succeed()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource();
+            var timer = new FakeClock();
 
-        // Act
-        Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds());
-        subject.SetResult(true);
-        timer.Complete();
+            // Act
+            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds());
+            subject.SetResult();
+            timer.Complete();
 
-        // Assert
-        await action.Should().NotThrowAsync();
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_it_did_not_complete_in_time_it_should_fail()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Expected subject to complete within 1s because test testArg.");
+        }
+
+        [Fact]
+        public async Task When_it_is_null_it_should_fail()
+        {
+            // Arrange
+            TaskCompletionSource subject = null;
+
+            // Act
+            Func<Task> action = () => subject.Should().CompleteWithinAsync(1.Seconds());
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Expected subject to complete within 1s, but found <null>.");
+        }
+
+        [Fact]
+        public async Task When_it_completes_in_time_and_it_is_not_expected_it_should_fail()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            subject.SetResult();
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>().WithMessage("*to not complete within*because test testArg*");
+        }
+
+        [Fact]
+        public async Task When_it_did_not_complete_in_time_and_it_is_not_expected_it_should_succeed()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds());
+            timer.Complete();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_it_is_null_and_we_validate_to_not_complete_it_should_fail()
+        {
+            // Arrange
+            TaskCompletionSource subject = null;
+
+            // Act
+            Func<Task> action = () => subject.Should().NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Expected subject to not complete within 1s because test testArg, but found <null>.");
+        }
     }
+#endif
 
-    [Fact]
-    public async Task When_TCS_completes_in_time_and_result_is_expected_it_should_succeed()
+    public class Generic
     {
-        // Arrange
-        var subject = new TaskCompletionSource<int>();
-        var timer = new FakeClock();
+        [Fact]
+        public async Task When_it_completes_in_time_it_should_succeed()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource<bool>();
+            var timer = new FakeClock();
 
-        // Act
-        Func<Task> action = async () => (await subject.Should(timer).CompleteWithinAsync(1.Seconds())).Which.Should().Be(42);
-        subject.SetResult(42);
-        timer.Complete();
+            // Act
+            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds());
+            subject.SetResult(true);
+            timer.Complete();
 
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
 
-    [Fact]
-    public async Task When_TCS_completes_in_time_and_async_result_is_expected_it_should_succeed()
-    {
-        // Arrange
-        var subject = new TaskCompletionSource<int>();
-        var timer = new FakeClock();
+        [Fact]
+        public async Task When_it_completes_in_time_and_result_is_expected_it_should_succeed()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource<int>();
+            var timer = new FakeClock();
 
-        // Act
-        Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds()).WithResult(42);
-        subject.SetResult(42);
-        timer.Complete();
+            // Act
+            Func<Task> action = async () => (await subject.Should(timer).CompleteWithinAsync(1.Seconds())).Which.Should().Be(42);
+            subject.SetResult(42);
+            timer.Complete();
 
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
 
-    [Fact]
-    public async Task When_TCS_completes_in_time_and_result_is_not_expected_it_should_fail()
-    {
-        // Arrange
-        var testSubject = new TaskCompletionSource<int>();
-        var timer = new FakeClock();
+        [Fact]
+        public async Task When_it_completes_in_time_and_async_result_is_expected_it_should_succeed()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource<int>();
+            var timer = new FakeClock();
 
-        // Act
-        Func<Task> action = async () => (await testSubject.Should(timer).CompleteWithinAsync(1.Seconds())).Which.Should().Be(42);
-        testSubject.SetResult(99);
-        timer.Complete();
+            // Act
+            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds()).WithResult(42);
+            subject.SetResult(42);
+            timer.Complete();
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected *testSubject* to be 42, but found 99 (difference of 57).");
-    }
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
 
-    [Fact]
-    public async Task When_TCS_completes_in_time_and_async_result_is_not_expected_it_should_fail()
-    {
-        // Arrange
-        var testSubject = new TaskCompletionSource<int>();
-        var timer = new FakeClock();
+        [Fact]
+        public async Task When_it_completes_in_time_and_result_is_not_expected_it_should_fail()
+        {
+            // Arrange
+            var testSubject = new TaskCompletionSource<int>();
+            var timer = new FakeClock();
 
-        // Act
-        Func<Task> action = () => testSubject.Should(timer).CompleteWithinAsync(1.Seconds()).WithResult(42);
-        testSubject.SetResult(99);
-        timer.Complete();
+            // Act
+            Func<Task> action = async () =>
+                (await testSubject.Should(timer).CompleteWithinAsync(1.Seconds())).Which.Should().Be(42);
+            testSubject.SetResult(99);
+            timer.Complete();
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected testSubject to be 42, but found 99.");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Expected *testSubject* to be 42, but found 99 (difference of 57).");
+        }
 
-    [Fact]
-    public async Task When_TCS_did_not_complete_in_time_it_should_fail()
-    {
-        // Arrange
-        var subject = new TaskCompletionSource<bool>();
-        var timer = new FakeClock();
+        [Fact]
+        public async Task When_it_completes_in_time_and_async_result_is_not_expected_it_should_fail()
+        {
+            // Arrange
+            var testSubject = new TaskCompletionSource<int>();
+            var timer = new FakeClock();
 
-        // Act
-        Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
-        timer.Complete();
+            // Act
+            Func<Task> action = () => testSubject.Should(timer).CompleteWithinAsync(1.Seconds()).WithResult(42);
+            testSubject.SetResult(99);
+            timer.Complete();
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected subject to complete within 1s because test testArg.");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Expected testSubject to be 42, but found 99.");
+        }
 
-    [Fact]
-    public async Task When_TCS_is_null_it_should_fail()
-    {
-        // Arrange
-        TaskCompletionSource<bool> subject = null;
+        [Fact]
+        public async Task When_it_did_not_complete_in_time_it_should_fail()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource<bool>();
+            var timer = new FakeClock();
 
-        // Act
-        Func<Task> action = () => subject.Should().CompleteWithinAsync(1.Seconds());
+            // Act
+            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            timer.Complete();
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected subject to complete within 1s, but found <null>.");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Expected subject to complete within 1s because test testArg.");
+        }
 
-    [Fact]
-    public async Task When_TCS_completes_in_time_and_it_is_not_expected_it_should_fail()
-    {
-        // Arrange
-        var subject = new TaskCompletionSource<bool>();
-        var timer = new FakeClock();
+        [Fact]
+        public async Task When_it_is_null_it_should_fail()
+        {
+            // Arrange
+            TaskCompletionSource<bool> subject = null;
 
-        // Act
-        Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
-        subject.SetResult(true);
-        timer.Complete();
+            // Act
+            Func<Task> action = () => subject.Should().CompleteWithinAsync(1.Seconds());
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>().WithMessage("Did not expect*to complete within*because test testArg*");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Expected subject to complete within 1s, but found <null>.");
+        }
 
-    [Fact]
-    public async Task When_TCS_did_not_complete_in_time_and_it_is_not_expected_it_should_succeed()
-    {
-        // Arrange
-        var subject = new TaskCompletionSource<bool>();
-        var timer = new FakeClock();
+        [Fact]
+        public async Task When_it_completes_in_time_and_it_is_not_expected_it_should_fail()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource<bool>();
+            var timer = new FakeClock();
 
-        // Act
-        Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds());
-        timer.Complete();
+            // Act
+            Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            subject.SetResult(true);
+            timer.Complete();
 
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>().WithMessage("Did not expect*to complete within*because test testArg*");
+        }
 
-    [Fact]
-    public async Task When_TCS_is_null_and_we_validate_to_not_complete_it_should_fail()
-    {
-        // Arrange
-        TaskCompletionSource<bool> subject = null;
+        [Fact]
+        public async Task When_it_did_not_complete_in_time_and_it_is_not_expected_it_should_succeed()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource<bool>();
+            var timer = new FakeClock();
 
-        // Act
-        Func<Task> action = () => subject.Should().NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            // Act
+            Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds());
+            timer.Complete();
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Did not expect subject to complete within 1s because test testArg, but found <null>.");
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_it_is_null_and_we_validate_to_not_complete_it_should_fail()
+        {
+            // Arrange
+            TaskCompletionSource<bool> subject = null;
+
+            // Act
+            Func<Task> action = () => subject.Should().NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Did not expect subject to complete within 1s because test testArg, but found <null>.");
+        }
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,19 +16,19 @@ sidebar:
 * Added a `ParentType` to `IObjectInfo` to help determining the parent in a call to `Using`/`When` constructs - [#1950](https://github.com/fluentassertions/fluentassertions/pull/1950)
 
 ### Fixes
-* Fix `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)
+* Fixed `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)
 
 ## 6.7.0
 
 ### What's new
-* Add `BeDefined` and `NotBeDefined` to assert on existence of an enum value - [#1888](https://github.com/fluentassertions/fluentassertions/pull/1888)
+* Added `BeDefined` and `NotBeDefined` to assert on existence of an enum value - [#1888](https://github.com/fluentassertions/fluentassertions/pull/1888)
 * Added the ability to exclude fields & properties marked as non-browsable in the code editor from structural equality comparisons - [#1807](https://github.com/fluentassertions/fluentassertions/pull/1807) & [#1812](https://github.com/fluentassertions/fluentassertions/pull/1812)
 * Assertions on the collection types in System.Data (`DataSet.Tables`, `DataTable.Columns`, `DataTable.Rows`) have been restored - [#1812](https://github.com/fluentassertions/fluentassertions/pull/1812)
-* Add `For`/`Exclude` to allow exclusion of members inside a collection - [#1782](https://github.com/fluentassertions/fluentassertions/pull/1782)
+* Added `For`/`Exclude` to allow exclusion of members inside a collection - [#1782](https://github.com/fluentassertions/fluentassertions/pull/1782)
 * Added overload for `HaveElement` for `XDocument` and `XElement` to assert on number of XML nodes - [#1880](https://github.com/fluentassertions/fluentassertions/pull/1880)
 
 ### Fixes
-* Fix the failure message for regex matches (occurrence overload) to include the missing subject - [#1913](https://github.com/fluentassertions/fluentassertions/pull/1913)
+* Fixed the failure message for regex matches (occurrence overload) to include the missing subject - [#1913](https://github.com/fluentassertions/fluentassertions/pull/1913)
 * Fixed `WithArgs` matching too many events when at least one argument matched the expected type - [#1920](https://github.com/fluentassertions/fluentassertions/pull/1920)
 
 ## 6.6.0
@@ -61,7 +61,7 @@ sidebar:
 ### Fixes
 * Improved the documentation on `BeLowerCased` and `BeUpperCased` for strings with non-alphabetic characters - [#1792](https://github.com/fluentassertions/fluentassertions/pull/1792)
 * Caller identification does not handle all arguments using `new` - [#1794](https://github.com/fluentassertions/fluentassertions/pull/1794)
-* Resolve an issue preventing `HaveAccessModifier` from correctly recognizing internal interfaces and enums - [#1793](https://github.com/fluentassertions/fluentassertions/issues/1793)
+* Resolved an issue preventing `HaveAccessModifier` from correctly recognizing internal interfaces and enums - [#1793](https://github.com/fluentassertions/fluentassertions/issues/1793)
 * Improved tracing for nested `AssertionScope`s - [#1797](https://github.com/fluentassertions/fluentassertions/pull/1797)
 
 ### Fixes (Extensibility)
@@ -70,9 +70,9 @@ sidebar:
 ## 6.4.0
 
 ### What's New
-* Adding `ThatAreStatic()` and `ThatAreNotStatic()` for filtering in method assertions - [#1740](https://github.com/fluentassertions/fluentassertions/pull/1740)
-* Adding new assertions for the `HttpStatusCode` of an `HttpResponseMessage` - [#1737](https://github.com/fluentassertions/fluentassertions/pull/1737)
-* Adding non-generic overloads for `WithInnerExceptionExactly` and `WithInnerException` - [#1769](https://github.com/fluentassertions/fluentassertions/pull/1769)
+* Added `ThatAreStatic()` and `ThatAreNotStatic()` for filtering in method assertions - [#1740](https://github.com/fluentassertions/fluentassertions/pull/1740)
+* Added new assertions for the `HttpStatusCode` of an `HttpResponseMessage` - [#1737](https://github.com/fluentassertions/fluentassertions/pull/1737)
+* Added non-generic overloads for `WithInnerExceptionExactly` and `WithInnerException` - [#1769](https://github.com/fluentassertions/fluentassertions/pull/1769)
 
 ### Fixes
 * `ContainItemsAssignableTo` now expects at least one item assignable to `T` - [#1765](https://github.com/fluentassertions/fluentassertions/pull/1765)
@@ -86,20 +86,20 @@ sidebar:
 ## 6.3.0
 
 ### What's New
-* Adding `ThatAreAsync()` and `ThatAreNotAsync()` for filtering in method assertions - [#1725](https://github.com/fluentassertions/fluentassertions/pull/1725)
-* Adding `ThatAreVirtual()` and `ThatAreNotVirtual()` for filtering in method assertions - [#1744](https://github.com/fluentassertions/fluentassertions/pull/1744)
-* Adding collection content to assertion messages for `HaveCountGreaterThan()`, `HaveCountGreaterThanOrEqualTo()`, `HaveCountLessThan()` and `HaveCountLessThanOrEqualTo()` - [#1760](https://github.com/fluentassertions/fluentassertions/pull/1760)
+* Added `ThatAreAsync()` and `ThatAreNotAsync()` for filtering in method assertions - [#1725](https://github.com/fluentassertions/fluentassertions/pull/1725)
+* Added `ThatAreVirtual()` and `ThatAreNotVirtual()` for filtering in method assertions - [#1744](https://github.com/fluentassertions/fluentassertions/pull/1744)
+* Added collection content to assertion messages for `HaveCountGreaterThan()`, `HaveCountGreaterThanOrEqualTo()`, `HaveCountLessThan()` and `HaveCountLessThanOrEqualTo()` - [#1760](https://github.com/fluentassertions/fluentassertions/pull/1760)
 
 ### Fixes
 * Prevent multiple enumeration of `IEnumerable`s in parameter-less `ContainSingle()` - [#1753](https://github.com/fluentassertions/fluentassertions/pull/1753)
-* Change `HaveCount()` assertion message order to state expected and actual collection count before dumping its content` - [#1760](https://github.com/fluentassertions/fluentassertions/pull/1760)
+* Changed `HaveCount()` assertion message order to state expected and actual collection count before dumping its content` - [#1760](https://github.com/fluentassertions/fluentassertions/pull/1760)
 * `CompleteWithinAsync` did not take initial sync computation into account when measuring execution time - [1762](https://github.com/fluentassertions/fluentassertions/pull/1762).
 
 ## 6.2.0
 
 ### What's New
 
-* Adding new overloads to all `GreaterOrEqualTo` and `LessOrEqualTo` assertions, adding the word `Than` - [#1673](https://github.com/fluentassertions/fluentassertions/pull/1673)
+* Added new overloads to all `GreaterOrEqualTo` and `LessOrEqualTo` assertions, adding the word `Than` - [#1673](https://github.com/fluentassertions/fluentassertions/pull/1673)
 * `BeAsync()` and `NotBeAsync()` are now also available on `MethodInfoSelectorAssertions` - [#1700](https://github.com/fluentassertions/fluentassertions/pull/1700)
 
 ### Fixes

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's new
 * Added `ContainInConsecutiveOrder` and `NotContainInConsecutiveOrder` assertions to check if a collection contains items in a specific order and to be consecutive - [#1963](https://github.com/fluentassertions/fluentassertions/pull/1963)
 * Added `NotCompleteWithinAsync` for assertions on `Task` - [#1967](https://github.com/fluentassertions/fluentassertions/pull/1967)
+* Added `CompleteWithinAsync` and `NotCompleteWithinAsync` for non-generic `TaskCompletionSource` (.NET 6 and above) - [#1961](https://github.com/fluentassertions/fluentassertions/pull/1961)
 * Added a `ParentType` to `IObjectInfo` to help determining the parent in a call to `Using`/`When` constructs - [#1950](https://github.com/fluentassertions/fluentassertions/pull/1950)
 
 ### Fixes


### PR DESCRIPTION
The non-generic `TaskCompletionSource` was introduced in .NET 5.

Special thanks to my colleague René H. inspiring this feature.

I took the liberty to adjust the wording in the changelog. I hope this is in your sense.