### PR TITLE
Improve coverage on data assertions

### DIFF
--- a/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq.Expressions;
@@ -32,51 +31,9 @@ internal class DataEquivalencyAssertionOptions<T> : EquivalencyAssertionOptions<
 
     public ISet<string> ExcludeColumnNames => excludeColumnNames;
 
-    public IReadOnlyDictionary<string, ISet<string>> ExcludeColumnNamesByTableName { get; }
-
-    private class ColumnNamesByTableNameAdapter : IReadOnlyDictionary<string, ISet<string>>
-    {
-        private readonly DataEquivalencyAssertionOptions<T> owner;
-
-        public ColumnNamesByTableNameAdapter(DataEquivalencyAssertionOptions<T> owner)
-        {
-            this.owner = owner;
-        }
-
-        public ISet<string> this[string key] => owner.excludeColumnNamesByTableName[key];
-
-        public IEnumerable<string> Keys => owner.excludeColumnNamesByTableName.Keys;
-
-        public IEnumerable<ISet<string>> Values => owner.excludeColumnNamesByTableName.Values;
-
-        public int Count => owner.excludeColumnNamesByTableName.Count;
-
-        public bool ContainsKey(string key) => owner.excludeColumnNamesByTableName.ContainsKey(key);
-
-        public bool TryGetValue(string key, out ISet<string> value)
-        {
-            bool result = owner.excludeColumnNamesByTableName.TryGetValue(key, out HashSet<string> concreteValue);
-
-            value = concreteValue;
-
-            return result;
-        }
-
-        public IEnumerator<KeyValuePair<string, ISet<string>>> GetEnumerator()
-        {
-            foreach (KeyValuePair<string, HashSet<string>> entry in owner.excludeColumnNamesByTableName)
-            {
-                yield return new KeyValuePair<string, ISet<string>>(entry.Key, entry.Value);
-            }
-        }
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-    }
-
     public DataEquivalencyAssertionOptions(EquivalencyAssertionOptions defaults)
         : base(defaults)
     {
-        ExcludeColumnNamesByTableName = new ColumnNamesByTableNameAdapter(this);
     }
 
     public IDataEquivalencyAssertionOptions<T> AllowingMismatchedTypes()

--- a/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
@@ -143,7 +143,7 @@ internal class DataEquivalencyAssertionOptions<T> : EquivalencyAssertionOptions<
             return memberExpression.Member;
         }
 
-        throw new Exception("Expression must be a simple member access");
+        throw new ArgumentException("Expression must be a simple member access", nameof(expression));
     }
 
     private static Expression<Func<IMemberInfo, bool>> BuildMemberSelectionPredicate(Type relatedSubjectType, MemberInfo referencedMember)

--- a/Tests/FluentAssertions.Equivalency.Specs/DataColumnSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataColumnSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using Xunit;
 using Xunit.Sdk;
@@ -75,6 +76,43 @@ public class DataColumnSpecs : DataSpecs
         // Act & Assert
         dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
             .ExcludingColumn(dataColumn2));
+    }
+
+    [Fact]
+    public void When_DataColumn_has_changes_but_is_excluded_as_params_it_should_succeed()
+    {
+        // Arrange
+        var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+        var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+        var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+        var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+        dataColumn2.Unique = true;
+        dataColumn2.Caption = "Test";
+
+        // Act & Assert
+        dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+            .ExcludingColumns(dataColumn2));
+    }
+
+    [Fact]
+    public void When_DataColumn_has_changes_but_is_excluded_as_enumerable_it_should_succeed()
+    {
+        // Arrange
+        var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+        var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+        var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+        var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+        dataColumn2.Unique = true;
+        dataColumn2.Caption = "Test";
+
+        // Act & Assert
+        IEnumerable<DataColumn> excludedColumns = new[] { dataColumn2 };
+        dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+            .ExcludingColumns(excludedColumns));
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/TypedDataSetSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TypedDataSetSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -188,7 +189,7 @@ public class TypedDataSetSpecs : DataSpecs
         dataSet2.TypedDataTable1.Rows[0].RowError = "Manually added error";
 
         // Act
-        Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2, config => config.ExcludingTables("TypedDataTable1"));
+        Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2, config => config.ExcludingTable("TypedDataTable1"));
 
         // Assert
         action.Should().Throw<XunitException>().Which.Message.Should().Contain("HasErrors");
@@ -206,7 +207,38 @@ public class TypedDataSetSpecs : DataSpecs
 
         // Act & Assert
         dataSet1.Should().BeEquivalentTo(dataSet2,
+            config => config.Excluding(dataSet => dataSet.HasErrors).ExcludingTable("TypedDataTable1"));
+    }
+
+    [Fact]
+    public void When_HasErrors_does_not_match_and_property_is_excluded_as_params_it_should_succeed()
+    {
+        // Arrange
+        var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+        var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+        dataSet2.TypedDataTable1.Rows[0].RowError = "Manually added error";
+
+        // Act & Assert
+        dataSet1.Should().BeEquivalentTo(dataSet2,
             config => config.Excluding(dataSet => dataSet.HasErrors).ExcludingTables("TypedDataTable1"));
+    }
+
+    [Fact]
+    public void When_HasErrors_does_not_match_and_property_is_excluded_as_list_it_should_succeed()
+    {
+        // Arrange
+        var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+        var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+        dataSet2.TypedDataTable1.Rows[0].RowError = "Manually added error";
+
+        // Act & Assert
+        IEnumerable<string> excludedTales = new[] { "TypedDataTable1" };
+        dataSet1.Should().BeEquivalentTo(dataSet2,
+            config => config.Excluding(dataSet => dataSet.HasErrors).ExcludingTables(excludedTales));
     }
 
     [Fact]


### PR DESCRIPTION
I've added new tests to improve code coverage according to #1823.
While analyzing the code I found that there was thrown an `Exception`, an exception type which shall not be used directly. I've changed it to `ArgumentException` which should compatible.

Further tests on `DataEquivalencyAssertionOptions` I could not create because I do not understand their intention.

Please note (and check?) the method `ExcludingColumns(string tableName, IEnumerable<string> columnNames)` which creates locally a variable named `excludeColumnNames` which hides similar member. I'm not sure whether this is correct or potential bug. Maybe @logiclrd can check this because you created this code in #1419.