### PR TITLE
Add first rough attempt of improving string assertion failure messages

### DIFF
--- a/Src/FluentAssertions/Primitives/StringStartValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringStartValidator.cs
@@ -45,9 +45,21 @@ internal class StringStartValidator : StringValidator
         {
             int indexOfMismatch = Subject.IndexOfFirstMismatch(Expected, stringComparison);
 
+            string subjectIndexMarker = $" ↓ (index {indexOfMismatch})";
+            string expectedIndexMarker = $" ↑ (index {indexOfMismatch})";
+            string subjectDescription = "Subject:  ";
+            string expectationDescription = "Expected: ";
+
             Assertion.FailWith(
-                ExpectationDescription + "{0}{reason}, but {1} differs near " + Subject.IndexedSegmentAt(indexOfMismatch) + ".",
-                Expected, Subject);
+                ExpectationDescription + "{0}{reason}, but actually got:" + Environment.NewLine +
+                subjectIndexMarker.PadLeft(subjectDescription.Length + indexOfMismatch + subjectIndexMarker.Length) + Environment.NewLine +
+                $"{subjectDescription}{{1}}" + Environment.NewLine +
+                $"{expectationDescription}{{0}}" + Environment.NewLine +
+                expectedIndexMarker.PadLeft(expectationDescription.Length + indexOfMismatch + expectedIndexMarker.Length), Expected, Subject);
+
+            // Assertion.FailWith(
+            //     ExpectationDescription + "{0}{reason}, but {1} differs near " + Subject.IndexedSegmentAt(indexOfMismatch) + ".",
+            //     Expected, Subject);
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -186,6 +186,21 @@ public partial class StringAssertionSpecs
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected string to be \r\n\"A\\r\\nC\", but \r\n\"A\\r\\nB\" differs near \"B\" (index 3).");
         }
+
+        [Fact]
+        public void String_comparision_fail_with_improved_failure_message()
+        {
+            // Arrange
+            string subject = "String with \rnewline";
+            string expected = "String with \ra newline";
+
+            // Act
+            subject.Should().Be(expected);
+            Action act = () => subject.Should().Be(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*↓ (pos 13)*↑ (pos 13)*");
+        }
     }
 
     public class NotBe


### PR DESCRIPTION
This closes #2050

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

To do:

- [ ] Decide what to do with really long strings