### PR TITLE
Add support for asserting [ReadOnly]Span<char> and [ReadOnly]Span<T>

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -344,6 +344,28 @@ public static class AssertionExtensions
         return new GenericCollectionAssertions<T>(actualValue);
     }
 
+#if !NETFRAMEWORK && !NETSTANDARD2_0
+    /// <summary>
+    /// Returns an <see cref="GenericCollectionAssertions{T}"/> object that can be used to assert the
+    /// current <see cref="Span{T}"/>.
+    /// </summary>
+    [Pure]
+    public static GenericCollectionAssertions<T> Should<T>(this Span<T> actualValue)
+    {
+        return new GenericCollectionAssertions<T>(actualValue.ToArray());
+    }
+
+    /// <summary>
+    /// Returns an <see cref="GenericCollectionAssertions{T}"/> object that can be used to assert the
+    /// current <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    [Pure]
+    public static GenericCollectionAssertions<T> Should<T>(this ReadOnlySpan<T> actualValue)
+    {
+        return new GenericCollectionAssertions<T>(actualValue.ToArray());
+    }
+#endif
+
     /// <summary>
     /// Returns an <see cref="StringCollectionAssertions"/> object that can be used to assert the
     /// current <see cref="IEnumerable{T}"/>.
@@ -748,6 +770,28 @@ public static class AssertionExtensions
     {
         return new StringAssertions(actualValue);
     }
+
+#if !NETFRAMEWORK && !NETSTANDARD2_0
+    /// <summary>
+    /// Returns an <see cref="StringAssertions"/> object that can be used to assert the
+    /// current <see cref="Span{T}"/>.
+    /// </summary>
+    [Pure]
+    public static StringAssertions Should(this Span<char> actualValue)
+    {
+        return new StringAssertions(actualValue.ToString());
+    }
+
+    /// <summary>
+    /// Returns an <see cref="StringAssertions"/> object that can be used to assert the
+    /// current <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    [Pure]
+    public static StringAssertions Should(this ReadOnlySpan<char> actualValue)
+    {
+        return new StringAssertions(actualValue.ToString());
+    }
+#endif
 
     /// <summary>
     /// Returns an <see cref="SimpleTimeSpanAssertions"/> object that can be used to assert the

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -75,10 +75,12 @@ namespace FluentAssertions
         public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
         public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
         public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should(this System.Net.Http.HttpResponseMessage actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this System.ReadOnlySpan<char> actualValue) { }
         public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
         public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
         public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this System.Span<char> actualValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions Should(this System.Threading.Tasks.TaskCompletionSource tcs) { }
         public static FluentAssertions.Primitives.TimeOnlyAssertions Should(this System.TimeOnly actualValue) { }
         public static FluentAssertions.Primitives.NullableTimeOnlyAssertions Should(this System.TimeOnly? actualValue) { }
@@ -154,6 +156,8 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.ReadOnlySpan<T> actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Span<T> actualValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -73,10 +73,12 @@ namespace FluentAssertions
         public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
         public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
         public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should(this System.Net.Http.HttpResponseMessage actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this System.ReadOnlySpan<char> actualValue) { }
         public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
         public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
         public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this System.Span<char> actualValue) { }
         public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
         public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
         public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
@@ -141,6 +143,8 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.ReadOnlySpan<T> actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Span<T> actualValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -73,10 +73,12 @@ namespace FluentAssertions
         public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
         public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
         public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should(this System.Net.Http.HttpResponseMessage actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this System.ReadOnlySpan<char> actualValue) { }
         public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
         public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
         public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this System.Span<char> actualValue) { }
         public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
         public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
         public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
@@ -141,6 +143,8 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.ReadOnlySpan<T> actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Span<T> actualValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -73,10 +73,12 @@ namespace FluentAssertions
         public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
         public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
         public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should(this System.Net.Http.HttpResponseMessage actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this System.ReadOnlySpan<char> actualValue) { }
         public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
         public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
         public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this System.Span<char> actualValue) { }
         public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
         public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
         public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
@@ -141,6 +143,8 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.ReadOnlySpan<T> actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Span<T> actualValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]


### PR DESCRIPTION
When writing a test for an implementation of `ISpanFormattable` I was surprised that my Span<char> did not have a Should() method. I figured that the solution proposed by @jnyrup in https://github.com/fluentassertions/fluentassertions/issues/902#issuecomment-1167769893 would be a welcome addition to the library.

Fixes #902