### PR TITLE
Add ThatAre[Not]Abstract, ThatAre[Not]Overridable to MethodInfoSelector (as mentioned in More Assertions on types #645)

### DIFF
--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -134,6 +134,42 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
     }
 
     /// <summary>
+    /// Only return methods that are overridable
+    /// </summary>
+    /// <returns></returns>
+    public MethodInfoSelector ThatAreOverridable()
+    {
+        selectedMethods = selectedMethods.Where(method => !method.IsFinal && method.IsVirtual);
+        return this;
+    }
+
+    /// <summary>
+    /// Only return methods that are not overridable
+    /// </summary>
+    /// <returns></returns>
+    public MethodInfoSelector ThatAreNotOverridable()
+    {
+        selectedMethods = selectedMethods.Where(method => method.IsFinal || !method.IsVirtual);
+        return this;
+    }
+
+    /// <summary>
+    /// Only return methods that are abstract
+    /// </summary>
+    /// <returns></returns>
+    public MethodInfoSelector ThatAreAbstract()
+    {
+        selectedMethods = selectedMethods.Where(method => method.IsAbstract);
+        return this;
+    }
+
+    public MethodInfoSelector ThatAreNotAbstract()
+    {
+        selectedMethods = selectedMethods.Where(method => !method.IsAbstract);
+        return this;
+    }
+
+    /// <summary>
     /// Only return methods that are async. 
     /// </summary>
     public MethodInfoSelector ThatAreAsync()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2466,18 +2466,22 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreAbstract() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotAbstract() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotOverridable() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreOverridable() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreStatic() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2596,18 +2596,22 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreAbstract() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotAbstract() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotOverridable() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreOverridable() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreStatic() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -2468,18 +2468,22 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreAbstract() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotAbstract() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotOverridable() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreOverridable() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreStatic() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -2468,18 +2468,22 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreAbstract() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotAbstract() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotOverridable() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreOverridable() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreStatic() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2417,18 +2417,22 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreAbstract() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotAbstract() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotOverridable() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreOverridable() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreStatic() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2468,18 +2468,22 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreAbstract() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotAbstract() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotOverridable() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotVirtual() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreOverridable() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreStatic() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -274,6 +274,62 @@ public class MethodInfoSelectorSpecs
     }
 
     [Fact]
+    public void When_selecting_methods_that_are_overridable_it_should_only_return_the_applicable_methods()
+    {
+        // Arrange
+        Type type = typeof(TestClassForMethodSelectorWithAbstractAndVirtualMethods);
+
+        // Act
+        IEnumerable<MethodInfo> methods = type.Methods().ThatAreOverridable().ToArray();
+
+        // Assert
+        int overridableMethodsCount = 6;
+        methods.Should().HaveCount(overridableMethodsCount);
+    }
+
+    [Fact]
+    public void When_selecting_methods_that_are_not_overridable_it_should_only_return_the_applicable_methods()
+    {
+        // Arrange
+        Type type = typeof(TestClassForMethodSelectorWithAbstractAndVirtualMethods);
+
+        // Act
+        IEnumerable<MethodInfo> methods = type.Methods().ThatAreNotOverridable();
+
+        // Assert
+        int notOverridableCount = 4;
+        methods.Should().HaveCount(notOverridableCount);
+    }
+
+    [Fact]
+    public void When_selecting_methods_that_are_abstract_it_should_only_return_the_applicable_methods()
+    {
+        // Arrange
+        Type type = typeof(TestClassForMethodSelectorWithAbstractAndVirtualMethods);
+
+        // Act
+        IEnumerable<MethodInfo> methods = type.Methods().ThatAreAbstract().ToArray();
+
+        // Assert
+        int abstractMethodsCount = 3;
+        methods.Should().HaveCount(abstractMethodsCount);
+    }
+
+    [Fact]
+    public void When_selecting_methods_that_are_not_abstract_it_should_only_return_the_applicable_methods()
+    {
+        // Arrange
+        Type type = typeof(TestClassForMethodSelectorWithAbstractAndVirtualMethods);
+
+        // Act
+        IEnumerable<MethodInfo> methods = type.Methods().ThatAreNotAbstract().ToArray();
+
+        // Assert
+        int notAbstractMethodsCount = 7;
+        methods.Should().HaveCount(notAbstractMethodsCount);
+    }
+
+    [Fact]
     public void When_selecting_methods_that_are_async_it_should_only_return_the_applicable_methods()
     {
         // Arrange
@@ -481,6 +537,29 @@ internal class TestClassForMethodSelectorWithStaticAndNonStaticMethod
     public static void PublicStaticMethod() { }
 
     public void PublicNonStaticMethod() { }
+}
+
+internal abstract class TestClassForMethodSelectorWithAbstractAndVirtualMethods
+{
+    public abstract void PublicAbstractMethod();
+
+    protected abstract void ProtectedAbstractMethod();
+
+    internal abstract void InternalAbstractMethod();
+
+    public virtual void PublicVirtualMethod() { }
+
+    protected virtual void ProptectedVirtualMethod() { }
+
+    internal virtual void InternalVirtualMethod() { }
+
+    public void PublicNotAbstractMethod() { }
+
+    protected void ProtectedNotAbstractMethod() { }
+
+    internal void InternalNotAbstractMethod() { }
+
+    private void PrivateAbstractMethod() { }
 }
 
 internal class TestClassForMethodReturnTypesSelector


### PR DESCRIPTION
…or (as mentioned in More Assertions on types #645)

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).