### PR TITLE
Fix a typo on the Assembly References documentation page

### DIFF
--- a/docs/_pages/assemblies.md
+++ b/docs/_pages/assemblies.md
@@ -9,7 +9,7 @@ sidebar:
 
 You also have access to methods to assert an assembly does or does not reference another assembly.
 These are typically used to enforce layers within an application, such as for example, asserting the web layer does not reference the data layer.
-To assert the references, use the the following syntax:
+To assert the references, use the following syntax:
 
 ```csharp
 assembly.Should().Reference(otherAssembly);


### PR DESCRIPTION
Fixes a typo (a redundant 'the' definite article) on the [Assembly References](https://fluentassertions.com/assemblies/) documentation page.  