### PR TITLE
Comparable type assertions referential equality

### DIFF
--- a/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
@@ -21,20 +21,18 @@ public class ComparableSpecs
         }
 
         [Fact]
-        public void When_two_instances_are_the_same_reference_but_are_not_considered_equal_it_should_not_succeed()
+        public void When_two_instances_are_the_same_reference_but_are_not_considered_equal_it_should_succeed()
         {
             // Arrange
             var subject = new SameInstanceIsNotEqualClass();
             var other = subject;
 
             // Act
-            Action act = () => subject.Should().Be(other, "they have the same property values");
+            Action act = () => subject.Should().Be(other);
 
             // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected*SameInstanceIsNotEqualClass*because they have the same property values, but found*SameInstanceIsNotEqualClass*.");
+            act.Should().NotThrow(
+                "This is inconsistent with the behavior ObjectAssertions.Be but is how ComparableTypeAssertions.Be has always worked.");
         }
 
         [Fact]
@@ -58,7 +56,7 @@ public class ComparableSpecs
     public class NotBe
     {
         [Fact]
-        public void When_two_references_to_the_same_instance_are_not_equal_it_should_succeed()
+        public void When_two_references_to_the_same_instance_are_not_equal_it_should_throw()
         {
             // Arrange
             var subject = new SameInstanceIsNotEqualClass();
@@ -68,7 +66,8 @@ public class ComparableSpecs
             Action act = () => subject.Should().NotBe(other);
 
             // Assert
-            act.Should().NotThrow();
+            act.Should().Throw<XunitException>(
+                "This is inconsistent with the behavior ObjectAssertions.Be but is how ComparableTypeAssertions.Be has always worked.");
         }
 
         [Fact]
@@ -118,6 +117,21 @@ public class ComparableSpecs
             act
                 .Should().Throw<XunitException>()
                 .WithMessage("Expected value to be one of {4, 5} because those are the valid values, but found 3.");
+        }
+
+        [Fact]
+        public void When_two_instances_are_the_same_reference_but_are_not_considered_equal_it_should_succeed()
+        {
+            // Arrange
+            var subject = new SameInstanceIsNotEqualClass();
+            var other = subject;
+
+            // Act
+            Action act = () => subject.Should().BeOneOf(other);
+
+            // Assert
+            act.Should().NotThrow(
+                "This is inconsistent with the behavior ObjectAssertions.Be but is how ComparableTypeAssertions.Be has always worked.");
         }
 
         [Fact]
@@ -656,7 +670,7 @@ public class ComparableOfString : IComparable<ComparableOfString>
     }
 }
 
-public class SameInstanceIsNotEqualClass
+public class SameInstanceIsNotEqualClass : IComparable<SameInstanceIsNotEqualClass>
 {
     public override bool Equals(object obj)
     {
@@ -667,6 +681,9 @@ public class SameInstanceIsNotEqualClass
     {
         return 1;
     }
+
+    int IComparable<SameInstanceIsNotEqualClass>.CompareTo(SameInstanceIsNotEqualClass other) =>
+        throw new NotSupportedException("This type is meant for assertions using Equals()");
 }
 
 public class EquatableOfInt : IComparable<EquatableOfInt>

--- a/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
@@ -106,28 +106,13 @@ public class ComparableSpecs
     public class BeOneOf
     {
         [Fact]
-        public void When_a_value_is_not_one_of_the_specified_values_it_should_throw()
+        public void When_a_value_is_not_equal_to_one_of_the_specified_values_it_should_throw()
         {
             // Arrange
-            var value = new ComparableOfInt(3);
+            var value = new EquatableOfInt(3);
 
             // Act
-            Action act = () => value.Should().BeOneOf(new ComparableOfInt(4), new ComparableOfInt(5));
-
-            // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {4, 5}, but found 3.");
-        }
-
-        [Fact]
-        public void When_a_value_is_not_one_of_the_specified_values_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            var value = new ComparableOfInt(3);
-
-            // Act
-            Action act = () => value.Should().BeOneOf(new[] { new ComparableOfInt(4), new ComparableOfInt(5) }, "because those are the valid values");
+            Action act = () => value.Should().BeOneOf(new[] { new EquatableOfInt(4), new EquatableOfInt(5) }, "because those are the valid {0}", "values");
 
             // Assert
             act
@@ -136,28 +121,13 @@ public class ComparableSpecs
         }
 
         [Fact]
-        public void When_a_value_is_comparable_to_but_a_different_instance_of_one_of_the_specified_values_it_should_fail()
+        public void When_a_value_is_equal_to_one_of_the_specified_values_it_should_succeed()
         {
             // Arrange
-            var value = new ComparableOfInt(4);
+            var value = new EquatableOfInt(4);
 
             // Act
-            Action act = () => value.Should().BeOneOf(new ComparableOfInt(4), new ComparableOfInt(5));
-
-            // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {4, 5}, but found 4.");
-        }
-
-        [Fact]
-        public void When_a_value_is_the_same_instance_as_one_of_the_specified_values_it_should_succeed()
-        {
-            // Arrange
-            var value = new ComparableOfInt(4);
-
-            // Act
-            Action act = () => value.Should().BeOneOf(value, new ComparableOfInt(5));
+            Action act = () => value.Should().BeOneOf(new EquatableOfInt(4), new EquatableOfInt(5));
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
@@ -141,7 +141,7 @@ public class ComparableSpecs
         {
             // Arrange
             var subject = new ComparableCustomer(42);
-            var expected = new CustomerDTO(42);
+            var expected = new CustomerDto(42);
 
             // Act / Assert
             subject.Should().BeEquivalentTo(expected);
@@ -152,7 +152,7 @@ public class ComparableSpecs
         {
             // Arrange
             var subject = new ComparableCustomer(42);
-            var expected = new CustomerDTO(42);
+            var expected = new CustomerDto(42);
 
             // Act / Assert
             subject.Should().BeEquivalentTo(expected)
@@ -164,7 +164,7 @@ public class ComparableSpecs
         {
             // Arrange
             var subject = new ComparableCustomer(42);
-            var expected = new CustomerDTO(42);
+            var expected = new CustomerDto(42);
 
             // Act / Assert
             subject.Should().BeEquivalentTo(expected, opt => opt)
@@ -176,7 +176,7 @@ public class ComparableSpecs
         {
             // Arrange
             var subject = new ComparableCustomer(42);
-            var expected = new AnotherCustomerDTO(42)
+            var expected = new AnotherCustomerDto(42)
             {
                 SomeOtherProperty = 1337
             };
@@ -192,7 +192,7 @@ public class ComparableSpecs
         {
             // Arrange
             var subject = new ComparableCustomer(42);
-            var expected = new AnotherCustomerDTO(42);
+            var expected = new AnotherCustomerDto(42);
 
             // Act
             Action act = () => subject.Should().BeEquivalentTo(expected, config: null);
@@ -207,7 +207,7 @@ public class ComparableSpecs
         {
             // Arrange
             var subject = new ComparableCustomer(42);
-            var expected = new AnotherCustomerDTO(42)
+            var expected = new AnotherCustomerDto(42)
             {
                 SomeOtherProperty = 1337
             };
@@ -658,10 +658,6 @@ public class ComparableOfString : IComparable<ComparableOfString>
 
 public class SameInstanceIsNotEqualClass
 {
-    public SameInstanceIsNotEqualClass()
-    {
-    }
-
     public override bool Equals(object obj)
     {
         return false;
@@ -736,9 +732,9 @@ public class ComparableCustomer : IComparable<ComparableCustomer>
     }
 }
 
-public class CustomerDTO
+public class CustomerDto
 {
-    public CustomerDTO(int id)
+    public CustomerDto(int id)
     {
         Id = id;
     }
@@ -746,9 +742,9 @@ public class CustomerDTO
     public int Id { get; }
 }
 
-public class AnotherCustomerDTO
+public class AnotherCustomerDto
 {
-    public AnotherCustomerDTO(int id)
+    public AnotherCustomerDto(int id)
     {
         Id = id;
     }

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -6,8 +6,6 @@ using System.Xml.Schema;
 using System.Xml.Serialization;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
-using FluentAssertions.Primitives;
-using FluentAssertions.Specs.Numeric;
 using Xunit;
 using Xunit.Sdk;
 


### PR DESCRIPTION
`SameInstanceIsNotEqualClass` did not implement `IComparable<T>` so `Should` resolved to `ObjectAssertions` instead of `ComparableTypeAssertions`.

The PR is structured into three commits for easier reviewing.

This is a follow-up to #2036 and #2028