### PR TITLE
Add `ThatAre[Not]Sealed` to `TypeSelector.cs`

### DIFF
--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -192,9 +192,9 @@ public class TypeSelector : IEnumerable<Type>
         return this;
     }
 
-    ///<summary>
+    /// <summary>
     /// Filters and returns the types that are not sealed
-    ///</summary>
+    /// </summary>
     public TypeSelector ThatAreNotSealed()
     {
         types = types.Where(t => !t.IsSealed).ToList();

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -184,19 +184,17 @@ public class TypeSelector : IEnumerable<Type>
     }
 
     /// <summary>
-    /// Determines wether the type is sealed
+    /// Filters the types that are sealed
     /// </summary>
-    /// <returns></returns>
     public TypeSelector ThatAreSealed()
     {
         types = types.Where(t => t.IsSealed).ToList();
         return this;
     }
 
-    /// <summary>
-    /// Determines wheter the type is not sealed
-    /// </summary>
-    /// <returns></returns>
+    ///<summary>
+    /// Filters the types that are not sealed
+    ///</summary>
     public TypeSelector ThatAreNotSealed()
     {
         types = types.Where(t => !t.IsSealed).ToList();

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -184,7 +184,7 @@ public class TypeSelector : IEnumerable<Type>
     }
 
     /// <summary>
-    /// Filters the types that are sealed
+    /// Filters and returns the types that are sealed
     /// </summary>
     public TypeSelector ThatAreSealed()
     {
@@ -193,7 +193,7 @@ public class TypeSelector : IEnumerable<Type>
     }
 
     ///<summary>
-    /// Filters the types that are not sealed
+    /// Filters and returns the types that are not sealed
     ///</summary>
     public TypeSelector ThatAreNotSealed()
     {

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -184,6 +184,26 @@ public class TypeSelector : IEnumerable<Type>
     }
 
     /// <summary>
+    /// Determines wether the type is sealed
+    /// </summary>
+    /// <returns></returns>
+    public TypeSelector ThatAreSealed()
+    {
+        types = types.Where(t => t.IsSealed).ToList();
+        return this;
+    }
+
+    /// <summary>
+    /// Determines wheter the type is not sealed
+    /// </summary>
+    /// <returns></returns>
+    public TypeSelector ThatAreNotSealed()
+    {
+        types = types.Where(t => !t.IsSealed).ToList();
+        return this;
+    }
+
+    /// <summary>
     /// Determines whether the type is static
     /// </summary>
     public TypeSelector ThatAreStatic()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2653,8 +2653,10 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2783,8 +2783,10 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -2655,8 +2655,10 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -2655,8 +2655,10 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2604,8 +2604,10 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2655,8 +2655,10 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -8,6 +8,7 @@ using Internal.Main.Test;
 using Internal.NotOnlyClasses.Test;
 using Internal.Other.Test;
 using Internal.Other.Test.Common;
+using Internal.SealedAndNotSealedClasses.Test;
 using Internal.StaticAndNonStaticClasses.Test;
 using Internal.UnwrapSelectorTestTypes.Test;
 using Xunit;
@@ -496,6 +497,40 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
+        public void When_selecting_types_that_are_sealed_classes_it_should_return_the_correct_types()
+        {
+            // Arrange
+            Assembly assembly = typeof(SealedClass).GetTypeInfo().Assembly;
+
+            // Act
+            IEnumerable<Type> types = AllTypes.From(assembly)
+                .ThatAreInNamespace("Internal.SealedAndNotSealedClasses.Test")
+                .ThatAreSealed();
+
+            // Assert
+            types.Should()
+                .ContainSingle()
+                .Which.Should().Be(typeof(SealedClass));
+        }
+
+        [Fact]
+        public void When_selecting_types_that_are_not_sealed_classes_it_should_return_the_correct_types()
+        {
+            // Arrange
+            Assembly assembly = typeof(NotSealedClass).GetTypeInfo().Assembly;
+
+            // Act
+            IEnumerable<Type> types = AllTypes.From(assembly)
+                .ThatAreInNamespace("Internal.SealedAndNotSealedClasses.Test")
+                .ThatAreNotSealed();
+
+            // Assert
+            types.Should()
+                .ContainSingle()
+                .Which.Should().Be(typeof(NotSealedClass));
+        }
+
+        [Fact]
         public void When_selecting_types_that_are_static_classes_it_should_return_the_correct_types()
         {
             // Arrange
@@ -729,6 +764,17 @@ namespace Internal.UnwrapSelectorTestTypes.Test
         IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)integers).GetEnumerator();
 
         IEnumerator<string> IEnumerable<string>.GetEnumerator() => strings.GetEnumerator();
+    }
+}
+
+namespace Internal.SealedAndNotSealedClasses.Test
+{
+    internal sealed class SealedClass
+    {
+    }
+
+    internal class NotSealedClass
+    {
     }
 }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,6 +10,7 @@ sidebar:
 ## Unreleased
 
 ### What's new
+* Added `ThatAre[Not]Sealed` method for filtering the types - [#2059](https://github.com/fluentassertions/fluentassertions/pull/2059)
 * Added `BeOneOf` methods for object comparisons and `IComparable`s - [#2028](https://github.com/fluentassertions/fluentassertions/pull/2028)
 * Added `BeCloseTo` and `NotBeCloseTo` to `TimeOnly` - [#2030](https://github.com/fluentassertions/fluentassertions/pull/2030)
 

--- a/docs/_pages/typesandmethods.md
+++ b/docs/_pages/typesandmethods.md
@@ -106,6 +106,24 @@ types.Should().BeInNamespace("Internal.Main.Test.ISomeInterfaceTests");
 
 var properties = types.Properties().ThatArePublicOrInternal;
 properties.Should().BeVirtual();
+
+
+var types = typeof(SealedClass).Assembly.Types()
+	.ThatAreInNamespace("Internal.SealedAndNotSealedClasses.Test")
+	.ThatAreSealed();
+	
+types.Should()
+	.ContainSingle()
+	.Which.Should().Be(typeof(SealedClass));
+	
+
+var types = typeof(NotSealedClass).Assembly.Types()
+	.ThatAreInNamespace("Internal.SealedAndNotSealedClasses.Test")
+	.ThatAreNotSealed();
+	
+types.Should()
+	.ContainSingle()
+	.Which.Should.Be(typeof(NotSealedClass));
 ```
 
 Alternatively you can use this more fluent syntax instead.

--- a/docs/_pages/typesandmethods.md
+++ b/docs/_pages/typesandmethods.md
@@ -106,24 +106,6 @@ types.Should().BeInNamespace("Internal.Main.Test.ISomeInterfaceTests");
 
 var properties = types.Properties().ThatArePublicOrInternal;
 properties.Should().BeVirtual();
-
-
-var types = typeof(SealedClass).Assembly.Types()
-	.ThatAreInNamespace("Internal.SealedAndNotSealedClasses.Test")
-	.ThatAreSealed();
-	
-types.Should()
-	.ContainSingle()
-	.Which.Should().Be(typeof(SealedClass));
-	
-
-var types = typeof(NotSealedClass).Assembly.Types()
-	.ThatAreInNamespace("Internal.SealedAndNotSealedClasses.Test")
-	.ThatAreNotSealed();
-	
-types.Should()
-	.ContainSingle()
-	.Which.Should.Be(typeof(NotSealedClass));
 ```
 
 Alternatively you can use this more fluent syntax instead.


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).