### PR TITLE
Add `Imply()` to `BooleanAssertions`

### DIFF
--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
@@ -129,12 +130,15 @@ public class BooleanAssertions<TAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> Imply(bool implicator,
+        [CallerArgumentExpression("implicator")] string implicatorMessage = "",
+        string because = "",
+        params object[] becauseArgs)
     {
         Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {context:boolean} ({0}) to imply {1} ({2}){reason}, ", Subject, nameof(implicator), implicator)
+            .WithExpectation("Expected {context:boolean} ({0}) to imply {1} ({2}){reason}, ", Subject, implicatorMessage, implicator)
             .FailWith("but found null.")
             .Then
             .ForCondition(!Subject.Value || implicator)

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -118,15 +118,26 @@ public class BooleanAssertions<TAssertions>
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
-    public AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs)
+    /// <summary>
+    /// Asserts that the value implies the specified <paramref name="implicator"/> value.
+    /// </summary>
+    /// <param name="implicator">The second value for the implication</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+    /// </param>
+    public AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {context:boolean} ({0}) to imply {1} ({2}){reason}, ", Subject, nameof(expectation), expectation)
+            .WithExpectation("Expected {context:boolean} ({0}) to imply {1} ({2}){reason}, ", Subject, nameof(implicator), implicator)
             .FailWith("but found null.")
             .Then
-            .ForCondition(!Subject.Value || expectation)
+            .ForCondition(!Subject.Value || implicator)
             .FailWith("but it did not.")
             .Then
             .ClearExpectation();

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -120,10 +120,16 @@ public class BooleanAssertions<TAssertions>
 
     public AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs)
     {
-        Execute.Assertion            
-            .ForCondition(!Subject.Value || expectation)
+        Execute.Assertion
+            .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:boolean} ({0}) to imply {1} ({2}){reason}, but it did not.", Subject, nameof(expectation), expectation);
+            .WithExpectation("Expected {context:boolean} ({0}) to imply {1} ({2}){reason}, ", Subject, nameof(expectation), expectation)
+            .FailWith("but found null.")
+            .Then
+            .ForCondition(!Subject.Value || expectation)
+            .FailWith("but it did not.")
+            .Then
+            .ClearExpectation();
         
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
@@ -122,7 +121,7 @@ public class BooleanAssertions<TAssertions>
     /// <summary>
     /// Asserts that the value implies the specified <paramref name="consequent"/> value.
     /// </summary>
-    /// <param name="consequent">The right hand side for the implication</param>
+    /// <param name="consequent">The right hand side of the implication</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -123,6 +123,7 @@ public class BooleanAssertions<TAssertions>
     /// Asserts that the value implies the specified <paramref name="consequent"/> value.
     /// </summary>
     /// <param name="consequent">The right hand side for the implication</param>
+    /// <remarks>If you want to use the `because` / `becauseArgs` construct, it is **necessary** to use the caller argument expression, because this would lead to unexpected failure messages, when omitted!</remarks>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -123,7 +123,6 @@ public class BooleanAssertions<TAssertions>
     /// Asserts that the value implies the specified <paramref name="consequent"/> value.
     /// </summary>
     /// <param name="consequent">The right hand side for the implication</param>
-    /// <remarks>If you want to use the `because` / `becauseArgs` construct, it is **necessary** to use the caller argument expression, because this would lead to unexpected failure messages, when omitted!</remarks>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -132,7 +131,6 @@ public class BooleanAssertions<TAssertions>
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
     public AndConstraint<TAssertions> Imply(bool consequent,
-        [CallerArgumentExpression(nameof(consequent))] string consequentMessage = "",
         string because = "",
         params object[] becauseArgs)
     {
@@ -141,7 +139,7 @@ public class BooleanAssertions<TAssertions>
         Execute.Assertion
             .ForCondition(antecedent is not null)
             .BecauseOf(because, becauseArgs)
-            .WithExpectation($"Expected {{context:antecedent}} ({{0}}) to imply {consequentMessage} ({{1}}){{reason}}, ", antecedent, consequent)
+            .WithExpectation($"Expected {{context:antecedent}} ({{0}}) to imply consequent ({{1}}){{reason}}, ", antecedent, consequent)
             .FailWith("but found null.")
             .Then
             .ForCondition(!antecedent.Value || consequent)

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -118,6 +118,16 @@ public class BooleanAssertions<TAssertions>
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
+    public AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs)
+    {
+        Execute.Assertion            
+            .ForCondition(!Subject.Value || expectation)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:boolean} ({0}) to imply {1} ({2}){reason}, but it did not.", Subject, nameof(expectation), expectation);
+        
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
         throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean Be() instead?");

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -120,9 +120,9 @@ public class BooleanAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Asserts that the value implies the specified <paramref name="implicator"/> value.
+    /// Asserts that the value implies the specified <paramref name="consequent"/> value.
     /// </summary>
-    /// <param name="implicator">The second value for the implication</param>
+    /// <param name="consequent">The right hand side for the implication</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -130,18 +130,20 @@ public class BooleanAssertions<TAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<TAssertions> Imply(bool implicator,
-        [CallerArgumentExpression("implicator")] string implicatorMessage = "",
+    public AndConstraint<TAssertions> Imply(bool consequent,
+        [CallerArgumentExpression(nameof(consequent))] string consequentMessage = "",
         string because = "",
         params object[] becauseArgs)
     {
+        bool? antecedent = Subject;
+
         Execute.Assertion
-            .ForCondition(Subject is not null)
+            .ForCondition(antecedent is not null)
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {context:boolean} ({0}) to imply {1} ({2}){reason}, ", Subject, implicatorMessage, implicator)
+            .WithExpectation($"Expected {{context:antecedent}} ({{0}}) to imply {consequentMessage} ({{1}}){{reason}}, ", antecedent, consequent)
             .FailWith("but found null.")
             .Then
-            .ForCondition(!Subject.Value || implicator)
+            .ForCondition(!antecedent.Value || consequent)
             .FailWith("but it did not.")
             .Then
             .ClearExpectation();

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -139,7 +139,7 @@ public class BooleanAssertions<TAssertions>
         Execute.Assertion
             .ForCondition(antecedent is not null)
             .BecauseOf(because, becauseArgs)
-            .WithExpectation($"Expected {{context:antecedent}} ({{0}}) to imply consequent ({{1}}){{reason}}, ", antecedent, consequent)
+            .WithExpectation("Expected {context:antecedent} ({0}) to imply consequent ({1}){reason}, ", antecedent, consequent)
             .FailWith("but found null.")
             .Then
             .ForCondition(!antecedent.Value || consequent)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, [System.Runtime.CompilerServices.CallerArgumentExpression("implicator")] string implicatorMessage = "", string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, [System.Runtime.CompilerServices.CallerArgumentExpression("consequent")] string consequentMessage = "", string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, [System.Runtime.CompilerServices.CallerArgumentExpression("consequent")] string consequentMessage = "", string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, [System.Runtime.CompilerServices.CallerArgumentExpression("implicator")] string implicatorMessage = "", string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1816,6 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1841,7 +1841,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, [System.Runtime.CompilerServices.CallerArgumentExpression("implicator")] string implicatorMessage = "", string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateOnlyAssertions : FluentAssertions.Primitives.DateOnlyAssertions<FluentAssertions.Primitives.DateOnlyAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1841,6 +1841,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateOnlyAssertions : FluentAssertions.Primitives.DateOnlyAssertions<FluentAssertions.Primitives.DateOnlyAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1841,7 +1841,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateOnlyAssertions : FluentAssertions.Primitives.DateOnlyAssertions<FluentAssertions.Primitives.DateOnlyAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1841,7 +1841,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, [System.Runtime.CompilerServices.CallerArgumentExpression("implicator")] string implicatorMessage = "", string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, [System.Runtime.CompilerServices.CallerArgumentExpression("consequent")] string consequentMessage = "", string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateOnlyAssertions : FluentAssertions.Primitives.DateOnlyAssertions<FluentAssertions.Primitives.DateOnlyAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1841,7 +1841,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, [System.Runtime.CompilerServices.CallerArgumentExpression("consequent")] string consequentMessage = "", string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateOnlyAssertions : FluentAssertions.Primitives.DateOnlyAssertions<FluentAssertions.Primitives.DateOnlyAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, [System.Runtime.CompilerServices.CallerArgumentExpression("implicator")] string implicatorMessage = "", string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, [System.Runtime.CompilerServices.CallerArgumentExpression("consequent")] string consequentMessage = "", string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, [System.Runtime.CompilerServices.CallerArgumentExpression("consequent")] string consequentMessage = "", string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, [System.Runtime.CompilerServices.CallerArgumentExpression("implicator")] string implicatorMessage = "", string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1816,6 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, [System.Runtime.CompilerServices.CallerArgumentExpression("implicator")] string implicatorMessage = "", string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, [System.Runtime.CompilerServices.CallerArgumentExpression("consequent")] string consequentMessage = "", string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, [System.Runtime.CompilerServices.CallerArgumentExpression("consequent")] string consequentMessage = "", string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, [System.Runtime.CompilerServices.CallerArgumentExpression("implicator")] string implicatorMessage = "", string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1816,6 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1767,7 +1767,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1767,7 +1767,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, [System.Runtime.CompilerServices.CallerArgumentExpression("implicator")] string implicatorMessage = "", string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, [System.Runtime.CompilerServices.CallerArgumentExpression("consequent")] string consequentMessage = "", string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1767,7 +1767,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, [System.Runtime.CompilerServices.CallerArgumentExpression("implicator")] string implicatorMessage = "", string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1767,6 +1767,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1767,7 +1767,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, [System.Runtime.CompilerServices.CallerArgumentExpression("consequent")] string consequentMessage = "", string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, [System.Runtime.CompilerServices.CallerArgumentExpression("implicator")] string implicatorMessage = "", string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, [System.Runtime.CompilerServices.CallerArgumentExpression("consequent")] string consequentMessage = "", string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, [System.Runtime.CompilerServices.CallerArgumentExpression("consequent")] string consequentMessage = "", string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool consequent, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1816,7 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
-        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool implicator, [System.Runtime.CompilerServices.CallerArgumentExpression("implicator")] string implicatorMessage = "", string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1816,6 +1816,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
+        public FluentAssertions.AndConstraint<TAssertions> Imply(bool expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -6,151 +6,198 @@ namespace FluentAssertions.Specs.Primitives;
 
 public class BooleanAssertionSpecs
 {
-    [Fact]
-    public void Should_succeed_when_asserting_boolean_value_true_is_true()
+    public class BeTrue
     {
-        // Arrange
-        bool boolean = true;
+        [Fact]
+        public void Should_succeed_when_asserting_boolean_value_true_is_true()
+        {
+            // Arrange
+            bool boolean = true;
 
-        // Act / Assert
-        boolean.Should().BeTrue();
+            // Act / Assert
+            boolean.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_boolean_value_false_is_true()
+        {
+            // Arrange
+            bool boolean = false;
+
+            // Act
+            Action action = () => boolean.Should().BeTrue();
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Should_fail_with_descriptive_message_when_asserting_boolean_value_false_is_true()
+        {
+            // Act
+            Action action = () =>
+                false.Should().BeTrue("because we want to test the failure {0}", "message");
+
+            // Assert
+            action
+                .Should().Throw<XunitException>()
+                .WithMessage("Expected boolean to be true because we want to test the failure message, but found False.");
+        }
     }
 
-    [Fact]
-    public void Should_fail_when_asserting_boolean_value_false_is_true()
+    public class BeFalse
     {
-        // Arrange
-        bool boolean = false;
+        [Fact]
+        public void Should_succeed_when_asserting_boolean_value_false_is_false()
+        {
+            // Act
+            Action action = () =>
+                false.Should().BeFalse();
 
-        // Act
-        Action action = () => boolean.Should().BeTrue();
+            // Assert
+            action.Should().NotThrow();
+        }
 
-        // Assert
-        action.Should().Throw<XunitException>();
+        [Fact]
+        public void Should_fail_when_asserting_boolean_value_true_is_false()
+        {
+            // Act
+            Action action = () =>
+                true.Should().BeFalse();
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Should_fail_with_descriptive_message_when_asserting_boolean_value_true_is_false()
+        {
+            // Act
+            Action action = () =>
+                true.Should().BeFalse("we want to test the failure {0}", "message");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected boolean to be false because we want to test the failure message, but found True.");
+        }
     }
 
-    [Fact]
-    public void Should_fail_with_descriptive_message_when_asserting_boolean_value_false_is_true()
+    public class Be
     {
-        // Act
-        Action action = () =>
-            false.Should().BeTrue("because we want to test the failure {0}", "message");
+        [Fact]
+        public void Should_succeed_when_asserting_boolean_value_to_be_equal_to_the_same_value()
+        {
+            // Act
+            Action action = () =>
+                false.Should().Be(false);
 
-        // Assert
-        action
-            .Should().Throw<XunitException>()
-            .WithMessage("Expected boolean to be true because we want to test the failure message, but found False.");
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_boolean_value_to_be_equal_to_a_different_value()
+        {
+            // Act
+            Action action = () =>
+                false.Should().Be(true);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Should_fail_with_descriptive_message_when_asserting_boolean_value_to_be_equal_to_a_different_value()
+        {
+            // Act
+            Action action = () =>
+                false.Should().Be(true, "because we want to test the failure {0}", "message");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("*Expected*boolean*True*because we want to test the failure message, but found False.*");
+        }
     }
 
-    [Fact]
-    public void Should_succeed_when_asserting_boolean_value_false_is_false()
+    public class NotBe
     {
-        // Act
-        Action action = () =>
-            false.Should().BeFalse();
+        [Fact]
+        public void Should_succeed_when_asserting_boolean_value_not_to_be_equal_to_the_same_value()
+        {
+            // Act
+            Action action = () =>
+                true.Should().NotBe(false);
 
-        // Assert
-        action.Should().NotThrow();
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_boolean_value_not_to_be_equal_to_a_different_value()
+        {
+            // Act
+            Action action = () =>
+                true.Should().NotBe(true);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Should_fail_with_descriptive_message_when_asserting_boolean_value_not_to_be_equal_to_a_different_value()
+        {
+            // Act
+            Action action = () =>
+                true.Should().NotBe(true, "because we want to test the failure {0}", "message");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("*Expected*boolean*True*because we want to test the failure message, but found True.*");
+        }
+
+        [Fact]
+        public void Should_throw_a_helpful_error_when_accidentally_using_equals()
+        {
+            // Act
+            Action action = () => true.Should().Equals(true);
+
+            // Assert
+            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+        }
     }
 
-    [Fact]
-    public void Should_fail_when_asserting_boolean_value_true_is_false()
+    public class Imply
     {
-        // Act
-        Action action = () =>
-            true.Should().BeFalse();
+        public static TheoryData<bool, bool> PassingImplications => new()
+        {
+            { false, false },
+            { false, true },
+            { true, true }
+        };
 
-        // Assert
-        action.Should().Throw<XunitException>();
-    }
+        public static TheoryData<bool, bool> NonPassingImplications => new()
+        {
+            { true, false }
+        };
 
-    [Fact]
-    public void Should_fail_with_descriptive_message_when_asserting_boolean_value_true_is_false()
-    {
-        // Act
-        Action action = () =>
-            true.Should().BeFalse("we want to test the failure {0}", "message");
+        [Theory]
+        [MemberData(nameof(PassingImplications), MemberType = typeof(BooleanAssertionSpecs.Imply))]
+        public void A_implies_B(bool a, bool b)
+        {
+            // Act / Assert
+            a.Should().Imply(b);
+        }
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("Expected boolean to be false because we want to test the failure message, but found True.");
-    }
+        [Theory]
+        [MemberData(nameof(NonPassingImplications), MemberType = typeof(BooleanAssertionSpecs.Imply))]
+        public void A_does_not_imply_B(bool a, bool b)
+        {
+            // Act
+            Action act = () => a.Should().Imply(b);
 
-    [Fact]
-    public void Should_succeed_when_asserting_boolean_value_to_be_equal_to_the_same_value()
-    {
-        // Act
-        Action action = () =>
-            false.Should().Be(false);
-
-        // Assert
-        action.Should().NotThrow();
-    }
-
-    [Fact]
-    public void Should_fail_when_asserting_boolean_value_to_be_equal_to_a_different_value()
-    {
-        // Act
-        Action action = () =>
-            false.Should().Be(true);
-
-        // Assert
-        action.Should().Throw<XunitException>();
-    }
-
-    [Fact]
-    public void Should_fail_with_descriptive_message_when_asserting_boolean_value_to_be_equal_to_a_different_value()
-    {
-        // Act
-        Action action = () =>
-            false.Should().Be(true, "because we want to test the failure {0}", "message");
-
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("*Expected*boolean*True*because we want to test the failure message, but found False.*");
-    }
-
-    [Fact]
-    public void Should_succeed_when_asserting_boolean_value_not_to_be_equal_to_the_same_value()
-    {
-        // Act
-        Action action = () =>
-            true.Should().NotBe(false);
-
-        // Assert
-        action.Should().NotThrow();
-    }
-
-    [Fact]
-    public void Should_fail_when_asserting_boolean_value_not_to_be_equal_to_a_different_value()
-    {
-        // Act
-        Action action = () =>
-            true.Should().NotBe(true);
-
-        // Assert
-        action.Should().Throw<XunitException>();
-    }
-
-    [Fact]
-    public void Should_fail_with_descriptive_message_when_asserting_boolean_value_not_to_be_equal_to_a_different_value()
-    {
-        // Act
-        Action action = () =>
-            true.Should().NotBe(true, "because we want to test the failure {0}", "message");
-
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("*Expected*boolean*True*because we want to test the failure message, but found True.*");
-    }
-
-    [Fact]
-    public void Should_throw_a_helpful_error_when_accidentally_using_equals()
-    {
-        // Act
-        Action action = () => true.Should().Equals(true);
-
-        // Assert
-        action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*to imply*but it did not*");
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -184,7 +184,7 @@ public class BooleanAssertionSpecs
 
         [Theory]
         [MemberData(nameof(PassingImplications), MemberType = typeof(BooleanAssertionSpecs.Imply))]
-        public void A_implies_B(bool? a, bool b)
+        public void Subject_implies_(bool? a, bool b)
         {
             // Act / Assert
             a.Should().Imply(b);
@@ -195,11 +195,11 @@ public class BooleanAssertionSpecs
         public void A_does_not_imply_B(bool? a, bool b)
         {
             // Act
-            Action act = () => a.Should().Imply(b);
+            Action act = () => a.Should().Imply(b, "because we want to test the {0}", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*to imply*but*");
+                .WithMessage("Expected*to imply*test the failure*but*");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -195,11 +195,11 @@ public class BooleanAssertionSpecs
         public void Subject_does_not_imply_implicator(bool? subject, bool implicator)
         {
             // Act
-            Action act = () => subject.Should().Imply(implicator, "because we want to test the {0}", "failure");
+            Action act = () => subject.Should().Imply(implicator, nameof(implicator), "because we want to test the {0}", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*to imply*test the failure*but*");
+                .WithMessage("Expected*to imply *implicator*test the failure*but*");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -183,23 +183,23 @@ public class BooleanAssertionSpecs
         };
 
         [Theory]
-        [MemberData(nameof(PassingImplications), MemberType = typeof(BooleanAssertionSpecs.Imply))]
-        public void Subject_implies_implicator(bool? subject, bool implicator)
+        [MemberData(nameof(PassingImplications))]
+        public void Subject_implies_implicator(bool? antecedent, bool consequent)
         {
             // Act / Assert
-            subject.Should().Imply(implicator);
+            antecedent.Should().Imply(consequent);
         }
 
         [Theory]
-        [MemberData(nameof(NonPassingImplications), MemberType = typeof(BooleanAssertionSpecs.Imply))]
-        public void Subject_does_not_imply_implicator(bool? subject, bool implicator)
+        [MemberData(nameof(NonPassingImplications))]
+        public void Subject_does_not_imply_implicator(bool? antecedent, bool consequent)
         {
             // Act
-            Action act = () => subject.Should().Imply(implicator, nameof(implicator), "because we want to test the {0}", "failure");
+            Action act = () => antecedent.Should().Imply(consequent, nameof(consequent), "because we want to test the {0}", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*to imply *implicator*test the failure*but*");
+                .WithMessage("Expected*to imply consequent*test the failure*but*");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -184,18 +184,18 @@ public class BooleanAssertionSpecs
 
         [Theory]
         [MemberData(nameof(PassingImplications), MemberType = typeof(BooleanAssertionSpecs.Imply))]
-        public void Subject_implies_(bool? a, bool b)
+        public void Subject_implies_implicator(bool? subject, bool implicator)
         {
             // Act / Assert
-            a.Should().Imply(b);
+            subject.Should().Imply(implicator);
         }
 
         [Theory]
         [MemberData(nameof(NonPassingImplications), MemberType = typeof(BooleanAssertionSpecs.Imply))]
-        public void A_does_not_imply_B(bool? a, bool b)
+        public void Subject_does_not_imply_implicator(bool? subject, bool implicator)
         {
             // Act
-            Action act = () => a.Should().Imply(b, "because we want to test the {0}", "failure");
+            Action act = () => subject.Should().Imply(implicator, "because we want to test the {0}", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -169,9 +169,9 @@ public class BooleanAssertionSpecs
     public class Imply
     {
         [Theory]
-        [InlineData(false, false )]
-        [InlineData(false, true )]
-        [InlineData(true, true )]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
         public void Antecedent_implies_consequent(bool? antecedent, bool consequent)
         {
             // Act / Assert

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -168,21 +168,23 @@ public class BooleanAssertionSpecs
 
     public class Imply
     {
-        public static TheoryData<bool, bool> PassingImplications => new()
+        public static TheoryData<bool?, bool> PassingImplications => new()
         {
             { false, false },
             { false, true },
             { true, true }
         };
 
-        public static TheoryData<bool, bool> NonPassingImplications => new()
+        public static TheoryData<bool?, bool> NonPassingImplications => new()
         {
+            { null, true },
+            { null, false },
             { true, false }
         };
 
         [Theory]
         [MemberData(nameof(PassingImplications), MemberType = typeof(BooleanAssertionSpecs.Imply))]
-        public void A_implies_B(bool a, bool b)
+        public void A_implies_B(bool? a, bool b)
         {
             // Act / Assert
             a.Should().Imply(b);
@@ -190,14 +192,14 @@ public class BooleanAssertionSpecs
 
         [Theory]
         [MemberData(nameof(NonPassingImplications), MemberType = typeof(BooleanAssertionSpecs.Imply))]
-        public void A_does_not_imply_B(bool a, bool b)
+        public void A_does_not_imply_B(bool? a, bool b)
         {
             // Act
             Action act = () => a.Should().Imply(b);
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*to imply*but it did not*");
+                .WithMessage("Expected*to imply*but*");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -168,22 +168,10 @@ public class BooleanAssertionSpecs
 
     public class Imply
     {
-        public static TheoryData<bool?, bool> PassingImplications => new()
-        {
-            { false, false },
-            { false, true },
-            { true, true }
-        };
-
-        public static TheoryData<bool?, bool> NonPassingImplications => new()
-        {
-            { null, true },
-            { null, false },
-            { true, false }
-        };
-
         [Theory]
-        [MemberData(nameof(PassingImplications))]
+        [InlineData(false, false )]
+        [InlineData(false, true )]
+        [InlineData(true, true )]
         public void Antecedent_implies_consequent(bool? antecedent, bool consequent)
         {
             // Act / Assert
@@ -191,7 +179,9 @@ public class BooleanAssertionSpecs
         }
 
         [Theory]
-        [MemberData(nameof(NonPassingImplications))]
+        [InlineData(null, true)]
+        [InlineData(null, false)]
+        [InlineData(true, false)]
         public void Antecedent_does_not_imply_consequent(bool? antecedent, bool consequent)
         {
             // Act

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -195,11 +195,11 @@ public class BooleanAssertionSpecs
         public void Subject_does_not_imply_implicator(bool? antecedent, bool consequent)
         {
             // Act
-            Action act = () => antecedent.Should().Imply(consequent, nameof(consequent), "because we want to test the {0}", "failure");
+            Action act = () => antecedent.Should().Imply(consequent, "because we want to test the {0}", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*to imply consequent*test the failure*but*");
+                .WithMessage("Expected antecedent*to imply consequent*test the failure*but*");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -184,7 +184,7 @@ public class BooleanAssertionSpecs
 
         [Theory]
         [MemberData(nameof(PassingImplications))]
-        public void Subject_implies_implicator(bool? antecedent, bool consequent)
+        public void Antecedent_implies_consequent(bool? antecedent, bool consequent)
         {
             // Act / Assert
             antecedent.Should().Imply(consequent);
@@ -192,7 +192,7 @@ public class BooleanAssertionSpecs
 
         [Theory]
         [MemberData(nameof(NonPassingImplications))]
-        public void Subject_does_not_imply_implicator(bool? antecedent, bool consequent)
+        public void Antecedent_does_not_imply_consequent(bool? antecedent, bool consequent)
         {
             // Act
             Action act = () => antecedent.Should().Imply(consequent, "because we want to test the {0}", "failure");

--- a/docs/_pages/booleans.md
+++ b/docs/_pages/booleans.md
@@ -23,3 +23,9 @@ Obviously the above assertions also work for nullable booleans, but if you reall
 theBoolean.Should().NotBeFalse();
 theBoolean.Should().NotBeTrue();
 ```
+
+Implication: see [here](https://mathworld.wolfram.com/Implies.html)
+```csharp
+bool anotherBoolean = true;
+theBoolean.Should().Imply(anotherBoolean);
+```

--- a/docs/_pages/booleans.md
+++ b/docs/_pages/booleans.md
@@ -35,3 +35,5 @@ Passing a custom caller argument expression is beneficial for this assertion to 
 bool anotherBoolean = true;
 theBoolean.Should().Imply(anotherBoolean, nameof(anotherBoolean));
 ```
+
+If you want to use the `because` / `becauseArgs` construct, it is **necessary** to use the caller argument expression, because this would lead to unexpected failure messages, when omitted!

--- a/docs/_pages/booleans.md
+++ b/docs/_pages/booleans.md
@@ -29,11 +29,3 @@ Implication: see [here](https://mathworld.wolfram.com/Implies.html)
 bool anotherBoolean = true;
 theBoolean.Should().Imply(anotherBoolean);
 ```
-
-Passing a custom caller argument expression is beneficial for this assertion to get the second parameter name in the failure message
-```csharp
-bool anotherBoolean = true;
-theBoolean.Should().Imply(anotherBoolean, nameof(anotherBoolean));
-```
-
-If you want to use the `because` / `becauseArgs` construct, it is **necessary** to use the caller argument expression, because this would lead to unexpected failure messages, when omitted!

--- a/docs/_pages/booleans.md
+++ b/docs/_pages/booleans.md
@@ -29,3 +29,9 @@ Implication: see [here](https://mathworld.wolfram.com/Implies.html)
 bool anotherBoolean = true;
 theBoolean.Should().Imply(anotherBoolean);
 ```
+
+Passing a custom caller argument expression is beneficial for this assertion to get the second parameter name in the failure message
+```csharp
+bool anotherBoolean = true;
+theBoolean.Should().Imply(anotherBoolean, nameof(anotherBoolean));
+```

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,6 +10,7 @@ sidebar:
 ## Unreleased
 
 ### What's new
+* Added `Imply` method to `BooleanAssertions` - [#2074](https://github.com/fluentassertions/fluentassertions/pull/2074)
 * Added `ThatAre[Not]Interfaces` method for filtering the types - [#2057](https://github.com/fluentassertions/fluentassertions/pull/2057)
 * Added `ThatAre[Not]Abstract` method for filtering the types - [#2058](https://github.com/fluentassertions/fluentassertions/pull/2058)
 * Added `ThatAre[Not]Sealed` method for filtering the types - [#2059](https://github.com/fluentassertions/fluentassertions/pull/2059)


### PR DESCRIPTION
Closes #1886 

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).