### PR TITLE
Global record equivalency settings were not taken into account

### DIFF
--- a/Src/FluentAssertions/Equivalency/Execution/CollectionMemberAssertionOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CollectionMemberAssertionOptionsDecorator.cs
@@ -65,7 +65,7 @@ internal class CollectionMemberAssertionOptionsDecorator : IEquivalencyAssertion
 
     public bool ExcludeNonBrowsableOnExpectation => inner.ExcludeNonBrowsableOnExpectation;
 
-    public bool CompareRecordsByValue => inner.CompareRecordsByValue;
+    public bool? CompareRecordsByValue => inner.CompareRecordsByValue;
 
     public EqualityStrategy GetEqualityStrategy(Type type)
     {

--- a/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
@@ -88,7 +88,7 @@ public interface IEquivalencyAssertionOptions
     /// <summary>
     /// Gets a value indicating whether records should be compared by value instead of their members
     /// </summary>
-    bool CompareRecordsByValue { get; }
+    bool? CompareRecordsByValue { get; }
 
     /// <summary>
     /// Gets the currently configured tracer, or <c>null</c> if no tracing was configured.

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -60,7 +60,7 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
     private bool ignoreNonBrowsableOnSubject;
     private bool excludeNonBrowsableOnExpectation;
 
-    private bool compareRecordsByValue;
+    private bool? compareRecordsByValue;
 
     #endregion
 
@@ -176,7 +176,7 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
 
     bool IEquivalencyAssertionOptions.ExcludeNonBrowsableOnExpectation => excludeNonBrowsableOnExpectation;
 
-    public bool CompareRecordsByValue => compareRecordsByValue;
+    public bool? CompareRecordsByValue => compareRecordsByValue;
 
     EqualityStrategy IEquivalencyAssertionOptions.GetEqualityStrategy(Type requestedType)
     {
@@ -202,9 +202,9 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
             {
                 strategy = EqualityStrategy.ForceEquals;
             }
-            else if (type.IsRecord())
+            else if ((compareRecordsByValue.HasValue || getDefaultEqualityStrategy is null) && type.IsRecord())
             {
-                strategy = compareRecordsByValue ? EqualityStrategy.ForceEquals : EqualityStrategy.ForceMembers;
+                strategy = compareRecordsByValue is true ? EqualityStrategy.ForceEquals : EqualityStrategy.ForceMembers;
             }
             else
             {
@@ -760,7 +760,7 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
         builder.AppendLine($"- Compare tuples by their properties");
         builder.AppendLine($"- Compare anonymous types by their properties");
 
-        if (compareRecordsByValue)
+        if (compareRecordsByValue is true)
         {
             builder.AppendLine("- Compare records by value");
         }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -864,7 +864,7 @@ namespace FluentAssertions.Equivalency
     public interface IEquivalencyAssertionOptions
     {
         bool AllowInfiniteRecursion { get; }
-        bool CompareRecordsByValue { get; }
+        bool? CompareRecordsByValue { get; }
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
@@ -1027,7 +1027,7 @@ namespace FluentAssertions.Equivalency
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
-        public bool CompareRecordsByValue { get; }
+        public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -877,7 +877,7 @@ namespace FluentAssertions.Equivalency
     public interface IEquivalencyAssertionOptions
     {
         bool AllowInfiniteRecursion { get; }
-        bool CompareRecordsByValue { get; }
+        bool? CompareRecordsByValue { get; }
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
@@ -1040,7 +1040,7 @@ namespace FluentAssertions.Equivalency
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
-        public bool CompareRecordsByValue { get; }
+        public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -864,7 +864,7 @@ namespace FluentAssertions.Equivalency
     public interface IEquivalencyAssertionOptions
     {
         bool AllowInfiniteRecursion { get; }
-        bool CompareRecordsByValue { get; }
+        bool? CompareRecordsByValue { get; }
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
@@ -1027,7 +1027,7 @@ namespace FluentAssertions.Equivalency
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
-        public bool CompareRecordsByValue { get; }
+        public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -864,7 +864,7 @@ namespace FluentAssertions.Equivalency
     public interface IEquivalencyAssertionOptions
     {
         bool AllowInfiniteRecursion { get; }
-        bool CompareRecordsByValue { get; }
+        bool? CompareRecordsByValue { get; }
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
@@ -1027,7 +1027,7 @@ namespace FluentAssertions.Equivalency
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
-        public bool CompareRecordsByValue { get; }
+        public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -857,7 +857,7 @@ namespace FluentAssertions.Equivalency
     public interface IEquivalencyAssertionOptions
     {
         bool AllowInfiniteRecursion { get; }
-        bool CompareRecordsByValue { get; }
+        bool? CompareRecordsByValue { get; }
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
@@ -1020,7 +1020,7 @@ namespace FluentAssertions.Equivalency
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
-        public bool CompareRecordsByValue { get; }
+        public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -864,7 +864,7 @@ namespace FluentAssertions.Equivalency
     public interface IEquivalencyAssertionOptions
     {
         bool AllowInfiniteRecursion { get; }
-        bool CompareRecordsByValue { get; }
+        bool? CompareRecordsByValue { get; }
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
@@ -1027,7 +1027,7 @@ namespace FluentAssertions.Equivalency
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
-        public bool CompareRecordsByValue { get; }
+        public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }

--- a/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
+++ b/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
@@ -72,7 +72,7 @@ public class UsersOfGetClosedGenericInterfaces
 
         public bool ExcludeNonBrowsableOnExpectation => throw new NotImplementedException();
 
-        public bool CompareRecordsByValue => throw new NotImplementedException();
+        public bool? CompareRecordsByValue => throw new NotImplementedException();
 
         public ITraceWriter TraceWriter => throw new NotImplementedException();
 

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -127,6 +127,34 @@ public class AssertionOptionsSpecs
         }
     }
 
+    public class When_modifying_record_settings_globally : Given_temporary_global_assertion_options
+    {
+        public When_modifying_record_settings_globally()
+        {
+            When(() =>
+            {
+                AssertionOptions.AssertEquivalencyUsing(
+                    options => options.ComparingByValue(typeof(Position)));
+            });
+        }
+
+        [Fact]
+        public void It_should_use_the_global_settings_for_comparing_records()
+        {
+            new Position(123).Should().BeEquivalentTo(new Position(123));    
+        }
+
+        private record Position
+        {
+            private readonly int value;
+
+            public Position(int value)
+            {
+                this.value = value;
+            }
+        }
+    }
+
     [Collection("AssertionOptionsSpecs")]
     public class When_assertion_doubles_should_always_allow_small_deviations :
         Given_temporary_global_assertion_options

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -14,387 +14,384 @@ namespace FluentAssertions.Specs;
 
 public class AssertionOptionsSpecs
 {
-    [Fact]
-    public void When_injecting_a_null_configurer_it_should_throw()
+    // Due to tests that call AssertionOptions
+    [CollectionDefinition("AssertionOptionsSpecs", DisableParallelization = true)]
+    public class AssertionOptionsSpecsDefinition { }
+    
+    public abstract class Given_temporary_global_assertion_options : GivenWhenThen
     {
-        // Arrange
-        Action act = () => AssertionOptions.AssertEquivalencyUsing(defaultsConfigurer: null);
-
-        // Assert
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("defaultsConfigurer");
-    }
-}
-
-// Due to tests that call AssertionOptions
-[CollectionDefinition("AssertionOptionsSpecs", DisableParallelization = true)]
-public class AssertionOptionsSpecsDefinition { }
-
-[Collection("AssertionOptionsSpecs")]
-public class When_concurrently_getting_equality_strategy : GivenSubject<EquivalencyAssertionOptions, Action>
-{
-    public When_concurrently_getting_equality_strategy()
-    {
-        When(() =>
+        protected override void Dispose(bool disposing)
         {
-            IEquivalencyAssertionOptions equivalencyAssertionOptions = new EquivalencyAssertionOptions();
-            return () => Parallel.For(0, 10_000, new ParallelOptions { MaxDegreeOfParallelism = 8 },
-                _ => equivalencyAssertionOptions.GetEqualityStrategy(typeof(IEnumerable))
-            );
-        });
+            AssertionOptions.AssertEquivalencyUsing(_ => new EquivalencyAssertionOptions());
+
+            base.Dispose(disposing);
+        }
     }
 
-    [Fact]
-    public void It_should_not_throw()
+    [Collection("AssertionOptionsSpecs")]
+    public class When_injecting_a_null_configurer : GivenSubject<EquivalencyAssertionOptions, Action>
     {
-        Result.Should().NotThrow();
-    }
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class When_modifying_global_reference_type_settings_a_previous_assertion_should_not_have_any_effect
-    : Given_temporary_global_assertion_options
-{
-    public When_modifying_global_reference_type_settings_a_previous_assertion_should_not_have_any_effect()
-    {
-        Given(() =>
+        public When_injecting_a_null_configurer()
         {
-            // Trigger a first equivalency check using the default global settings
-            new MyValueType { Value = 1 }.Should().BeEquivalentTo(new MyValueType { Value = 2 });
-        });
+            When(() => { return () => AssertionOptions.AssertEquivalencyUsing(defaultsConfigurer: null); });
+        }
 
-        When(() =>
+        [Fact]
+        public void It_should_throw()
         {
-            AssertionOptions.AssertEquivalencyUsing(o => o.ComparingByMembers<MyValueType>());
-        });
+            Result.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("defaultsConfigurer");
+        }
     }
 
-    [Fact]
-    public void It_should_try_to_compare_the_classes_by_member_semantics_and_thus_throw()
+    [Collection("AssertionOptionsSpecs")]
+    public class When_concurrently_getting_equality_strategy : GivenSubject<EquivalencyAssertionOptions, Action>
     {
-        Action act = () => new MyValueType { Value = 1 }.Should().BeEquivalentTo(new MyValueType { Value = 2 });
-
-        act.Should().Throw<XunitException>();
-    }
-}
-
-internal class MyValueType
-{
-    public int Value { get; set; }
-
-    public override bool Equals(object obj) => true;
-
-    public override int GetHashCode() => 0;
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class When_modifying_global_value_type_settings_a_previous_assertion_should_not_have_any_effect
-    : Given_temporary_global_assertion_options
-{
-    public When_modifying_global_value_type_settings_a_previous_assertion_should_not_have_any_effect()
-    {
-        Given(() =>
+        public When_concurrently_getting_equality_strategy()
         {
-            // Trigger a first equivalency check using the default global settings
-            new MyClass { Value = 1 }.Should().BeEquivalentTo(new MyClass { Value = 1 });
-        });
+            When(() =>
+            {
+                IEquivalencyAssertionOptions equivalencyAssertionOptions = new EquivalencyAssertionOptions();
+                return () => Parallel.For(0, 10_000, new ParallelOptions { MaxDegreeOfParallelism = 8 },
+                    _ => equivalencyAssertionOptions.GetEqualityStrategy(typeof(IEnumerable))
+                );
+            });
+        }
 
-        When(() =>
+        [Fact]
+        public void It_should_not_throw()
         {
-            AssertionOptions.AssertEquivalencyUsing(o => o.ComparingByValue<MyClass>());
-        });
+            Result.Should().NotThrow();
+        }
     }
 
-    [Fact]
-    public void It_should_try_to_compare_the_classes_by_value_semantics_and_thus_throw()
+    [Collection("AssertionOptionsSpecs")]
+    public class When_modifying_global_reference_type_settings_a_previous_assertion_should_not_have_any_effect
+        : Given_temporary_global_assertion_options
     {
-        Action act = () => new MyClass { Value = 1 }.Should().BeEquivalentTo(new MyClass { Value = 1 });
-
-        act.Should().Throw<XunitException>();
-    }
-}
-
-internal class MyClass
-{
-    public int Value { get; set; }
-}
-
-public abstract class Given_temporary_global_assertion_options : GivenWhenThen
-{
-    protected override void Dispose(bool disposing)
-    {
-        AssertionOptions.AssertEquivalencyUsing(_ => new EquivalencyAssertionOptions());
-
-        base.Dispose(disposing);
-    }
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class When_assertion_doubles_should_always_allow_small_deviations :
-    Given_temporary_global_assertion_options
-{
-    public When_assertion_doubles_should_always_allow_small_deviations()
-    {
-        When(() =>
+        public When_modifying_global_reference_type_settings_a_previous_assertion_should_not_have_any_effect()
         {
-            AssertionOptions.AssertEquivalencyUsing(options => options
-                .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.01))
+            Given(() =>
+            {
+                // Trigger a first equivalency check using the default global settings
+                new MyValueType { Value = 1 }.Should().BeEquivalentTo(new MyValueType { Value = 2 });
+            });
+
+            When(() => { AssertionOptions.AssertEquivalencyUsing(o => o.ComparingByMembers<MyValueType>()); });
+        }
+
+        [Fact]
+        public void It_should_try_to_compare_the_classes_by_member_semantics_and_thus_throw()
+        {
+            Action act = () => new MyValueType { Value = 1 }.Should().BeEquivalentTo(new MyValueType { Value = 2 });
+
+            act.Should().Throw<XunitException>();
+        }
+
+        internal class MyValueType
+        {
+            public int Value { get; set; }
+
+            public override bool Equals(object obj) => true;
+
+            public override int GetHashCode() => 0;
+        }
+    }
+
+    [Collection("AssertionOptionsSpecs")]
+    public class When_modifying_global_value_type_settings_a_previous_assertion_should_not_have_any_effect
+        : Given_temporary_global_assertion_options
+    {
+        public When_modifying_global_value_type_settings_a_previous_assertion_should_not_have_any_effect()
+        {
+            Given(() =>
+            {
+                // Trigger a first equivalency check using the default global settings
+                new MyClass { Value = 1 }.Should().BeEquivalentTo(new MyClass { Value = 1 });
+            });
+
+            When(() => { AssertionOptions.AssertEquivalencyUsing(o => o.ComparingByValue<MyClass>()); });
+        }
+
+        [Fact]
+        public void It_should_try_to_compare_the_classes_by_value_semantics_and_thus_throw()
+        {
+            Action act = () => new MyClass { Value = 1 }.Should().BeEquivalentTo(new MyClass { Value = 1 });
+
+            act.Should().Throw<XunitException>();
+        }
+
+        internal class MyClass
+        {
+            public int Value { get; set; }
+        }
+    }
+
+    [Collection("AssertionOptionsSpecs")]
+    public class When_assertion_doubles_should_always_allow_small_deviations :
+        Given_temporary_global_assertion_options
+    {
+        public When_assertion_doubles_should_always_allow_small_deviations()
+        {
+            When(() =>
+            {
+                AssertionOptions.AssertEquivalencyUsing(options => options
+                    .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.01))
+                    .WhenTypeIs<double>());
+            });
+        }
+
+        [Fact]
+        public void Then_it_should_ignore_small_differences_without_the_need_of_local_options()
+        {
+            var actual = new
+            {
+                Value = 1D / 3D
+            };
+
+            var expected = new
+            {
+                Value = 0.33D
+            };
+
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            act.Should().NotThrow();
+        }
+    }
+
+    [Collection("AssertionOptionsSpecs")]
+    public class When_local_similar_options_are_used : Given_temporary_global_assertion_options
+    {
+        public When_local_similar_options_are_used()
+        {
+            When(() =>
+            {
+                AssertionOptions.AssertEquivalencyUsing(options => options
+                    .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.01))
+                    .WhenTypeIs<double>());
+            });
+        }
+
+        [Fact]
+        public void Then_they_should_override_the_global_options()
+        {
+            var actual = new
+            {
+                Value = 1D / 3D
+            };
+
+            var expected = new
+            {
+                Value = 0.33D
+            };
+
+            Action act = () => actual.Should().BeEquivalentTo(expected, options => options
+                .Using<double>(ctx => ctx.Subject.Should().Be(ctx.Expectation))
                 .WhenTypeIs<double>());
-        });
-    }
 
-    [Fact]
-    public void Then_it_should_ignore_small_differences_without_the_need_of_local_options()
-    {
-        var actual = new
+            act.Should().Throw<XunitException>().WithMessage("Expected*");
+        }
+
+        [Fact]
+        public void Then_they_should_not_affect_any_other_assertions()
         {
-            Value = 1D / 3D
-        };
+            var actual = new
+            {
+                Value = 1D / 3D
+            };
 
-        var expected = new
+            var expected = new
+            {
+                Value = 0.33D
+            };
+
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            act.Should().NotThrow();
+        }
+    }
+
+    [Collection("AssertionOptionsSpecs")]
+    public class Given_self_resetting_equivalency_plan : GivenWhenThen
+    {
+        protected override void Dispose(bool disposing)
         {
-            Value = 0.33D
-        };
+            Plan.Reset();
+            base.Dispose(disposing);
+        }
 
-        Action act = () => actual.Should().BeEquivalentTo(expected);
-
-        act.Should().NotThrow();
-    }
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class When_local_similar_options_are_used : Given_temporary_global_assertion_options
-{
-    public When_local_similar_options_are_used()
-    {
-        When(() =>
+        protected static EquivalencyPlan Plan
         {
-            AssertionOptions.AssertEquivalencyUsing(options => options
-                .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.01))
-                .WhenTypeIs<double>());
-        });
+            get { return AssertionOptions.EquivalencyPlan; }
+        }
     }
 
-    [Fact]
-    public void Then_they_should_override_the_global_options()
+    [Collection("AssertionOptionsSpecs")]
+    public class When_inserting_a_step : Given_self_resetting_equivalency_plan
     {
-        var actual = new
+        public When_inserting_a_step()
         {
-            Value = 1D / 3D
-        };
+            When(() => Plan.Insert<MyEquivalencyStep>());
+        }
 
-        var expected = new
+        [Fact]
+        public void Then_it_should_precede_all_other_steps()
         {
-            Value = 0.33D
-        };
+            var addedStep = Plan.LastOrDefault(s => s is MyEquivalencyStep);
 
-        Action act = () => actual.Should().BeEquivalentTo(expected, options => options
-            .Using<double>(ctx => ctx.Subject.Should().Be(ctx.Expectation))
-            .WhenTypeIs<double>());
-
-        act.Should().Throw<XunitException>().WithMessage("Expected*");
+            Plan.Should().StartWith(addedStep);
+        }
     }
 
-    [Fact]
-    public void Then_they_should_not_affect_any_other_assertions()
+    [Collection("AssertionOptionsSpecs")]
+    public class When_inserting_a_step_before_another : Given_self_resetting_equivalency_plan
     {
-        var actual = new
+        public When_inserting_a_step_before_another()
         {
-            Value = 1D / 3D
-        };
+            When(() => Plan.InsertBefore<DictionaryEquivalencyStep, MyEquivalencyStep>());
+        }
 
-        var expected = new
+        [Fact]
+        public void Then_it_should_precede_that_particular_step()
         {
-            Value = 0.33D
-        };
+            var addedStep = Plan.LastOrDefault(s => s is MyEquivalencyStep);
+            var successor = Plan.LastOrDefault(s => s is DictionaryEquivalencyStep);
 
-        Action act = () => actual.Should().BeEquivalentTo(expected);
-
-        act.Should().NotThrow();
-    }
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class Given_self_resetting_equivalency_plan : GivenWhenThen
-{
-    protected override void Dispose(bool disposing)
-    {
-        Plan.Reset();
-        base.Dispose(disposing);
+            Plan.Should().HaveElementPreceding(successor, addedStep);
+        }
     }
 
-    protected static EquivalencyPlan Plan
+    [Collection("AssertionOptionsSpecs")]
+    public class When_appending_a_step : Given_self_resetting_equivalency_plan
     {
-        get { return AssertionOptions.EquivalencyPlan; }
-    }
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class When_inserting_a_step : Given_self_resetting_equivalency_plan
-{
-    public When_inserting_a_step()
-    {
-        When(() => Plan.Insert<MyEquivalencyStep>());
-    }
-
-    [Fact]
-    public void Then_it_should_precede_all_other_steps()
-    {
-        var addedStep = Plan.LastOrDefault(s => s is MyEquivalencyStep);
-
-        Plan.Should().StartWith(addedStep);
-    }
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class When_inserting_a_step_before_another : Given_self_resetting_equivalency_plan
-{
-    public When_inserting_a_step_before_another()
-    {
-        When(() => Plan.InsertBefore<DictionaryEquivalencyStep, MyEquivalencyStep>());
-    }
-
-    [Fact]
-    public void Then_it_should_precede_that_particular_step()
-    {
-        var addedStep = Plan.LastOrDefault(s => s is MyEquivalencyStep);
-        var successor = Plan.LastOrDefault(s => s is DictionaryEquivalencyStep);
-
-        Plan.Should().HaveElementPreceding(successor, addedStep);
-    }
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class When_appending_a_step : Given_self_resetting_equivalency_plan
-{
-    public When_appending_a_step()
-    {
-        When(() => Plan.Add<MyEquivalencyStep>());
-    }
-
-    [Fact]
-    public void Then_it_should_precede_the_final_builtin_step()
-    {
-        var equivalencyStep = Plan.LastOrDefault(s => s is SimpleEqualityEquivalencyStep);
-        var subjectStep = Plan.LastOrDefault(s => s is MyEquivalencyStep);
-
-        Plan.Should().HaveElementPreceding(equivalencyStep, subjectStep);
-    }
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class When_appending_a_step_after_another : Given_self_resetting_equivalency_plan
-{
-    public When_appending_a_step_after_another()
-    {
-        When(() => Plan.AddAfter<DictionaryEquivalencyStep, MyEquivalencyStep>());
-    }
-
-    [Fact]
-    public void Then_it_should_precede_the_final_builtin_step()
-    {
-        var addedStep = Plan.LastOrDefault(s => s is MyEquivalencyStep);
-        var predecessor = Plan.LastOrDefault(s => s is DictionaryEquivalencyStep);
-
-        Plan.Should().HaveElementSucceeding(predecessor, addedStep);
-    }
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class When_appending_a_step_and_no_builtin_steps_are_there : Given_self_resetting_equivalency_plan
-{
-    public When_appending_a_step_and_no_builtin_steps_are_there()
-    {
-        When(() =>
+        public When_appending_a_step()
         {
-            Plan.Clear();
-            Plan.Add<MyEquivalencyStep>();
-        });
-    }
+            When(() => Plan.Add<MyEquivalencyStep>());
+        }
 
-    [Fact]
-    public void Then_it_should_precede_the_simple_equality_step()
-    {
-        var subjectStep = Plan.LastOrDefault(s => s is MyEquivalencyStep);
-
-        Plan.Should().EndWith(subjectStep);
-    }
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class When_removing_a_specific_step : Given_self_resetting_equivalency_plan
-{
-    public When_removing_a_specific_step()
-    {
-        When(() => Plan.Remove<SimpleEqualityEquivalencyStep>());
-    }
-
-    [Fact]
-    public void Then_it_should_precede_the_simple_equality_step()
-    {
-        Plan.Should().NotContain(s => s is SimpleEqualityEquivalencyStep);
-    }
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class When_removing_a_specific_step_that_doesnt_exist : Given_self_resetting_equivalency_plan
-{
-    public When_removing_a_specific_step_that_doesnt_exist()
-    {
-        WhenAction = () => Plan.Remove<MyEquivalencyStep>();
-    }
-
-    [Fact]
-    public void Then_it_should_precede_the_simple_equality_step()
-    {
-        WhenAction.Should().NotThrow();
-    }
-}
-
-internal class MyEquivalencyStep : IEquivalencyStep
-{
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
-    {
-        Execute.Assertion.FailWith(GetType().FullName);
-
-        return EquivalencyResult.AssertionCompleted;
-    }
-}
-
-[Collection("AssertionOptionsSpecs")]
-public class When_global_formatting_settings_are_modified : GivenWhenThen
-{
-    private FormattingOptions oldSettings;
-
-    public When_global_formatting_settings_are_modified()
-    {
-        Given(() =>
+        [Fact]
+        public void Then_it_should_precede_the_final_builtin_step()
         {
-            oldSettings = AssertionOptions.FormattingOptions.Clone();
-        });
+            var equivalencyStep = Plan.LastOrDefault(s => s is SimpleEqualityEquivalencyStep);
+            var subjectStep = Plan.LastOrDefault(s => s is MyEquivalencyStep);
 
-        When(() =>
+            Plan.Should().HaveElementPreceding(equivalencyStep, subjectStep);
+        }
+    }
+
+    [Collection("AssertionOptionsSpecs")]
+    public class When_appending_a_step_after_another : Given_self_resetting_equivalency_plan
+    {
+        public When_appending_a_step_after_another()
         {
-            AssertionOptions.FormattingOptions.UseLineBreaks = true;
-            AssertionOptions.FormattingOptions.MaxDepth = 123;
-            AssertionOptions.FormattingOptions.MaxLines = 33;
-        });
+            When(() => Plan.AddAfter<DictionaryEquivalencyStep, MyEquivalencyStep>());
+        }
+
+        [Fact]
+        public void Then_it_should_precede_the_final_builtin_step()
+        {
+            var addedStep = Plan.LastOrDefault(s => s is MyEquivalencyStep);
+            var predecessor = Plan.LastOrDefault(s => s is DictionaryEquivalencyStep);
+
+            Plan.Should().HaveElementSucceeding(predecessor, addedStep);
+        }
     }
 
-    [Fact]
-    public void Then_the_current_assertion_scope_should_use_these_settings()
+    [Collection("AssertionOptionsSpecs")]
+    public class When_appending_a_step_and_no_builtin_steps_are_there : Given_self_resetting_equivalency_plan
     {
-        AssertionScope.Current.FormattingOptions.UseLineBreaks.Should().BeTrue();
-        AssertionScope.Current.FormattingOptions.MaxDepth.Should().Be(123);
-        AssertionScope.Current.FormattingOptions.MaxLines.Should().Be(33);
+        public When_appending_a_step_and_no_builtin_steps_are_there()
+        {
+            When(() =>
+            {
+                Plan.Clear();
+                Plan.Add<MyEquivalencyStep>();
+            });
+        }
+
+        [Fact]
+        public void Then_it_should_precede_the_simple_equality_step()
+        {
+            var subjectStep = Plan.LastOrDefault(s => s is MyEquivalencyStep);
+
+            Plan.Should().EndWith(subjectStep);
+        }
     }
 
-    protected override void Dispose(bool disposing)
+    [Collection("AssertionOptionsSpecs")]
+    public class When_removing_a_specific_step : Given_self_resetting_equivalency_plan
     {
-        AssertionOptions.FormattingOptions.MaxDepth = oldSettings.MaxDepth;
-        AssertionOptions.FormattingOptions.UseLineBreaks = oldSettings.UseLineBreaks;
-        AssertionOptions.FormattingOptions.MaxLines = oldSettings.MaxLines;
+        public When_removing_a_specific_step()
+        {
+            When(() => Plan.Remove<SimpleEqualityEquivalencyStep>());
+        }
 
-        base.Dispose(disposing);
+        [Fact]
+        public void Then_it_should_precede_the_simple_equality_step()
+        {
+            Plan.Should().NotContain(s => s is SimpleEqualityEquivalencyStep);
+        }
+    }
+
+    [Collection("AssertionOptionsSpecs")]
+    public class When_removing_a_specific_step_that_doesnt_exist : Given_self_resetting_equivalency_plan
+    {
+        public When_removing_a_specific_step_that_doesnt_exist()
+        {
+            WhenAction = () => Plan.Remove<MyEquivalencyStep>();
+        }
+
+        [Fact]
+        public void Then_it_should_precede_the_simple_equality_step()
+        {
+            WhenAction.Should().NotThrow();
+        }
+    }
+
+    [Collection("AssertionOptionsSpecs")]
+    public class When_global_formatting_settings_are_modified : GivenWhenThen
+    {
+        private FormattingOptions oldSettings;
+
+        public When_global_formatting_settings_are_modified()
+        {
+            Given(() => { oldSettings = AssertionOptions.FormattingOptions.Clone(); });
+
+            When(() =>
+            {
+                AssertionOptions.FormattingOptions.UseLineBreaks = true;
+                AssertionOptions.FormattingOptions.MaxDepth = 123;
+                AssertionOptions.FormattingOptions.MaxLines = 33;
+            });
+        }
+
+        [Fact]
+        public void Then_the_current_assertion_scope_should_use_these_settings()
+        {
+            AssertionScope.Current.FormattingOptions.UseLineBreaks.Should().BeTrue();
+            AssertionScope.Current.FormattingOptions.MaxDepth.Should().Be(123);
+            AssertionScope.Current.FormattingOptions.MaxLines.Should().Be(33);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            AssertionOptions.FormattingOptions.MaxDepth = oldSettings.MaxDepth;
+            AssertionOptions.FormattingOptions.UseLineBreaks = oldSettings.UseLineBreaks;
+            AssertionOptions.FormattingOptions.MaxLines = oldSettings.MaxLines;
+
+            base.Dispose(disposing);
+        }
+    }
+
+    internal class MyEquivalencyStep : IEquivalencyStep
+    {
+        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+            IEquivalencyValidator nestedValidator)
+        {
+            Execute.Assertion.FailWith(GetType().FullName);
+
+            return EquivalencyResult.AssertionCompleted;
+        }
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,6 +18,7 @@ sidebar:
 ### Fixes
 * Fixed `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)
 * Changed `MatchEquivalentOf` to use `CultureInfo.InvariantCulture` instead of `CultureInfo.CurrentCulture` - [#1985](https://github.com/fluentassertions/fluentassertions/pull/1985).
+* Fixes `BeEquivalentTo` not taking into account any `record` equivalency settings coming from the `AssertionOptions` - [#1984](https://github.com/fluentassertions/fluentassertions/pull/1984)
 
 ## 6.7.0
 


### PR DESCRIPTION
Fixes #1977 

Because of the way `GetEqualityStrategy` was implemented, the behavior for records never took into account any global settings. 

Unfortunately, this requires a breaking change on the `IEquivalencyAssertionOptions` interface, but given its core usage and the very unlikely possibility to use that from consumer code, I think that's acceptable. 

**Note** First commit is just a refactoring. 