### PR TITLE
New tests for better code coverage on collection assertions

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -263,7 +263,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
             .FailWith("but found a null element.")
             .Then
             .ForCondition(subject => subject.All(x => expectedType == GetType(x)))
-            .FailWith("but found {0}.", subject => $"but found [{string.Join(", ", subject.Select(x => GetType(x).FullName))}].")
+            .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => GetType(x).FullName))}]")
             .Then
             .ClearExpectation();
 
@@ -758,7 +758,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject is not null)
-            .FailWith("Expected {context:collection} to contain {0}{reason}, but found <null>.", expected);
+            .FailWith("Expected {context:collection} to contain {0}{reason}, but found <null>.", expectedObjects);
 
         if (success)
         {
@@ -770,13 +770,14 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:collection} {0} to contain {1}{reason}, but could not find {2}.",
-                            Subject, expected, missingItems);
+                            Subject, expectedObjects, missingItems);
                 }
                 else
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} {0} to contain {1}{reason}.", Subject, expected.First());
+                        .FailWith("Expected {context:collection} {0} to contain {1}{reason}.",
+                            Subject, expectedObjects.Single());
                 }
             }
         }
@@ -2166,8 +2167,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} {0} to not contain element {1}{reason}.", Subject,
-                            unexpectedObjects.First());
+                        .FailWith("Expected {context:collection} {0} to not contain {1}{reason}.",
+                            Subject, unexpectedObjects.First());
                 }
             }
         }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeAssignableTo.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_types_in_a_collection_is_matched_against_a_null_type_it_should_throw()
         {
             // Arrange
-            var collection = new int[0];
+            var collection = Array.Empty<int>();
 
             // Act
             Action act = () => collection.Should().AllBeAssignableTo(null);
@@ -49,7 +49,17 @@ public partial class CollectionAssertionSpecs
         public void When_all_of_the_types_in_a_collection_match_expected_type_it_should_succeed()
         {
             // Arrange
-            var collection = new int[] { 1, 2, 3 };
+            var collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().AllBeAssignableTo(typeof(int));
+        }
+
+        [Fact]
+        public void When_all_of_the_types_in_a_collection_match_expected_generic_type_it_should_succeed()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
 
             // Act / Assert
             collection.Should().AllBeAssignableTo<int>();
@@ -59,7 +69,7 @@ public partial class CollectionAssertionSpecs
         public void When_matching_a_collection_against_a_type_it_should_return_the_casted_items()
         {
             // Arrange
-            var collection = new int[] { 1, 2, 3 };
+            var collection = new[] { 1, 2, 3 };
 
             // Act / Assert
             collection.Should().AllBeAssignableTo<int>()
@@ -70,7 +80,7 @@ public partial class CollectionAssertionSpecs
         public void When_all_of_the_types_in_a_collection_match_the_type_or_subtype_it_should_succeed()
         {
             // Arrange
-            var collection = new object[] { new Exception(), new ArgumentException() };
+            var collection = new object[] { new Exception(), new ArgumentException("foo") };
 
             // Act / Assert
             collection.Should().AllBeAssignableTo<Exception>();
@@ -78,6 +88,20 @@ public partial class CollectionAssertionSpecs
 
         [Fact]
         public void When_one_of_the_types_does_not_match_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            var collection = new object[] { 1, "2", 3 };
+
+            // Act
+            Action act = () => collection.Should().AllBeAssignableTo(typeof(int), "because they are of different type");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to be \"System.Int32\" because they are of different type, but found \"[System.Int32, System.String, System.Int32]\".");
+        }
+
+        [Fact]
+        public void When_one_of_the_types_does_not_match_the_generic_type_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
             var collection = new object[] { 1, "2", 3 };
@@ -108,7 +132,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_is_of_matching_types_it_should_succeed()
         {
             // Arrange
-            var collection = new Type[] { typeof(Exception), typeof(ArgumentException) };
+            var collection = new[] { typeof(Exception), typeof(ArgumentException) };
 
             // Act / Assert
             collection.Should().AllBeAssignableTo<Exception>();
@@ -118,7 +142,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_of_types_contains_one_type_that_does_not_match_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
-            var collection = new Type[] { typeof(int), typeof(string), typeof(int) };
+            var collection = new[] { typeof(int), typeof(string), typeof(int) };
 
             // Act
             Action act = () => collection.Should().AllBeAssignableTo<int>("because they are of different type");
@@ -142,7 +166,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_of_different_types_and_objects_are_all_assignable_to_type_it_should_succeed()
         {
             // Arrange
-            var collection = new object[] { typeof(Exception), new ArgumentException() };
+            var collection = new object[] { typeof(Exception), new ArgumentException("foo") };
 
             // Act / Assert
             collection.Should().AllBeAssignableTo<Exception>();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeOfType.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeOfType.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_types_in_a_collection_is_matched_against_a_null_type_exactly_it_should_throw()
         {
             // Arrange
-            var collection = new int[0];
+            var collection = Array.Empty<int>();
 
             // Act
             Action act = () => collection.Should().AllBeOfType(null);
@@ -49,7 +49,17 @@ public partial class CollectionAssertionSpecs
         public void When_all_of_the_types_in_a_collection_match_expected_type_exactly_it_should_succeed()
         {
             // Arrange
-            var collection = new int[] { 1, 2, 3 };
+            var collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().AllBeOfType(typeof(int));
+        }
+
+        [Fact]
+        public void When_all_of_the_types_in_a_collection_match_expected_generic_type_exactly_it_should_succeed()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
 
             // Act / Assert
             collection.Should().AllBeOfType<int>();
@@ -59,7 +69,7 @@ public partial class CollectionAssertionSpecs
         public void When_matching_a_collection_against_an_exact_type_it_should_return_the_casted_items()
         {
             // Arrange
-            var collection = new int[] { 1, 2, 3 };
+            var collection = new[] { 1, 2, 3 };
 
             // Act / Assert
             collection.Should().AllBeOfType<int>()
@@ -70,7 +80,21 @@ public partial class CollectionAssertionSpecs
         public void When_one_of_the_types_does_not_match_exactly_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
-            var collection = new object[] { new Exception(), new ArgumentException() };
+            var collection = new object[] { new Exception(), new ArgumentException("foo") };
+
+            // Act
+            Action act = () => collection.Should().AllBeOfType(typeof(Exception), "because they are of different type");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to be \"System.Exception\" because they are of different type, but found \"[System.Exception, System.ArgumentException]\".");
+        }
+
+        [Fact]
+        public void When_one_of_the_types_does_not_match_exactly_the_generic_type_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            var collection = new object[] { new Exception(), new ArgumentException("foo") };
 
             // Act
             Action act = () => collection.Should().AllBeOfType<Exception>("because they are of different type");
@@ -98,7 +122,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_of_types_match_expected_type_exactly_it_should_succeed()
         {
             // Arrange
-            var collection = new Type[] { typeof(int), typeof(int), typeof(int) };
+            var collection = new[] { typeof(int), typeof(int), typeof(int) };
 
             // Act / Assert
             collection.Should().AllBeOfType<int>();
@@ -108,7 +132,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_of_types_and_objects_match_type_exactly_it_should_succeed()
         {
             // Arrange
-            var collection = new object[] { typeof(ArgumentException), new ArgumentException() };
+            var collection = new object[] { typeof(ArgumentException), new ArgumentException("foo") };
 
             // Act / Assert
             collection.Should().AllBeOfType<ArgumentException>();
@@ -118,7 +142,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_of_types_and_objects_do_not_match_type_exactly_it_should_throw()
         {
             // Arrange
-            var collection = new object[] { typeof(Exception), new ArgumentException() };
+            var collection = new object[] { typeof(Exception), new ArgumentException("foo") };
 
             // Act
             Action act = () => collection.Should().AllBeOfType<ArgumentException>();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
@@ -80,6 +80,38 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
+        public void When_a_collection_does_not_contain_a_single_element_collection_it_should_throw_with_clear_explanation()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().Contain(new[] { 4 }, "because {0}", "we do");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3} to contain 4 because we do.");
+        }
+
+        [Fact]
+        public void When_a_collection_does_not_contain_other_collection_with_assertion_scope_it_should_throw_with_clear_explanation()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().Contain(new[] { 4 }).And.Contain(new[] { 5, 6 });
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*to contain 4*to contain {5, 6}*");
+        }
+
+        [Fact]
         public void When_the_contents_of_a_collection_are_checked_against_an_empty_collection_it_should_throw_clear_explanation()
         {
             // Arrange
@@ -332,6 +364,21 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
+        public void When_collection_contains_unexpected_item_it_should_throw()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should()
+                .NotContain(new[] { 2 }, "because we {0} like them", "don't");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3} to not contain 2 because we don't like them.");
+        }
+
+        [Fact]
         public void When_collection_contains_unexpected_items_it_should_throw()
         {
             // Arrange
@@ -344,6 +391,37 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected collection {1, 2, 3} to not contain {1, 2, 4} because we don't like them, but found {1, 2}.");
+        }
+
+        [Fact]
+        public void When_asserting_multiple_collection_in_assertion_scope_all_should_be_reported()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotContain(new[] { 1, 2 }).And.NotContain(new[] { 3 });
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*to not contain {1, 2}*to not contain 3*");
+        }
+
+        [Fact]
+        public void When_asserting_collection_to_not_contain_an_empty_collection_it_should_throw()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().NotContain(Array.Empty<int>());
+
+            // Assert
+            act.Should().Throw<ArgumentException>().WithMessage("Cannot verify*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInOrder.cs
@@ -90,6 +90,21 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
+        public void When_a_collection_does_not_contain_items_with_assertion_scope_all_items_are_reported()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                new[] { 1, 2, 3 }.Should().ContainInOrder(4).And.ContainInOrder(5);
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*but 4 (index 0)*but 5 (index 0)*");
+        }
+
+        [Fact]
         public void When_passing_in_null_while_checking_for_ordered_containment_it_should_throw_with_a_clear_explanation()
         {
             // Act

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCount.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCount.cs
@@ -60,6 +60,24 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
+        public void When_asserting_a_collection_with_incorrect_predicates_in_assertion_scope_all_are_reported()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().HaveCount(c => c > 3).And.HaveCount(c => c < 3);
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*to have a count (c > 3)*to have a count (c < 3)*");
+        }
+
+        [Fact]
         public void When_collection_has_a_count_that_not_matches_the_predicate_it_should_throw()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainNulls.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainNulls.cs
@@ -38,6 +38,24 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
+        public void When_collection_contains_nulls_that_are_unexpected_it_supports_chaining()
+        {
+            // Arrange
+            var collection = new[] { new object(), null };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotContainNulls().And.HaveCount(c => c > 1);
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*but found one*");
+        }
+
+        [Fact]
         public void When_collection_contains_multiple_nulls_that_are_unexpected_it_should_throw()
         {
             // Arrange
@@ -49,6 +67,24 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected collection not to contain <null>s*because they are evil*{1, 3}*");
+        }
+
+        [Fact]
+        public void When_collection_contains_multiple_nulls_that_are_unexpected_it_supports_chaining()
+        {
+            // Arrange
+            var collection = new[] { new object(), null, new object(), null };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotContainNulls().And.HaveCount(c => c > 1);
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*but found several*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyHaveUniqueItems.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyHaveUniqueItems.cs
@@ -38,6 +38,24 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
+        public void When_a_collection_contains_duplicate_items_it_supports_chaining()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3, 3 };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().OnlyHaveUniqueItems().And.HaveCount(c => c > 1);
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*but item 3 is not unique.");
+        }
+
+        [Fact]
         public void When_a_collection_contains_multiple_duplicate_items_it_should_throw()
         {
             // Arrange
@@ -49,6 +67,24 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected collection to only have unique items because we don't like duplicates, but items {2, 3} are not unique.");
+        }
+
+        [Fact]
+        public void When_a_collection_contains_multiple_duplicate_items_it_supports_chaining()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 2, 3, 3 };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().OnlyHaveUniqueItems().And.HaveCount(c => c > 1);
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*but items {2, 3} are not unique.");
         }
 
         [Fact]
@@ -138,6 +174,31 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected collection to only have unique items*on e.Text*because we don't like duplicates, but items*two*two*three*three*are not unique.");
+        }
+
+        [Fact]
+        public void When_a_collection_contains_multiple_duplicates_on_different_properties_all_should_be_reported()
+        {
+            // Arrange
+            IEnumerable<SomeClass> collection = new[]
+            {
+                new SomeClass { Text = "one", Number = 1 },
+                new SomeClass { Text = "two", Number = 2 },
+                new SomeClass { Text = "two", Number = 2 },
+                new SomeClass { Text = "three", Number = 3 },
+                new SomeClass { Text = "three", Number = 4 }
+            };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().OnlyHaveUniqueItems(e => e.Text).And.OnlyHaveUniqueItems(e => e.Number);
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*have unique items on e.Text*have unique items on e.Number*");
         }
 
         [Fact]


### PR DESCRIPTION
I've added new tests for better code coverage on collection assertions according to #1823.
While writing these tests I found some inconsistencies in building assertion messages which I've fixed silently.