### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           2.1.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       DOTNET_NOLOGO: true
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,6 @@ jobs:
         path-to-lcov: TestResults/reports/lcov.info
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: ./Artifacts/*


### PR DESCRIPTION
Comparing the build times of [this](https://github.com/fluentassertions/fluentassertions/actions/runs/3164810440/jobs/5153372571) with two [recent](https://github.com/fluentassertions/fluentassertions/actions/runs/3122473666/jobs/5064728646) [ones](https://github.com/fluentassertions/fluentassertions/actions/runs/3162917145/jobs/5152321555)

Upgrading `actions/setup-dotnet` saves 50s because it now sees that dotnet 3.1.x and 6.0.x are already installed on the build agents 🚀 
 
It also resolves this build warning:
![image](https://user-images.githubusercontent.com/919634/193413465-18fb1c51-cce3-4e3d-9edd-9cdbfa443b20.png)