### PR TITLE
Make it possible for third-party libraries to access the underlying collection of instances of ReadOnlyNonGenericCollectionWrapper`2

### DIFF
--- a/Src/FluentAssertions/Common/ICollectionWrapper.cs
+++ b/Src/FluentAssertions/Common/ICollectionWrapper.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+
+namespace FluentAssertions.Common
+{
+    /// <summary>
+    /// Used to provide access to the underlying <typeparamref name="TCollection"/> for an object that wraps an underlying
+    /// collection.
+    /// </summary>
+    /// <typeparam name="TCollection">Collection type.</typeparam>
+    public interface ICollectionWrapper<TCollection>
+        where TCollection : ICollection
+    {
+        TCollection UnderlyingCollection { get; }
+    }
+}

--- a/Src/FluentAssertions/Common/ReadOnlyNonGenericCollectionWrapper.cs
+++ b/Src/FluentAssertions/Common/ReadOnlyNonGenericCollectionWrapper.cs
@@ -33,7 +33,7 @@ internal static class ReadOnlyNonGenericCollectionWrapper
     }
 }
 
-internal class ReadOnlyNonGenericCollectionWrapper<TCollection, TItem> : ICollection<TItem>
+internal class ReadOnlyNonGenericCollectionWrapper<TCollection, TItem> : ICollection<TItem>, ICollectionWrapper<TCollection>
     where TCollection : ICollection
 {
     public TCollection UnderlyingCollection { get; }

--- a/Src/FluentAssertions/DataColumnCollectionAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataColumnCollectionAssertionExtensions.cs
@@ -30,7 +30,7 @@ public static class DataColumnCollectionAssertionExtensions
         Guard.ThrowIfArgumentIsNull(
             expected, nameof(expected), "Cannot verify same reference against a <null> collection (use BeNull instead?).");
 
-        if (assertion.Subject is ReadOnlyNonGenericCollectionWrapper<DataColumnCollection, DataColumn> wrapper)
+        if (assertion.Subject is ICollectionWrapper<DataColumnCollection> wrapper)
         {
             var actualSubject = wrapper.UnderlyingCollection;
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -635,6 +635,11 @@ namespace FluentAssertions.Common
         System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
         FluentAssertions.Common.ITimer StartTimer();
     }
+    public interface ICollectionWrapper<TCollection>
+        where TCollection : System.Collections.ICollection
+    {
+        TCollection UnderlyingCollection { get; }
+    }
     public interface IConfigurationStore
     {
         string GetSetting(string name);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -647,6 +647,11 @@ namespace FluentAssertions.Common
         System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
         FluentAssertions.Common.ITimer StartTimer();
     }
+    public interface ICollectionWrapper<TCollection>
+        where TCollection : System.Collections.ICollection
+    {
+        TCollection UnderlyingCollection { get; }
+    }
     public interface IConfigurationStore
     {
         string GetSetting(string name);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -635,6 +635,11 @@ namespace FluentAssertions.Common
         System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
         FluentAssertions.Common.ITimer StartTimer();
     }
+    public interface ICollectionWrapper<TCollection>
+        where TCollection : System.Collections.ICollection
+    {
+        TCollection UnderlyingCollection { get; }
+    }
     public interface IConfigurationStore
     {
         string GetSetting(string name);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -635,6 +635,11 @@ namespace FluentAssertions.Common
         System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
         FluentAssertions.Common.ITimer StartTimer();
     }
+    public interface ICollectionWrapper<TCollection>
+        where TCollection : System.Collections.ICollection
+    {
+        TCollection UnderlyingCollection { get; }
+    }
     public interface IConfigurationStore
     {
         string GetSetting(string name);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -628,6 +628,11 @@ namespace FluentAssertions.Common
         System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
         FluentAssertions.Common.ITimer StartTimer();
     }
+    public interface ICollectionWrapper<TCollection>
+        where TCollection : System.Collections.ICollection
+    {
+        TCollection UnderlyingCollection { get; }
+    }
     public interface IConfigurationStore
     {
         string GetSetting(string name);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -635,6 +635,11 @@ namespace FluentAssertions.Common
         System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
         FluentAssertions.Common.ITimer StartTimer();
     }
+    public interface ICollectionWrapper<TCollection>
+        where TCollection : System.Collections.ICollection
+    {
+        TCollection UnderlyingCollection { get; }
+    }
     public interface IConfigurationStore
     {
         string GetSetting(string name);


### PR DESCRIPTION
Initial implementation: Per @dennisdoomen in comments on #1893, this PR marks the `ReadOnlyNonGenericCollectionWrapper<TCollection, TItem>` type public so that it can be referenced by an extension package. An XMLDoc comment is added to advise perusers that the type is an internal implementation detail, despite its access modifier.

Take two: Instead of altering the `ReadOnlyNonGenericCollectionWrapper<TCollection, TItem>` type, an interface `IHasUnderlyingCollection<TCollection>` is introduced that permits consumers to interact with types that have an `UnderlyingCollection` of a specific type without needing access to the actual implementation.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).