### PR TITLE
Use langword instead of <c> for C# keywords

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -39,8 +39,8 @@ public static class AssertionExtensions
     /// Invokes the specified action on a subject so that you can chain it
     /// with any of the assertions from <see cref="ActionAssertions"/>
     /// </summary>
-    /// <exception cref="ArgumentNullException"><paramref name="subject"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="subject"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
     [Pure]
     public static Action Invoking<T>(this T subject, Action<T> action)
     {
@@ -54,8 +54,8 @@ public static class AssertionExtensions
     /// Invokes the specified action on a subject so that you can chain it
     /// with any of the assertions from <see cref="FunctionAssertions{T}"/>
     /// </summary>
-    /// <exception cref="ArgumentNullException"><paramref name="subject"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="subject"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
     [Pure]
     public static Func<TResult> Invoking<T, TResult>(this T subject, Func<T, TResult> action)
     {
@@ -113,8 +113,8 @@ public static class AssertionExtensions
     /// <returns>
     /// Returns an object for asserting that the execution time matches certain conditions.
     /// </returns>
-    /// <exception cref="ArgumentNullException"><paramref name="subject"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="subject"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
     [MustUseReturnValue /* do not use Pure because this method executes the action before returning to the caller */]
     public static MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, Expression<Action<T>> action,
         StartTimer createTimer = null)
@@ -134,7 +134,7 @@ public static class AssertionExtensions
     /// <returns>
     /// Returns an object for asserting that the execution time matches certain conditions.
     /// </returns>
-    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
     [MustUseReturnValue /* do not use Pure because this method executes the action before returning to the caller */]
     public static ExecutionTime ExecutionTime(this Action action, StartTimer createTimer = null)
     {
@@ -150,7 +150,7 @@ public static class AssertionExtensions
     /// <returns>
     /// Returns an object for asserting that the execution time matches certain conditions.
     /// </returns>
-    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
     [MustUseReturnValue /* do not use Pure because this method executes the action before returning to the caller */]
     public static ExecutionTime ExecutionTime(this Func<Task> action)
     {
@@ -229,7 +229,7 @@ public static class AssertionExtensions
 
     /// <summary>
     /// Forces enumerating a collection. Should be used to assert that a method that uses the
-    /// <c>yield</c> keyword throws a particular exception.
+    /// <see langword="yield"/> keyword throws a particular exception.
     /// </summary>
     [Pure]
     public static Action Enumerating(this Func<IEnumerable> enumerable)
@@ -239,7 +239,7 @@ public static class AssertionExtensions
 
     /// <summary>
     /// Forces enumerating a collection. Should be used to assert that a method that uses the
-    /// <c>yield</c> keyword throws a particular exception.
+    /// <see langword="yield"/> keyword throws a particular exception.
     /// </summary>
     [Pure]
     public static Action Enumerating<T>(this Func<IEnumerable<T>> enumerable)
@@ -249,7 +249,7 @@ public static class AssertionExtensions
 
     /// <summary>
     /// Forces enumerating a collection of the provided <paramref name="subject"/>.
-    /// Should be used to assert that a method that uses the <c>yield</c> keyword throws a particular exception.
+    /// Should be used to assert that a method that uses the <see langword="yield"/> keyword throws a particular exception.
     /// </summary>
     /// <param name="subject">The object that exposes the method or property.</param>
     /// <param name="enumerable">A reference to the method or property to force enumeration of.</param>
@@ -783,7 +783,7 @@ public static class AssertionExtensions
     /// Returns a <see cref="TypeAssertions"/> object that can be used to assert the
     /// current <see cref="Type"/>.
     /// </summary>
-    /// <exception cref="ArgumentNullException"><paramref name="typeSelector"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="typeSelector"/> is <see langword="null"/>.</exception>
     [Pure]
     public static TypeSelectorAssertions Should(this TypeSelector typeSelector)
     {
@@ -818,7 +818,7 @@ public static class AssertionExtensions
     /// current <see cref="MethodInfoSelector"/>.
     /// </summary>
     /// <seealso cref="TypeAssertions"/>
-    /// <exception cref="ArgumentNullException"><paramref name="methodSelector"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="methodSelector"/> is <see langword="null"/>.</exception>
     [Pure]
     public static MethodInfoSelectorAssertions Should(this MethodInfoSelector methodSelector)
     {
@@ -843,7 +843,7 @@ public static class AssertionExtensions
     /// current <see cref="PropertyInfoSelector"/>.
     /// </summary>
     /// <seealso cref="TypeAssertions"/>
-    /// <exception cref="ArgumentNullException"><paramref name="propertyInfoSelector"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="propertyInfoSelector"/> is <see langword="null"/>.</exception>
     [Pure]
     public static PropertyInfoSelectorAssertions Should(this PropertyInfoSelector propertyInfoSelector)
     {

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -103,7 +103,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expectedType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expectedType"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> AllBeAssignableTo(Type expectedType, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(expectedType, nameof(expectedType));
@@ -247,7 +247,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expectedType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expectedType"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> AllBeOfType(Type expectedType, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(expectedType, nameof(expectedType));
@@ -413,7 +413,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <remarks>
     /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<SubsequentOrderingAssertions<T>> BeInAscendingOrder(
         IComparer<T> comparer, string because = "", params object[] becauseArgs)
     {
@@ -440,7 +440,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <remarks>
     /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<SubsequentOrderingAssertions<T>> BeInAscendingOrder<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
     {
@@ -528,7 +528,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <remarks>
     /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<SubsequentOrderingAssertions<T>> BeInDescendingOrder(
         IComparer<T> comparer, string because = "", params object[] becauseArgs)
     {
@@ -555,7 +555,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <remarks>
     /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
     {
@@ -637,7 +637,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expectedSuperset"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expectedSuperset"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> BeSubsetOf(IEnumerable<T> expectedSuperset, string because = "",
         params object[] becauseArgs)
     {
@@ -704,7 +704,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
     public AndWhichConstraint<TAssertions, T> Contain(Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
@@ -743,7 +743,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="expected"/> is empty.</exception>
     public AndConstraint<TAssertions> Contain(IEnumerable<T> expected, string because = "", params object[] becauseArgs)
     {
@@ -831,7 +831,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="config"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="config"/> is <see langword="null"/>.</exception>
     public AndWhichConstraint<TAssertions, T> ContainEquivalentOf<TExpectation>(TExpectation expectation, Func<EquivalencyAssertionOptions<TExpectation>,
             EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs)
     {
@@ -905,7 +905,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> ContainInOrder(IEnumerable<T> expected, string because = "",
         params object[] becauseArgs)
     {
@@ -967,7 +967,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> ContainInConsecutiveOrder(IEnumerable<T> expected, string because = "",
         params object[] becauseArgs)
     {
@@ -1103,7 +1103,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
     public AndWhichConstraint<TAssertions, T> ContainSingle(Expression<Func<T, bool>> predicate,
         string because = "", params object[] becauseArgs)
     {
@@ -1313,7 +1313,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="countPredicate"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="countPredicate"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> HaveCount(Expression<Func<int, bool>> countPredicate, string because = "",
         params object[] becauseArgs)
     {
@@ -1592,7 +1592,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> HaveSameCount<TExpectation>(IEnumerable<TExpectation> otherCollection, string because = "",
         params object[] becauseArgs)
     {
@@ -1625,7 +1625,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> IntersectWith(IEnumerable<T> otherCollection, string because = "",
         params object[] becauseArgs)
     {
@@ -1803,7 +1803,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <remarks>
     /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotBeInAscendingOrder(
         IComparer<T> comparer, string because = "", params object[] becauseArgs)
     {
@@ -1830,7 +1830,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <remarks>
     /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
     {
@@ -1917,7 +1917,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <remarks>
     /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotBeInDescendingOrder(
         IComparer<T> comparer, string because = "", params object[] becauseArgs)
     {
@@ -1944,7 +1944,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <remarks>
     /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
     {
@@ -2097,7 +2097,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotContain(Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
@@ -2134,7 +2134,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="unexpected"/> is empty.</exception>
     public AndConstraint<TAssertions> NotContain(IEnumerable<T> unexpected, string because = "", params object[] becauseArgs)
     {
@@ -2222,7 +2222,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="config"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="config"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, Func<EquivalencyAssertionOptions<TExpectation>,
         EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs)
     {
@@ -2302,7 +2302,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// Elements are compared using their <see cref="object.Equals(object)" /> implementation.
     /// </remarks>
     /// <param name="unexpected">A <see cref="Array"/> with the unexpected elements.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotContainInOrder(params T[] unexpected)
     {
         return NotContainInOrder(unexpected, string.Empty);
@@ -2322,7 +2322,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotContainInOrder(IEnumerable<T> unexpected, string because = "",
         params object[] becauseArgs)
     {
@@ -2371,7 +2371,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// Elements are compared using their <see cref="object.Equals(object)" /> implementation.
     /// </remarks>
     /// <param name="unexpected">A <see cref="Array"/> with the unexpected elements.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotContainInConsecutiveOrder(params T[] unexpected)
     {
         return NotContainInConsecutiveOrder(unexpected, string.Empty);
@@ -2391,7 +2391,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotContainInConsecutiveOrder(IEnumerable<T> unexpected, string because = "",
         params object[] becauseArgs)
     {
@@ -2445,7 +2445,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     }
 
     /// <summary>
-    /// Asserts that the collection does not contain any <c>null</c> items.
+    /// Asserts that the collection does not contain any <see langword="null"/> items.
     /// </summary>
     /// <param name="predicate">The predicate when evaluated should not be null.</param>
     /// <param name="because">
@@ -2455,7 +2455,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotContainNulls<TKey>(Expression<Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
         where TKey : class
     {
@@ -2485,7 +2485,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     }
 
     /// <summary>
-    /// Asserts that the collection does not contain any <c>null</c> items.
+    /// Asserts that the collection does not contain any <see langword="null"/> items.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -2541,7 +2541,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotEqual(IEnumerable<T> unexpected, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare collection with <null>.");
@@ -2605,7 +2605,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotHaveSameCount<TExpectation>(IEnumerable<TExpectation> otherCollection, string because = "",
         params object[] becauseArgs)
     {
@@ -2644,7 +2644,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotIntersectWith(IEnumerable<T> otherCollection, string because = "",
         params object[] becauseArgs)
     {
@@ -2683,7 +2683,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> OnlyContain(
         Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
     {
@@ -2722,7 +2722,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(Expression<Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
@@ -2825,7 +2825,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> AllSatisfy(Action<T> expected, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify against a <null> inspector");
@@ -2879,7 +2879,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// The element inspectors, which inspect each element in turn. The
     /// total number of element inspectors must exactly match the number of elements in the collection.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="elementInspectors"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="elementInspectors"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="elementInspectors"/> is empty.</exception>
     public AndConstraint<TAssertions> SatisfyRespectively(params Action<T>[] elementInspectors)
     {
@@ -2901,7 +2901,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="expected"/> is empty.</exception>
     public AndConstraint<TAssertions> SatisfyRespectively(IEnumerable<Action<T>> expected, string because = "", params object[] becauseArgs)
     {
@@ -2967,7 +2967,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// The predicates that the elements of the collection must match.
     /// The total number of predicates must exactly match the number of elements in the collection.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="predicates"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicates"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="predicates"/> is empty.</exception>
     public AndConstraint<TAssertions> Satisfy(params Expression<Func<T, bool>>[] predicates)
     {
@@ -2990,7 +2990,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="predicates"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicates"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="predicates"/> is empty.</exception>
     public AndConstraint<TAssertions> Satisfy(IEnumerable<Expression<Func<T, bool>>> predicates, string because = "", params object[] becauseArgs)
     {
@@ -3063,7 +3063,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expectation"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expectation"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> StartWith(IEnumerable<T> expectation, string because = "", params object[] becauseArgs)
     {
         return StartWith(expectation, (a, b) => EqualityComparer<T>.Default.Equals(a, b), because, becauseArgs);
@@ -3086,7 +3086,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expectation"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expectation"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> StartWith<TExpectation>(
         IEnumerable<TExpectation> expectation, Func<T, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs)
     {

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -234,7 +234,7 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     /// </item>
     /// </list>
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="wildcardPattern"/> is empty.</exception>
     public AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "",
         params object[] becauseArgs)
@@ -319,7 +319,7 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     /// </item>
     /// </list>
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="wildcardPattern"/> is empty.</exception>
     public AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "",
         params object[] becauseArgs)

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -175,7 +175,7 @@ internal static class TypeExtensions
     /// Finds the property by a case-sensitive name.
     /// </summary>
     /// <returns>
-    /// Returns <c>null</c> if no such property exists.
+    /// Returns <see langword="null"/> if no such property exists.
     /// </returns>
     public static PropertyInfo FindProperty(this Type type, string propertyName, Type preferredType)
     {
@@ -193,7 +193,7 @@ internal static class TypeExtensions
     /// Finds the field by a case-sensitive name.
     /// </summary>
     /// <returns>
-    /// Returns <c>null</c> if no such property exists.
+    /// Returns <see langword="null"/> if no such property exists.
     /// </returns>
     public static FieldInfo FindField(this Type type, string fieldName, Type preferredType)
     {

--- a/Src/FluentAssertions/Equivalency/IAssertionContext.cs
+++ b/Src/FluentAssertions/Equivalency/IAssertionContext.cs
@@ -7,7 +7,7 @@ namespace FluentAssertions.Equivalency;
 public interface IAssertionContext<TSubject>
 {
     /// <summary>
-    /// Gets the <see cref="IMember"/> of the member that returned the current object, or <c>null</c> if the current
+    /// Gets the <see cref="IMember"/> of the member that returned the current object, or <see langword="null"/> if the current
     /// object represents the root object.
     /// </summary>
     INode SelectedNode { get; }

--- a/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
@@ -91,7 +91,7 @@ public interface IEquivalencyAssertionOptions
     bool? CompareRecordsByValue { get; }
 
     /// <summary>
-    /// Gets the currently configured tracer, or <c>null</c> if no tracing was configured.
+    /// Gets the currently configured tracer, or <see langword="null"/> if no tracing was configured.
     /// </summary>
     ITraceWriter TraceWriter { get; }
 

--- a/Src/FluentAssertions/Equivalency/IEquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyValidationContext.cs
@@ -10,7 +10,7 @@ namespace FluentAssertions.Equivalency;
 public interface IEquivalencyValidationContext
 {
     /// <summary>
-    /// Gets the <see cref="INode"/> of the member that returned the current object, or <c>null</c> if the current
+    /// Gets the <see cref="INode"/> of the member that returned the current object, or <see langword="null"/> if the current
     /// object represents the root object.
     /// </summary>
     INode CurrentNode { get; }

--- a/Src/FluentAssertions/Equivalency/IMemberMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/IMemberMatchingRule.cs
@@ -12,19 +12,19 @@ public interface IMemberMatchingRule
     /// </summary>
     /// <remarks>
     /// Whether or not a match is required or optional is up to the specific rule. If no match is found and this is not an issue,
-    /// simply return <c>null</c>.
+    /// simply return <see langword="null"/>.
     /// </remarks>
     /// <param name="expectedMember">
     /// The <see cref="IMember"/> of the subject's member for which a match must be found. Can never
-    /// be <c>null</c>.
+    /// be <see langword="null"/>.
     /// </param>
     /// <param name="subject">
-    /// The subject object for which a matching member must be returned. Can never be <c>null</c>.
+    /// The subject object for which a matching member must be returned. Can never be <see langword="null"/>.
     /// </param>
     /// <param name="parent"></param>
     /// <param name="options"></param>
     /// <returns>
-    /// Returns the <see cref="IMember"/> of the property with which to compare the subject with, or <c>null</c>
+    /// Returns the <see cref="IMember"/> of the property with which to compare the subject with, or <see langword="null"/>
     /// if no match was found.
     /// </returns>
     IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions options);

--- a/Src/FluentAssertions/Equivalency/INode.cs
+++ b/Src/FluentAssertions/Equivalency/INode.cs
@@ -32,7 +32,7 @@ public interface INode
     /// Gets the type of the parent node, e.g. the type that declares a property or field.
     /// </summary>
     /// <value>
-    /// Is <c>null</c> for the root object.
+    /// Is <see langword="null"/> for the root object.
     /// </value>
     [CanBeNull]
     Type ParentType { get; }

--- a/Src/FluentAssertions/Equivalency/IObjectInfo.cs
+++ b/Src/FluentAssertions/Equivalency/IObjectInfo.cs
@@ -18,7 +18,7 @@ public interface IObjectInfo
     /// Gets the type of the parent, e.g. the type that declares a property or field.
     /// </summary>
     /// <value>
-    /// Is <c>null</c> for the root object.
+    /// Is <see langword="null"/> for the root object.
     /// </value>
     [CanBeNull]
     Type ParentType { get; }

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -116,7 +116,7 @@ internal class DictionaryInterfaceInfo
     /// Tries to convert an object into a dictionary typed to the <see cref="Key"/> and <see cref="Value"/> of the current <see cref="DictionaryInterfaceInfo"/>.
     /// </summary>
     /// <returns>
-    /// <c>true</c> if the conversion succeeded or <c>false</c> otherwise.
+    /// <see langword="true"/> if the conversion succeeded or <see langword="false"/> otherwise.
     /// </returns>
     public bool TryConvertFrom(object convertable, out object dictionary)
     {

--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -98,7 +98,7 @@ public static class EventRaisingExtensions
     /// Returns only the events having arguments matching both type and all predicates.
     /// </returns>
     /// <remarks>
-    /// If a <c>null</c> is provided as predicate argument, the corresponding event parameter value is ignored.
+    /// If a <see langword="null"/> is provided as predicate argument, the corresponding event parameter value is ignored.
     /// </remarks>
     public static IEventRecording WithArgs<T>(this IEventRecording eventRecording, params Expression<Func<T, bool>>[] predicates)
     {

--- a/Src/FluentAssertions/Events/EventAssertions.cs
+++ b/Src/FluentAssertions/Events/EventAssertions.cs
@@ -82,7 +82,7 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
     /// </summary>
     /// <param name="propertyExpression">
     /// A lambda expression referring to the property for which the property changed event should have been raised, or
-    /// <c>null</c> to refer to all properties.
+    /// <see langword="null"/> to refer to all properties.
     /// </param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion

--- a/Src/FluentAssertions/Events/IMonitor.cs
+++ b/Src/FluentAssertions/Events/IMonitor.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions.Events;
 public interface IMonitor<T> : IDisposable
 {
     /// <summary>
-    /// Gets the object that is being monitored or <c>null</c> if the object has been GCed.
+    /// Gets the object that is being monitored or <see langword="null"/> if the object has been GCed.
     /// </summary>
     T Subject { get; }
 

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -14,7 +14,7 @@ namespace FluentAssertions.Execution;
 /// </summary>
 /// <remarks>
 /// This class is supposed to have a very short life time and is not safe to be used in assertion that cross thread-boundaries
-/// such as when using <c>async</c> or <c>await</c>.
+/// such as when using <see langword="async"/> or <see langword="await"/>.
 /// </remarks>
 public sealed class AssertionScope : IAssertionScope
 {

--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -27,7 +27,7 @@ public class GivenSelector<T>
     /// Specify the condition that must be satisfied upon the subject selected through a prior selector.
     /// </summary>
     /// <param name="predicate">
-    /// If <c>true</c> the assertion will be treated as successful and no exceptions will be thrown.
+    /// If <see langword="true"/> the assertion will be treated as successful and no exceptions will be thrown.
     /// </param>
     /// <remarks>
     /// The condition will not be evaluated if the prior assertion failed,

--- a/Src/FluentAssertions/Execution/IAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/IAssertionScope.cs
@@ -16,7 +16,7 @@ public interface IAssertionScope : IDisposable
     /// Specify the condition that must be satisfied.
     /// </summary>
     /// <param name="condition">
-    /// If <c>true</c> the assertion will be treated as successful and no exceptions will be thrown.
+    /// If <see langword="true"/> the assertion will be treated as successful and no exceptions will be thrown.
     /// </param>
     IAssertionScope ForCondition(bool condition);
 
@@ -109,7 +109,7 @@ public interface IAssertionScope : IDisposable
     public Continuation FailWith(string message, params Func<object>[] argProviders);
 
     /// <summary>
-    /// Specify the reason why you expect the condition to be <c>true</c>.
+    /// Specify the reason why you expect the condition to be <see langword="true"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase compatible with <see cref="string.Format(string,object[])"/> explaining why the condition should

--- a/Src/FluentAssertions/FluentActions.cs
+++ b/Src/FluentAssertions/FluentActions.cs
@@ -39,14 +39,14 @@ public static class FluentActions
 
     /// <summary>
     /// Forces enumerating a collection. Should be used to assert that a method that uses the
-    /// <c>yield</c> keyword throws a particular exception.
+    /// <see langword="yield"/> keyword throws a particular exception.
     /// </summary>
     [Pure]
     public static Action Enumerating(Func<IEnumerable> enumerable) => enumerable.Enumerating();
 
     /// <summary>
     /// Forces enumerating a collection. Should be used to assert that a method that uses the
-    /// <c>yield</c> keyword throws a particular exception.
+    /// <see langword="yield"/> keyword throws a particular exception.
     /// </summary>
     [Pure]
     public static Action Enumerating<T>(Func<IEnumerable<T>> enumerable) => enumerable.Enumerating();

--- a/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
@@ -10,7 +10,7 @@ public class AggregateExceptionValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -21,7 +21,7 @@ public class AttributeBasedFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/ByteValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ByteValueFormatter.cs
@@ -9,7 +9,7 @@ public class ByteValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/DateOnlyValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateOnlyValueFormatter.cs
@@ -12,7 +12,7 @@ public class DateOnlyValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
@@ -11,7 +11,7 @@ public class DateTimeOffsetValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/DecimalValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DecimalValueFormatter.cs
@@ -9,7 +9,7 @@ public class DecimalValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -19,7 +19,7 @@ public class DefaultValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value.</param>
     /// <returns>
-    /// <c>true</c> if this instance can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if this instance can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public virtual bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/DictionaryValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DictionaryValueFormatter.cs
@@ -20,7 +20,7 @@ public class DictionaryValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public virtual bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
@@ -10,7 +10,7 @@ public class DoubleValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/EnumValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumValueFormatter.cs
@@ -10,7 +10,7 @@ public class EnumValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public virtual bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
@@ -20,7 +20,7 @@ public class EnumerableValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public virtual bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
@@ -10,7 +10,7 @@ public class ExceptionValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/ExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExpressionValueFormatter.cs
@@ -10,7 +10,7 @@ public class ExpressionValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/GuidValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/GuidValueFormatter.cs
@@ -9,7 +9,7 @@ public class GuidValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/IValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/IValueFormatter.cs
@@ -14,7 +14,7 @@ public interface IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     bool CanHandle(object value);
 

--- a/Src/FluentAssertions/Formatting/Int16ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/Int16ValueFormatter.cs
@@ -9,7 +9,7 @@ public class Int16ValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/Int32ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/Int32ValueFormatter.cs
@@ -9,7 +9,7 @@ public class Int32ValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/Int64ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/Int64ValueFormatter.cs
@@ -9,7 +9,7 @@ public class Int64ValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
+++ b/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
@@ -11,7 +11,7 @@ public class MultidimensionalArrayFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/NullValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/NullValueFormatter.cs
@@ -7,7 +7,7 @@ public class NullValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/PropertyInfoFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PropertyInfoFormatter.cs
@@ -9,7 +9,7 @@ public class PropertyInfoFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/SByteValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/SByteValueFormatter.cs
@@ -9,7 +9,7 @@ public class SByteValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/SingleValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/SingleValueFormatter.cs
@@ -10,7 +10,7 @@ public class SingleValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/StringValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/StringValueFormatter.cs
@@ -7,7 +7,7 @@ public class StringValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/TimeOnlyValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TimeOnlyValueFormatter.cs
@@ -12,7 +12,7 @@ public class TimeOnlyValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
@@ -12,7 +12,7 @@ public class TimeSpanValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/UInt16ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/UInt16ValueFormatter.cs
@@ -9,7 +9,7 @@ public class UInt16ValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/UInt32ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/UInt32ValueFormatter.cs
@@ -9,7 +9,7 @@ public class UInt32ValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/UInt64ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/UInt64ValueFormatter.cs
@@ -9,7 +9,7 @@ public class UInt64ValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/XAttributeValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XAttributeValueFormatter.cs
@@ -9,7 +9,7 @@ public class XAttributeValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
@@ -12,7 +12,7 @@ public class XElementValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Formatting/XmlReaderValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XmlReaderValueFormatter.cs
@@ -9,7 +9,7 @@ public class XmlReaderValueFormatter : IValueFormatter
     /// </summary>
     /// <param name="value">The value for which to create a <see cref="string"/>.</param>
     /// <returns>
-    /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <see langword="false"/>.
     /// </returns>
     public bool CanHandle(object value)
     {

--- a/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
@@ -27,7 +27,7 @@ public class NullableNumericAssertions<T, TAssertions> : NumericAssertions<T, TA
     }
 
     /// <summary>
-    /// Asserts that a nullable numeric value is not <c>null</c>.
+    /// Asserts that a nullable numeric value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -47,7 +47,7 @@ public class NullableNumericAssertions<T, TAssertions> : NumericAssertions<T, TA
     }
 
     /// <summary>
-    /// Asserts that a nullable numeric value is not <c>null</c>.
+    /// Asserts that a nullable numeric value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -62,7 +62,7 @@ public class NullableNumericAssertions<T, TAssertions> : NumericAssertions<T, TA
     }
 
     /// <summary>
-    /// Asserts that a nullable numeric value is <c>null</c>.
+    /// Asserts that a nullable numeric value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -82,7 +82,7 @@ public class NullableNumericAssertions<T, TAssertions> : NumericAssertions<T, TA
     }
 
     /// <summary>
-    /// Asserts that a nullable numeric value is <c>null</c>.
+    /// Asserts that a nullable numeric value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -37,7 +37,7 @@ public class BooleanAssertions<TAssertions>
     public bool? Subject { get; }
 
     /// <summary>
-    /// Asserts that the value is <c>false</c>.
+    /// Asserts that the value is <see langword="false"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -57,7 +57,7 @@ public class BooleanAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Asserts that the value is <c>true</c>.
+    /// Asserts that the value is <see langword="true"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion

--- a/Src/FluentAssertions/Primitives/EnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/EnumAssertions.cs
@@ -374,7 +374,7 @@ public class EnumAssertions<TEnum, TAssertions>
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <returns>An <see cref="AndConstraint{T}" /> which can be used to chain assertions.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> Match(Expression<Func<TEnum?, bool>> predicate,
         string because = "",
         params object[] becauseArgs)

--- a/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
@@ -28,7 +28,7 @@ public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAsserti
     }
 
     /// <summary>
-    /// Asserts that a nullable boolean value is not <c>null</c>.
+    /// Asserts that a nullable boolean value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -48,7 +48,7 @@ public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAsserti
     }
 
     /// <summary>
-    /// Asserts that a nullable boolean value is not <c>null</c>.
+    /// Asserts that a nullable boolean value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -63,7 +63,7 @@ public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAsserti
     }
 
     /// <summary>
-    /// Asserts that a nullable boolean value is <c>null</c>.
+    /// Asserts that a nullable boolean value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -83,7 +83,7 @@ public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAsserti
     }
 
     /// <summary>
-    /// Asserts that a nullable boolean value is <c>null</c>.
+    /// Asserts that a nullable boolean value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -140,7 +140,7 @@ public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAsserti
     }
 
     /// <summary>
-    /// Asserts that the value is not <c>false</c>.
+    /// Asserts that the value is not <see langword="false"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -160,7 +160,7 @@ public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAsserti
     }
 
     /// <summary>
-    /// Asserts that the value is not <c>true</c>.
+    /// Asserts that the value is not <see langword="true"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion

--- a/Src/FluentAssertions/Primitives/NullableDateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateOnlyAssertions.cs
@@ -31,7 +31,7 @@ public class NullableDateOnlyAssertions<TAssertions> : DateOnlyAssertions<TAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="DateOnly"/> value is not <c>null</c>.
+    /// Asserts that a nullable <see cref="DateOnly"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -51,7 +51,7 @@ public class NullableDateOnlyAssertions<TAssertions> : DateOnlyAssertions<TAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="DateOnly"/> value is not <c>null</c>.
+    /// Asserts that a nullable <see cref="DateOnly"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -66,7 +66,7 @@ public class NullableDateOnlyAssertions<TAssertions> : DateOnlyAssertions<TAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="DateOnly"/> value is <c>null</c>.
+    /// Asserts that a nullable <see cref="DateOnly"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -86,7 +86,7 @@ public class NullableDateOnlyAssertions<TAssertions> : DateOnlyAssertions<TAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="DateOnly"/> value is <c>null</c>.
+    /// Asserts that a nullable <see cref="DateOnly"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion

--- a/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
@@ -38,7 +38,7 @@ public class NullableDateTimeAssertions<TAssertions> : DateTimeAssertions<TAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="DateTime"/> value is not <c>null</c>.
+    /// Asserts that a nullable <see cref="DateTime"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -58,7 +58,7 @@ public class NullableDateTimeAssertions<TAssertions> : DateTimeAssertions<TAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="DateTime"/> value is not <c>null</c>.
+    /// Asserts that a nullable <see cref="DateTime"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -73,7 +73,7 @@ public class NullableDateTimeAssertions<TAssertions> : DateTimeAssertions<TAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="DateTime"/> value is <c>null</c>.
+    /// Asserts that a nullable <see cref="DateTime"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -93,7 +93,7 @@ public class NullableDateTimeAssertions<TAssertions> : DateTimeAssertions<TAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="DateTime"/> value is <c>null</c>.
+    /// Asserts that a nullable <see cref="DateTime"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion

--- a/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
@@ -37,7 +37,7 @@ public class NullableDateTimeOffsetAssertions<TAssertions> : DateTimeOffsetAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="DateTimeOffset"/> value is not <c>null</c>.
+    /// Asserts that a nullable <see cref="DateTimeOffset"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -57,7 +57,7 @@ public class NullableDateTimeOffsetAssertions<TAssertions> : DateTimeOffsetAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="DateTimeOffset"/> value is not <c>null</c>.
+    /// Asserts that a nullable <see cref="DateTimeOffset"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -72,7 +72,7 @@ public class NullableDateTimeOffsetAssertions<TAssertions> : DateTimeOffsetAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="DateTimeOffset"/> value is <c>null</c>.
+    /// Asserts that a nullable <see cref="DateTimeOffset"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -93,7 +93,7 @@ public class NullableDateTimeOffsetAssertions<TAssertions> : DateTimeOffsetAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="DateTimeOffset"/> value is <c>null</c>.
+    /// Asserts that a nullable <see cref="DateTimeOffset"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion

--- a/Src/FluentAssertions/Primitives/NullableEnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableEnumAssertions.cs
@@ -28,7 +28,7 @@ public class NullableEnumAssertions<TEnum, TAssertions> : EnumAssertions<TEnum, 
     }
 
     /// <summary>
-    /// Asserts that a nullable <typeparamref name="TEnum"/> value is not <c>null</c>.
+    /// Asserts that a nullable <typeparamref name="TEnum"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -48,7 +48,7 @@ public class NullableEnumAssertions<TEnum, TAssertions> : EnumAssertions<TEnum, 
     }
 
     /// <summary>
-    /// Asserts that a nullable <typeparamref name="TEnum"/> is not <c>null</c>.
+    /// Asserts that a nullable <typeparamref name="TEnum"/> is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -63,7 +63,7 @@ public class NullableEnumAssertions<TEnum, TAssertions> : EnumAssertions<TEnum, 
     }
 
     /// <summary>
-    /// Asserts that a nullable <typeparamref name="TEnum"/> value is <c>null</c>.
+    /// Asserts that a nullable <typeparamref name="TEnum"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -83,7 +83,7 @@ public class NullableEnumAssertions<TEnum, TAssertions> : EnumAssertions<TEnum, 
     }
 
     /// <summary>
-    /// Asserts that a nullable <typeparamref name="TEnum"/> value is <c>null</c>.
+    /// Asserts that a nullable <typeparamref name="TEnum"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion

--- a/Src/FluentAssertions/Primitives/NullableGuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableGuidAssertions.cs
@@ -29,7 +29,7 @@ public class NullableGuidAssertions<TAssertions> : GuidAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="Guid"/> value is not <c>null</c>.
+    /// Asserts that a nullable <see cref="Guid"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -49,7 +49,7 @@ public class NullableGuidAssertions<TAssertions> : GuidAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="Guid"/> value is not <c>null</c>.
+    /// Asserts that a nullable <see cref="Guid"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -64,7 +64,7 @@ public class NullableGuidAssertions<TAssertions> : GuidAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="Guid"/> value is <c>null</c>.
+    /// Asserts that a nullable <see cref="Guid"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -84,7 +84,7 @@ public class NullableGuidAssertions<TAssertions> : GuidAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="Guid"/> value is <c>null</c>.
+    /// Asserts that a nullable <see cref="Guid"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion

--- a/Src/FluentAssertions/Primitives/NullableSimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableSimpleTimeSpanAssertions.cs
@@ -37,7 +37,7 @@ public class NullableSimpleTimeSpanAssertions<TAssertions> : SimpleTimeSpanAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="TimeSpan"/> value is not <c>null</c>.
+    /// Asserts that a nullable <see cref="TimeSpan"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -57,7 +57,7 @@ public class NullableSimpleTimeSpanAssertions<TAssertions> : SimpleTimeSpanAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="TimeSpan"/> value is not <c>null</c>.
+    /// Asserts that a nullable <see cref="TimeSpan"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -72,7 +72,7 @@ public class NullableSimpleTimeSpanAssertions<TAssertions> : SimpleTimeSpanAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="TimeSpan"/> value is <c>null</c>.
+    /// Asserts that a nullable <see cref="TimeSpan"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -92,7 +92,7 @@ public class NullableSimpleTimeSpanAssertions<TAssertions> : SimpleTimeSpanAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="TimeSpan"/> value is <c>null</c>.
+    /// Asserts that a nullable <see cref="TimeSpan"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion

--- a/Src/FluentAssertions/Primitives/NullableTimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableTimeOnlyAssertions.cs
@@ -31,7 +31,7 @@ public class NullableTimeOnlyAssertions<TAssertions> : TimeOnlyAssertions<TAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="TimeOnly"/> value is not <c>null</c>.
+    /// Asserts that a nullable <see cref="TimeOnly"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -51,7 +51,7 @@ public class NullableTimeOnlyAssertions<TAssertions> : TimeOnlyAssertions<TAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="TimeOnly"/> value is not <c>null</c>.
+    /// Asserts that a nullable <see cref="TimeOnly"/> value is not <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -66,7 +66,7 @@ public class NullableTimeOnlyAssertions<TAssertions> : TimeOnlyAssertions<TAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="TimeOnly"/> value is <c>null</c>.
+    /// Asserts that a nullable <see cref="TimeOnly"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
@@ -86,7 +86,7 @@ public class NullableTimeOnlyAssertions<TAssertions> : TimeOnlyAssertions<TAsser
     }
 
     /// <summary>
-    /// Asserts that a nullable <see cref="TimeOnly"/> value is <c>null</c>.
+    /// Asserts that a nullable <see cref="TimeOnly"/> value is <see langword="null"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -148,7 +148,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expectedType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expectedType"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> BeOfType(Type expectedType, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(expectedType, nameof(expectedType));
@@ -206,7 +206,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="unexpectedType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="unexpectedType"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotBeOfType(Type unexpectedType, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(unexpectedType, nameof(unexpectedType));
@@ -281,7 +281,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
     /// <returns>An <see cref="AndConstraint{TAssertions}"/> which can be used to chain assertions.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="type"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> BeAssignableTo(Type type, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(type, nameof(type));
@@ -339,7 +339,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
     /// <returns>An <see cref="AndConstraint{TAssertions}"/> which can be used to chain assertions.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="type"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotBeAssignableTo(Type type, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(type, nameof(type));
@@ -397,7 +397,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <returns>An <see cref="AndConstraint{T}" /> which can be used to chain assertions.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> Match<T>(Expression<Func<T, bool>> predicate,
         string because = "",
         params object[] becauseArgs)

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -205,7 +205,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// </item>
     /// </list>
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="wildcardPattern"/> is empty.</exception>
     public AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs)
     {
@@ -255,7 +255,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// </item>
     /// </list>
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="wildcardPattern"/> is empty.</exception>
     public AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs)
     {
@@ -307,7 +307,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// </item>
     /// </list>
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="wildcardPattern"/> is empty.</exception>
     public AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "",
         params object[] becauseArgs)
@@ -363,7 +363,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// </item>
     /// </list>
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="wildcardPattern"/> is empty.</exception>
     public AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "",
         params object[] becauseArgs)
@@ -1302,7 +1302,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     }
 
     /// <summary>
-    /// Asserts that a string is neither <c>null</c> nor <see cref="string.Empty"/>.
+    /// Asserts that a string is neither <see langword="null"/> nor <see cref="string.Empty"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -1322,7 +1322,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     }
 
     /// <summary>
-    /// Asserts that a string is either <c>null</c> or <see cref="string.Empty"/>.
+    /// Asserts that a string is either <see langword="null"/> or <see cref="string.Empty"/>.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -1342,7 +1342,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     }
 
     /// <summary>
-    /// Asserts that a string is neither <c>null</c> nor <see cref="string.Empty"/> nor white space
+    /// Asserts that a string is neither <see langword="null"/> nor <see cref="string.Empty"/> nor white space
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -1362,7 +1362,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     }
 
     /// <summary>
-    /// Asserts that a string is either <c>null</c> or <see cref="string.Empty"/> or white space
+    /// Asserts that a string is either <see langword="null"/> or <see cref="string.Empty"/> or white space
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -32,7 +32,7 @@ public class AssemblyAssertions : ReferenceTypeAssertions<Assembly, AssemblyAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="assembly"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="assembly"/> is <see langword="null"/>.</exception>
     public AndConstraint<AssemblyAssertions> NotReference(Assembly assembly, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(assembly, nameof(assembly));
@@ -71,7 +71,7 @@ public class AssemblyAssertions : ReferenceTypeAssertions<Assembly, AssemblyAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="assembly"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="assembly"/> is <see langword="null"/>.</exception>
     public AndConstraint<AssemblyAssertions> Reference(Assembly assembly, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(assembly, nameof(assembly));
@@ -110,7 +110,7 @@ public class AssemblyAssertions : ReferenceTypeAssertions<Assembly, AssemblyAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
     public AndWhichConstraint<AssemblyAssertions, Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));

--- a/Src/FluentAssertions/Specialized/ExecutionTime.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTime.cs
@@ -12,7 +12,7 @@ public class ExecutionTime
     /// Initializes a new instance of the <see cref="ExecutionTime"/> class.
     /// </summary>
     /// <param name="action">The action of which the execution time must be asserted.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
     public ExecutionTime(Action action, StartTimer createTimer)
         : this(action, "the action", createTimer)
     {
@@ -22,7 +22,7 @@ public class ExecutionTime
     /// Initializes a new instance of the <see cref="ExecutionTime"/> class.
     /// </summary>
     /// <param name="action">The action of which the execution time must be asserted.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
     public ExecutionTime(Func<Task> action, StartTimer createTimer)
         : this(action, "the action", createTimer)
     {
@@ -33,7 +33,7 @@ public class ExecutionTime
     /// </summary>
     /// <param name="action">The action of which the execution time must be asserted.</param>
     /// <param name="actionDescription">The description of the action to be asserted.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
     protected ExecutionTime(Action action, string actionDescription, StartTimer createTimer)
     {
         Guard.ThrowIfArgumentIsNull(action, nameof(action));
@@ -73,7 +73,7 @@ public class ExecutionTime
     /// The original constructor shall stay in place in order to keep backward-compatibility
     /// and to avoid unnecessary wrapping action in <see cref="Task"/>.
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
     protected ExecutionTime(Func<Task> action, string actionDescription, StartTimer createTimer)
     {
         Guard.ThrowIfArgumentIsNull(action, nameof(action));

--- a/Src/FluentAssertions/Specialized/MemberExecutionTime.cs
+++ b/Src/FluentAssertions/Specialized/MemberExecutionTime.cs
@@ -11,8 +11,8 @@ public class MemberExecutionTime<T> : ExecutionTime
     /// </summary>
     /// <param name="subject">The object that exposes the method or property.</param>
     /// <param name="action">A reference to the method or property to measure the execution time of.</param>
-    /// <exception cref="NullReferenceException"><paramref name="subject"/> is <c>null</c>.</exception>
-    /// <exception cref="NullReferenceException"><paramref name="action"/> is <c>null</c>.</exception>
+    /// <exception cref="NullReferenceException"><paramref name="subject"/> is <see langword="null"/>.</exception>
+    /// <exception cref="NullReferenceException"><paramref name="action"/> is <see langword="null"/>.</exception>
     public MemberExecutionTime(T subject, Expression<Action<T>> action, StartTimer createTimer)
         : base(() => action.Compile()(subject), "(" + action.Body + ")", createTimer)
     {

--- a/Src/FluentAssertions/TypeExtensions.cs
+++ b/Src/FluentAssertions/TypeExtensions.cs
@@ -41,7 +41,7 @@ public static class TypeExtensions
     /// <summary>
     /// Returns a method selector for the current <see cref="Type"/>.
     /// </summary>
-    /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="type"/> is <see langword="null"/>.</exception>
     public static MethodInfoSelector Methods(this Type type)
     {
         return new MethodInfoSelector(type);
@@ -50,7 +50,7 @@ public static class TypeExtensions
     /// <summary>
     /// Returns a method selector for the current <see cref="Type"/>.
     /// </summary>
-    /// <exception cref="ArgumentNullException"><paramref name="typeSelector"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="typeSelector"/> is <see langword="null"/>.</exception>
     public static MethodInfoSelector Methods(this TypeSelector typeSelector)
     {
         Guard.ThrowIfArgumentIsNull(typeSelector, nameof(typeSelector));
@@ -61,7 +61,7 @@ public static class TypeExtensions
     /// <summary>
     /// Returns a property selector for the current <see cref="Type"/>.
     /// </summary>
-    /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="type"/> is <see langword="null"/>.</exception>
     public static PropertyInfoSelector Properties(this Type type)
     {
         return new PropertyInfoSelector(type);
@@ -70,7 +70,7 @@ public static class TypeExtensions
     /// <summary>
     /// Returns a property selector for the current <see cref="Type"/>.
     /// </summary>
-    /// <exception cref="ArgumentNullException"><paramref name="typeSelector"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="typeSelector"/> is <see langword="null"/>.</exception>
     public static PropertyInfoSelector Properties(this TypeSelector typeSelector)
     {
         Guard.ThrowIfArgumentIsNull(typeSelector, nameof(typeSelector));

--- a/Src/FluentAssertions/Types/MemberInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MemberInfoAssertions.cs
@@ -71,7 +71,7 @@ public abstract class MemberInfoAssertions<TSubject, TAssertions> : ReferenceTyp
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="isMatchingAttributePredicate"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="isMatchingAttributePredicate"/> is <see langword="null"/>.</exception>
     public AndWhichConstraint<MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(
         Expression<Func<TAttribute, bool>> isMatchingAttributePredicate,
         string because = "", params object[] becauseArgs)
@@ -117,7 +117,7 @@ public abstract class MemberInfoAssertions<TSubject, TAssertions> : ReferenceTyp
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="isMatchingAttributePredicate"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="isMatchingAttributePredicate"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(
         Expression<Func<TAttribute, bool>> isMatchingAttributePredicate,
         string because = "", params object[] becauseArgs)

--- a/Src/FluentAssertions/Types/MethodInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoAssertions.cs
@@ -169,7 +169,7 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="returnType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="returnType"/> is <see langword="null"/>.</exception>
     public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> Return(Type returnType, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(returnType, nameof(returnType));
@@ -246,7 +246,7 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="returnType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="returnType"/> is <see langword="null"/>.</exception>
     public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> NotReturn(Type returnType, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(returnType, nameof(returnType));

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -18,7 +18,7 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
     /// Initializes a new instance of the <see cref="MethodInfoSelector"/> class.
     /// </summary>
     /// <param name="type">The type from which to select methods.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="type"/> is <see langword="null"/>.</exception>
     public MethodInfoSelector(Type type)
         : this(new[] { type })
     {
@@ -28,7 +28,7 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
     /// Initializes a new instance of the <see cref="MethodInfoSelector"/> class.
     /// </summary>
     /// <param name="types">The types from which to select methods.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="types"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="types"/> is <see langword="null"/>.</exception>
     public MethodInfoSelector(IEnumerable<Type> types)
     {
         Guard.ThrowIfArgumentIsNull(types, nameof(types));

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -21,7 +21,7 @@ public class MethodInfoSelectorAssertions
     /// Initializes a new instance of the <see cref="MethodInfoSelectorAssertions"/> class.
     /// </summary>
     /// <param name="methods">The methods to assert.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="methods"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="methods"/> is <see langword="null"/>.</exception>
     public MethodInfoSelectorAssertions(params MethodInfo[] methods)
     {
         Guard.ThrowIfArgumentIsNull(methods, nameof(methods));

--- a/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
@@ -270,7 +270,7 @@ public class PropertyInfoAssertions :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="propertyType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="propertyType"/> is <see langword="null"/>.</exception>
     public AndConstraint<PropertyInfoAssertions> Return(Type propertyType,
         string because = "", params object[] becauseArgs)
     {
@@ -319,7 +319,7 @@ public class PropertyInfoAssertions :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="propertyType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="propertyType"/> is <see langword="null"/>.</exception>
     public AndConstraint<PropertyInfoAssertions> NotReturn(Type propertyType, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(propertyType, nameof(propertyType));

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -18,7 +18,7 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
     /// Initializes a new instance of the <see cref="PropertyInfoSelector"/> class.
     /// </summary>
     /// <param name="type">The type from which to select properties.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="type"/> is <see langword="null"/>.</exception>
     public PropertyInfoSelector(Type type)
         : this(new[] { type })
     {
@@ -28,7 +28,7 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
     /// Initializes a new instance of the <see cref="PropertyInfoSelector"/> class.
     /// </summary>
     /// <param name="types">The types from which to select properties.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="types"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="types"/> is <see langword="null"/>.</exception>
     public PropertyInfoSelector(IEnumerable<Type> types)
     {
         Guard.ThrowIfArgumentIsNull(types, nameof(types));

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -25,7 +25,7 @@ public class PropertyInfoSelectorAssertions
     /// Initializes a new instance of the <see cref="PropertyInfoSelectorAssertions"/> class, for a number of <see cref="PropertyInfo"/> objects.
     /// </summary>
     /// <param name="properties">The properties to assert.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="properties"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="properties"/> is <see langword="null"/>.</exception>
     public PropertyInfoSelectorAssertions(params PropertyInfo[] properties)
     {
         Guard.ThrowIfArgumentIsNull(properties, nameof(properties));

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -451,7 +451,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <see langword="null"/>.</exception>
     public AndConstraint<TypeAssertions> Implement(Type interfaceType, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(interfaceType, nameof(interfaceType));
@@ -500,7 +500,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <see langword="null"/>.</exception>
     public AndConstraint<TypeAssertions> NotImplement(Type interfaceType, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(interfaceType, nameof(interfaceType));
@@ -549,7 +549,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="baseType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="baseType"/> is <see langword="null"/>.</exception>
     public AndConstraint<TypeAssertions> BeDerivedFrom(Type baseType, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(baseType, nameof(baseType));
@@ -600,7 +600,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="baseType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="baseType"/> is <see langword="null"/>.</exception>
     public AndConstraint<TypeAssertions> NotBeDerivedFrom(Type baseType, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(baseType, nameof(baseType));
@@ -845,8 +845,8 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="propertyType"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="propertyType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
     public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty(
         Type propertyType, string name, string because = "", params object[] becauseArgs)
     {
@@ -891,7 +891,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
     public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty<TProperty>(
         string name, string because = "", params object[] becauseArgs)
     {
@@ -909,7 +909,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
     public AndConstraint<TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
@@ -946,8 +946,8 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
     public AndConstraint<TypeAssertions> HaveExplicitProperty(
         Type interfaceType, string name, string because = "", params object[] becauseArgs)
     {
@@ -990,7 +990,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
     public AndConstraint<TypeAssertions> HaveExplicitProperty<TInterface>(
         string name, string because = "", params object[] becauseArgs)
         where TInterface : class
@@ -1011,8 +1011,8 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
     public AndConstraint<TypeAssertions> NotHaveExplicitProperty(
         Type interfaceType, string name, string because = "", params object[] becauseArgs)
     {
@@ -1056,7 +1056,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
     public AndConstraint<TypeAssertions> NotHaveExplicitProperty<TInterface>(
         string name, string because = "", params object[] becauseArgs)
         where TInterface : class
@@ -1078,9 +1078,9 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <see langword="null"/>.</exception>
     public AndConstraint<TypeAssertions> HaveExplicitMethod(
         Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
     {
@@ -1126,8 +1126,8 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <see langword="null"/>.</exception>
     public AndConstraint<TypeAssertions> HaveExplicitMethod<TInterface>(
         string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         where TInterface : class
@@ -1149,9 +1149,9 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <see langword="null"/>.</exception>
     public AndConstraint<TypeAssertions> NotHaveExplicitMethod(
         Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
     {
@@ -1197,8 +1197,8 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <see langword="null"/>.</exception>
     public AndConstraint<TypeAssertions> NotHaveExplicitMethod<TInterface>(
         string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         where TInterface : class
@@ -1219,8 +1219,8 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="indexerType"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="indexerType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <see langword="null"/>.</exception>
     public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveIndexer(
         Type indexerType, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
     {
@@ -1267,7 +1267,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <see langword="null"/>.</exception>
     public AndConstraint<TypeAssertions> NotHaveIndexer(
         IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
     {
@@ -1308,8 +1308,8 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <see langword="null"/>.</exception>
     public AndWhichConstraint<TypeAssertions, MethodInfo> HaveMethod(
         string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
     {
@@ -1353,8 +1353,8 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <see langword="null"/>.</exception>
     public AndConstraint<TypeAssertions> NotHaveMethod(
         string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
     {
@@ -1395,7 +1395,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <see langword="null"/>.</exception>
     public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveConstructor(
         IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
     {
@@ -1452,7 +1452,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <see langword="null"/>.</exception>
     public AndWhichConstraint<TypeAssertions, ConstructorInfo> NotHaveConstructor(
         IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
     {
@@ -1610,8 +1610,8 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="sourceType"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="targetType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="sourceType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="targetType"/> is <see langword="null"/>.</exception>
     public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplicitConversionOperator(
         Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
     {
@@ -1672,8 +1672,8 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="sourceType"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="targetType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="sourceType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="targetType"/> is <see langword="null"/>.</exception>
     public AndConstraint<TypeAssertions> NotHaveImplicitConversionOperator(
         Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
     {
@@ -1732,8 +1732,8 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="sourceType"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="targetType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="sourceType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="targetType"/> is <see langword="null"/>.</exception>
     public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplicitConversionOperator(
         Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
     {
@@ -1794,8 +1794,8 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="sourceType"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="targetType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="sourceType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="targetType"/> is <see langword="null"/>.</exception>
     public AndConstraint<TypeAssertions> NotHaveExplicitConversionOperator(
         Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
     {

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -167,7 +167,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expectedName"/> is <c>null</c> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expectedName"/> is <see langword="null"/> or empty.</exception>
     public AndConstraint<XElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because = "",
         params object[] becauseArgs)
     {
@@ -189,7 +189,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expectedName"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expectedName"/> is <see langword="null"/>.</exception>
     public AndConstraint<XElementAssertions> HaveAttribute(XName expectedName, string expectedValue, string because = "",
         params object[] becauseArgs)
     {
@@ -239,7 +239,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/> or empty.</exception>
     public AndWhichConstraint<XElementAssertions, XElement> HaveElement(string expected, string because = "",
         params object[] becauseArgs)
     {
@@ -260,7 +260,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
     public AndWhichConstraint<XElementAssertions, XElement> HaveElement(XName expected, string because = "",
         params object[] becauseArgs)
     {


### PR DESCRIPTION
[Recommended XML tags for C# documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#see) recommends using `<see langword="keyword"/>` when referring to language keywords.

Split of from #2023