### PR TITLE
Escape brackets in execution time failures

### DIFF
--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Specialized;
@@ -77,7 +78,7 @@ public class ExecutionTimeAssertions
             .ForCondition(Condition(elapsed))
             .BecauseOf(because, becauseArgs)
             .FailWith("Execution of " +
-                      execution.ActionDescription + " should be less than or equal to {0}{reason}, but it required " +
+                      execution.ActionDescription.EscapePlaceholders() + " should be less than or equal to {0}{reason}, but it required " +
                       (isRunning ? "more than " : "exactly ") + "{1}.",
                 maxDuration,
                 elapsed);
@@ -110,7 +111,7 @@ public class ExecutionTimeAssertions
             .ForCondition(Condition(execution.ElapsedTime))
             .BecauseOf(because, becauseArgs)
             .FailWith("Execution of " +
-                      execution.ActionDescription + " should be less than {0}{reason}, but it required " +
+                      execution.ActionDescription.EscapePlaceholders() + " should be less than {0}{reason}, but it required " +
                       (isRunning ? "more than " : "exactly ") + "{1}.",
                 maxDuration,
                 elapsed);
@@ -140,7 +141,7 @@ public class ExecutionTimeAssertions
             .ForCondition(Condition(elapsed))
             .BecauseOf(because, becauseArgs)
             .FailWith("Execution of " +
-                      execution.ActionDescription + " should be greater than or equal to {0}{reason}, but it required " +
+                      execution.ActionDescription.EscapePlaceholders() + " should be greater than or equal to {0}{reason}, but it required " +
                       (isRunning ? "more than " : "exactly ") + "{1}.",
                 minDuration,
                 elapsed);
@@ -173,7 +174,7 @@ public class ExecutionTimeAssertions
             .ForCondition(Condition(elapsed))
             .BecauseOf(because, becauseArgs)
             .FailWith("Execution of " +
-                      execution.ActionDescription + " should be greater than {0}{reason}, but it required " +
+                      execution.ActionDescription.EscapePlaceholders() + " should be greater than {0}{reason}, but it required " +
                       (isRunning ? "more than " : "exactly ") + "{1}.",
                 minDuration,
                 elapsed);
@@ -218,7 +219,7 @@ public class ExecutionTimeAssertions
         Execute.Assertion
             .ForCondition(MinCondition(elapsed) && MaxCondition(elapsed))
             .BecauseOf(because, becauseArgs)
-            .FailWith("Execution of " + execution.ActionDescription +
+            .FailWith("Execution of " + execution.ActionDescription.EscapePlaceholders() +
                       " should be within {0} from {1}{reason}, but it required " +
                       (isRunning ? "more than " : "exactly ") + "{2}.",
                 precision,

--- a/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions.Extensions;
@@ -84,6 +85,20 @@ public class ExecutionTimeAssertionsSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "*action should be less than or equal to 100ms, but it required more than*");
+        }
+
+        [Fact]
+        public void Actions_with_brackets_fail_with_correctly_formatted_message()
+        {
+            // Arrange
+            var subject = new List<object>();
+
+            // Act
+            Action act = () => subject.ExecutionTimeOf(s => s.AddRange(new object[] { })).Should().BeLessOrEqualTo(1.Nanoseconds());
+
+            // Assert
+            act.Should().ThrowExactly<XunitException>()
+                .Which.Message.Should().Contain("{}").And.NotContain("{0}");
         }
     }
 
@@ -189,6 +204,20 @@ public class ExecutionTimeAssertionsSpecs
             act.Should().Throw<XunitException>().WithMessage(
                 "*action should be less than 100ms, but it required more than*");
         }
+
+        [Fact]
+        public void Actions_with_brackets_fail_with_correctly_formatted_message()
+        {
+            // Arrange
+            var subject = new List<object>();
+
+            // Act
+            Action act = () => subject.ExecutionTimeOf(s => s.AddRange(new object[] { })).Should().BeLessThan(1.Nanoseconds());
+
+            // Assert
+            act.Should().ThrowExactly<XunitException>()
+                .Which.Message.Should().Contain("{}").And.NotContain("{0}");
+        }
     }
 
     public class BeGreaterThanOrEqualTo
@@ -265,6 +294,20 @@ public class ExecutionTimeAssertionsSpecs
             // Assert
             act.Should().NotThrow<XunitException>();
         }
+
+        [Fact]
+        public void Actions_with_brackets_fail_with_correctly_formatted_message()
+        {
+            // Arrange
+            var subject = new List<object>();
+
+            // Act
+            Action act = () => subject.ExecutionTimeOf(s => s.AddRange(new object[] { })).Should().BeGreaterThanOrEqualTo(1.Days());
+
+            // Assert
+            act.Should().ThrowExactly<XunitException>()
+                .Which.Message.Should().Contain("{}").And.NotContain("{0}");
+        }
     }
 
     public class BeGreaterThan
@@ -340,6 +383,20 @@ public class ExecutionTimeAssertionsSpecs
 
             // Assert
             act.Should().NotThrow<XunitException>();
+        }
+
+        [Fact]
+        public void Actions_with_brackets_fail_with_correctly_formatted_message()
+        {
+            // Arrange
+            var subject = new List<object>();
+
+            // Act
+            Action act = () => subject.ExecutionTimeOf(s => s.AddRange(new object[] { })).Should().BeGreaterThan(1.Days());
+
+            // Assert
+            act.Should().ThrowExactly<XunitException>()
+                .Which.Message.Should().Contain("{}").And.NotContain("{0}");
         }
     }
 
@@ -436,6 +493,21 @@ public class ExecutionTimeAssertionsSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "*action should be within 50ms from 100ms, but it required*");
+        }
+
+        [Fact]
+        public void Actions_with_brackets_fail_with_correctly_formatted_message()
+        {
+            // Arrange
+            var subject = new List<object>();
+
+            // Act
+            Action act = () => subject.ExecutionTimeOf(s => s.AddRange(new object[] { }))
+                .Should().BeCloseTo(1.Days(), 50.Milliseconds());
+
+            // Assert
+            act.Should().ThrowExactly<XunitException>()
+                .Which.Message.Should().Contain("{}").And.NotContain("{0}");
         }
     }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -19,6 +19,7 @@ sidebar:
 * Fixed `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)
 * Changed `MatchEquivalentOf` to use `CultureInfo.InvariantCulture` instead of `CultureInfo.CurrentCulture` - [#1985](https://github.com/fluentassertions/fluentassertions/pull/1985).
 * Fixes `BeEquivalentTo` not taking into account any `record` equivalency settings coming from the `AssertionOptions` - [#1984](https://github.com/fluentassertions/fluentassertions/pull/1984)
+* Fixed `ExecutionTimeOf` formatting failing when the expression includes {} - [#1994](https://github.com/fluentassertions/fluentassertions/pull/1994)
 
 ## 6.7.0
 


### PR DESCRIPTION
Expressions can contain brackets, which cause the failure message formatting to fail. I escaped all of the cases for execution time, not sure if there are other types affected

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).