### PR TITLE
Improves how BeEquivalentTo handles fields hiding base-class fields

### DIFF
--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -178,16 +178,19 @@ internal static class TypeExtensions
     /// <returns>
     /// Returns <see langword="null"/> if no such property exists.
     /// </returns>
-    public static PropertyInfo FindProperty(this Type type, string propertyName, Type preferredType)
+    public static PropertyInfo FindProperty(this Type type, string propertyName)
     {
-        List<PropertyInfo> properties =
-            type.GetProperties(AllInstanceMembersFlag)
-                .Where(pi => pi.Name == propertyName)
-                .ToList();
+        while (type != typeof(object))
+        {
+            if (type.GetProperty(propertyName, AllInstanceMembersFlag | BindingFlags.DeclaredOnly) is { } property)
+            {
+                return property;
+            }
 
-        return properties.Count > 1
-            ? properties.SingleOrDefault(p => p.PropertyType == preferredType)
-            : properties.SingleOrDefault();
+            type = type.BaseType;
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -196,16 +199,19 @@ internal static class TypeExtensions
     /// <returns>
     /// Returns <see langword="null"/> if no such property exists.
     /// </returns>
-    public static FieldInfo FindField(this Type type, string fieldName, Type preferredType)
+    public static FieldInfo FindField(this Type type, string fieldName)
     {
-        List<FieldInfo> properties =
-            type.GetFields(AllInstanceMembersFlag)
-                .Where(pi => pi.Name == fieldName)
-                .ToList();
+        while (type != typeof(object))
+        {
+            if (type.GetField(fieldName, AllInstanceMembersFlag | BindingFlags.DeclaredOnly) is { } field)
+            {
+                return field;
+            }
 
-        return properties.Count > 1
-            ? properties.SingleOrDefault(p => p.FieldType == preferredType)
-            : properties.SingleOrDefault();
+            type = type.BaseType;
+        }
+
+        return null;
     }
 
     public static IEnumerable<MemberInfo> GetNonPrivateMembers(this Type typeToReflect, MemberVisibility visibility)

--- a/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
@@ -35,7 +35,7 @@ internal class MappedMemberMatchingRule<TExpectation, TSubject> : IMemberMatchin
         {
             if (expectedMember.Name == expectationMemberName)
             {
-                var member = MemberFactory.Find(subject, subjectMemberName, expectedMember.Type, parent);
+                var member = MemberFactory.Find(subject, subjectMemberName, parent);
                 if (member is null)
                 {
                     throw new ArgumentException(

--- a/Src/FluentAssertions/Equivalency/Matching/MappedPathMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedPathMatchingRule.cs
@@ -50,7 +50,7 @@ internal class MappedPathMatchingRule : IMemberMatchingRule
 
         if (path.IsEquivalentTo(expectedMember.PathAndName))
         {
-            var member = MemberFactory.Find(subject, subjectPath.MemberName, expectedMember.Type, parent);
+            var member = MemberFactory.Find(subject, subjectPath.MemberName, parent);
             if (member is null)
             {
                 throw new ArgumentException(

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -15,13 +15,13 @@ internal class MustMatchByNameRule : IMemberMatchingRule
 
         if (config.IncludedProperties != MemberVisibility.None)
         {
-            PropertyInfo propertyInfo = subject.GetType().FindProperty(expectedMember.Name, expectedMember.Type);
+            PropertyInfo propertyInfo = subject.GetType().FindProperty(expectedMember.Name);
             subjectMember = (propertyInfo is not null) && !propertyInfo.IsIndexer() ? new Property(propertyInfo, parent) : null;
         }
 
         if ((subjectMember is null) && config.IncludedFields != MemberVisibility.None)
         {
-            FieldInfo fieldInfo = subject.GetType().FindField(expectedMember.Name, expectedMember.Type);
+            FieldInfo fieldInfo = subject.GetType().FindField(expectedMember.Name);
             subjectMember = (fieldInfo is not null) ? new Field(fieldInfo, parent) : null;
         }
 

--- a/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
@@ -10,13 +10,13 @@ internal class TryMatchByNameRule : IMemberMatchingRule
 {
     public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions config)
     {
-        PropertyInfo property = subject.GetType().FindProperty(expectedMember.Name, expectedMember.Type);
+        PropertyInfo property = subject.GetType().FindProperty(expectedMember.Name);
         if ((property is not null) && !property.IsIndexer())
         {
             return new Property(property, parent);
         }
 
-        FieldInfo field = subject.GetType().FindField(expectedMember.Name, expectedMember.Type);
+        FieldInfo field = subject.GetType().FindField(expectedMember.Name);
         return (field is not null) ? new Field(field, parent) : null;
     }
 

--- a/Src/FluentAssertions/Equivalency/MemberFactory.cs
+++ b/Src/FluentAssertions/Equivalency/MemberFactory.cs
@@ -21,15 +21,15 @@ public static class MemberFactory
         throw new NotSupportedException($"Don't know how to deal with a {memberInfo.MemberType}");
     }
 
-    internal static IMember Find(object target, string memberName, Type preferredMemberType, INode parent)
+    internal static IMember Find(object target, string memberName, INode parent)
     {
-        PropertyInfo property = target.GetType().FindProperty(memberName, preferredMemberType);
+        PropertyInfo property = target.GetType().FindProperty(memberName);
         if ((property is not null) && !property.IsIndexer())
         {
             return new Property(property, parent);
         }
 
-        FieldInfo field = target.GetType().FindField(memberName, preferredMemberType);
+        FieldInfo field = target.GetType().FindField(memberName);
         return (field is not null) ? new Field(field, parent) : null;
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -531,15 +531,40 @@ public class SelectionRulesSpecs
         }
 
         [Fact]
+        public void Ignores_properties_of_the_same_runtime_types_hidden_by_the_derived_class()
+        {
+            // Arrange
+            var subject = new SubclassHidingStringProperty
+            {
+                Property = "DerivedValue"
+            };
+
+            ((BaseWithStringProperty)subject).Property = "ActualBaseValue";
+
+            var expectation = new SubclassHidingStringProperty
+            {
+                Property = "DerivedValue"
+            };
+
+            ((BaseWithStringProperty)expectation).Property = "ExpectedBaseValue";
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation);
+        }
+
+        [Fact]
         public void Includes_hidden_property_of_the_base_when_using_a_reference_to_the_base()
         {
             // Arrange
-            var subject = new SubclassAHidingProperty<string>
+            BaseWithProperty subject = new SubclassAHidingProperty<string>
             {
                 Property = "ActualDerivedValue"
             };
 
-            ((BaseWithProperty)subject).Property = "BaseValue";
+            // FA doesn't know the compile-time type of the subject, so even though we pass a reference to the base-class,
+            // at run-time, it'll start finding the property on the subject starting from the run-time type, and thus ignore the
+            // hidden base-class field
+            ((SubclassAHidingProperty<string>)subject).Property = "BaseValue";
 
             AnotherBaseWithProperty expectation = new SubclassBHidingProperty<string>
             {
@@ -617,27 +642,171 @@ public class SelectionRulesSpecs
             act.Should().Throw<InvalidOperationException>().WithMessage("*No members were found *");
         }
 
-        public class BaseWithProperty
+        private class BaseWithProperty
         {
             public object Property { get; set; }
         }
 
-        public class SubclassAHidingProperty<T> : BaseWithProperty
+        private class SubclassAHidingProperty<T> : BaseWithProperty
         {
             public new T Property { get; set; }
         }
 
-        public class AnotherBaseWithProperty
+        private class BaseWithStringProperty
+        {
+            public string Property { get; set; }
+        }
+
+        private class SubclassHidingStringProperty : BaseWithStringProperty
+        {
+            public new string Property { get; set; }
+        }
+
+        private class AnotherBaseWithProperty
         {
             public object Property { get; set; }
         }
 
-        public class SubclassBHidingProperty<T> : AnotherBaseWithProperty
+        private class SubclassBHidingProperty<T> : AnotherBaseWithProperty
         {
             public new T Property
             {
                 get; set;
             }
+        }
+
+        [Fact]
+        public void Ignores_fields_hidden_by_the_derived_class()
+        {
+            // Arrange
+            var subject = new SubclassAHidingField
+            {
+                Field = "DerivedValue"
+            };
+
+            ((BaseWithField)subject).Field = "ActualBaseValue";
+
+            var expectation = new SubclassBHidingField
+            {
+                Field = "DerivedValue"
+            };
+
+            ((AnotherBaseWithField)expectation).Field = "ExpectedBaseValue";
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, options => options.IncludingFields());
+        }
+
+        [Fact]
+        public void Includes_hidden_field_of_the_base_when_using_a_reference_to_the_base()
+        {
+            // Arrange
+            BaseWithField subject = new SubclassAHidingField
+            {
+                Field = "BaseValueFromSubject"
+            };
+
+            // FA doesn't know the compile-time type of the subject, so even though we pass a reference to the base-class,
+            // at run-time, it'll start finding the field on the subject starting from the run-time type, and thus ignore the
+            // hidden base-class field
+            ((SubclassAHidingField)subject).Field = "BaseValueFromExpectation";
+
+            AnotherBaseWithField expectation = new SubclassBHidingField
+            {
+                Field = "ExpectedDerivedValue"
+            };
+
+            expectation.Field = "BaseValueFromExpectation";
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, options => options.IncludingFields());
+        }
+
+        [Fact]
+        public void Run_type_typing_ignores_hidden_fields_even_when_using_a_reference_to_the_base_class()
+        {
+            // Arrange
+            var subject = new SubclassAHidingField
+            {
+                Field = "DerivedValue"
+            };
+
+            ((BaseWithField)subject).Field = "ActualBaseValue";
+
+            AnotherBaseWithField expectation = new SubclassBHidingField
+            {
+                Field = "DerivedValue"
+            };
+
+            expectation.Field = "ExpectedBaseValue";
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, options => options.IncludingFields().RespectingRuntimeTypes());
+        }
+
+        [Fact]
+        public void Including_the_derived_field_excludes_the_hidden_field()
+        {
+            // Arrange
+            var subject = new SubclassAHidingField
+            {
+                Field = "DerivedValue"
+            };
+
+            ((BaseWithField)subject).Field = "ActualBaseValue";
+
+            var expectation = new SubclassBHidingField
+            {
+                Field = "DerivedValue"
+            };
+
+            ((AnotherBaseWithField)expectation).Field = "ExpectedBaseValue";
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, options => options
+                .IncludingFields()
+                .Including(_ => _.Field));
+        }
+
+        [Fact]
+        public void Excluding_the_field_hiding_the_base_class_one_does_not_reveal_the_latter()
+        {
+            // Arrange
+            var subject = new SubclassAHidingField();
+
+            ((BaseWithField)subject).Field = "ActualBaseValue";
+
+            var expectation = new SubclassBHidingField();
+
+            ((AnotherBaseWithField)expectation).Field = "ExpectedBaseValue";
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, options => options
+                .IncludingFields()
+                .Excluding(b => b.Field));
+
+            // Assert
+            act.Should().Throw<InvalidOperationException>().WithMessage("*No members were found *");
+        }
+
+        private class BaseWithField
+        {
+            public string Field;
+        }
+
+        private class SubclassAHidingField : BaseWithField
+        {
+            public new string Field;
+        }
+
+        private class AnotherBaseWithField
+        {
+            public string Field;
+        }
+
+        private class SubclassBHidingField : AnotherBaseWithField
+        {
+            public new string Field;
         }
     }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,8 @@ sidebar:
 
 ### Fixes
 
+* `BeEquivalentTo` no longer crashes on fields hiding base-class fields - [#1990](https://github.com/fluentassertions/fluentassertions/pull/1990)
+
 ## 6.9.0
 
 ### What's new


### PR DESCRIPTION
Fixes #1982 

If a derived class is used as the expectation and hides a base-class field of the same type using the `new` keyword, FA would get confused about which field to use. Now, it'll start at the compile- or run-time type (depending on the options and reference passed) and find the property or field from there. 

This does have a potential side-effect. Since we don't know the compile-time type of the subject-under-test, we now do the same thing for the subject's properties and fields. Before this PR, we tried to find the best match. 

**Note** Review by commit

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).