### PR TITLE
Calculate the difference between the subject and the expected nearby time

### DIFF
--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -168,12 +168,18 @@ public class DateTimeAssertions<TAssertions>
         long distanceToMaxInTicks = (DateTime.MaxValue - nearbyTime).Ticks;
         DateTime maximumValue = nearbyTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
+        TimeSpan? difference = (Subject - nearbyTime)?.Duration();
+
         Execute.Assertion
-            .ForCondition((Subject >= minimumValue) && (Subject.Value <= maximumValue))
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:the date and time} to be within {0} from {1}{reason}, but found {2}.",
-                precision,
-                nearbyTime, Subject);
+            .WithExpectation("Expected {context:the date and time} to be within {0} from {1}{reason}", precision, nearbyTime)
+            .ForCondition(Subject is not null)
+            .FailWith(", but found <null>.")
+            .Then
+            .ForCondition((Subject >= minimumValue) && (Subject <= maximumValue))
+            .FailWith(", but {0} was off by {1}.", Subject, difference)
+            .Then
+            .ClearExpectation();
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -304,12 +304,18 @@ public class DateTimeOffsetAssertions<TAssertions>
         long distanceToMaxInTicks = (DateTimeOffset.MaxValue - nearbyTime).Ticks;
         DateTimeOffset maximumValue = nearbyTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
+        TimeSpan? difference = (Subject - nearbyTime)?.Duration();
+
         Execute.Assertion
-            .ForCondition(Subject >= minimumValue && (Subject <= maximumValue))
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:the date and time} to be within {0} from {1}{reason}, but it was {2}.",
-                precision,
-                nearbyTime, Subject);
+            .WithExpectation("Expected {context:the date and time} to be within {0} from {1}{reason}", precision, nearbyTime)
+            .ForCondition(Subject is not null)
+            .FailWith(", but found <null>.")
+            .Then
+            .ForCondition(Subject >= minimumValue && Subject <= maximumValue)
+            .FailWith(", but {0} was off by {1}.", Subject, difference)
+            .Then
+            .ClearExpectation();
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
@@ -483,7 +483,7 @@ public class DateTimeAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected time to be within 20ms from <2012-03-13 12:15:31>, but found <2012-03-13 12:15:30.979>.");
+                    "Expected time to be within 20ms from <2012-03-13 12:15:31>, but <2012-03-13 12:15:30.979> was off by 21ms.");
         }
 
         [Fact]
@@ -499,7 +499,7 @@ public class DateTimeAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected time to be within 20ms from <2012-03-13 12:15:31>, but found <2012-03-13 12:15:30.979>.");
+                    "Expected time to be within 20ms from <2012-03-13 12:15:31>, but <2012-03-13 12:15:30.979> was off by 21ms.");
         }
 
         [Fact]
@@ -515,7 +515,7 @@ public class DateTimeAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected time to be within 20ms from <2012-03-13 12:15:31>, but found <2012-03-13 12:15:31.021>.");
+                    "Expected time to be within 20ms from <2012-03-13 12:15:31>, but <2012-03-13 12:15:31.021> was off by 21ms.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -661,7 +661,7 @@ public class DateTimeOffsetAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected time to be within 20ms from <2012-03-13 12:15:31 +1H>, but it was <2012-03-13 12:15:30.979 +1H>.");
+                    "Expected time to be within 20ms from <2012-03-13 12:15:31 +1H>, but <2012-03-13 12:15:30.979 +1H> was off by 21ms.");
         }
 
         [Fact]
@@ -677,7 +677,7 @@ public class DateTimeOffsetAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected time to be within 20ms from <2012-03-13 12:15:31 +1h>, but it was <2012-03-13 12:15:31.021 +1h>.");
+                    "Expected time to be within 20ms from <2012-03-13 12:15:31 +1h>, but <2012-03-13 12:15:31.021 +1h> was off by 21ms.");
         }
 
         [Fact]
@@ -693,7 +693,7 @@ public class DateTimeOffsetAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected time to be within 35ms from <2012-03-13 12:15:31 +1h>, but it was <2012-03-13 12:15:31.036 +1h>.");
+                    "Expected time to be within 35ms from <2012-03-13 12:15:31 +1h>, but <2012-03-13 12:15:31.036 +1h> was off by 36ms.");
         }
 
         [Fact]
@@ -722,7 +722,7 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*, but it was <null>.");
+                .WithMessage("Expected*, but found <null>.");
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -19,8 +19,11 @@ sidebar:
 ### Fixes
 * Fixed `For`/`Exclude` not excluding properties in objects in a collection - [#1953](https://github.com/fluentassertions/fluentassertions/pull/1953)
 * Changed `MatchEquivalentOf` to use `CultureInfo.InvariantCulture` instead of `CultureInfo.CurrentCulture` - [#1985](https://github.com/fluentassertions/fluentassertions/pull/1985).
-* Fixes `BeEquivalentTo` not taking into account any `record` equivalency settings coming from the `AssertionOptions` - [#1984](https://github.com/fluentassertions/fluentassertions/pull/1984)
+* Fixed `BeEquivalentTo` not taking into account any `record` equivalency settings coming from the `AssertionOptions` - [#1984](https://github.com/fluentassertions/fluentassertions/pull/1984)
 * Fixed `ExecutionTimeOf` formatting failing when the expression includes {} - [#1994](https://github.com/fluentassertions/fluentassertions/pull/1994)
+
+### Enhancements
+* Included the time difference in the error message of `BeCloseTo` - [#2012](https://github.com/fluentassertions/fluentassertions/pull/2012)
 
 ## 6.7.0
 


### PR DESCRIPTION
Closes #2012 

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).