### PR TITLE
Use InvariantCulture when doing case-insensitive matches

### DIFF
--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
@@ -30,7 +30,7 @@ internal class StringWildcardMatchingValidator : StringValidator
 
     private bool IsMatch()
     {
-        RegexOptions options = IgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
+        RegexOptions options = IgnoreCase ? (RegexOptions.IgnoreCase | RegexOptions.CultureInvariant) : RegexOptions.None;
 
         string input = CleanNewLines(Subject);
         string pattern = ConvertWildcardToRegEx(CleanNewLines(Expected));

--- a/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
@@ -325,6 +325,14 @@ public class StringComparisonSpecs
             .WithMessage("*1.234*", "it should always use . as decimal separator");
     }
 
+    [CulturedTheory("tr-TR")]
+    [MemberData(nameof(EquivalencyData))]
+    public void Matching_strings_for_equivalence_ignores_the_culture(string subject, string expected)
+    {
+        // Assert
+        subject.Should().MatchEquivalentOf(expected);
+    }
+
     public static IEnumerable<object[]> EquivalencyData
     {
         get

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,6 +17,7 @@ sidebar:
 
 ### Fixes
 * Fixed `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)
+* Changed `MatchEquivalentOf` to use `CultureInfo.InvariantCulture` instead of `CultureInfo.CurrentCulture` - [#1985](https://github.com/fluentassertions/fluentassertions/pull/1985).
 
 ## 6.7.0
 


### PR DESCRIPTION
I recently learned that regex in C# per default uses the current culture when doing case-insensitive matches.
This means that we current fails the Turkey Test, i.e. considering `i` and `I` equivalent when disregarding casing.

For 6.0.0 we changed all other known string comparisons to use Invariant culture, see #1283.