### PR TITLE
Add process env variable `DOTNET_CLI_UI_LANGUAGE` also inside targets

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -132,6 +132,7 @@ class Build : NukeBuild
         {
             DotNetTest(s => s
                 .SetConfiguration("Release")
+                .SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
                 .EnableNoBuild()
                 .CombineWith(
                     cc => cc.SetProjectFile(Solution.Specs.Approval_Tests)));
@@ -165,6 +166,7 @@ class Build : NukeBuild
 
             DotNetTest(s => s
                 .SetConfiguration("Debug")
+                .SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
                 .EnableNoBuild()
                 .SetDataCollector("XPlat Code Coverage")
                 .SetResultsDirectory(TestResultsDirectory)
@@ -221,6 +223,7 @@ class Build : NukeBuild
 
             DotNetTest(s => s
                 .SetConfiguration("Debug")
+                .SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
                 .EnableNoBuild()
                 .SetDataCollector("XPlat Code Coverage")
                 .SetResultsDirectory(TestResultsDirectory)


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

As proposed in https://github.com/fluentassertions/fluentassertions/pull/2084#issuecomment-1370862201, also adding it to the specific test targets inside NUKE for IDE guys :D