### PR TITLE
Exposes the IMonitor object to extensions methods.

### DIFF
--- a/Src/FluentAssertions/Events/EventAssertions.cs
+++ b/Src/FluentAssertions/Events/EventAssertions.cs
@@ -16,13 +16,16 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
 {
     private const string PropertyChangedEventName = "PropertyChanged";
 
-    private readonly IMonitor<T> monitor;
-
     protected internal EventAssertions(IMonitor<T> monitor)
         : base(monitor.Subject)
     {
-        this.monitor = monitor;
+        this.Monitor = monitor;
     }
+    
+    /// <summary>
+    /// Gets the <see cref="IMonitor{T}"/> which is being asserted.
+    /// </summary>
+    public IMonitor<T> Monitor { get; }
 
     /// <summary>
     /// Asserts that an object has raised a particular event at least once.
@@ -39,12 +42,12 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
     /// </param>
     public IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs)
     {
-        IEventRecording recording = monitor.GetRecordingFor(eventName);
+        IEventRecording recording = Monitor.GetRecordingFor(eventName);
         if (!recording.Any())
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected object {0} to raise event {1}{reason}, but it did not.", monitor.Subject, eventName);
+                .FailWith("Expected object {0} to raise event {1}{reason}, but it did not.", Monitor.Subject, eventName);
         }
 
         return recording;
@@ -65,12 +68,12 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
     /// </param>
     public void NotRaise(string eventName, string because = "", params object[] becauseArgs)
     {
-        IEventRecording events = monitor.GetRecordingFor(eventName);
+        IEventRecording events = Monitor.GetRecordingFor(eventName);
         if (events.Any())
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected object {0} to not raise event {1}{reason}, but it did.", monitor.Subject, eventName);
+                .FailWith("Expected object {0} to not raise event {1}{reason}, but it did.", Monitor.Subject, eventName);
         }
     }
 
@@ -93,14 +96,14 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
     {
         string propertyName = propertyExpression?.GetPropertyInfo().Name;
 
-        IEventRecording recording = monitor.GetRecordingFor(PropertyChangedEventName);
+        IEventRecording recording = Monitor.GetRecordingFor(PropertyChangedEventName);
 
         if (!recording.Any())
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected object {0} to raise event {1} for property {2}{reason}, but it did not raise that event at all.",
-                    monitor.Subject, PropertyChangedEventName, propertyName);
+                    Monitor.Subject, PropertyChangedEventName, propertyName);
         }
 
         var actualPropertyNames = recording
@@ -113,7 +116,7 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
             .ForCondition(actualPropertyNames.Contains(propertyName))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected object {0} to raise event {1} for property {2}{reason}, but it was only raised for {3}.",
-                monitor.Subject, PropertyChangedEventName, propertyName, actualPropertyNames);
+                Monitor.Subject, PropertyChangedEventName, propertyName, actualPropertyNames);
 
         return recording;
     }
@@ -134,7 +137,7 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
     public void NotRaisePropertyChangeFor(Expression<Func<T, object>> propertyExpression,
         string because = "", params object[] becauseArgs)
     {
-        IEventRecording recording = monitor.GetRecordingFor(PropertyChangedEventName);
+        IEventRecording recording = Monitor.GetRecordingFor(PropertyChangedEventName);
 
         string propertyName = propertyExpression.GetPropertyInfo().Name;
 
@@ -143,7 +146,7 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect object {0} to raise the {1} event for property {2}{reason}, but it did.",
-                    monitor.Subject, PropertyChangedEventName, propertyName);
+                    Monitor.Subject, PropertyChangedEventName, propertyName);
         }
     }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1257,6 +1257,7 @@ namespace FluentAssertions.Events
     {
         protected EventAssertions(FluentAssertions.Events.IMonitor<T> monitor) { }
         protected override string Identifier { get; }
+        public FluentAssertions.Events.IMonitor<T> Monitor { get; }
         public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
         public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Events.IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1270,6 +1270,7 @@ namespace FluentAssertions.Events
     {
         protected EventAssertions(FluentAssertions.Events.IMonitor<T> monitor) { }
         protected override string Identifier { get; }
+        public FluentAssertions.Events.IMonitor<T> Monitor { get; }
         public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
         public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Events.IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1257,6 +1257,7 @@ namespace FluentAssertions.Events
     {
         protected EventAssertions(FluentAssertions.Events.IMonitor<T> monitor) { }
         protected override string Identifier { get; }
+        public FluentAssertions.Events.IMonitor<T> Monitor { get; }
         public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
         public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Events.IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1257,6 +1257,7 @@ namespace FluentAssertions.Events
     {
         protected EventAssertions(FluentAssertions.Events.IMonitor<T> monitor) { }
         protected override string Identifier { get; }
+        public FluentAssertions.Events.IMonitor<T> Monitor { get; }
         public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
         public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Events.IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1257,6 +1257,7 @@ namespace FluentAssertions.Events
     {
         protected EventAssertions(FluentAssertions.Events.IMonitor<T> monitor) { }
         protected override string Identifier { get; }
+        public FluentAssertions.Events.IMonitor<T> Monitor { get; }
         public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
         public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Events.IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -629,6 +629,20 @@ public class EventAssertionSpecs
             act.Should().Throw<ArgumentException>()
                 .WithParameterName("expression");
         }
+
+        [Fact]
+        public void Event_Assertions_should_expose_monitor()
+        {
+            // Arrange
+            var subject = new EventRaisingClass();
+            using var monitor = subject.Monitor();
+
+            // Act
+            var exposedMonitor = monitor.Should().Monitor;
+
+            // Assert
+            ((object)exposedMonitor).Should().BeSameAs(monitor);
+        }
     }
 
     public class Metadata

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -631,7 +631,7 @@ public class EventAssertionSpecs
         }
 
         [Fact]
-        public void Event_Assertions_should_expose_monitor()
+        public void Event_assertions_should_expose_the_monitor()
         {
             // Arrange
             var subject = new EventRaisingClass();

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,6 +14,8 @@ sidebar:
 * Added `NotCompleteWithinAsync` for assertions on `Task` - [#1967](https://github.com/fluentassertions/fluentassertions/pull/1967)
 * Added `CompleteWithinAsync` and `NotCompleteWithinAsync` for non-generic `TaskCompletionSource` (.NET 6 and above) - [#1961](https://github.com/fluentassertions/fluentassertions/pull/1961)
 * Added a `ParentType` to `IObjectInfo` to help determining the parent in a call to `Using`/`When` constructs - [#1950](https://github.com/fluentassertions/fluentassertions/pull/1950)
+* Added a `Monitor` to `EventAssertions` to enable writing extension methods for event assertions. 
+[#2008](https://github.com/fluentassertions/fluentassertions/pull/2008)
 
 ### Fixes
 * Fixed `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,8 +14,7 @@ sidebar:
 * Added `NotCompleteWithinAsync` for assertions on `Task` - [#1967](https://github.com/fluentassertions/fluentassertions/pull/1967)
 * Added `CompleteWithinAsync` and `NotCompleteWithinAsync` for non-generic `TaskCompletionSource` (.NET 6 and above) - [#1961](https://github.com/fluentassertions/fluentassertions/pull/1961)
 * Added a `ParentType` to `IObjectInfo` to help determining the parent in a call to `Using`/`When` constructs - [#1950](https://github.com/fluentassertions/fluentassertions/pull/1950)
-* Added a `Monitor` to `EventAssertions` to enable writing extension methods for event assertions. 
-[#2008](https://github.com/fluentassertions/fluentassertions/pull/2008)
+* Added a `Monitor` to `EventAssertions` to enable writing extension methods for event assertions. - [#2008](https://github.com/fluentassertions/fluentassertions/pull/2008)
 
 ### Fixes
 * Fixed `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)


### PR DESCRIPTION
Changed the private field to a public property, thereby exposing the IMonitor object to extensions methods.

Closes #2008

- Added Unit test.
- Ran and updated accept api changes.
- Added release notes.