### PR TITLE
Improve performance of `IsTuple()`

### DIFF
--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -547,6 +547,9 @@ internal static class TypeExtensions
             return false;
         }
 
+#if !(NET47 || NETSTANDARD2_0)
+        return typeof(ITuple).IsAssignableFrom(type);
+#else
         Type openType = type.GetGenericTypeDefinition();
         return openType == typeof(ValueTuple<>)
                || openType == typeof(ValueTuple<,>)
@@ -564,6 +567,7 @@ internal static class TypeExtensions
                || openType == typeof(Tuple<,,,,,>)
                || openType == typeof(Tuple<,,,,,,>)
                || (openType == typeof(Tuple<,,,,,,,>) && IsTuple(type.GetGenericArguments()[7]));
+#endif
     }
 
     private static bool IsAnonymousType(this Type type)


### PR DESCRIPTION
net471/netcoreapp20/netstandard21 introduced the `ITuple` interface which all `Tuple` and `ValueTuple` types implement.

So for a modern TFM like net6 `IsTuple()` can be 3-5 times faster.

|  Method |              Runtime |      DataType |       Mean |     Error |    StdDev | Ratio | RatioSD |
|-------- |--------------------- |-------------- |-----------:|----------:|----------:|------:|--------:|
| develop |             .NET 6.0 |        `List<>` |  47.839 ns | 0.8258 ns | 0.7725 ns |  1.00 |    0.00 |
|      PR |             .NET 6.0 |        `List<>` |   9.802 ns | 0.1631 ns | 0.1525 ns |  0.20 |    0.00 |
|         |                      |               |            |           |           |       |         |
| develop | .NET Framework 4.7.2 |        `List<>` |  80.891 ns | 0.8988 ns | 0.8407 ns |  1.00 |    0.00 |
|      PR | .NET Framework 4.7.2 |        `List<>` |  80.430 ns | 0.6259 ns | 0.5855 ns |  0.99 |    0.01 |
|         |                      |               |            |           |           |       |         |
| develop |             .NET 6.0 |           `int` |   3.010 ns | 0.0505 ns | 0.0472 ns |  1.00 |    0.00 |
|      PR |             .NET 6.0 |           `int` |   2.050 ns | 0.0530 ns | 0.0496 ns |  0.68 |    0.02 |
|         |                      |               |            |           |           |       |         |
| develop | .NET Framework 4.7.2 |           `int` |   3.647 ns | 0.0616 ns | 0.0546 ns |  1.00 |    0.00 |
|      PR | .NET Framework 4.7.2 |           `int` |   3.384 ns | 0.0527 ns | 0.0493 ns |  0.93 |    0.02 |
|         |                      |               |            |           |           |       |         |
| develop |             .NET 6.0 | `Tuple<,,,,,,>` |  46.740 ns | 0.4925 ns | 0.4366 ns |  1.00 |    0.00 |
|      PR |             .NET 6.0 | `Tuple<,,,,,,>` |   9.503 ns | 0.0889 ns | 0.0788 ns |  0.20 |    0.00 |
|         |                      |               |            |           |           |       |         |
| develop | .NET Framework 4.7.2 | `Tuple<,,,,,,>` |  98.615 ns | 0.4232 ns | 0.3304 ns |  1.00 |    0.00 |
|      PR | .NET Framework 4.7.2 | `Tuple<,,,,,,>` |  99.058 ns | 0.8715 ns | 0.7726 ns |  1.00 |    0.01 |
|         |                      |               |            |           |           |       |         |
| develop |             .NET 6.0 |  `ValueTuple<>` |  26.587 ns | 0.4768 ns | 0.4460 ns |  1.00 |    0.00 |
|      PR |             .NET 6.0 |  `ValueTuple<>` |   9.522 ns | 0.1355 ns | 0.1268 ns |  0.36 |    0.01 |
|         |                      |               |            |           |           |       |         |
| develop | .NET Framework 4.7.2 |  `ValueTuple<>` |  92.137 ns | 1.4755 ns | 1.3080 ns |  1.00 |    0.00 |
|      PR | .NET Framework 4.7.2 |  `ValueTuple<>` |  91.266 ns | 0.3388 ns | 0.2645 ns |  0.99 |    0.01 |

<details>
<summary>benchmark code</summary>

```cs
using System;
using System.Collections.Generic;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Jobs;
using FluentAssertions.Common;

namespace Benchmarks;

[SimpleJob(RuntimeMoniker.Net472)]
[SimpleJob(RuntimeMoniker.Net60)]
public class IsTupleBenchmarks
{
    [Params(
        typeof(int),
        typeof(List<int>),

        typeof(ValueTuple<int>),
        typeof(Tuple<int, int, int, int, int, int, int>)
    )]
    public Type DataType { get; set; }

    [Benchmark(Baseline = true)]
    public bool IsTuple() => DataType.IsTuple();
}
```

</details>