### PR TITLE
Fix timeout check in WithResult extension

### DIFF
--- a/Src/FluentAssertions/AsyncAssertionsExtensions.cs
+++ b/Src/FluentAssertions/AsyncAssertionsExtensions.cs
@@ -18,6 +18,12 @@ public static class AsyncAssertionsExtensions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
+    /// <remarks>
+    /// Please note that this assertion cannot identify whether the previous assertion was successful or not.
+    /// In case it was not successful and it is running within an active <see cref="FluentAssertions.Execution.AssertionScope"/>
+    /// there is no current result to compare with.
+    /// So, this extension will compare with the default value.
+    /// </remarks>
     public static async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<T>, T>> WithResult<T>(
         this Task<AndWhichConstraint<GenericAsyncFunctionAssertions<T>, T>> task,
         T expected, string because = "", params object[] becauseArgs)

--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -51,13 +51,13 @@ public class GenericAsyncFunctionAssertions<TResult> : AsyncFunctionAssertions<T
             if (success)
             {
                 bool completesWithinTimeout = await CompletesWithinTimeoutAsync(task, remainingTime);
-                Execute.Assertion
-                    .ForCondition(completesWithinTimeout)
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
-            }
+                success = Execute.Assertion
+                .ForCondition(completesWithinTimeout)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
+        }
 
-            TResult result = task.IsCompleted ? task.Result : default;
+            TResult result = success ? task.Result : default;
             return new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>(this, result);
         }
 

--- a/Tests/FluentAssertions.Specs/FakeClock.cs
+++ b/Tests/FluentAssertions.Specs/FakeClock.cs
@@ -9,7 +9,7 @@ namespace FluentAssertions.Specs;
 /// Implementation of <see cref="IClock"/> for testing purposes only.
 /// </summary>
 /// <remarks>
-/// It allows you to control the "current" time.
+/// It allows you to control the "current" date and time for test purposes.
 /// </remarks>
 internal class FakeClock : IClock
 {
@@ -25,17 +25,26 @@ internal class FakeClock : IClock
 
     public ITimer StartTimer() => new TestTimer(() => elapsedTime);
 
+    /// <summary>
+    /// Advances the internal clock.
+    /// </summary>
     public void Delay(TimeSpan timeToDelay)
     {
         elapsedTime += timeToDelay;
     }
 
+    /// <summary>
+    /// Simulates the completion of the pending delay task.
+    /// </summary>
     public void Complete()
     {
         // the value is not relevant
         delayTask.SetResult(true);
     }
 
+    /// <summary>
+    /// Simulates the completion of the pending delay task after the internal clock has been advanced.
+    /// </summary>
     public void CompleteAfter(TimeSpan timeSpan)
     {
         Delay(timeSpan);

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's new
 
 ### Fixes
+* Fixed hanging of `CompleteWithinAsync` when used with `WithResult` and `AssertionScope` - [#2101](https://github.com/fluentassertions/fluentassertions/pull/2101)
 
 * `BeEquivalentTo` no longer crashes on fields hiding base-class fields - [#1990](https://github.com/fluentassertions/fluentassertions/pull/1990)
 


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).

Fixes #1969