### PR TITLE
Add `ThatAre[Not]Abstract`, `ThatAre[Not]Static` and `ThatAre[Not]Virtual` to `PropertyInfoSelector`

### DIFF
--- a/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
@@ -4,33 +4,18 @@ namespace FluentAssertions.Common;
 
 internal static class PropertyInfoExtensions
 {
-    /// <summary>
-    /// Checks if the property is virtual
-    /// </summary>
-    /// <param name="property"></param>
-    /// <returns></returns>
     internal static bool IsVirtual(this PropertyInfo property)
     {
         MethodInfo methodInfo = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
         return !methodInfo.IsNonVirtual();
     }
 
-    /// <summary>
-    /// Checks if the property is static 
-    /// </summary>
-    /// <param name="property"></param>
-    /// <returns></returns>
     internal static bool IsStatic(this PropertyInfo property)
     {
         MethodInfo methodInfo = property.GetGetMethod(nonPublic: true);
         return methodInfo.IsStatic;
     }
 
-    /// <summary>
-    /// Checks if the property is Abstract
-    /// </summary>
-    /// <param name="property"></param>
-    /// <returns></returns>
     internal static bool IsAbstract(this PropertyInfo property)
     {
         MethodInfo methodInfo = property.GetGetMethod(nonPublic: true);

--- a/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
@@ -12,13 +12,13 @@ internal static class PropertyInfoExtensions
 
     internal static bool IsStatic(this PropertyInfo property)
     {
-        MethodInfo methodInfo = property.GetGetMethod(nonPublic: true);
+        MethodInfo methodInfo = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
         return methodInfo.IsStatic;
     }
 
     internal static bool IsAbstract(this PropertyInfo property)
     {
-        MethodInfo methodInfo = property.GetGetMethod(nonPublic: true);
+        MethodInfo methodInfo = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
         return methodInfo.IsAbstract;
     }
 }

--- a/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
@@ -4,9 +4,36 @@ namespace FluentAssertions.Common;
 
 internal static class PropertyInfoExtensions
 {
+    /// <summary>
+    /// Checks if the property is virtual
+    /// </summary>
+    /// <param name="property"></param>
+    /// <returns></returns>
     internal static bool IsVirtual(this PropertyInfo property)
     {
         MethodInfo methodInfo = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
         return !methodInfo.IsNonVirtual();
+    }
+
+    /// <summary>
+    /// Checks if the property is static 
+    /// </summary>
+    /// <param name="property"></param>
+    /// <returns></returns>
+    internal static bool IsStatic(this PropertyInfo property)
+    {
+        MethodInfo methodInfo = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
+        return methodInfo.IsStatic;
+    }
+
+    /// <summary>
+    /// Checks if the property is Abstract
+    /// </summary>
+    /// <param name="property"></param>
+    /// <returns></returns>
+    internal static bool IsAbstract(this PropertyInfo property)
+    {
+        MethodInfo methodInfo = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
+        return methodInfo.IsAbstract;
     }
 }

--- a/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
@@ -22,7 +22,7 @@ internal static class PropertyInfoExtensions
     /// <returns></returns>
     internal static bool IsStatic(this PropertyInfo property)
     {
-        MethodInfo methodInfo = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
+        MethodInfo methodInfo = property.GetGetMethod(nonPublic: true);
         return methodInfo.IsStatic;
     }
 
@@ -33,7 +33,7 @@ internal static class PropertyInfoExtensions
     /// <returns></returns>
     internal static bool IsAbstract(this PropertyInfo property)
     {
-        MethodInfo methodInfo = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
+        MethodInfo methodInfo = property.GetGetMethod(nonPublic: true);
         return methodInfo.IsAbstract;
     }
 }

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -35,7 +35,8 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
         Guard.ThrowIfArgumentContainsNull(types, nameof(types));
 
         selectedProperties = types.SelectMany(t => t
-            .GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+            .GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance
+                            | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static));
     }
 
     /// <summary>
@@ -51,6 +52,78 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
                 return (getter is not null) && (getter.IsPublic || getter.IsAssembly);
             });
 
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Only select the properties that are abstract
+    /// </summary>
+    public PropertyInfoSelector ThatAreAbstract
+    {
+        get
+        {
+            selectedProperties = selectedProperties.Where(property => property.IsAbstract());
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Only select the properties that are not abstract
+    /// </summary>
+    public PropertyInfoSelector ThatAreNotAbstract
+    {
+        get
+        {
+            selectedProperties = selectedProperties.Where(property => !property.IsAbstract());
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Only select the properties that are static
+    /// </summary>
+    public PropertyInfoSelector ThatAreStatic
+    {
+        get
+        {
+            selectedProperties = selectedProperties.Where(property => property.IsStatic());
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Only select the properties that are not static
+    /// </summary>
+    public PropertyInfoSelector ThatAreNotStatic
+    {
+        get
+        {
+            selectedProperties = selectedProperties.Where(property => !property.IsStatic());
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Only select the properties that are virtual
+    /// </summary>
+    public PropertyInfoSelector ThatAreVirtual
+    {
+        get
+        {
+            selectedProperties = selectedProperties.Where(property => property.IsVirtual());
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Only select the properties that are not virtual
+    /// </summary>
+    public PropertyInfoSelector ThatAreNotVirtual
+    {
+        get
+        {
+            selectedProperties = selectedProperties.Where(property => !property.IsVirtual());
             return this;
         }
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2526,7 +2526,13 @@ namespace FluentAssertions.Types
     {
         public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
         public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreAbstract { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotAbstract { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotStatic { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotVirtual { get; }
         public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreStatic { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreVirtual { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
         public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
         public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2656,7 +2656,13 @@ namespace FluentAssertions.Types
     {
         public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
         public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreAbstract { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotAbstract { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotStatic { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotVirtual { get; }
         public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreStatic { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreVirtual { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
         public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
         public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -2528,7 +2528,13 @@ namespace FluentAssertions.Types
     {
         public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
         public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreAbstract { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotAbstract { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotStatic { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotVirtual { get; }
         public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreStatic { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreVirtual { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
         public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
         public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -2528,7 +2528,13 @@ namespace FluentAssertions.Types
     {
         public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
         public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreAbstract { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotAbstract { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotStatic { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotVirtual { get; }
         public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreStatic { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreVirtual { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
         public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
         public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2477,7 +2477,13 @@ namespace FluentAssertions.Types
     {
         public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
         public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreAbstract { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotAbstract { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotStatic { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotVirtual { get; }
         public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreStatic { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreVirtual { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
         public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
         public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2528,7 +2528,13 @@ namespace FluentAssertions.Types
     {
         public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
         public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreAbstract { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotAbstract { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotStatic { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotVirtual { get; }
         public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreStatic { get; }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreVirtual { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
         public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
         public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -151,7 +151,7 @@ public class PropertyInfoSelectorSpecs
     }
 
     [Fact]
-    public void When_seletcing_properties_that_are_not_virtual_it_should_return_only_the_applicable_properties()
+    public void When_selecting_properties_that_are_not_virtual_it_should_return_only_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertySelector);

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -86,7 +86,7 @@ public class PropertyInfoSelectorSpecs
     }
 
     [Fact]
-    public void When_selecting_properteis_that_are_abstract_it_should_return_only_the_applicable_properties()
+    public void When_selecting_properties_that_are_abstract_it_should_return_only_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertySelector);
@@ -95,8 +95,7 @@ public class PropertyInfoSelectorSpecs
         IEnumerable<PropertyInfo> properties = type.Properties().ThatAreAbstract.ToArray();
 
         // Assert
-        int abstractPropertiesCount = 1;
-        properties.Should().HaveCount(abstractPropertiesCount);
+        properties.Should().HaveCount(1);
     }
 
     [Fact]
@@ -109,8 +108,7 @@ public class PropertyInfoSelectorSpecs
         IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotAbstract.ToArray();
 
         // Assert
-        int notArbastractPropertiesCount = 10;
-        properties.Should().HaveCount(notArbastractPropertiesCount);
+        properties.Should().HaveCount(10);
     }
 
     [Fact]
@@ -162,8 +160,7 @@ public class PropertyInfoSelectorSpecs
         IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotVirtual.ToArray();
 
         // Assert
-        int notVirtualPropertiesCount = 5;
-        properties.Should().HaveCount(notVirtualPropertiesCount);
+        properties.Should().HaveCount(5);
     }
 
     [Fact]
@@ -372,7 +369,7 @@ internal abstract class TestClassForPropertySelector
 
     protected static string ProtectedStaticStringProperty { get; set; }
 
-    private static string ProtectedStaticStringPropertyWithAttribute { get; set; }
+    private static string PrivateStaticStringProperty { get; set; }
 
     // An abstract method/property is implicitly a virtual method/property.
     public abstract string PublicAbstractStringProperty { get; set; }

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -74,15 +74,13 @@ public class PropertyInfoSelectorSpecs
     public void When_selecting_properties_that_are_public_or_internal_it_should_return_only_the_applicable_properties()
     {
         // Arrange
-        Type type = typeof(TestClassForPropertySelector);
+        Type type = typeof(TestClassForPropertySelectorWithInternalAndPublicProperties);
 
         // Act
         IEnumerable<PropertyInfo> properties = type.Properties().ThatArePublicOrInternal.ToArray();
 
         // Assert
-        const int PublicPropertyCount = 5;
-        const int InternalPropertyCount = 2;
-        properties.Should().HaveCount(PublicPropertyCount + InternalPropertyCount);
+        properties.Should().HaveCount(2);
     }
 
     [Fact]
@@ -95,7 +93,7 @@ public class PropertyInfoSelectorSpecs
         IEnumerable<PropertyInfo> properties = type.Properties().ThatAreAbstract.ToArray();
 
         // Assert
-        properties.Should().HaveCount(1);
+        properties.Should().HaveCount(2);
     }
 
     [Fact]
@@ -134,7 +132,7 @@ public class PropertyInfoSelectorSpecs
         IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotStatic.ToArray();
 
         // Assert
-        properties.Should().HaveCount(7);
+        properties.Should().HaveCount(8);
     }
 
     [Fact]
@@ -147,7 +145,7 @@ public class PropertyInfoSelectorSpecs
         IEnumerable<PropertyInfo> properties = type.Properties().ThatAreVirtual.ToArray();
 
         // Assert
-        properties.Should().HaveCount(6);
+        properties.Should().HaveCount(7);
     }
 
     [Fact]
@@ -202,7 +200,7 @@ public class PropertyInfoSelectorSpecs
         IEnumerable<PropertyInfo> properties = type.Properties().OfType<string>().ToArray();
 
         // Assert
-        properties.Should().HaveCount(7);
+        properties.Should().HaveCount(8);
     }
 
     [Fact]
@@ -352,7 +350,7 @@ public class PropertyInfoSelectorSpecs
         returnTypes.Should()
             .BeEquivalentTo(new[]
             {
-                typeof(string), typeof(string), typeof(string)
+                typeof(string), typeof(string), typeof(string), typeof(string)
                 , typeof(string), typeof(string), typeof(string)
                 , typeof(string), typeof(int), typeof(int), typeof(int), typeof(int)
             });
@@ -361,9 +359,22 @@ public class PropertyInfoSelectorSpecs
 
 #region Internal classes used in unit tests
 
+internal class TestClassForPropertySelectorWithInternalAndPublicProperties
+{
+    public static string PublicStaticStringProperty { get; }
+
+    internal static string InternalStaticStringProperty { get; set; }
+
+    protected static string ProtectedStaticStringProperty { get; set; }
+
+    private static string PrivateStaticStringProperty { get; set; }
+}
+
 internal abstract class TestClassForPropertySelector
 {
-    public static string PublicStaticStringProperty { get; set; }
+    private static string myPrivateStaticStringField;
+
+    public static string PublicStaticStringProperty { set => myPrivateStaticStringField = value; }
 
     internal static string InternalStaticStringProperty { get; set; }
 
@@ -374,7 +385,11 @@ internal abstract class TestClassForPropertySelector
     // An abstract method/property is implicitly a virtual method/property.
     public abstract string PublicAbstractStringProperty { get; set; }
 
-    public virtual string PublicVirtualStringProperty { get; set; }
+    public abstract string PublicAbstractStringPropertyWithSetterOnly { set; }
+
+    private string myPrivateStringField;
+
+    public virtual string PublicVirtualStringProperty { set => myPrivateStringField = value; }
 
     [DummyProperty]
     public virtual string PublicVirtualStringPropertyWithAttribute { get; set; }

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using FluentAssertions.Types;
 using Internal.Main.Test;
@@ -79,9 +80,90 @@ public class PropertyInfoSelectorSpecs
         IEnumerable<PropertyInfo> properties = type.Properties().ThatArePublicOrInternal.ToArray();
 
         // Assert
-        const int PublicPropertyCount = 3;
-        const int InternalPropertyCount = 1;
+        const int PublicPropertyCount = 5;
+        const int InternalPropertyCount = 2;
         properties.Should().HaveCount(PublicPropertyCount + InternalPropertyCount);
+    }
+
+    [Fact]
+    public void When_selecting_properteis_that_are_abstract_it_should_return_only_the_applicable_properties()
+    {
+        // Arrange
+        Type type = typeof(TestClassForPropertySelector);
+
+        // Act
+        IEnumerable<PropertyInfo> properties = type.Properties().ThatAreAbstract.ToArray();
+
+        // Assert
+        int abstractPropertiesCount = 1;
+        properties.Should().HaveCount(abstractPropertiesCount);
+    }
+
+    [Fact]
+    public void When_selecting_properties_that_are_not_abstract_it_should_return_only_the_applicable_properties()
+    {
+        // Arrange
+        Type type = typeof(TestClassForPropertySelector);
+
+        // Act
+        IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotAbstract.ToArray();
+
+        // Assert
+        int notArbastractPropertiesCount = 10;
+        properties.Should().HaveCount(notArbastractPropertiesCount);
+    }
+
+    [Fact]
+    public void When_selecting_properties_that_are_static_it_should_return_only_the_applicable_properties()
+    {
+        // Arrange
+        Type type = typeof(TestClassForPropertySelector);
+
+        // Act
+        IEnumerable<PropertyInfo> properties = type.Properties().ThatAreStatic.ToArray();
+
+        // Assert
+        properties.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void When_selecting_properties_that_are_not_static_it_should_return_only_the_applicable_properties()
+    {
+        // Arrange
+        Type type = typeof(TestClassForPropertySelector);
+
+        // Act
+        IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotStatic.ToArray();
+
+        // Assert
+        properties.Should().HaveCount(7);
+    }
+
+    [Fact]
+    public void When_selecting_properties_that_are_virtual_it_should_return_only_the_applicable_properties()
+    {
+        // Arrange
+        Type type = typeof(TestClassForPropertySelector);
+
+        // Act
+        IEnumerable<PropertyInfo> properties = type.Properties().ThatAreVirtual.ToArray();
+
+        // Assert
+        properties.Should().HaveCount(6);
+    }
+
+    [Fact]
+    public void When_seletcing_properties_that_are_not_virtual_it_should_return_only_the_applicable_properties()
+    {
+        // Arrange
+        Type type = typeof(TestClassForPropertySelector);
+
+        // Act
+        IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotVirtual.ToArray();
+
+        // Assert
+        int notVirtualPropertiesCount = 5;
+        properties.Should().HaveCount(notVirtualPropertiesCount);
     }
 
     [Fact]
@@ -123,7 +205,7 @@ public class PropertyInfoSelectorSpecs
         IEnumerable<PropertyInfo> properties = type.Properties().OfType<string>().ToArray();
 
         // Assert
-        properties.Should().HaveCount(2);
+        properties.Should().HaveCount(7);
     }
 
     [Fact]
@@ -271,14 +353,30 @@ public class PropertyInfoSelectorSpecs
 
         // Assert
         returnTypes.Should()
-            .BeEquivalentTo(new[] { typeof(string), typeof(string), typeof(int), typeof(int), typeof(int), typeof(int) });
+            .BeEquivalentTo(new[]
+            {
+                typeof(string), typeof(string), typeof(string)
+                , typeof(string), typeof(string), typeof(string)
+                , typeof(string), typeof(int), typeof(int), typeof(int), typeof(int)
+            });
     }
 }
 
 #region Internal classes used in unit tests
 
-internal class TestClassForPropertySelector
+internal abstract class TestClassForPropertySelector
 {
+    public static string PublicStaticStringProperty { get; set; }
+
+    internal static string InternalStaticStringProperty { get; set; }
+
+    protected static string ProtectedStaticStringProperty { get; set; }
+
+    private static string ProtectedStaticStringPropertyWithAttribute { get; set; }
+
+    // An abstract method/property is implicitly a virtual method/property.
+    public abstract string PublicAbstractStringProperty { get; set; }
+
     public virtual string PublicVirtualStringProperty { get; set; }
 
     [DummyProperty]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,8 +10,12 @@ sidebar:
 ## Unreleased
 
 ### What's new
+* Added `ThatAre[Not]Abstract`, `ThatAre[Not]Static` and `ThatAre[Not]Virtual` for filtering in property assertions - [#2054](https://github.com/fluentassertions/fluentassertions/pull/2054)
 * Added `BeOneOf` methods for object comparisons and `IComparable`s - [#2028](https://github.com/fluentassertions/fluentassertions/pull/2028)
 * Added `BeCloseTo` and `NotBeCloseTo` to `TimeOnly` - [#2030](https://github.com/fluentassertions/fluentassertions/pull/2030)
+
+### Fixes
+* Quering properties on classes, e.g. typeof(MyClass).Properties(), now also includes static properties - [#2054](https://github.com/fluentassertions/fluentassertions/pull/2054)
 
 ## 6.8.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,7 +10,7 @@ sidebar:
 ## Unreleased
 
 ### What's new
-* Added `ThatAre[Not]Abstract`, `ThatAre[Not]Static` and `ThatAre[Not]Virtual` for filtering in property assertions - [#2054](https://github.com/fluentassertions/fluentassertions/pull/2054)
+* Added `ThatAre[Not]Abstract`, `ThatAre[Not]Static` and `ThatAre[Not]Virtual` properties for filtering in `PropertyInfoSelector.cs` - [#2054](https://github.com/fluentassertions/fluentassertions/pull/2054)
 * Added `BeOneOf` methods for object comparisons and `IComparable`s - [#2028](https://github.com/fluentassertions/fluentassertions/pull/2028)
 * Added `BeCloseTo` and `NotBeCloseTo` to `TimeOnly` - [#2030](https://github.com/fluentassertions/fluentassertions/pull/2030)
 

--- a/docs/_pages/typesandmethods.md
+++ b/docs/_pages/typesandmethods.md
@@ -61,6 +61,32 @@ typeof(MyController).Methods()
   .Should()
   .BeDecoratedWith<ValidateAntiForgeryTokenAttribute>(
     "because all Actions with HttpPost require ValidateAntiForgeryToken");
+	
+typeof(MyController).Properties()
+	.ThatAreAbstract
+	.ToArray()
+	.Should()
+	.HaveCount(2);
+
+typeof(MyController).Properties()
+	.ThatAreStatic
+	.ToArray()
+	.Should()
+	.HaveCount(3);
+	
+typeof(MyController).Properties()
+	.ThatAreVirtual
+	.ToArray()
+	.Should()
+	.HaveCount(4);
+	
+typeof(MyController).Properties()
+	.ThatAreNotAbstract
+	.ThatAreNotStatic
+	.ThatAreNotVirtual
+	.ToArray()
+	.Should()
+	.HaveCount(5);
 ```
 
 You can also perform assertions on all of methods return types to check class contract.

--- a/docs/_pages/typesandmethods.md
+++ b/docs/_pages/typesandmethods.md
@@ -61,32 +61,6 @@ typeof(MyController).Methods()
   .Should()
   .BeDecoratedWith<ValidateAntiForgeryTokenAttribute>(
     "because all Actions with HttpPost require ValidateAntiForgeryToken");
-	
-typeof(MyController).Properties()
-	.ThatAreAbstract
-	.ToArray()
-	.Should()
-	.HaveCount(2);
-
-typeof(MyController).Properties()
-	.ThatAreStatic
-	.ToArray()
-	.Should()
-	.HaveCount(3);
-	
-typeof(MyController).Properties()
-	.ThatAreVirtual
-	.ToArray()
-	.Should()
-	.HaveCount(4);
-	
-typeof(MyController).Properties()
-	.ThatAreNotAbstract
-	.ThatAreNotStatic
-	.ThatAreNotVirtual
-	.ToArray()
-	.Should()
-	.HaveCount(5);
 ```
 
 You can also perform assertions on all of methods return types to check class contract.


### PR DESCRIPTION
Part of #645

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).