### PR TITLE
Remove usage of method name in test method name

### DIFF
--- a/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
@@ -9,7 +9,7 @@ public class MemberMatchingSpecs
 {
     [Fact]
     [SuppressMessage("ReSharper", "StringLiteralTypo")]
-    public void When_using_ExcludingMissingMembers_both_fields_and_properties_should_be_ignored()
+    public void When_excluding_missing_members_both_fields_and_properties_should_be_ignored()
     {
         // Arrange
         var class1 = new ClassWithSomeFieldsAndProperties


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).