### PR TITLE
Set process dotnet cli language to en-US

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -140,7 +140,6 @@ class Build : NukeBuild
 
             DotNetTest(s => s
                 .SetConfiguration("Debug")
-                .SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-us")
                 .EnableNoBuild()
                 .SetDataCollector("XPlat Code Coverage")
                 .SetResultsDirectory(TestResultsDirectory)
@@ -195,7 +194,6 @@ class Build : NukeBuild
 
             DotNetTest(s => s
                 .SetConfiguration("Debug")
-                .SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-us")
                 .EnableNoBuild()
                 .SetDataCollector("XPlat Code Coverage")
                 .SetResultsDirectory(TestResultsDirectory)

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -140,6 +140,7 @@ class Build : NukeBuild
 
             DotNetTest(s => s
                 .SetConfiguration("Debug")
+                .SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-us")
                 .EnableNoBuild()
                 .SetDataCollector("XPlat Code Coverage")
                 .SetResultsDirectory(TestResultsDirectory)
@@ -194,6 +195,7 @@ class Build : NukeBuild
 
             DotNetTest(s => s
                 .SetConfiguration("Debug")
+                .SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-us")
                 .EnableNoBuild()
                 .SetDataCollector("XPlat Code Coverage")
                 .SetResultsDirectory(TestResultsDirectory)

--- a/build.ps1
+++ b/build.ps1
@@ -25,6 +25,7 @@ $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
 $env:DOTNET_MULTILEVEL_LOOKUP = 0
 $env:DOTNET_ROLL_FORWARD = "Major"
 $env:NUKE_TELEMETRY_OPTOUT = 1
+$env:DOTNET_CLI_UI_LANGUAGE = "en-US"
 
 ###########################################################################
 # EXECUTION

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,7 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_MULTILEVEL_LOOKUP=0
 export DOTNET_ROLL_FORWARD="Major"
 export NUKE_TELEMETRY_OPTOUT=1
+export DOTNET_CLI_UI_LANGUAGE="en-US"
 
 ###########################################################################
 # EXECUTION


### PR DESCRIPTION
This ref. 
https://github.com/dotnet/sdk/issues/29543
https://github.com/dotnet/sdk/issues/28975
https://github.com/dotnet/sdk/issues/28975#issuecomment-1359645133

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

This is a workaround for users who running NUKE on the local dev device and having a different dotnet cli language than `en-US` and using the latest .NET7 sdk (at this time 7.0.101). Therefore the test steps are failing.

I don't know when the [pull request](https://github.com/dotnet/sdk/pull/29559) (which fixes the problem) is being merged.. Maybe this change here is not necessary, but I thought I give this hint according this bug.