### PR TITLE
Prepare constructors of `AsyncFunctionAssertions` to make them protected in V7

### DIFF
--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -15,11 +15,13 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     where TTask : Task
     where TAssertions : AsyncFunctionAssertions<TTask, TAssertions>
 {
+    [Obsolete("This class is intended as base class. This ctor is accidentally public and will be removed in Version 7.")]
     public AsyncFunctionAssertions(Func<TTask> subject, IExtractExceptions extractor)
         : this(subject, extractor, new Clock())
     {
     }
 
+    [Obsolete("This class is intended as base class. This ctor is accidentally public and will be made protected in Version 7.")]
     public AsyncFunctionAssertions(Func<TTask> subject, IExtractExceptions extractor, IClock clock)
         : base(subject, extractor, clock)
     {

--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -14,7 +14,9 @@ public class GenericAsyncFunctionAssertions<TResult> : AsyncFunctionAssertions<T
     }
 
     public GenericAsyncFunctionAssertions(Func<Task<TResult>> subject, IExtractExceptions extractor, IClock clock)
+#pragma warning disable CS0618 // is currently obsolete to make it protected in Version 7
         : base(subject, extractor, clock)
+#pragma warning restore CS0618
     {
     }
 

--- a/Src/FluentAssertions/Specialized/NonGenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/NonGenericAsyncFunctionAssertions.cs
@@ -12,7 +12,9 @@ public class NonGenericAsyncFunctionAssertions : AsyncFunctionAssertions<Task, N
     }
 
     public NonGenericAsyncFunctionAssertions(Func<Task> subject, IExtractExceptions extractor, IClock clock)
+#pragma warning disable CS0618 // is currently obsolete to make it protected in Version 7
         : base(subject, extractor, clock)
+#pragma warning restore CS0618
     {
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2242,7 +2242,11 @@ namespace FluentAssertions.Specialized
         where TTask : System.Threading.Tasks.Task
         where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
+        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
+            "e removed in Version 7.")]
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
+            "e made protected in Version 7.")]
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2360,7 +2360,11 @@ namespace FluentAssertions.Specialized
         where TTask : System.Threading.Tasks.Task
         where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
+        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
+            "e removed in Version 7.")]
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
+            "e made protected in Version 7.")]
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -2242,7 +2242,11 @@ namespace FluentAssertions.Specialized
         where TTask : System.Threading.Tasks.Task
         where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
+        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
+            "e removed in Version 7.")]
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
+            "e made protected in Version 7.")]
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -2242,7 +2242,11 @@ namespace FluentAssertions.Specialized
         where TTask : System.Threading.Tasks.Task
         where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
+        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
+            "e removed in Version 7.")]
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
+            "e made protected in Version 7.")]
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2194,7 +2194,11 @@ namespace FluentAssertions.Specialized
         where TTask : System.Threading.Tasks.Task
         where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
+        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
+            "e removed in Version 7.")]
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
+            "e made protected in Version 7.")]
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2242,7 +2242,11 @@ namespace FluentAssertions.Specialized
         where TTask : System.Threading.Tasks.Task
         where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
+        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
+            "e removed in Version 7.")]
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
+            "e made protected in Version 7.")]
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }


### PR DESCRIPTION
While implementing #1967 I found Rider hint on the second constructor of `AsyncFunctionAssertions` that it can be made protected.
Thinking deeper I found that the this class is constructed like a base class but not implemented like that.

I recommend to make this class a real base class, maybe also with renaming, but at least making used ctor protected and removing unused ctor. Further some methods can be moved to one base class because it is over written in the other one (with `new`).
All these are breaking changes, I guess. This is why I recommend to make the ctors obsolete today.
What do you think?