### PR TITLE
Bump required .NET SDK to v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
           2.1.x
           3.1.x
           6.0.x
+          7.0.x
 
     - name: Run NUKE
       run: ./build.ps1
@@ -66,6 +67,7 @@ jobs:
           2.1.x
           3.1.x
           6.0.x
+          7.0.x
 
     - name: Run NUKE
       run: ./build.sh UnitTests

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See https://www.fluentassertions.com for [background information](https://fluent
 Originally authored by Dennis Doomen with Jonas Nyrup as the productive side-kick. Notable contributions were provided by Artur Krajewski, Lukas Grützmacher and David Omid.
 
 # How do I build this?
-Install Visual Studio 2022 17.0+ or JetBrains Rider 2021.3 as well as the Build Tools 2022 (including the Universal Windows Platform build tools). You will also need to have .NET Framework 4.7 SDK and .NET 6.0 SDK installed. Check [global.json](global.json) for the current minimum required version.
+Install Visual Studio 2022 17.0+ or JetBrains Rider 2021.3 as well as the Build Tools 2022 (including the Universal Windows Platform build tools). You will also need to have .NET Framework 4.7 SDK and .NET 7.0 SDK installed. Check [global.json](global.json) for the current minimum required version.
 
 # What are these Approval.Tests?
 This is a special set of tests that use the [Verify](https://github.com/VerifyTests/Verify) project to verify whether you've introduced any breaking changes in the public API of the library.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.400",
+        "version": "7.0.101",
         "rollForward": "latestMajor"
     }
 }


### PR DESCRIPTION
In #2076 I began using `nameof()` within an attribute which is technically a [C#11 feature](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/extended-nameof-scope), but seems to work as long as you use C#11 compatible SDK.