### PR TITLE
Extend `ThatArePublicOrInternal` to also look at the setter of properties

### DIFF
--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -40,7 +40,7 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
     }
 
     /// <summary>
-    /// Only select the properties that have atleast one public or internal accessor
+    /// Only select the properties that have at least one public or internal accessor
     /// </summary>
     public PropertyInfoSelector ThatArePublicOrInternal
     {

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -48,8 +48,8 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
         {
             selectedProperties = selectedProperties.Where(property =>
             {
-                MethodInfo getter = property.GetGetMethod(nonPublic: true);
-                return (getter is not null) && (getter.IsPublic || getter.IsAssembly);
+                MethodInfo methodInfo = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
+                return (methodInfo is not null) && (methodInfo.IsPublic || methodInfo.IsAssembly);
             });
 
             return this;

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -40,7 +40,7 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
     }
 
     /// <summary>
-    /// Only select the properties that have a public or internal getter.
+    /// Only select the properties that have a public or internal getter and setter.
     /// </summary>
     public PropertyInfoSelector ThatArePublicOrInternal
     {

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -40,7 +40,7 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
     }
 
     /// <summary>
-    /// Only select the properties that have a public or internal getter and setter.
+    /// Only select the properties that have atleast one public or internal accessor
     /// </summary>
     public PropertyInfoSelector ThatArePublicOrInternal
     {
@@ -48,8 +48,8 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
         {
             selectedProperties = selectedProperties.Where(property =>
             {
-                MethodInfo methodInfo = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
-                return (methodInfo is not null) && (methodInfo.IsPublic || methodInfo.IsAssembly);
+                return property.GetGetMethod(nonPublic: true) is { IsPublic: true } or { IsAssembly: true }
+                    || property.GetSetMethod(nonPublic: true) is { IsPublic: true } or { IsAssembly: true };
             });
 
             return this;

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -381,6 +381,19 @@ public class PropertyInfoSelectorSpecs
         // Assert
         properties.Should().HaveCount(8);
     }
+
+    [Fact]
+    public void When_selecting_properties_with_atleast_one_accessor_being_private_should_return_the_applicable_properties()
+    {
+        // Arrange
+        Type type = typeof(TestClassForPropertyInfoSelectorWithOnePrivateAccessor);
+
+        // Act
+        IEnumerable<PropertyInfo> properties = type.Properties().ThatArePublicOrInternal.ToArray();
+
+        // Assert
+        properties.Should().HaveCount(4);
+    }
 }
 
 #region Internal classes used in unit tests
@@ -490,7 +503,18 @@ public class TestClassForPropertyInfoSelector
 
     public static string InternalStaticStringProperty { get; set; }
 
-    public int PublicIntProperty { init; get; }
+    public int PublicIntProperty { get; init; }
+}
+
+public class TestClassForPropertyInfoSelectorWithOnePrivateAccessor
+{
+    public bool PublicBoolPrivateGet { private get; set; }
+
+    public bool PublicBoolPrivateSet { get; private set; }
+
+    internal bool InternalBoolPrivateGet { private get;  set; }
+
+    internal bool InternalBoolPrivateSet { get; private set; }
 }
 
 #endregion

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -357,7 +357,7 @@ public class PropertyInfoSelectorSpecs
     }
 
     [Fact]
-    public void When_selecting_propeties_with_only_set_accessors_it_should_return_the_applicable_properties()
+    public void When_selecting_properties_with_only_set_accessors_it_should_return_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertyInfoSelector);
@@ -370,7 +370,7 @@ public class PropertyInfoSelectorSpecs
     }
 
     [Fact]
-    public void When_selecting_propeties_with_different_accessors_from_an_abstract_class_should_return_the_applicable_properties()
+    public void When_selecting_properties_with_different_accessors_from_an_abstract_class_should_return_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertySelector);

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -357,7 +357,7 @@ public class PropertyInfoSelectorSpecs
     }
 
     [Fact]
-    public void When_selecting_properties_with_only_set_accessors_it_should_return_the_applicable_properties()
+    public void When_a_property_only_has_a_public_setter_it_should_be_included_in_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertyInfoSelector);

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -370,7 +370,7 @@ public class PropertyInfoSelectorSpecs
     }
 
     [Fact]
-    public void When_selecting_propeties_with_different_accessors_from_a_abstract_class_should_return_the_applicable_properties()
+    public void When_selecting_propeties_with_different_accessors_from_an_abstract_class_should_return_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertySelector);

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -355,6 +355,32 @@ public class PropertyInfoSelectorSpecs
                 , typeof(string), typeof(int), typeof(int), typeof(int), typeof(int)
             });
     }
+
+    [Fact]
+    public void When_selecting_propeties_with_only_set_accessors_it_should_return_the_applicable_properties()
+    {
+        // Arrange
+        Type type = typeof(TestClassForPropertyInfoSelector);
+
+        // Act
+        IEnumerable<PropertyInfo> properties = type.Properties().ThatArePublicOrInternal.ToArray();
+
+        // Assert
+        properties.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void When_selecting_propeties_with_different_accessors_from_a_abstract_class_should_return_the_applicable_properties()
+    {
+        // Arrange
+        Type type = typeof(TestClassForPropertySelector);
+
+        // Act
+        IEnumerable<PropertyInfo> properties = type.Properties().ThatArePublicOrInternal.ToArray();
+
+        // Assert
+        properties.Should().HaveCount(8);
+    }
 }
 
 #region Internal classes used in unit tests
@@ -454,6 +480,17 @@ public class DummyPropertyAttribute : Attribute
     }
 
     public string Value { get; private set; }
+}
+
+public class TestClassForPropertyInfoSelector
+{
+    private static string myPrivateStaticStringField;
+
+    public static string PublicStaticStringProperty { set => myPrivateStaticStringField = value; }
+
+    public static string InternalStaticStringProperty { get; set; }
+
+    public int PublicIntProperty { init; get; }
 }
 
 #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -20,7 +20,7 @@ sidebar:
 * Added new extension methods to be able to write `Exactly.Times(n)`, `AtLeast.Times(n)` and `AtMost.Times(n)` in a more fluent way - [#2047](https://github.com/fluentassertions/fluentassertions/pull/2047)
 
 ### Fixes
-* Fixed `ThatArePublicOrInternal` property of `PropertyInfoSelector` not including properties with set accessors - [#2084] (https://github.com/fluentassertions/fluentassertions/pull/2082)
+* `PropertyInfoSelector.ThatArePublicOrInternal` now takes the setter into account when determining if a property is `public` or `internal` - [#2082] (https://github.com/fluentassertions/fluentassertions/pull/2082)
 * Quering properties on classes, e.g. `typeof(MyClass).Properties()`, now also includes static properties - [#2054](https://github.com/fluentassertions/fluentassertions/pull/2054)
 * Nested AssertionScopes now print the inner scope reportables - [#2044](https://github.com/fluentassertions/fluentassertions/pull/2044)
 * Throw `ArgumentException` instead of `ArgumentNullException` when a required `string` argument is empty - [#2023](https://github.com/fluentassertions/fluentassertions/pull/2023)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -20,6 +20,7 @@ sidebar:
 * Added new extension methods to be able to write `Exactly.Times(n)`, `AtLeast.Times(n)` and `AtMost.Times(n)` in a more fluent way - [#2047](https://github.com/fluentassertions/fluentassertions/pull/2047)
 
 ### Fixes
+* Fixed `ThatArePublicOrInternal` property of `PropertyInfoSelector` not including properties with set accessors - [#2084] (https://github.com/fluentassertions/fluentassertions/pull/2082)
 * Quering properties on classes, e.g. `typeof(MyClass).Properties()`, now also includes static properties - [#2054](https://github.com/fluentassertions/fluentassertions/pull/2054)
 * Nested AssertionScopes now print the inner scope reportables - [#2044](https://github.com/fluentassertions/fluentassertions/pull/2044)
 * Throw `ArgumentException` instead of `ArgumentNullException` when a required `string` argument is empty - [#2023](https://github.com/fluentassertions/fluentassertions/pull/2023)


### PR DESCRIPTION
## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).