### PR TITLE
Document alternatives for collection order

### DIFF
--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -47,7 +47,8 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
 
     /// <summary>
     /// Expects the current collection to contain all the same elements in the same order as the collection identified by
-    /// <paramref name="expected" />. Elements are compared using their <see cref="object.Equals(object)" />.
+    /// <paramref name="expected" />. Elements are compared using their <see cref="object.Equals(object)" />.  To ignore
+    /// the element order, use <see cref="BeEquivalentTo(string[])"/> instead.
     /// </summary>
     /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
     public new AndConstraint<TAssertions> Equal(params string[] expected)
@@ -57,7 +58,8 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
 
     /// <summary>
     /// Expects the current collection to contain all the same elements in the same order as the collection identified by
-    /// <paramref name="expected" />. Elements are compared using their <see cref="object.Equals(object)" />.
+    /// <paramref name="expected" />. Elements are compared using their <see cref="object.Equals(object)" />.  To ignore
+    /// the element order, use <see cref="BeEquivalentTo(string[])"/> instead.
     /// </summary>
     /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
     public AndConstraint<TAssertions> Equal(IEnumerable<string> expected)
@@ -69,7 +71,8 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     /// Asserts that a collection of string is equivalent to another collection of strings.
     /// </summary>
     /// <remarks>
-    /// The two collections are equivalent when they both contain the same strings in any order.
+    /// The two collections are equivalent when they both contain the same strings in any order. To assert that the elements
+    /// are in the same order, use <see cref="Equal(string[])"/> instead.
     /// </remarks>
     public AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation)
     {
@@ -80,7 +83,8 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     /// Asserts that a collection of objects is equivalent to another collection of objects.
     /// </summary>
     /// <remarks>
-    /// The two collections are equivalent when they both contain the same strings in any order.
+    /// The two collections are equivalent when they both contain the same strings in any order.  To assert that the elements
+    /// are in the same order, use <see cref="Equal(string[])"/> instead.
     /// </remarks>
     /// <param name="expectation">An <see cref="IEnumerable{String}"/> with the expected elements.</param>
     /// <param name="because">
@@ -99,7 +103,8 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     /// Asserts that a collection of objects is equivalent to another collection of objects.
     /// </summary>
     /// <remarks>
-    /// The two collections are equivalent when they both contain the same strings in any order.
+    /// The two collections are equivalent when they both contain the same strings in any order.  To assert that the elements
+    /// are in the same order, use <see cref="Equal(string[])"/> instead.
     /// </remarks>
     /// <param name="expectation">An <see cref="IEnumerable{String}"/> with the expected elements.</param>
     /// <param name="config">

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -59,7 +59,7 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     /// <summary>
     /// Expects the current collection to contain all the same elements in the same order as the collection identified by
     /// <paramref name="expected" />. Elements are compared using their <see cref="object.Equals(object)" />.  To ignore
-    /// the element order, use <see cref="BeEquivalentTo(string[])"/> instead.
+    /// the element order, use <see cref="BeEquivalentTo(IEnumerable{string}, string, object[])"/> instead.
     /// </summary>
     /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
     public AndConstraint<TAssertions> Equal(IEnumerable<string> expected)
@@ -84,7 +84,7 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     /// </summary>
     /// <remarks>
     /// The two collections are equivalent when they both contain the same strings in any order.  To assert that the elements
-    /// are in the same order, use <see cref="Equal(string[])"/> instead.
+    /// are in the same order, use <see cref="Equal(IEnumerable{string})"/> instead.
     /// </remarks>
     /// <param name="expectation">An <see cref="IEnumerable{String}"/> with the expected elements.</param>
     /// <param name="because">


### PR DESCRIPTION
Hi Folks,

Thanks again for this awesome library.  I often forget which assertion I should use on collections when I want to assert on the order of the elements or ignore it.  This change adds the suggestion for the "other" one to the XML docs for the string collection assertions.  The idea here is somewhat similar to my previous [usability PR](https://github.com/fluentassertions/fluentassertions/pull/2006).

![image](https://user-images.githubusercontent.com/3755379/206306647-adfb4644-b500-4be3-85ff-f0dd53d8206a.png)

If this change is acceptable to you all, I can add a similar change to the other collection assertions classes as well.  Wordsmithing suggestions definitely welcome.

If this is not an interesting PR to you, no worries and we can close it.

Many thanks!

## IMPORTANT

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).