### PR TITLE
`Equals` error message updates

### DIFF
--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -474,7 +474,7 @@ public class NumericAssertions<T, TAssertions>
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-        throw new NotSupportedException("Calling Equals on Assertion classes is not supported.");
+        throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
 
     private protected virtual bool IsNaN(T value) => false;
 

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -3963,4 +3963,17 @@ public class NumericAssertionSpecs
         // Assert
         action.Should().NotThrow();
     }
+
+    [Fact]
+    public void When_accidentally_using_equals_returns_numeric_appropriate_error()
+    {
+        // Arrange
+        int value = 1;
+
+        // Act
+        Action action = () => value.Should().Equals(1);
+
+        // Assert
+        action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+    }
 }


### PR DESCRIPTION
Work in progress PR for #1997 .  Just wanted to see if this is the right idea.  If this looks good, I will go through the rest of the corresponding errors, keeping the follow-up comments in mind, update the release notes, etc.  I think it would also be good to have this exact error message in the docs somewhere with a little explainer.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).