### PR TITLE
Add `ThatAre[Not]ValueTypes` method to `TypeSelector.cs`

### DIFF
--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -174,8 +174,7 @@ public class TypeSelector : IEnumerable<Type>
     /// </summary>
     public TypeSelector ThatAreValueTypes()
     {
-        types = types.Where(t => t.IsValueType)
-            .ToList();
+        types = types.Where(t => t.IsValueType).ToList();
         return this;
     }
 
@@ -184,8 +183,7 @@ public class TypeSelector : IEnumerable<Type>
     /// </summary>
     public TypeSelector ThatAreNotValueTypes()
     {
-        types = types.Where(t => !t.IsValueType)
-            .ToList();
+        types = types.Where(t => !t.IsValueType).ToList();
         return this;
     }
 

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -170,6 +170,26 @@ public class TypeSelector : IEnumerable<Type>
     }
 
     /// <summary>
+    /// Filters and returns the types that are value types
+    /// </summary>
+    public TypeSelector ThatAreValueTypes()
+    {
+        types = types.Where(t => t.IsValueType)
+            .ToList();
+        return this;
+    }
+
+    /// <summary>
+    /// Filters and returns the types that are not value types
+    /// </summary>
+    public TypeSelector ThatAreNotValueTypes()
+    {
+        types = types.Where(t => !t.IsValueType)
+            .ToList();
+        return this;
+    }
+
+    /// <summary>
     /// Determines whether the type is a class
     /// </summary>
     public TypeSelector ThatAreClasses()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2674,9 +2674,11 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatAreSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2804,9 +2804,11 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatAreSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -2676,9 +2676,11 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatAreSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -2676,9 +2676,11 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatAreSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2625,9 +2625,11 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatAreSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2676,9 +2676,11 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatAreSealed() { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -503,7 +503,7 @@ namespace FluentAssertions.Specs.Types
         public void When_selecting_types_that_are_value_types_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(InternalEnumValueType).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(InternalEnumValueType).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly)
@@ -519,7 +519,7 @@ namespace FluentAssertions.Specs.Types
         public void When_selecting_types_that_are_not_value_types_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(InternalEnumValueType).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(InternalEnumValueType).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly)

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -13,6 +13,7 @@ using Internal.Other.Test.Common;
 using Internal.SealedAndNotSealedClasses.Test;
 using Internal.StaticAndNonStaticClasses.Test;
 using Internal.UnwrapSelectorTestTypes.Test;
+using Internal.ValueTypesAndNotValueTypes.Test;
 using Xunit;
 using ISomeInterface = Internal.Main.Test.ISomeInterface;
 
@@ -499,6 +500,38 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
+        public void When_selecting_types_that_are_value_types_it_should_return_the_correct_types()
+        {
+            // Arrange
+            Assembly assembly = typeof(InternalEnumValueType).GetTypeInfo().Assembly;
+
+            // Act
+            IEnumerable<Type> types = AllTypes.From(assembly)
+                .ThatAreInNamespace("Internal.ValueTypesAndNotValueTypes.Test")
+                .ThatAreValueTypes();
+
+            // Assert
+            types.Should()
+                .HaveCount(3);
+        }
+
+        [Fact]
+        public void When_selecting_types_that_are_not_value_types_it_should_return_the_correct_types()
+        {
+            // Arrange
+            Assembly assembly = typeof(InternalEnumValueType).GetTypeInfo().Assembly;
+
+            // Act
+            IEnumerable<Type> types = AllTypes.From(assembly)
+                .ThatAreInNamespace("Internal.ValueTypesAndNotValueTypes.Test")
+                .ThatAreNotValueTypes();
+
+            // Assert
+            types.Should()
+                .HaveCount(3);
+        }
+
+        [Fact]
         public void When_selecting_types_that_are_abstract_classes_it_should_return_the_correct_types()
         {
             // Arrange
@@ -874,6 +907,33 @@ namespace Internal.SealedAndNotSealedClasses.Test
     }
 
     internal class NotSealedClass
+    {
+    }
+}
+
+namespace Internal.ValueTypesAndNotValueTypes.Test
+{
+    internal struct InternalStructValueType
+    {
+    }
+
+    internal record struct InternalRecordStructValueType
+    {
+    }
+
+    internal class InternalClassNotValueType
+    {
+    }
+
+    internal record class InternalRecordClass
+    {
+    }
+
+    internal enum InternalEnumValueType
+    {
+    }
+
+    internal interface InternalInterfaceNotValueType
     {
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,6 +10,7 @@ sidebar:
 ## Unreleased
 
 ### What's new
+* Added `ThatAre[Not]ValueTypes` method for filtering the types - [#2083](https://github.com/fluentassertions/fluentassertions/pull/2083)
 * Added `ThatAre[Not]Interfaces` method for filtering the types - [#2057](https://github.com/fluentassertions/fluentassertions/pull/2057)
 * Added `ThatAre[Not]Abstract` method for filtering the types - [#2058](https://github.com/fluentassertions/fluentassertions/pull/2058)
 * Added `ThatAre[Not]Sealed` method for filtering the types - [#2059](https://github.com/fluentassertions/fluentassertions/pull/2059)


### PR DESCRIPTION
## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).