### PR TITLE
Bump minimum SDK to 6.0.400

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.100",
+        "version": "6.0.400",
         "rollForward": "latestMajor"
     }
 }


### PR DESCRIPTION
PolySharp requires a newer SDK to use source generators