### PR TITLE
Split `Build.cs` into partial classes depending on use case

### DIFF
--- a/Build/Build.Documentation.cs
+++ b/Build/Build.Documentation.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using Nuke.Common;
+using Nuke.Common.Tooling;
+using static Serilog.Log;
+
+partial class Build
+{
+#if OS_WINDOWS
+    [PackageExecutable("Node.js.redist", "node.exe", Version = "16.17.1", Framework = "win-x64")]
+#elif OS_MAC
+    [PackageExecutable("Node.js.redist", "node", Version = "16.17.1", Framework = "osx-x64")]
+#else
+    [PackageExecutable("Node.js.redist", "node", Version = "16.17.1", Framework = "linux-x64")]
+#endif
+    Tool Node;
+
+    string YarnCli => ToolPathResolver.GetPackageExecutable("Yarn.MSBuild", "yarn.js", "1.22.19");
+
+    Target SpellCheck => _ => _
+        .OnlyWhenDynamic(() => RunAllTargets || HasDocumentationChanges)
+        .Executes(() =>
+        {
+            Node($"{YarnCli} install --silent", RootDirectory);
+            Node($"{YarnCli} --silent run cspell --no-summary", RootDirectory,
+                customLogger: (_, msg) => Error(msg));
+        });
+
+    bool HasDocumentationChanges =>
+        Changes.Any(x => x.StartsWith("docs"));
+}

--- a/Build/Build.Shared.cs
+++ b/Build/Build.Shared.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using LibGit2Sharp;
+using Nuke.Common;
+using Nuke.Common.Execution;
+using Nuke.Common.Git;
+using Nuke.Common.Tools.DotNet;
+
+[UnsetVisualStudioEnvironmentVariables]
+[DotNetVerbosityMapping]
+partial class Build : NukeBuild
+{
+    [Parameter("The target branch for the pull request")]
+    readonly string PullRequestBase;
+
+    [GitRepository]
+    readonly GitRepository GitRepository;
+
+    Repository Repository => new(GitRepository.LocalDirectory);
+    Tree TargetBranch => Repository.Branches[PullRequestBase].Tip.Tree;
+    Tree SourceBranch => Repository.Branches[Repository.Head.FriendlyName].Tip.Tree;
+
+    bool RunAllTargets => string.IsNullOrWhiteSpace(PullRequestBase);
+
+    string[] Changes =>
+        Repository.Diff
+            .Compare<TreeChanges>(TargetBranch, SourceBranch)
+            .Where(x => x.Exists)
+            .Select(x => x.Path)
+            .ToArray();
+
+    /* Support plugins are available for:
+       - JetBrains ReSharper        https://nuke.build/resharper
+       - JetBrains Rider            https://nuke.build/rider
+       - Microsoft VisualStudio     https://nuke.build/visualstudio
+       - Microsoft VSCode           https://nuke.build/vscode
+    */
+
+    public static int Main() => Execute<Build>(x => x.SpellCheck, x => x.Push);
+}


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome