### PR TITLE
Order strings with ordinal comparison

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -395,7 +395,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<SubsequentOrderingAssertions<T>> BeInAscendingOrder<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs)
     {
-        return BeInAscendingOrder(propertyExpression, Comparer<TSelector>.Default, because, becauseArgs);
+        return BeInAscendingOrder(propertyExpression, GetComparer<TSelector>(), because, becauseArgs);
     }
 
     /// <summary>
@@ -467,7 +467,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// </remarks>
     public AndConstraint<SubsequentOrderingAssertions<T>> BeInAscendingOrder(string because = "", params object[] becauseArgs)
     {
-        return BeInAscendingOrder(Comparer<T>.Default, because, becauseArgs);
+        return BeInAscendingOrder(GetComparer<T>(), because, becauseArgs);
     }
 
     /// <summary>
@@ -512,7 +512,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs)
     {
-        return BeInDescendingOrder(propertyExpression, Comparer<TSelector>.Default, because, becauseArgs);
+        return BeInDescendingOrder(propertyExpression, GetComparer<TSelector>(), because, becauseArgs);
     }
 
     /// <summary>
@@ -584,7 +584,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// </remarks>
     public AndConstraint<SubsequentOrderingAssertions<T>> BeInDescendingOrder(string because = "", params object[] becauseArgs)
     {
-        return BeInDescendingOrder(Comparer<T>.Default, because, becauseArgs);
+        return BeInDescendingOrder(GetComparer<T>(), because, becauseArgs);
     }
 
     /// <summary>
@@ -1788,7 +1788,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs)
     {
-        return NotBeInAscendingOrder(propertyExpression, Comparer<TSelector>.Default, because, becauseArgs);
+        return NotBeInAscendingOrder(propertyExpression, GetComparer<TSelector>(), because, becauseArgs);
     }
 
     /// <summary>
@@ -1860,7 +1860,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// </remarks>
     public AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs)
     {
-        return NotBeInAscendingOrder(Comparer<T>.Default, because, becauseArgs);
+        return NotBeInAscendingOrder(GetComparer<T>(), because, becauseArgs);
     }
 
     /// <summary>
@@ -1904,7 +1904,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs)
     {
-        return NotBeInDescendingOrder(propertyExpression, Comparer<TSelector>.Default, because, becauseArgs);
+        return NotBeInDescendingOrder(propertyExpression, GetComparer<TSelector>(), because, becauseArgs);
     }
 
     /// <summary>
@@ -1976,7 +1976,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// </remarks>
     public AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs)
     {
-        return NotBeInDescendingOrder(Comparer<T>.Default, because, becauseArgs);
+        return NotBeInDescendingOrder(GetComparer<T>(), because, becauseArgs);
     }
 
     /// <summary>
@@ -3480,4 +3480,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
 
         return expectedItems.Count;
     }
+
+    private protected static IComparer<TItem> GetComparer<TItem>() =>
+        typeof(TItem) == typeof(string) ? (IComparer<TItem>)(object)StringComparer.Ordinal : Comparer<TItem>.Default;
 }

--- a/Src/FluentAssertions/Collections/SubsequentOrderingAssertions.cs
+++ b/Src/FluentAssertions/Collections/SubsequentOrderingAssertions.cs
@@ -63,7 +63,7 @@ public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAsse
     public AndConstraint<SubsequentOrderingAssertions<T>> ThenBeInAscendingOrder<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs)
     {
-        return ThenBeInAscendingOrder(propertyExpression, Comparer<TSelector>.Default, because, becauseArgs);
+        return ThenBeInAscendingOrder(propertyExpression, GetComparer<TSelector>(), because, becauseArgs);
     }
 
     /// <summary>
@@ -114,7 +114,7 @@ public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAsse
     public AndConstraint<SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs)
     {
-        return ThenBeInDescendingOrder(propertyExpression, Comparer<TSelector>.Default, because, becauseArgs);
+        return ThenBeInDescendingOrder(propertyExpression, GetComparer<TSelector>(), because, becauseArgs);
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -76,7 +76,7 @@ public class DefaultValueFormatter : IValueFormatter
         formattedGraph.AddLine("{");
 
         MemberInfo[] members = GetMembers(type);
-        using var iterator = new Iterator<MemberInfo>(members.OrderBy(mi => mi.Name));
+        using var iterator = new Iterator<MemberInfo>(members.OrderBy(mi => mi.Name, StringComparer.Ordinal));
         while (iterator.MoveNext())
         {
             WriteMemberValueTextFor(obj, iterator.Current, formattedGraph, formatChild);

--- a/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
@@ -333,6 +333,23 @@ public class StringComparisonSpecs
         subject.Should().MatchEquivalentOf(expected);
     }
 
+    [CulturedFact("en-US")]
+    public void Culture_is_ignored_when_sorting_strings()
+    {
+        using var _ = new AssertionScope();
+        new[] { "A", "a" }.Should().BeInAscendingOrder()
+            .And.BeInAscendingOrder(e => e)
+            .And.ThenBeInAscendingOrder(e => e)
+            .And.NotBeInDescendingOrder()
+            .And.NotBeInDescendingOrder(e => e);
+
+        new[] { "a", "A" }.Should().BeInDescendingOrder()
+            .And.BeInDescendingOrder(e => e)
+            .And.ThenBeInDescendingOrder(e => e)
+            .And.NotBeInAscendingOrder()
+            .And.NotBeInAscendingOrder(e => e);
+    }
+
     private const string LowerCaseI = "i";
     private const string UpperCaseI = "I";
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -22,6 +22,7 @@ sidebar:
 * Quering properties on classes, e.g. `typeof(MyClass).Properties()`, now also includes static properties - [#2054](https://github.com/fluentassertions/fluentassertions/pull/2054)
 * Nested AssertionScopes now print the inner scope reportables - [#2044](https://github.com/fluentassertions/fluentassertions/pull/2044)
 * Throw `ArgumentException` instead of `ArgumentNullException` when a required `string` argument is empty - [#2023](https://github.com/fluentassertions/fluentassertions/pull/2023)
+* Assertions on the ordering of a collection of `string`s now uses ordinal comparison when an `IComparer<T>` is not provided - [#2075](https://github.com/fluentassertions/fluentassertions/pull/2075)
 
 ## 6.8.0
 


### PR DESCRIPTION
`Comparer<string>.Default` returns a culture aware string comparer. This may cause tests to fail when executed under a different culture.