### PR TITLE
Add fancy `ReportSummary`

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -13,6 +13,8 @@ using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.GitVersion;
 using Nuke.Common.Tools.ReportGenerator;
 using Nuke.Common.Tools.Xunit;
+using Nuke.Common.Utilities.Collections;
+using Nuke.Components;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.IO.PathConstruction;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
@@ -115,6 +117,10 @@ class Build : NukeBuild
         .OnlyWhenDynamic(() => RunAllTargets || HasSourceChanges)
         .Executes(() =>
         {
+            ReportSummary(s => s
+                .WhenNotNull(GitVersion,(_, o) => _
+                    .AddPair("Version", o.SemVer)));
+
             DotNetBuild(s => s
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration.CI)
@@ -258,6 +264,10 @@ class Build : NukeBuild
         .OnlyWhenDynamic(() => RunAllTargets || HasSourceChanges)
         .Executes(() =>
         {
+            ReportSummary(s => s
+                .WhenNotNull(SemVer,(_, semVer) => _
+                    .AddPair("Packed version", semVer)));
+
             DotNetPack(s => s
                 .SetProject(Solution.Core.FluentAssertions)
                 .SetOutputDirectory(ArtifactsDirectory)

--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -24,6 +24,7 @@
     <PackageDownload Include="Node.js.redist" Version="[16.17.1]" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
     <PackageReference Include="Nuke.Common" Version="6.3.0" />
+    <PackageReference Include="Nuke.Components" Version="6.3.0" />
     <PackageDownload Include="Yarn.MSBuild" Version="[1.22.19]" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Heavily inspired from the NUKE build pipeline

After checking something in the action outputs, I noticed this cool summary :)

If desired, I will add a summary to the tests as well ;-)

Looks like this now:

<img width="788" alt="image" src="https://user-images.githubusercontent.com/49762557/213882492-910621e5-ac33-4e2f-8d05-a6d48175384c.png">


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome