### PR TITLE
Added NotCompleteWithinAsync for Task assertions

### DIFF
--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -85,7 +85,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:task} to not complete within {0}{reason}, but found <null>.", timeSpan);
+            .FailWith("Did not expect {context:task} to complete within {0}{reason}, but found <null>.", timeSpan);
 
         if (success)
         {
@@ -96,7 +96,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
                 Execute.Assertion
                     .ForCondition(!completesWithinTimeout)
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:task} to not complete within {0}{reason}.", timeSpan);
+                    .FailWith("Did not expect {context:task} to complete within {0}{reason}.", timeSpan);
             }
         }
 

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -41,36 +41,63 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     public async Task<AndConstraint<TAssertions>> CompleteWithinAsync(
         TimeSpan timeSpan, string because = "", params object[] becauseArgs)
     {
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:task} to complete within {0}{reason}, but found <null>.", timeSpan);
 
-        ITimer timer = Clock.StartTimer();
-        TTask task = Subject.Invoke();
-        TimeSpan remainingTime = timeSpan - timer.Elapsed;
+        if (success)
+        {
+            (TTask task, TimeSpan remainingTime) = InvokeWithTimer(timeSpan);
 
+            success = Execute.Assertion
+                .ForCondition(remainingTime >= TimeSpan.Zero)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
+
+            if (success)
+            {
+                bool completesWithinTimeout = await CompletesWithinTimeoutAsync(task, remainingTime);
+                Execute.Assertion
+                    .ForCondition(completesWithinTimeout)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
+            }
+        }
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
+    /// Asserts that the current <typeparamref name="TTask"/> will not complete within the specified time.
+    /// </summary>
+    /// <param name="timeSpan">The allowed time span for the operation.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public async Task<AndConstraint<TAssertions>> NotCompleteWithinAsync(
+        TimeSpan timeSpan, string because = "", params object[] becauseArgs)
+    {
         bool success = Execute.Assertion
-            .ForCondition(remainingTime >= TimeSpan.Zero)
+            .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
+            .FailWith("Expected {context:task} to not complete within {0}{reason}, but found <null>.", timeSpan);
 
         if (success)
         {
-            using var timeoutCancellationTokenSource = new CancellationTokenSource();
-            Task completedTask =
-                await Task.WhenAny(task, Clock.DelayAsync(remainingTime, timeoutCancellationTokenSource.Token));
-
-            if (completedTask == task)
+            (Task task, TimeSpan remainingTime) = InvokeWithTimer(timeSpan);
+            if (remainingTime >= TimeSpan.Zero)
             {
-                timeoutCancellationTokenSource.Cancel();
-                await completedTask;
+                bool completesWithinTimeout = await CompletesWithinTimeoutAsync(task, remainingTime);
+                Execute.Assertion
+                    .ForCondition(!completesWithinTimeout)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:task} to not complete within {0}{reason}.", timeSpan);
             }
-
-            Execute.Assertion
-                .ForCondition(completedTask == task)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -264,6 +291,38 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
+    }
+
+    /// <summary>
+    ///     Monitors the specified task whether it completes withing the remaining time span.
+    /// </summary>
+    protected async Task<bool> CompletesWithinTimeoutAsync(Task target, TimeSpan remainingTime)
+    {
+        using var timeoutCancellationTokenSource = new CancellationTokenSource();
+
+        Task completedTask =
+            await Task.WhenAny(target, Clock.DelayAsync(remainingTime, timeoutCancellationTokenSource.Token));
+
+        if (completedTask != target)
+        {
+            return false;
+        }
+
+        // cancel the clock
+        timeoutCancellationTokenSource.Cancel();
+        return true;
+    }
+
+    /// <summary>
+    ///     Invokes the subject and measures the sync execution time.
+    /// </summary>
+    private protected (TTask result, TimeSpan remainingTime) InvokeWithTimer(TimeSpan timeSpan)
+    {
+        ITimer timer = Clock.StartTimer();
+        TTask result = Subject.Invoke();
+        TimeSpan remainingTime = timeSpan - timer.Elapsed;
+
+        return (result, remainingTime);
     }
 
     private static async Task<Exception> InvokeWithInterceptionAsync(Func<Task> action)

--- a/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
+++ b/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
@@ -79,7 +79,7 @@ public class TaskCompletionSourceAssertions<T>
         Execute.Assertion
             .ForCondition(subject is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context} to not complete within {0}{reason}, but found <null>.", timeSpan);
+            .FailWith("Did not expect {context} to complete within {0}{reason}, but found <null>.", timeSpan);
 
         using var timeoutCancellationTokenSource = new CancellationTokenSource();
         Task completedTask = await Task.WhenAny(
@@ -95,7 +95,7 @@ public class TaskCompletionSourceAssertions<T>
         Execute.Assertion
             .ForCondition(completedTask != subject.Task)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:task} to not complete within {0}{reason}.", timeSpan);
+            .FailWith("Did not expect {context:task} to complete within {0}{reason}.", timeSpan);
     }
 
     /// <inheritdoc/>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2237,6 +2237,8 @@ namespace FluentAssertions.Specialized
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        protected System.Threading.Tasks.Task<bool> CompletesWithinTimeoutAsync(System.Threading.Tasks.Task target, System.TimeSpan remainingTime) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2355,6 +2355,8 @@ namespace FluentAssertions.Specialized
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        protected System.Threading.Tasks.Task<bool> CompletesWithinTimeoutAsync(System.Threading.Tasks.Task target, System.TimeSpan remainingTime) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -2237,6 +2237,8 @@ namespace FluentAssertions.Specialized
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        protected System.Threading.Tasks.Task<bool> CompletesWithinTimeoutAsync(System.Threading.Tasks.Task target, System.TimeSpan remainingTime) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -2237,6 +2237,8 @@ namespace FluentAssertions.Specialized
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        protected System.Threading.Tasks.Task<bool> CompletesWithinTimeoutAsync(System.Threading.Tasks.Task target, System.TimeSpan remainingTime) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2189,6 +2189,8 @@ namespace FluentAssertions.Specialized
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        protected System.Threading.Tasks.Task<bool> CompletesWithinTimeoutAsync(System.Threading.Tasks.Task target, System.TimeSpan remainingTime) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2237,6 +2237,8 @@ namespace FluentAssertions.Specialized
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        protected System.Threading.Tasks.Task<bool> CompletesWithinTimeoutAsync(System.Threading.Tasks.Task target, System.TimeSpan remainingTime) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -71,7 +71,7 @@ namespace FluentAssertions.Specs.Execution
 
             // Assert
             await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Expected bob to not complete within 1s because test testArg.");
+                .WithMessage("Did not expect bob to complete within 1s because test testArg.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -9,7 +9,7 @@ namespace FluentAssertions.Specs.Specialized;
 
 public static class TaskAssertionSpecs
 {
-    public class DefaultContext
+    public class Extension
     {
         [Fact]
         public void When_getting_the_subject_it_should_remain_unchanged()
@@ -23,9 +23,12 @@ public static class TaskAssertionSpecs
             // Assert
             action.Should().NotThrow("the Subject should remain the same");
         }
+    }
 
+    public class CompleteWithinAsync
+    {
         [Fact]
-        public async Task When_subject_is_null_when_expecting_to_complete_it_should_throw()
+        public async Task When_subject_is_null_it_should_throw()
         {
             // Arrange
             var timeSpan = 0.Milliseconds();
@@ -41,7 +44,7 @@ public static class TaskAssertionSpecs
         }
 
         [Fact]
-        public async Task When_task_completes_fast_when_expecting_to_complete_it_should_succeed()
+        public async Task When_task_completes_fast_t_should_succeed()
         {
             // Arrange
             var timer = new FakeClock();
@@ -58,7 +61,7 @@ public static class TaskAssertionSpecs
         }
 
         [Fact]
-        public async Task When_task_consumes_time_in_sync_portion_when_expecting_to_complete_it_should_fail()
+        public async Task When_task_consumes_time_in_sync_portion_it_should_fail()
         {
             // Arrange
             var timer = new FakeClock();
@@ -83,7 +86,7 @@ public static class TaskAssertionSpecs
         }
 
         [Fact]
-        public async Task When_task_completes_late_when_expecting_to_complete_it_should_fail()
+        public async Task When_task_completes_late_it_should_fail()
         {
             // Arrange
             var timer = new FakeClock();
@@ -98,11 +101,90 @@ public static class TaskAssertionSpecs
         }
     }
 
+    public class NotCompleteWithinAsync
+    {
+        [Fact]
+        public async Task When_subject_is_null_it_should_throw()
+        {
+            // Arrange
+            var timeSpan = 0.Milliseconds();
+            Func<Task> action = null;
+
+            // Act
+            Func<Task> testAction = () => action.Should().NotCompleteWithinAsync(
+                timeSpan, "because we want to test the failure {0}", "message");
+
+            // Assert
+            await testAction.Should().ThrowAsync<XunitException>()
+                .WithMessage("*because we want to test the failure message*found <null>*");
+        }
+
+        [Fact]
+        public async Task When_task_completes_fast_it_should_throw()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
+
+            // Act
+            Func<Task> action = () => taskFactory
+                .Awaiting(t => (Task)t.Task).Should(timer)
+                .NotCompleteWithinAsync(100.Milliseconds());
+            taskFactory.SetResult(true);
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>();
+        }
+
+        [Fact]
+        public async Task When_task_consumes_time_in_sync_portion_it_should_succeed()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
+
+            // Act
+            Func<Task> action = () => taskFactory
+                .Awaiting(t =>
+                {
+                    // simulate sync work longer than accepted time
+                    timer.Delay(101.Milliseconds());
+                    return (Task)t.Task;
+                })
+                .Should(timer)
+                .NotCompleteWithinAsync(100.Milliseconds());
+
+            taskFactory.SetResult(true);
+            timer.Complete();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_task_completes_late_it_should_succeed()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
+
+            // Act
+            Func<Task> action = () => taskFactory
+                .Awaiting(t => (Task)t.Task).Should(timer)
+                .NotCompleteWithinAsync(100.Milliseconds());
+            timer.Complete();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+    }
+
     [Collection("UIFacts")]
-    public class UIThread
+    public class CompleteWithinAsyncUIFacts
     {
         [UIFact]
-        public async Task When_task_completes_fast_when_expecting_to_complete_it_should_succeed()
+        public async Task When_task_completes_fast_it_should_succeed()
         {
             // Arrange
             var timer = new FakeClock();
@@ -119,7 +201,7 @@ public static class TaskAssertionSpecs
         }
 
         [UIFact]
-        public async Task When_task_completes_late_when_expecting_to_complete_it_should_fail()
+        public async Task When_task_completes_late_it_should_fail()
         {
             // Arrange
             var timer = new FakeClock();

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -1,123 +1,89 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions.Common;
 using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.Specialized;
 
-public class TaskAssertionSpecs
+public static class TaskAssertionSpecs
 {
-    [Fact]
-    public void When_getting_the_subject_it_should_remain_unchanged()
+    public class DefaultContext
     {
-        // Arrange
-        Func<Task<int>> subject = () => Task.FromResult(42);
+        [Fact]
+        public void When_getting_the_subject_it_should_remain_unchanged()
+        {
+            // Arrange
+            Func<Task<int>> subject = () => Task.FromResult(42);
 
-        // Act
-        Action action = () => subject.Should().Subject.As<object>().Should().BeSameAs(subject);
+            // Act
+            Action action = () => subject.Should().Subject.As<object>().Should().BeSameAs(subject);
 
-        // Assert
-        action.Should().NotThrow("the Subject should remain the same");
-    }
+            // Assert
+            action.Should().NotThrow("the Subject should remain the same");
+        }
 
-    [Fact]
-    public async Task When_subject_is_null_when_expecting_to_complete_async_it_should_throw()
-    {
-        // Arrange
-        var timeSpan = 0.Milliseconds();
-        Func<Task> action = null;
+        [Fact]
+        public async Task When_subject_is_null_when_expecting_to_complete_it_should_throw()
+        {
+            // Arrange
+            var timeSpan = 0.Milliseconds();
+            Func<Task> action = null;
 
-        // Act
-        Func<Task> testAction = () => action.Should().CompleteWithinAsync(
-            timeSpan, "because we want to test the failure {0}", "message");
+            // Act
+            Func<Task> testAction = () => action.Should().CompleteWithinAsync(
+                timeSpan, "because we want to test the failure {0}", "message");
 
-        // Assert
-        await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
-    }
+            // Assert
+            await testAction.Should().ThrowAsync<XunitException>()
+                .WithMessage("*because we want to test the failure message*found <null>*");
+        }
 
-    [Fact]
-    public async Task When_task_completes_fast_async_it_should_succeed()
-    {
-        // Arrange
-        var timer = new FakeClock();
-        var taskFactory = new TaskCompletionSource<bool>();
-
-        // Act
-        Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
-        taskFactory.SetResult(true);
-        timer.Complete();
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task Sync_work_in_async_method_is_taken_into_account()
-    {
-        // Arrange
-        var timer = new FakeClock();
-        var taskFactory = new TaskCompletionSource<bool>();
-
-        // Act
-        Func<Task> action = () => taskFactory
-            .Awaiting(t =>
-            {
-                timer.Delay(101.Milliseconds());
-                return (Task)t.Task;
-            })
-            .Should(timer)
-            .CompleteWithinAsync(100.Milliseconds());
-
-        taskFactory.SetResult(true);
-        timer.Complete();
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>();
-    }
-
-    [Collection("UIFacts")]
-    public partial class UIFacts
-    {
-        [UIFact]
-        public async Task When_task_completes_on_UI_thread_fast_async_it_should_succeed()
+        [Fact]
+        public async Task When_task_completes_fast_when_expecting_to_complete_it_should_succeed()
         {
             // Arrange
             var timer = new FakeClock();
             var taskFactory = new TaskCompletionSource<bool>();
 
             // Act
-            Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+            Func<Task> action = () =>
+                taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
             taskFactory.SetResult(true);
             timer.Complete();
 
             // Assert
             await action.Should().NotThrowAsync();
         }
-    }
 
-    [Fact]
-    public async Task When_task_completes_slow_async_it_should_fail()
-    {
-        // Arrange
-        var timer = new FakeClock();
-        var taskFactory = new TaskCompletionSource<bool>();
+        [Fact]
+        public async Task When_task_consumes_time_in_sync_portion_when_expecting_to_complete_it_should_fail()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
 
-        // Act
-        Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
-        timer.Complete();
+            // Act
+            Func<Task> action = () => taskFactory
+                .Awaiting(t =>
+                {
+                    // simulate sync work longer than accepted time
+                    timer.Delay(101.Milliseconds());
+                    return (Task)t.Task;
+                })
+                .Should(timer)
+                .CompleteWithinAsync(100.Milliseconds());
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>();
-    }
+            taskFactory.SetResult(true);
+            timer.Complete();
 
-    public partial class UIFacts
-    {
-        [UIFact]
-        public async Task When_task_completes_on_UI_thread_slow_async_it_should_fail()
+            // Assert
+            await action.Should().ThrowAsync<XunitException>();
+        }
+
+        [Fact]
+        public async Task When_task_completes_late_when_expecting_to_complete_it_should_fail()
         {
             // Arrange
             var timer = new FakeClock();
@@ -130,15 +96,52 @@ public class TaskAssertionSpecs
             // Assert
             await action.Should().ThrowAsync<XunitException>();
         }
+    }
+
+    [Collection("UIFacts")]
+    public class UIThread
+    {
+        [UIFact]
+        public async Task When_task_completes_fast_when_expecting_to_complete_it_should_succeed()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
+
+            // Act
+            Func<Task> action = () =>
+                taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+            taskFactory.SetResult(true);
+            timer.Complete();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
 
         [UIFact]
-        public async Task When_task_is_checking_synchronization_context_on_UI_thread_it_should_succeed()
+        public async Task When_task_completes_late_when_expecting_to_complete_it_should_fail()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
+
+            // Act
+            Func<Task> action = () =>
+                taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>();
+        }
+
+        [UIFact]
+        public async Task When_task_is_checking_synchronization_context_it_should_succeed()
         {
             // Arrange
             Func<Task> task = CheckContextAsync;
 
             // Act
-            Func<Task> action = () => this.Awaiting(x => task()).Should().CompleteWithinAsync(1.Seconds());
+            Func<Task> action = () => this.Awaiting(_ => task()).Should().CompleteWithinAsync(1.Seconds());
 
             // Assert
             await action.Should().NotThrowAsync();

--- a/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
@@ -134,7 +134,7 @@ public class TaskCompletionSourceAssertionSpecs
         timer.Complete();
 
         // Assert
-        await action.Should().ThrowAsync<XunitException>().WithMessage("*to not complete within*because test testArg*");
+        await action.Should().ThrowAsync<XunitException>().WithMessage("Did not expect*to complete within*because test testArg*");
     }
 
     [Fact]
@@ -163,6 +163,6 @@ public class TaskCompletionSourceAssertionSpecs
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected subject to not complete within 1s because test testArg, but found <null>.");
+            .WithMessage("Did not expect subject to complete within 1s because test testArg, but found <null>.");
     }
 }

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -329,24 +329,6 @@ public static class TaskOfTAssertionSpecs
                 .WithMessage("* value of pollInterval must be non-negative*");
         }
 
-        [Fact] // TODO What is the relevant difference to When_subject_is_null_it_should_fail?
-        public async Task When_no_exception_should_be_thrown_for_null_after_wait_time_it_should_fail()
-        {
-            // Arrange
-            var waitTime = 2.Seconds();
-            var pollInterval = 10.Milliseconds();
-
-            Func<Task<int>> func = null;
-
-            // Act
-            Func<Task> action = () => func.Should()
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("*but found <null>*");
-        }
-
         [Fact]
         public async Task When_exception_is_thrown_before_timeout_it_should_fail()
         {

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -11,12 +11,12 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.Specialized;
 
-public class TaskOfTAssertionSpecs
+public static class TaskOfTAssertionSpecs
 {
     public class CompleteWithinAsync
     {
         [Fact]
-        public async Task When_subject_is_null_when_expecting_to_complete_async_it_should_throw()
+        public async Task When_subject_is_null_it_should_fail()
         {
             // Arrange
             var timeSpan = 0.Milliseconds();
@@ -32,7 +32,7 @@ public class TaskOfTAssertionSpecs
         }
 
         [Fact]
-        public async Task When_task_completes_fast_async_it_should_succeed()
+        public async Task When_task_completes_fast_it_should_succeed()
         {
             // Arrange
             var timer = new FakeClock();
@@ -55,7 +55,7 @@ public class TaskOfTAssertionSpecs
         }
 
         [Fact]
-        public async Task When_task_completes_async_and_result_is_not_expected_it_should_throw()
+        public async Task When_task_completes_and_result_is_not_expected_it_should_fail()
         {
             // Arrange
             var timer = new FakeClock();
@@ -80,7 +80,7 @@ public class TaskOfTAssertionSpecs
         }
 
         [Fact]
-        public async Task When_task_completes_async_and_async_result_is_not_expected_it_should_throw()
+        public async Task When_task_completes_and_async_result_is_not_expected_it_should_fail()
         {
             // Arrange
             var timer = new FakeClock();
@@ -102,7 +102,7 @@ public class TaskOfTAssertionSpecs
         }
 
         [Fact]
-        public async Task When_task_completes_slow_async_it_should_fail()
+        public async Task When_task_completes_late_it_should_fail()
         {
             // Arrange
             var timer = new FakeClock();
@@ -123,7 +123,7 @@ public class TaskOfTAssertionSpecs
         }
 
         [Fact]
-        public async Task Sync_work_in_async_method_is_taken_into_account()
+        public async Task When_task_consumes_time_in_sync_portion_it_should_fail()
         {
             // Arrange
             var timer = new FakeClock();
@@ -152,7 +152,7 @@ public class TaskOfTAssertionSpecs
     public class NotThrowAsync
     {
         [Fact]
-        public async Task When_subject_is_null_when_expecting_to_not_throw_async_it_should_throw()
+        public async Task When_subject_is_null_it_should_fail()
         {
             // Arrange
             Func<Task<int>> action = null;
@@ -167,7 +167,7 @@ public class TaskOfTAssertionSpecs
         }
 
         [Fact]
-        public async Task When_task_does_not_throw_async_it_should_succeed()
+        public async Task When_task_does_not_throw_it_should_succeed()
         {
             // Arrange
             var timer = new FakeClock();
@@ -189,35 +189,8 @@ public class TaskOfTAssertionSpecs
             await action.Should().NotThrowAsync();
         }
 
-        [Collection("UIFacts")]
-        public partial class UIFacts
-        {
-            [UIFact]
-            public async Task When_task_does_not_throw_async_on_UI_thread_it_should_succeed()
-            {
-                // Arrange
-                var timer = new FakeClock();
-                var taskFactory = new TaskCompletionSource<int>();
-
-                // Act
-                Func<Task> action = async () =>
-                {
-                    Func<Task<int>> func = () => taskFactory.Task;
-
-                    (await func.Should(timer).NotThrowAsync())
-                        .Which.Should().Be(42);
-                };
-
-                taskFactory.SetResult(42);
-                timer.Complete();
-
-                // Assert
-                await action.Should().NotThrowAsync();
-            }
-        }
-
         [Fact]
-        public async Task When_task_throws_async_it_should_fail()
+        public async Task When_task_throws_it_should_fail()
         {
             // Arrange
             var timer = new FakeClock();
@@ -233,33 +206,57 @@ public class TaskOfTAssertionSpecs
             // Assert
             await action.Should().ThrowAsync<XunitException>();
         }
+    }
 
-        public partial class UIFacts
+    [Collection("UIFacts")]
+    public class NotThrowAsyncUIFacts
+    {
+        [UIFact]
+        public async Task When_task_does_not_throw_it_should_succeed()
         {
-            [UIFact]
-            public async Task When_task_throws_async_on_UI_thread_it_should_fail()
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<int>();
+
+            // Act
+            Func<Task> action = async () =>
             {
-                // Arrange
-                var timer = new FakeClock();
+                Func<Task<int>> func = () => taskFactory.Task;
 
-                // Act
-                Func<Task> action = () =>
-                {
-                    Func<Task<int>> func = () => throw new AggregateException();
+                (await func.Should(timer).NotThrowAsync())
+                    .Which.Should().Be(42);
+            };
 
-                    return func.Should(timer).NotThrowAsync();
-                };
+            taskFactory.SetResult(42);
+            timer.Complete();
 
-                // Assert
-                await action.Should().ThrowAsync<XunitException>();
-            }
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [UIFact]
+        public async Task When_task_throws_it_should_fail()
+        {
+            // Arrange
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () =>
+            {
+                Func<Task<int>> func = () => throw new AggregateException();
+
+                return func.Should(timer).NotThrowAsync();
+            };
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>();
         }
     }
 
     public class NotThrowAfterAsync
     {
         [Fact]
-        public async Task When_subject_is_null_and_expecting_to_not_throw_async_it_should_throw()
+        public async Task When_subject_is_null_it_should_fail()
         {
             // Arrange
             var waitTime = 0.Milliseconds();
@@ -276,7 +273,7 @@ public class TaskOfTAssertionSpecs
         }
 
         [Fact]
-        public async Task When_wait_time_is_negative_and_expecting_to_not_throw_async_it_should_throw()
+        public async Task When_wait_time_is_negative_it_should_fail()
         {
             // Arrange
             var waitTime = -1.Milliseconds();
@@ -294,7 +291,7 @@ public class TaskOfTAssertionSpecs
         }
 
         [Fact]
-        public async Task When_poll_interval_is_negative_and_expecting_to_not_throw_async_it_should_throw()
+        public async Task When_poll_interval_is_negative_it_should_fail()
         {
             // Arrange
             var waitTime = 10.Milliseconds();
@@ -311,8 +308,8 @@ public class TaskOfTAssertionSpecs
                 .WithMessage("* value of pollInterval must be non-negative*");
         }
 
-        [Fact]
-        public async Task When_no_exception_should_be_thrown_async_for_null_after_wait_time_it_should_throw()
+        [Fact] // TODO What is the relevant difference to When_subject_is_null_it_should_fail?
+        public async Task When_no_exception_should_be_thrown_for_null_after_wait_time_it_should_fail()
         {
             // Arrange
             var waitTime = 2.Seconds();
@@ -330,7 +327,7 @@ public class TaskOfTAssertionSpecs
         }
 
         [Fact]
-        public async Task When_no_exception_should_be_thrown_async_after_wait_time_but_it_was_it_should_throw()
+        public async Task When_exception_is_thrown_before_timeout_it_should_fail()
         {
             // Arrange
             var waitTime = 2.Seconds();
@@ -360,42 +357,8 @@ public class TaskOfTAssertionSpecs
                 .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
         }
 
-        public partial class UIFacts
-        {
-            [UIFact]
-            public async Task When_no_exception_should_be_thrown_async_on_UI_thread_after_wait_time_but_it_was_it_should_throw()
-            {
-                // Arrange
-                var waitTime = 2.Seconds();
-                var pollInterval = 10.Milliseconds();
-
-                var clock = new FakeClock();
-                var timer = clock.StartTimer();
-                clock.CompleteAfter(waitTime);
-
-                Func<Task<int>> throwLongerThanWaitTime = async () =>
-                {
-                    if (timer.Elapsed <= waitTime.Multiply(1.5))
-                    {
-                        throw new ArgumentException("An exception was forced");
-                    }
-
-                    await Task.Yield();
-                    return 42;
-                };
-
-                // Act
-                Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-                    .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
-
-                // Assert
-                await action.Should().ThrowAsync<XunitException>()
-                    .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
-            }
-        }
-
         [Fact]
-        public async Task When_no_exception_should_be_thrown_async_after_wait_time_and_none_was_it_should_not_throw()
+        public async Task When_exception_is_thrown_after_timeout_it_should_succeed()
         {
             // Arrange
             var waitTime = 6.Seconds();
@@ -426,41 +389,72 @@ public class TaskOfTAssertionSpecs
             // Assert
             await act.Should().NotThrowAsync();
         }
+    }
 
-        public partial class UIFacts
+    public class NotThrowAfterAsyncUIFacts
+    {
+        [UIFact]
+        public async Task When_exception_is_thrown_before_timeout_it_should_fail()
         {
-            [UIFact]
-            public async Task When_no_exception_should_be_thrown_async_on_UI_thread_after_wait_time_and_none_was_it_should_not_throw()
+            // Arrange
+            var waitTime = 2.Seconds();
+            var pollInterval = 10.Milliseconds();
+
+            var clock = new FakeClock();
+            var timer = clock.StartTimer();
+            clock.CompleteAfter(waitTime);
+
+            Func<Task<int>> throwLongerThanWaitTime = async () =>
             {
-                // Arrange
-                var waitTime = 6.Seconds();
-                var pollInterval = 10.Milliseconds();
-
-                var clock = new FakeClock();
-                var timer = clock.StartTimer();
-                clock.Delay(waitTime);
-
-                Func<Task<int>> throwShorterThanWaitTime = async () =>
+                if (timer.Elapsed <= waitTime.Multiply(1.5))
                 {
-                    if (timer.Elapsed <= waitTime.Divide(12))
-                    {
-                        throw new ArgumentException("An exception was forced");
-                    }
+                    throw new ArgumentException("An exception was forced");
+                }
 
-                    await Task.Yield();
-                    return 42;
-                };
+                await Task.Yield();
+                return 42;
+            };
 
-                // Act
-                Func<Task> act = async () =>
+            // Act
+            Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
+                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+        }
+
+        [UIFact]
+        public async Task When_exception_is_thrown_after_timeout_it_should_succeed()
+        {
+            // Arrange
+            var waitTime = 6.Seconds();
+            var pollInterval = 10.Milliseconds();
+
+            var clock = new FakeClock();
+            var timer = clock.StartTimer();
+            clock.Delay(waitTime);
+
+            Func<Task<int>> throwShorterThanWaitTime = async () =>
+            {
+                if (timer.Elapsed <= waitTime.Divide(12))
                 {
-                    (await throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval))
-                        .Which.Should().Be(42);
-                };
+                    throw new ArgumentException("An exception was forced");
+                }
 
-                // Assert
-                await act.Should().NotThrowAsync();
-            }
+                await Task.Yield();
+                return 42;
+            };
+
+            // Act
+            Func<Task> act = async () =>
+            {
+                (await throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval))
+                    .Which.Should().Be(42);
+            };
+
+            // Assert
+            await act.Should().NotThrowAsync();
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 #if NETFRAMEWORK
 using FluentAssertions.Specs.Common;
@@ -25,6 +26,26 @@ public static class TaskOfTAssertionSpecs
             // Act
             Func<Task> testAction = () => action.Should().CompleteWithinAsync(
                 timeSpan, "because we want to test the failure {0}", "message");
+
+            // Assert
+            await testAction.Should().ThrowAsync<XunitException>()
+                .WithMessage("*because we want to test the failure message*found <null>*");
+        }
+
+        [Fact]
+        public async Task When_subject_is_null_with_AssertionScope_it_should_fail()
+        {
+            // Arrange
+            var timeSpan = 0.Milliseconds();
+            Func<Task<int>> action = null;
+
+            // Act
+            Func<Task> testAction = () =>
+            {
+                using var _ = new AssertionScope();
+                return action.Should().CompleteWithinAsync(
+                    timeSpan, "because we want to test the failure {0}", "message");
+            };
 
             // Assert
             await testAction.Should().ThrowAsync<XunitException>()

--- a/docs/_pages/executiontime.md
+++ b/docs/_pages/executiontime.md
@@ -49,11 +49,12 @@ someAction.ExecutionTime().Should().BeCloseTo(150.Milliseconds(), 50.Millisecond
 
 ## Tasks
 
-If you're dealing with a `Task`, you can also assert that it completed within a specified period of time:
+If you're dealing with a `Task`, you can also assert that it completed within a specified period of time or not completed:
 
 ```csharp
 Func<Task> someAsyncWork = () => SomethingReturningATask();
 await someAsyncWork.Should().CompleteWithinAsync(100.Milliseconds());
+await someAsyncWork.Should().NotCompleteWithinAsync(100.Milliseconds());
 ```
 
 If the `Task` is generic and returns a value, you can use that to write a continuing assertion:

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,7 @@ sidebar:
 
 ### What's new
 * Added `ContainInConsecutiveOrder` and `NotContainInConsecutiveOrder` assertions to check if a collection contains items in a specific order and to be consecutive - [#1963](https://github.com/fluentassertions/fluentassertions/pull/1963)
+* Added `NotCompleteWithinAsync` for assertions on `Task` - [#1967](https://github.com/fluentassertions/fluentassertions/pull/1967)
 
 ### Fixes
 * Fix `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)


### PR DESCRIPTION
In addition to `CompleteWithAsync` in assertions for `Task` and `Task<T>`, and similar to assertions for `TaskCompletionSource`, I added `NotCompleteWithinAsync`.
Checking the existing tests I found some inconsistency which I've fixed (hopefully) in several separate commits. Maybe you want to review these commits one by one for better overview.