### PR TITLE
Cleanups

### DIFF
--- a/Src/FluentAssertions/CallerIdentification/MultiLineCommentParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/MultiLineCommentParsingStrategy.cs
@@ -11,7 +11,7 @@ internal class MultiLineCommentParsingStrategy : IParsingStrategy
     {
         if (isCommentContext)
         {
-            var isEndOfMultilineComment = symbol == '/' && commentContextPreviousChar == '*';
+            var isEndOfMultilineComment = symbol is '/' && commentContextPreviousChar is '*';
             if (isEndOfMultilineComment)
             {
                 isCommentContext = false;
@@ -26,9 +26,9 @@ internal class MultiLineCommentParsingStrategy : IParsingStrategy
         }
 
         var isStartOfMultilineComment =
-            symbol == '*'
+            symbol is '*'
             && statement.Length > 0
-            && statement[^1] == '/';
+            && statement[^1] is '/';
         if (isStartOfMultilineComment)
         {
             statement.Remove(statement.Length - 1, 1);

--- a/Src/FluentAssertions/CallerIdentification/MultiLineCommentParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/MultiLineCommentParsingStrategy.cs
@@ -28,7 +28,7 @@ internal class MultiLineCommentParsingStrategy : IParsingStrategy
         var isStartOfMultilineComment =
             symbol == '*'
             && statement.Length > 0
-            && statement[statement.Length - 1] == '/';
+            && statement[^1] == '/';
         if (isStartOfMultilineComment)
         {
             statement.Remove(statement.Length - 1, 1);

--- a/Src/FluentAssertions/CallerIdentification/QuotesParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/QuotesParsingStrategy.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Text;
+﻿using System.Text;
 
 namespace FluentAssertions.CallerIdentification;
 
@@ -54,17 +53,7 @@ internal class QuotesParsingStrategy : IParsingStrategy
 
     private bool IsVerbatim(StringBuilder statement)
     {
-        return
-            statement.Length >= 1
-            &&
-                new[]
-                {
-                    "$@",
-                    "@$",
-                }
-                .Any(verbatimStringOpener =>
-                    previousChar == verbatimStringOpener[1]
-                    && statement[statement.Length - 1] == verbatimStringOpener[1]
-                    && statement[statement.Length - 2] == verbatimStringOpener[0]);
+        return (previousChar == '@' && statement.Length >= 2 && statement[^2] == '$' && statement[^1] == '@')
+            || (previousChar == '$' && statement.Length >= 2 && statement[^2] == '@' && statement[^1] == '$');
     }
 }

--- a/Src/FluentAssertions/CallerIdentification/QuotesParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/QuotesParsingStrategy.cs
@@ -10,7 +10,7 @@ internal class QuotesParsingStrategy : IParsingStrategy
 
     public ParsingState Parse(char symbol, StringBuilder statement)
     {
-        if (symbol == '"')
+        if (symbol is '"')
         {
             if (isQuoteContext)
             {
@@ -53,7 +53,7 @@ internal class QuotesParsingStrategy : IParsingStrategy
 
     private bool IsVerbatim(StringBuilder statement)
     {
-        return (previousChar == '@' && statement.Length >= 2 && statement[^2] == '$' && statement[^1] == '@')
-            || (previousChar == '$' && statement.Length >= 2 && statement[^2] == '@' && statement[^1] == '$');
+        return (previousChar is '@' && statement.Length >= 2 && statement[^2] is '$' && statement[^1] is '@')
+            || (previousChar is '$' && statement.Length >= 2 && statement[^2] is '@' && statement[^1] is '$');
     }
 }

--- a/Src/FluentAssertions/CallerIdentification/SemicolonParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/SemicolonParsingStrategy.cs
@@ -6,7 +6,7 @@ internal class SemicolonParsingStrategy : IParsingStrategy
 {
     public ParsingState Parse(char symbol, StringBuilder statement)
     {
-        if (symbol == ';')
+        if (symbol is ';')
         {
             statement.Clear();
             return ParsingState.Done;

--- a/Src/FluentAssertions/CallerIdentification/SingleLineCommentParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/SingleLineCommentParsingStrategy.cs
@@ -13,7 +13,7 @@ internal class SingleLineCommentParsingStrategy : IParsingStrategy
             return ParsingState.GoToNextSymbol;
         }
 
-        var doesSymbolStartComment = symbol == '/' && statement.Length > 0 && statement[^1] == '/';
+        var doesSymbolStartComment = symbol is '/' && statement.Length > 0 && statement[^1] is '/';
         if (!doesSymbolStartComment)
         {
             return ParsingState.InProgress;

--- a/Src/FluentAssertions/CallerIdentification/SingleLineCommentParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/SingleLineCommentParsingStrategy.cs
@@ -13,7 +13,7 @@ internal class SingleLineCommentParsingStrategy : IParsingStrategy
             return ParsingState.GoToNextSymbol;
         }
 
-        var doesSymbolStartComment = symbol == '/' && statement.Length > 0 && statement[statement.Length - 1] == '/';
+        var doesSymbolStartComment = symbol == '/' && statement.Length > 0 && statement[^1] == '/';
         if (!doesSymbolStartComment)
         {
             return ParsingState.InProgress;

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -71,7 +71,7 @@ public static class CallerIdentifier
         return caller;
     }
 
-    private class StackFrameReference : IDisposable
+    private sealed class StackFrameReference : IDisposable
     {
         public int SkipStackFrameCount { get; }
 

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -161,7 +161,7 @@ public static class CallerIdentifier
 
     private static bool IsCompilerServices(StackFrame frame)
     {
-        return frame.GetMethod()?.DeclaringType?.Namespace == "System.Runtime.CompilerServices";
+        return frame.GetMethod()?.DeclaringType?.Namespace is "System.Runtime.CompilerServices";
     }
 
     private static string ExtractVariableNameFrom(StackFrame frame)

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -3246,7 +3246,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     {
         string orderString = propertyExpression.GetMemberPath().ToString();
 
-        orderString = orderString == "\"\"" ? string.Empty : "by " + orderString;
+        orderString = orderString is "\"\"" ? string.Empty : "by " + orderString;
 
         return orderString;
     }

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -507,7 +507,7 @@ internal static class TypeExtensions
 
         bool IsGlobalNamespace() => @namespace is null;
         bool IsExactNamespace() => IsNamespacePrefix() && type.Namespace.Length == @namespace.Length;
-        bool IsParentNamespace() => IsNamespacePrefix() && type.Namespace[@namespace.Length] == '.';
+        bool IsParentNamespace() => IsNamespacePrefix() && type.Namespace[@namespace.Length] is '.';
         bool IsNamespacePrefix() => type.Namespace?.StartsWith(@namespace, StringComparison.Ordinal) == true;
     }
 
@@ -520,14 +520,14 @@ internal static class TypeExtensions
     public static MethodInfo GetExplicitConversionOperator(this Type type, Type sourceType, Type targetType)
     {
         return type
-            .GetConversionOperators(sourceType, targetType, name => name == "op_Explicit")
+            .GetConversionOperators(sourceType, targetType, name => name is "op_Explicit")
             .SingleOrDefault();
     }
 
     public static MethodInfo GetImplicitConversionOperator(this Type type, Type sourceType, Type targetType)
     {
         return type
-            .GetConversionOperators(sourceType, targetType, name => name == "op_Implicit")
+            .GetConversionOperators(sourceType, targetType, name => name is "op_Implicit")
             .SingleOrDefault();
     }
 

--- a/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -13,7 +13,7 @@ internal class MultiDimensionalArrayEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
     {
-        if (comparands.Expectation is not Array expectationAsArray || expectationAsArray?.Rank is 1)
+        if (comparands.Expectation is not Array expectationAsArray || expectationAsArray.Rank == 1)
         {
             return EquivalencyResult.ContinueWithNext;
         }

--- a/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -13,7 +13,7 @@ internal class MultiDimensionalArrayEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
     {
-        if (comparands.Expectation is not Array expectationAsArray || expectationAsArray?.Rank == 1)
+        if (comparands.Expectation is not Array expectationAsArray || expectationAsArray?.Rank is 1)
         {
             return EquivalencyResult.ContinueWithNext;
         }

--- a/Src/FluentAssertions/Equivalency/Ordering/CollectionMemberObjectInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/CollectionMemberObjectInfo.cs
@@ -7,11 +7,11 @@ internal class CollectionMemberObjectInfo : IObjectInfo
     public CollectionMemberObjectInfo(IObjectInfo context)
     {
         Path = GetAdjustedPropertyPath(context.Path);
-        
+
 #pragma warning disable CS0618
         Type = context.Type;
 #pragma warning restore CS0618
-        
+
         ParentType = context.ParentType;
         RuntimeType = context.RuntimeType;
         CompileTimeType = context.CompileTimeType;
@@ -23,7 +23,7 @@ internal class CollectionMemberObjectInfo : IObjectInfo
     }
 
     public Type Type { get; }
-    
+
     public Type ParentType { get; }
 
     public string Path { get; set; }

--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -57,7 +57,7 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
     /// <summary>
     /// Expression visitor which can detect whether the expression depends on parameters.
     /// </summary>
-    private class ParameterDetector : ExpressionVisitor
+    private sealed class ParameterDetector : ExpressionVisitor
     {
         public bool HasParameters { get; private set; }
 
@@ -77,7 +77,7 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
     /// <summary>
     /// Expression visitor which can replace constant sub-expressions with constant values.
     /// </summary>
-    private class ConstantSubExpressionReductionVisitor : ExpressionVisitor
+    private sealed class ConstantSubExpressionReductionVisitor : ExpressionVisitor
     {
         public override Expression Visit(Expression node)
         {
@@ -114,7 +114,7 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
     /// Expression visitor which can extract sub-expressions from an expression which has the following form:
     /// (SubExpression1) AND (SubExpression2) ... AND (SubExpressionN)
     /// </summary>
-    private class AndOperatorChainExtractor : ExpressionVisitor
+    private sealed class AndOperatorChainExtractor : ExpressionVisitor
     {
         public List<Expression> AndChain { get; } = new List<Expression>();
 

--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -10,7 +10,7 @@ namespace FluentAssertions.Formatting;
 /// </summary>
 public class PredicateLambdaExpressionValueFormatter : IValueFormatter
 {
-    public bool CanHandle(object value) => value is LambdaExpression lambdaExpression;
+    public bool CanHandle(object value) => value is LambdaExpression;
 
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {

--- a/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
@@ -140,7 +140,7 @@ public class ExtensibilitySpecs
 
     internal class ForeignKeyMatchingRule : IMemberMatchingRule
     {
-        public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions config)
+        public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions options)
         {
             string name = expectedMember.Name;
             if (name.EndsWith("Id", StringComparison.Ordinal))
@@ -191,7 +191,7 @@ public class ExtensibilitySpecs
 
     internal class StrictOrderingRule : IOrderingRule
     {
-        public OrderStrictness Evaluate(IObjectInfo memberInfo)
+        public OrderStrictness Evaluate(IObjectInfo objectInfo)
         {
             return OrderStrictness.Strict;
         }

--- a/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
@@ -626,7 +626,7 @@ public class ExtensibilitySpecs
     {
         public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
         {
-            if (comparands.Expectation is DateTime time)
+            if (comparands.Expectation is DateTime)
             {
                 throw new Exception("Failed");
             }


### PR DESCRIPTION
Various small cleanups.

PolySharp polyfills `Index` and `Range` for the net472 target.

Pattern matching vs (lifted) `==` is a complete minefield as they generate better/worse code in different cases.

[SharpLab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA+B6DACAvL7AdwEsA7AZwFgAocgFygFcw7sBlBsgcxoG8bsg7AAEAzNmAQIAG2wBRAI6MAhtPIAKYQEYADNnpQAlHgB8+hgH4AdABkYpLnQAWeAjoDcAoV8FZsTujoAB3IQLC5iZ0ZgK0gAWwwAEwg6Uhg6DCgIcmkAT1IMYnJyRhhyDCQAVh0ATi0fEXFJGWwABWVAmChSAFkOsCdNXXMjUxHrOwdnbCLsDxoAXxoaPwByItWiMipaBmZWAGEnZSg+BrEJKVlFFTV1AZOLbDBjXDMwV2xVgEFVz2ohNhzk0rm0OnQur1+oMHlAni8xh9Zj8/otltQ/AA5CDYAD6YGkMBOuK2pDSp12TBY2AAkqQ6GcAUILs1rkpVBoyHQnsRXmZiJ8tP9AcDLi12p1un06AN1FyeXyZjNyNghWjqDQgA===)

The reduced CC is either because:
* `if (comparands.Expectation is not Array expectationAsArray || expectationAsArray?.Rank == 1)` had a redundant null check.
  * The file is still 100% line and branch covered.
* `QuotesParsingStrategy.cs` has fewer lines of code, but coverage of that files remains unchanged.