### PR TITLE
Removed netcoreapp2.0 framework check in formatting precision tests

### DIFF
--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -458,11 +458,7 @@ public class FormatterSpecs
         string result = Formatter.ToString(value);
 
         // Assert
-#if NETCOREAPP3_0_OR_GREATER
-        result.Should().Be("0.33333334F");
-#else
-        result.Should().Be("0.333333343F");
-#endif
+        result.Should().BeOneOf("0.33333334F", "0.333333343F");
     }
 
     [Fact]
@@ -555,11 +551,7 @@ public class FormatterSpecs
         string result = Formatter.ToString(value);
 
         // Assert
-#if NETCOREAPP3_0_OR_GREATER
-        result.Should().Be("0.3333333333333333");
-#else
-        result.Should().Be("0.33333333333333331");
-#endif
+        result.Should().BeOneOf("0.3333333333333333", "0.33333333333333331");
     }
 
     [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,6 +17,7 @@ sidebar:
 
 ### Fixes
 * Fixed `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)
+* Fixed formatting precision tests that failed on netcoreapp2.0 framework for specific machines - [#1976](https://github.com/fluentassertions/fluentassertions/pull/1976)
 
 ## 6.7.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,7 +17,6 @@ sidebar:
 
 ### Fixes
 * Fixed `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)
-* Fixed formatting precision tests that failed on netcoreapp2.0 framework for specific machines - [#1976](https://github.com/fluentassertions/fluentassertions/pull/1976)
 
 ## 6.7.0
 


### PR DESCRIPTION
Fixes https://github.com/fluentassertions/fluentassertions/issues/1975

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).