### PR TITLE
EquivalencyValidator: ShouldCompareMembersThisDeep -> ShouldCompareNodesThisDeep.

### DIFF
--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -31,7 +31,7 @@ public class EquivalencyValidator : IEquivalencyValidator
     {
         var scope = AssertionScope.Current;
 
-        if (ShouldCompareMembersThisDeep(context.CurrentNode, context.Options, scope))
+        if (ShouldCompareNodesThisDeep(context.CurrentNode, context.Options, scope))
         {
             UpdateScopeWithReportableContext(scope, comparands, context.CurrentNode);
 
@@ -42,7 +42,7 @@ public class EquivalencyValidator : IEquivalencyValidator
         }
     }
 
-    private static bool ShouldCompareMembersThisDeep(INode currentNode, IEquivalencyAssertionOptions options,
+    private static bool ShouldCompareNodesThisDeep(INode currentNode, IEquivalencyAssertionOptions options,
         AssertionScope assertionScope)
     {
         bool shouldRecurse = options.AllowInfiniteRecursion || currentNode.Depth < MaxDepth;


### PR DESCRIPTION
Changes private function:
ShouldCompareMembersThisDeep to ShouldCompareNodesThisDeep.

@dennisdoomen

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).