### PR TITLE
Avoid exceptions when wrapping in `AssertionScope`

### DIFF
--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -674,13 +674,16 @@ public static class NumericAssertionsExtensions
     {
         Guard.ThrowIfArgumentIsNegative(precision);
 
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(parent.Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
-        var nonNullableAssertions = new SingleAssertions(parent.Subject.Value);
-        nonNullableAssertions.BeApproximately(expectedValue, precision, because, becauseArgs);
+        if (success)
+        {
+            var nonNullableAssertions = new SingleAssertions(parent.Subject.Value);
+            nonNullableAssertions.BeApproximately(expectedValue, precision, because, becauseArgs);
+        }
 
         return new AndConstraint<NullableNumericAssertions<float>>(parent);
     }
@@ -800,13 +803,16 @@ public static class NumericAssertionsExtensions
     {
         Guard.ThrowIfArgumentIsNegative(precision);
 
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(parent.Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
-        var nonNullableAssertions = new DoubleAssertions(parent.Subject.Value);
-        BeApproximately(nonNullableAssertions, expectedValue, precision, because, becauseArgs);
+        if (success)
+        {
+            var nonNullableAssertions = new DoubleAssertions(parent.Subject.Value);
+            BeApproximately(nonNullableAssertions, expectedValue, precision, because, becauseArgs);
+        }
 
         return new AndConstraint<NullableNumericAssertions<double>>(parent);
     }
@@ -926,13 +932,17 @@ public static class NumericAssertionsExtensions
     {
         Guard.ThrowIfArgumentIsNegative(precision);
 
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(parent.Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
-        var nonNullableAssertions = new DecimalAssertions(parent.Subject.Value);
-        BeApproximately(nonNullableAssertions, expectedValue, precision, because, becauseArgs);
+        if (success)
+        {
+            var nonNullableAssertions = new DecimalAssertions(parent.Subject.Value);
+            BeApproximately(nonNullableAssertions, expectedValue, precision, because, becauseArgs);
+        }
+
         return new AndConstraint<NullableNumericAssertions<decimal>>(parent);
     }
 

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -127,10 +127,15 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     {
         Type expectedType = typeof(TException);
 
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} to throw exactly {0}{reason}, but found <null>.", expectedType);
+
+        if (!success)
+        {
+            return new ExceptionAssertions<TException>(Array.Empty<TException>());
+        }
 
         Exception exception = await InvokeWithInterceptionAsync(Subject);
 
@@ -158,10 +163,15 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         params object[] becauseArgs)
         where TException : Exception
     {
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} to throw {0}{reason}, but found <null>.", typeof(TException));
+
+        if (!success)
+        {
+            return new ExceptionAssertions<TException>(Array.Empty<TException>());
+        }
 
         Exception exception = await InvokeWithInterceptionAsync(Subject);
         return ThrowInternal<TException>(exception, because, becauseArgs);
@@ -179,10 +189,15 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     /// </param>
     public async Task<AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs)
     {
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} not to throw{reason}, but found <null>.");
+
+        if (!success)
+        {
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
 
         try
         {
@@ -209,10 +224,15 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     public async Task<AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
         where TException : Exception
     {
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} not to throw{reason}, but found <null>.");
+
+        if (!success)
+        {
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
 
         try
         {
@@ -254,10 +274,15 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         Guard.ThrowIfArgumentIsNegative(waitTime);
         Guard.ThrowIfArgumentIsNegative(pollInterval);
 
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} not to throw any exceptions after {0}{reason}, but found <null>.", waitTime);
+
+        if (!success)
+        {
+            return Task.FromResult(new AndConstraint<TAssertions>((TAssertions)this));
+        }
 
         return AssertionTaskAsync();
 

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -38,10 +38,15 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
     public ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
         where TException : Exception
     {
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} to throw {0}{reason}, but found <null>.", typeof(TException));
+
+        if (!success)
+        {
+            return new ExceptionAssertions<TException>(Array.Empty<TException>());
+        }
 
         FailIfSubjectIsAsyncVoid();
         Exception exception = InvokeSubjectWithInterception();
@@ -61,10 +66,15 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
     public AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
         where TException : Exception
     {
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} not to throw {0}{reason}, but found <null>.", typeof(TException));
+
+        if (!success)
+        {
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
 
         FailIfSubjectIsAsyncVoid();
         Exception exception = InvokeSubjectWithInterception();
@@ -83,10 +93,15 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
     /// </param>
     public AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs)
     {
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} not to throw{reason}, but found <null>.");
+
+        if (!success)
+        {
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
 
         FailIfSubjectIsAsyncVoid();
         Exception exception = InvokeSubjectWithInterception();
@@ -113,10 +128,15 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
         params object[] becauseArgs)
         where TException : Exception
     {
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} to throw exactly {0}{reason}, but found <null>.", typeof(TException));
+
+        if (!success)
+        {
+            return new ExceptionAssertions<TException>(Array.Empty<TException>());
+        }
 
         FailIfSubjectIsAsyncVoid();
         Exception exception = InvokeSubjectWithInterception();
@@ -161,10 +181,15 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
         Guard.ThrowIfArgumentIsNegative(waitTime);
         Guard.ThrowIfArgumentIsNegative(pollInterval);
 
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} not to throw after {0}{reason}, but found <null>.", waitTime);
+
+        if (!success)
+        {
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
 
         FailIfSubjectIsAsyncVoid();
 

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -158,14 +158,15 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="waitTime"/> or <paramref name="pollInterval"/> are negative.</exception>
     public AndConstraint<TAssertions> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
     {
+        Guard.ThrowIfArgumentIsNegative(waitTime);
+        Guard.ThrowIfArgumentIsNegative(pollInterval);
+
         Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} not to throw after {0}{reason}, but found <null>.", waitTime);
 
         FailIfSubjectIsAsyncVoid();
-        Guard.ThrowIfArgumentIsNegative(waitTime);
-        Guard.ThrowIfArgumentIsNegative(pollInterval);
 
         TimeSpan? invocationEndTime = null;
         Exception exception = null;

--- a/Src/FluentAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Security;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
@@ -40,12 +41,18 @@ public class FunctionAssertions<T> : DelegateAssertions<Func<T>, FunctionAsserti
     /// </param>
     public new AndWhichConstraint<FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs)
     {
-        Execute.Assertion
+        bool success = Execute.Assertion
            .ForCondition(Subject is not null)
            .BecauseOf(because, becauseArgs)
            .FailWith("Expected {context} not to throw{reason}, but found <null>.");
 
-        T result = FunctionAssertionHelpers.NotThrow(Subject, because, becauseArgs);
+        T result = default;
+
+        if (success)
+        {
+            result = FunctionAssertionHelpers.NotThrow(Subject, because, becauseArgs);
+        }
+
         return new AndWhichConstraint<FunctionAssertions<T>, T>(this, result);
     }
 
@@ -74,12 +81,18 @@ public class FunctionAssertions<T> : DelegateAssertions<Func<T>, FunctionAsserti
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="waitTime"/> or <paramref name="pollInterval"/> are negative.</exception>
     public new AndWhichConstraint<FunctionAssertions<T>, T> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
     {
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} not to throw any exceptions after {0}{reason}, but found <null>.", waitTime);
 
-        T result = FunctionAssertionHelpers.NotThrowAfter(Subject, Clock, waitTime, pollInterval, because, becauseArgs);
+        T result = default;
+
+        if (success)
+        {
+            result = FunctionAssertionHelpers.NotThrowAfter(Subject, Clock, waitTime, pollInterval, because, becauseArgs);
+        }
+
         return new AndWhichConstraint<FunctionAssertions<T>, T>(this, result);
     }
 }

--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -79,10 +79,15 @@ public class GenericAsyncFunctionAssertions<TResult> : AsyncFunctionAssertions<T
     public new async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(
         string because = "", params object[] becauseArgs)
     {
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} not to throw{reason}, but found <null>.");
+
+        if (!success)
+        {
+            return new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>(this, default(TResult));
+        }
 
         try
         {
@@ -125,10 +130,16 @@ public class GenericAsyncFunctionAssertions<TResult> : AsyncFunctionAssertions<T
         Guard.ThrowIfArgumentIsNegative(waitTime);
         Guard.ThrowIfArgumentIsNegative(pollInterval);
 
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} not to throw any exceptions after {0}{reason}, but found <null>.", waitTime);
+
+        if (!success)
+        {
+            var result = new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>(this, default(TResult));
+            return Task.FromResult(result);
+        }
 
         return AssertionTaskAsync();
 

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 #if NETFRAMEWORK
 using FluentAssertions.Specs.Common;
@@ -33,12 +34,16 @@ public class AsyncFunctionExceptionAssertionSpecs
         Func<Task> action = null;
 
         // Act
-        Func<Task> testAction = () => action.Should().ThrowAsync<ArgumentException>(
-            "because we want to test the failure {0}", "message");
+        Func<Task> testAction = async () =>
+        {
+            using var _ = new AssertionScope();
+            await action.Should().ThrowAsync<ArgumentException>("because we want to test the failure {0}", "message");
+        };
 
         // Assert
         await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
     [Fact]
@@ -48,12 +53,16 @@ public class AsyncFunctionExceptionAssertionSpecs
         Func<Task> action = null;
 
         // Act
-        Func<Task> testAction = () => action.Should().NotThrowAsync<ArgumentException>(
-            "because we want to test the failure {0}", "message");
+        Func<Task> testAction = async () =>
+        {
+            using var _ = new AssertionScope();
+            await action.Should().NotThrowAsync<ArgumentException>("because we want to test the failure {0}", "message");
+        };
 
         // Assert
         await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
     [Fact]
@@ -63,12 +72,16 @@ public class AsyncFunctionExceptionAssertionSpecs
         Func<Task> action = null;
 
         // Act
-        Func<Task> testAction = () => action.Should().NotThrowAsync(
-            "because we want to test the failure {0}", "message");
+        Func<Task> testAction = async () =>
+        {
+            using var _ = new AssertionScope();
+            await action.Should().NotThrowAsync("because we want to test the failure {0}", "message");
+        };
 
         // Assert
         await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
     [Fact]
@@ -568,12 +581,16 @@ public class AsyncFunctionExceptionAssertionSpecs
         Func<Task> action = null;
 
         // Act
-        Func<Task> testAction = () => action.Should().ThrowExactlyAsync<ArgumentException>(
-            "because we want to test the failure {0}", "message");
+        Func<Task> testAction = async () =>
+        {
+            using var _ = new AssertionScope();
+            await action.Should().ThrowExactlyAsync<ArgumentException>("because we want to test the failure {0}", "message");
+        };
 
         // Assert
         await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
     [Fact]
@@ -1130,12 +1147,17 @@ public class AsyncFunctionExceptionAssertionSpecs
         Func<Task> action = null;
 
         // Act
-        Func<Task> testAction = () => action.Should().NotThrowAfterAsync(
-            waitTime, pollInterval, "because we want to test the failure {0}", "message");
+        Func<Task> testAction = async () =>
+        {
+            using var _ = new AssertionScope();
+            await action.Should().NotThrowAfterAsync(waitTime, pollInterval,
+                "because we want to test the failure {0}", "message");
+        };
 
         // Assert
         await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
@@ -20,11 +20,16 @@ public class FunctionExceptionAssertionSpecs
         Func<int> action = null;
 
         // Act
-        Action testAction = () => action.Should().NotThrow("because we want to test the failure {0}", "message");
+        Action testAction = () =>
+        {
+            using var _ = new AssertionScope();
+            action.Should().NotThrow("because we want to test the failure {0}", "message");
+        };
 
         // Assert
         testAction.Should().Throw<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
     [Fact]
@@ -138,12 +143,16 @@ public class FunctionExceptionAssertionSpecs
         Func<int> act = null;
 
         // Act
-        Action action = () => act.Should().Throw<ArgumentNullException>(
-            "because we want to test the failure {0}", "message");
+        Action action = () =>
+        {
+            using var _ = new AssertionScope();
+            act.Should().Throw<ArgumentNullException>("because we want to test the failure {0}", "message");
+        };
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
     [Fact]
@@ -258,12 +267,16 @@ public class FunctionExceptionAssertionSpecs
         Func<int> act = null;
 
         // Act
-        Action action = () => act.Should().ThrowExactly<ArgumentNullException>(
-            "because we want to test the failure {0}", "message");
+        Action action = () =>
+        {
+            using var _ = new AssertionScope();
+            act.Should().ThrowExactly<ArgumentNullException>("because we want to test the failure {0}", "message");
+        };
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
     [Fact]
@@ -356,12 +369,16 @@ public class FunctionExceptionAssertionSpecs
         Func<int> act = null;
 
         // Act
-        Action action = () => act.Should().NotThrow<ArgumentNullException>(
-            "because we want to test the failure {0}", "message");
+        Action action = () =>
+        {
+            using var _ = new AssertionScope();
+            act.Should().NotThrow<ArgumentNullException>("because we want to test the failure {0}", "message");
+        };
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
     [Fact]
@@ -450,12 +467,16 @@ public class FunctionExceptionAssertionSpecs
         Func<int> action = null;
 
         // Act
-        Action testAction = () => action.Should().NotThrowAfter(
-            waitTime, pollInterval, "because we want to test the failure {0}", "message");
+        Action testAction = () =>
+        {
+            using var _ = new AssertionScope();
+            action.Should().NotThrowAfter(waitTime, pollInterval, "because we want to test the failure {0}", "message");
+        };
 
         // Assert
         testAction.Should().Throw<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Exceptions/NotThrowSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/NotThrowSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using FluentAssertions.Execution;
 #if NETFRAMEWORK
 using FluentAssertions.Specs.Common;
 #endif
@@ -20,11 +21,16 @@ public class NotThrowSpecs
         Action act = null;
 
         // Act
-        Action action = () => act.Should().NotThrow("because we want to test the failure {0}", "message");
+        Action action = () =>
+        {
+            using var _ = new AssertionScope();
+            act.Should().NotThrow("because we want to test the failure {0}", "message");
+        };
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
     [Fact]
@@ -97,12 +103,17 @@ public class NotThrowSpecs
         Action act = null;
 
         // Act
-        Action action = () => act.Should().NotThrowAfter(0.Milliseconds(), 0.Milliseconds(),
-            "because we want to test the failure {0}", "message");
+        Action action = () =>
+        {
+            using var _ = new AssertionScope();
+            act.Should().NotThrowAfter(0.Milliseconds(), 0.Milliseconds(),
+                "because we want to test the failure {0}", "message");
+        };
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*");
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
 #pragma warning disable CS1998

--- a/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.cs
@@ -1,4 +1,5 @@
 using System;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -838,7 +839,11 @@ public class NullableNumericAssertionSpecs
             double? value = null;
 
             // Act
-            Action act = () => value.Should().BeApproximately(3.14, 0.001);
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                value.Should().BeApproximately(3.14, 0.001);
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -989,6 +994,24 @@ public class NullableNumericAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected value to approximate <null> +/- 0.1F, but it was 12F.");
+        }
+
+        [Fact]
+        public void When_nullable_float_has_no_value_it_should_throw()
+        {
+            // Arrange
+            float? value = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                value.Should().BeApproximately(3.14F, 0.001F);
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected value to approximate 3.14F +/- 0.001F, but it was <null>.");
         }
 
         [Fact]
@@ -1145,7 +1168,11 @@ public class NullableNumericAssertionSpecs
             decimal? value = null;
 
             // Act
-            Action act = () => value.Should().BeApproximately(3.14m, 0.001m);
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                value.Should().BeApproximately(3.14m, 0.001m);
+            };
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -201,12 +201,16 @@ public static class TaskOfTAssertionSpecs
             Func<Task<int>> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().NotThrowAsync(
-                "because we want to test the failure {0}", "message");
+            Func<Task> testAction = async () =>
+            {
+                using var _ = new AssertionScope();
+                await action.Should().NotThrowAsync("because we want to test the failure {0}", "message");
+            };
 
             // Assert
             await testAction.Should().ThrowAsync<XunitException>()
-                .WithMessage("*because we want to test the failure message*found <null>*");
+                .WithMessage("*because we want to test the failure message*found <null>*")
+                .Where(e => !e.Message.Contains("NullReferenceException"));
         }
 
         [Fact]
@@ -307,12 +311,17 @@ public static class TaskOfTAssertionSpecs
             Func<Task<int>> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().NotThrowAfterAsync(
-                waitTime, pollInterval, "because we want to test the failure {0}", "message");
+            Func<Task> testAction = async () =>
+            {
+                using var _ = new AssertionScope();
+                await action.Should().NotThrowAfterAsync(waitTime, pollInterval,
+                    "because we want to test the failure {0}", "message");
+            };
 
             // Assert
             await testAction.Should().ThrowAsync<XunitException>()
-                .WithMessage("*because we want to test the failure message*found <null>*");
+                .WithMessage("*because we want to test the failure message*found <null>*")
+                .Where(e => !e.Message.Contains("NullReferenceException"));
         }
 
         [Fact]


### PR DESCRIPTION
## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

#2101 inspired me to look for some more places, where we would continue assertion despite `Subject` being null, which would throw a `NullReferenceException` or `InvalidOperationException`.