### PR TITLE
Minor tweaks to the .editorconfig and reformatted the entire code base

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
+root = true
 # EditorConfig is awesome: http://EditorConfig.org
 
 # top-most EditorConfig file
-root = true
 
 # Global settings
 [*]
@@ -266,12 +266,38 @@ dotnet_diagnostic.AV2305.severity = none
 # AV2407: Region should be removed
 dotnet_diagnostic.AV2407.severity = none
 
-# ReSharper/Rider
 # Convert lambda expression to method group
 resharper_convert_closure_to_method_group_highlighting = none
 
+# Start each element in a object or collection initializer on a new line
 resharper_wrap_object_and_collection_initializer_style = chop_always
 
+# Force an empty line
 resharper_blank_lines_after_multiline_statements = 1
 
-resharper_keep_existing_initializer_arrangement = false
+# Don't remove existing line breaks
+resharper_keep_existing_initializer_arrangement = true
+resharper_keep_existing_arrangement = true
+
+# We care about that extra else after an else-if
+resharper_redundant_if_else_block_highlighting = none
+
+# Don't remove explicit default cases in switch statements 
+resharper_redundant_empty_switch_section_highlighting = none
+
+resharper_align_multiline_binary_expressions_chain = false
+
+# Only use new() when the type is obvious
+resharper_object_creation_when_type_not_evident = explicitly_typed
+resharper_object_creation_when_type_evident = target_typed
+
+# Indent 4 spaces per necessary indention
+resharper_continuous_indent_multiplier = 1
+
+# Avoid breaking a generic definition
+resharper_wrap_before_extends_colon = true
+
+resharper_blank_lines_before_multiline_statements = 1
+
+resharper_parentheses_non_obvious_operations = arithmetic, multiplicative, equality, relational, additive
+resharper_parentheses_redundancy_style = remove_if_not_clarifies_precedence

--- a/FluentAssertions.sln.DotSettings
+++ b/FluentAssertions.sln.DotSettings
@@ -6,62 +6,80 @@
 	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/IdentifierHighlightingEnabled/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StyleCop_002ESA1101/@EntryIndexedValue">DO_NOT_SHOW</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=Safe_0020Cleanup/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="Safe Cleanup"&gt;&lt;CSArrangeThisQualifier&gt;True&lt;/CSArrangeThisQualifier&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;/CSOptimizeUsings&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSCodeStyleAttributes ArrangeTypeAccessModifier="True" ArrangeTypeMemberAccessModifier="True" SortModifiers="True" RemoveRedundantParentheses="True" AddMissingParentheses="True" ArrangeBraces="True" ArrangeAttributes="True" ArrangeObjectCreation="True" ArrangeDefaultValue="True" ArrangeNamespaces="True" /&gt;&lt;CSMakeAutoPropertyGetOnly&gt;True&lt;/CSMakeAutoPropertyGetOnly&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;IDEA_SETTINGS&gt;&amp;lt;profile version="1.0"&amp;gt;&#xD;
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=Safe_0020Cleanup/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="Safe Cleanup"&gt;&lt;CSArrangeThisQualifier&gt;True&lt;/CSArrangeThisQualifier&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;/CSOptimizeUsings&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSCodeStyleAttributes ArrangeTypeAccessModifier="True" ArrangeTypeMemberAccessModifier="True" SortModifiers="True" AddMissingParentheses="True" ArrangeBraces="True" ArrangeAttributes="True" ArrangeObjectCreation="True" ArrangeDefaultValue="True" ArrangeNamespaces="True" RemoveRedundantParentheses="True" /&gt;&lt;CSMakeAutoPropertyGetOnly&gt;True&lt;/CSMakeAutoPropertyGetOnly&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;IDEA_SETTINGS&gt;&amp;lt;profile version="1.0"&amp;gt;&#xD;
   &amp;lt;option name="myName" value="Safe Cleanup" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="ES6ShorthandObjectProperty" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="JSArrowFunctionBracesCanBeRemoved" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="JSPrimitiveTypeWrapperUsage" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="JSRemoveUnnecessaryParentheses" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="JSUnnecessarySemicolon" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="TypeScriptExplicitMemberType" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="UnnecessaryContinueJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="UnnecessaryLabelJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="UnnecessaryLabelOnBreakStatementJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="UnnecessaryLabelOnContinueStatementJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="UnnecessaryReturnJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="WrongPropertyKeyValueDelimiter" enabled="false" level="WEAK WARNING" enabled_by_default="false" /&amp;gt;&#xD;
 &amp;lt;/profile&amp;gt;&lt;/IDEA_SETTINGS&gt;&lt;RIDER_SETTINGS&gt;&amp;lt;profile&amp;gt;&#xD;
   &amp;lt;Language id="CSS"&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
-    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="EditorConfig"&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="HTML"&amp;gt;&#xD;
-    &amp;lt;OptimizeImports&amp;gt;true&amp;lt;/OptimizeImports&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
-    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
+    &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="HTTP Request"&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="Handlebars"&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="Ini"&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="JSON"&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="Jade"&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="JavaScript"&amp;gt;&#xD;
-    &amp;lt;OptimizeImports&amp;gt;true&amp;lt;/OptimizeImports&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
-    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
+    &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="Markdown"&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="PowerShell"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="Properties"&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="RELAX-NG"&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="SQL"&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="VueExpr"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="XML"&amp;gt;&#xD;
-    &amp;lt;OptimizeImports&amp;gt;true&amp;lt;/OptimizeImports&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
-    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
+    &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="yaml"&amp;gt;&#xD;
-    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
-&amp;lt;/profile&amp;gt;&lt;/RIDER_SETTINGS&gt;&lt;/Profile&gt;</s:String>
+&amp;lt;/profile&amp;gt;&lt;/RIDER_SETTINGS&gt;&lt;XAMLCollapseEmptyTags&gt;False&lt;/XAMLCollapseEmptyTags&gt;&lt;/Profile&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">Safe Cleanup</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_FOR/@EntryValue">Required</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_FOREACH/@EntryValue">Required</s:String>
@@ -77,6 +95,9 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_WHILE_ON_NEW_LINE/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">130</s:Int64>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/BlankLineAfterProcessingInstructions/@EntryValue">False</s:Boolean>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/INDENT_SIZE/@EntryValue">1</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/WRAP_LIMIT/@EntryValue">130</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForBuiltInTypes/@EntryValue">UseExplicitType</s:String>
 	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForOtherTypes/@EntryValue">UseVarWhenEvident</s:String>

--- a/Src/FluentAssertions/AggregateExceptionExtractor.cs
+++ b/Src/FluentAssertions/AggregateExceptionExtractor.cs
@@ -13,7 +13,7 @@ public class AggregateExceptionExtractor : IExtractExceptions
     {
         if (typeof(T).IsSameOrInherits(typeof(AggregateException)))
         {
-            return (actualException is T exception) ? new[] { exception } : Enumerable.Empty<T>();
+            return actualException is T exception ? new[] { exception } : Enumerable.Empty<T>();
         }
 
         return GetExtractedExceptions<T>(actualException);

--- a/Src/FluentAssertions/AndWhichConstraint.cs
+++ b/Src/FluentAssertions/AndWhichConstraint.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using FluentAssertions.Common;
 using FluentAssertions.Formatting;
 
@@ -44,7 +43,7 @@ public class AndWhichConstraint<TParentConstraint, TMatchedElement> : AndConstra
                     ele => "\t" + Formatter.ToString(ele)));
 
             string message = "More than one object found.  FluentAssertions cannot determine which object is meant."
-                          + $"  Found objects:{Environment.NewLine}{foundObjects}";
+                + $"  Found objects:{Environment.NewLine}{foundObjects}";
 
             Services.ThrowException(message);
         }

--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -13,9 +13,6 @@ using System.Xml.Linq;
 using FluentAssertions.Collections;
 using FluentAssertions.Common;
 using FluentAssertions.Data;
-#if !NETSTANDARD2_0
-using FluentAssertions.Events;
-#endif
 using FluentAssertions.Numeric;
 using FluentAssertions.Primitives;
 using FluentAssertions.Reflection;
@@ -24,6 +21,9 @@ using FluentAssertions.Streams;
 using FluentAssertions.Types;
 using FluentAssertions.Xml;
 using JetBrains.Annotations;
+#if !NETSTANDARD2_0
+using FluentAssertions.Events;
+#endif
 
 namespace FluentAssertions;
 
@@ -140,7 +140,7 @@ public static class AssertionExtensions
     {
         createTimer ??= () => new StopwatchTimer();
 
-        return new(action, createTimer);
+        return new ExecutionTime(action, createTimer);
     }
 
     /// <summary>
@@ -154,7 +154,7 @@ public static class AssertionExtensions
     [MustUseReturnValue /* do not use Pure because this method executes the action before returning to the caller */]
     public static ExecutionTime ExecutionTime(this Func<Task> action)
     {
-        return new(action, () => new StopwatchTimer());
+        return new ExecutionTime(action, () => new StopwatchTimer());
     }
 
     /// <summary>
@@ -359,7 +359,8 @@ public static class AssertionExtensions
     /// current <see cref="IDictionary{TKey, TValue}"/>.
     /// </summary>
     [Pure]
-    public static GenericDictionaryAssertions<IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(this IDictionary<TKey, TValue> actualValue)
+    public static GenericDictionaryAssertions<IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(
+        this IDictionary<TKey, TValue> actualValue)
     {
         return new GenericDictionaryAssertions<IDictionary<TKey, TValue>, TKey, TValue>(actualValue);
     }
@@ -369,7 +370,8 @@ public static class AssertionExtensions
     /// current <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey, TValue}"/>.
     /// </summary>
     [Pure]
-    public static GenericDictionaryAssertions<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> actualValue)
+    public static GenericDictionaryAssertions<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(
+        this IEnumerable<KeyValuePair<TKey, TValue>> actualValue)
     {
         return new GenericDictionaryAssertions<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue>(actualValue);
     }
@@ -379,7 +381,8 @@ public static class AssertionExtensions
     /// current <typeparamref name="TCollection"/>.
     /// </summary>
     [Pure]
-    public static GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(this TCollection actualValue)
+    public static GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(
+        this TCollection actualValue)
         where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
     {
         return new GenericDictionaryAssertions<TCollection, TKey, TValue>(actualValue);
@@ -466,7 +469,6 @@ public static class AssertionExtensions
     }
 
 #if NET6_0_OR_GREATER
-
     /// <summary>
     /// Returns an <see cref="DateOnlyAssertions"/> object that can be used to assert the
     /// current <see cref="DateOnly"/>.
@@ -921,7 +923,6 @@ public static class AssertionExtensions
 #endif
 
 #if NET6_0_OR_GREATER
-
     /// <summary>
     /// Returns a <see cref="TaskCompletionSourceAssertions"/> object that can be used to assert the
     /// current <see cref="TaskCompletionSource"/>.
@@ -981,8 +982,7 @@ public static class AssertionExtensions
         InvalidShouldCall();
     }
 
-#if  NET6_0_OR_GREATER
-
+#if NET6_0_OR_GREATER
     /// <inheritdoc cref="Should(ExecutionTimeAssertions)" />
     [Obsolete("You are asserting the 'AndConstraint' itself. Remove the 'Should()' method directly following 'And'", error: true)]
     public static void Should<TAssertions>(this DateOnlyAssertions<TAssertions> _)
@@ -1091,7 +1091,8 @@ public static class AssertionExtensions
     [DoesNotReturn]
     private static void InvalidShouldCall()
     {
-        throw new InvalidOperationException("You are asserting the 'AndConstraint' itself. Remove the 'Should()' method directly following 'And'.");
+        throw new InvalidOperationException(
+            "You are asserting the 'AndConstraint' itself. Remove the 'Should()' method directly following 'And'.");
     }
 
     #endregion

--- a/Src/FluentAssertions/AssertionOptions.cs
+++ b/Src/FluentAssertions/AssertionOptions.cs
@@ -19,7 +19,7 @@ public static class AssertionOptions
 
     public static EquivalencyAssertionOptions<T> CloneDefaults<T>()
     {
-        return new(defaults);
+        return new EquivalencyAssertionOptions<T>(defaults);
     }
 
     internal static TOptions CloneDefaults<T, TOptions>(Func<EquivalencyAssertionOptions, TOptions> predicate)

--- a/Src/FluentAssertions/CallerIdentification/CallerStatementBuilder.cs
+++ b/Src/FluentAssertions/CallerIdentification/CallerStatementBuilder.cs
@@ -13,6 +13,7 @@ internal class CallerStatementBuilder
     internal CallerStatementBuilder()
     {
         statement = new StringBuilder();
+
         priorityOrderedParsingStrategies = new List<IParsingStrategy>
         {
             new QuotesParsingStrategy(),
@@ -28,19 +29,22 @@ internal class CallerStatementBuilder
     internal void Append(string symbols)
     {
         using var symbolEnumerator = symbols.GetEnumerator();
+
         while (symbolEnumerator.MoveNext() && parsingState != ParsingState.Done)
         {
             var hasParsingStrategyWaitingForEndContext = priorityOrderedParsingStrategies
                 .Any(s => s.IsWaitingForContextEnd());
 
             parsingState = ParsingState.InProgress;
+
             foreach (var parsingStrategy in
-                priorityOrderedParsingStrategies
-                    .SkipWhile(parsingStrategy =>
-                        hasParsingStrategyWaitingForEndContext
-                        && !parsingStrategy.IsWaitingForContextEnd()))
+                     priorityOrderedParsingStrategies
+                         .SkipWhile(parsingStrategy =>
+                             hasParsingStrategyWaitingForEndContext
+                             && !parsingStrategy.IsWaitingForContextEnd()))
             {
                 parsingState = parsingStrategy.Parse(symbolEnumerator.Current, statement);
+
                 if (parsingState != ParsingState.InProgress)
                 {
                     break;

--- a/Src/FluentAssertions/CallerIdentification/MultiLineCommentParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/MultiLineCommentParsingStrategy.cs
@@ -12,6 +12,7 @@ internal class MultiLineCommentParsingStrategy : IParsingStrategy
         if (isCommentContext)
         {
             var isEndOfMultilineComment = symbol is '/' && commentContextPreviousChar is '*';
+
             if (isEndOfMultilineComment)
             {
                 isCommentContext = false;
@@ -29,6 +30,7 @@ internal class MultiLineCommentParsingStrategy : IParsingStrategy
             symbol is '*'
             && statement.Length > 0
             && statement[^1] is '/';
+
         if (isStartOfMultilineComment)
         {
             statement.Remove(statement.Length - 1, 1);

--- a/Src/FluentAssertions/CallerIdentification/QuotesParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/QuotesParsingStrategy.cs
@@ -26,6 +26,7 @@ internal class QuotesParsingStrategy : IParsingStrategy
             else
             {
                 isQuoteContext = true;
+
                 if (IsVerbatim(statement))
                 {
                     isQuoteEscapeSymbol = '"';

--- a/Src/FluentAssertions/CallerIdentification/SingleLineCommentParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/SingleLineCommentParsingStrategy.cs
@@ -14,6 +14,7 @@ internal class SingleLineCommentParsingStrategy : IParsingStrategy
         }
 
         var doesSymbolStartComment = symbol is '/' && statement.Length > 0 && statement[^1] is '/';
+
         if (!doesSymbolStartComment)
         {
             return ParsingState.InProgress;

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -87,13 +87,13 @@ public static class CallerIdentifier
 
             int firstUserCodeFrameIndex = 0;
 
-            while ((firstUserCodeFrameIndex < allStackFrames.Length)
-                && IsCurrentAssembly(allStackFrames[firstUserCodeFrameIndex]))
+            while (firstUserCodeFrameIndex < allStackFrames.Length
+                   && IsCurrentAssembly(allStackFrames[firstUserCodeFrameIndex]))
             {
                 firstUserCodeFrameIndex++;
             }
 
-            SkipStackFrameCount = allStackFrames.Length - firstUserCodeFrameIndex + 1;
+            SkipStackFrameCount = (allStackFrames.Length - firstUserCodeFrameIndex) + 1;
 
             previousReference = StartStackSearchAfterStackFrame.Value;
             StartStackSearchAfterStackFrame.Value = this;
@@ -172,6 +172,7 @@ public static class CallerIdentifier
         if (!string.IsNullOrEmpty(statement))
         {
             Logger(statement);
+
             if (!IsBooleanLiteral(statement) && !IsNumeric(statement) && !IsStringLiteral(statement) &&
                 !StartsWithNewKeyword(statement))
             {
@@ -187,7 +188,7 @@ public static class CallerIdentifier
         string fileName = frame.GetFileName();
         int expectedLineNumber = frame.GetFileLineNumber();
 
-        if (string.IsNullOrEmpty(fileName) || (expectedLineNumber == 0))
+        if (string.IsNullOrEmpty(fileName) || expectedLineNumber == 0)
         {
             return null;
         }
@@ -204,9 +205,9 @@ public static class CallerIdentifier
             }
 
             return currentLine == expectedLineNumber
-                   && line != null
-                       ? GetSourceCodeStatementFrom(frame, reader, line)
-                       : null;
+                && line != null
+                    ? GetSourceCodeStatementFrom(frame, reader, line)
+                    : null;
         }
         catch
         {
@@ -218,12 +219,14 @@ public static class CallerIdentifier
     private static string GetSourceCodeStatementFrom(StackFrame frame, StreamReader reader, string line)
     {
         int column = frame.GetFileColumnNumber();
+
         if (column > 0)
         {
             line = line.Substring(Math.Min(column - 1, line.Length - 1));
         }
 
         var sb = new CallerStatementBuilder();
+
         do
         {
             sb.Append(line);

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -15,8 +15,7 @@ using FluentAssertions.Primitives;
 namespace FluentAssertions.Collections;
 
 [DebuggerNonUserCode]
-public class GenericCollectionAssertions<T> :
-    GenericCollectionAssertions<IEnumerable<T>, T, GenericCollectionAssertions<T>>
+public class GenericCollectionAssertions<T> : GenericCollectionAssertions<IEnumerable<T>, T, GenericCollectionAssertions<T>>
 {
     public GenericCollectionAssertions(IEnumerable<T> actualValue)
         : base(actualValue)
@@ -25,8 +24,8 @@ public class GenericCollectionAssertions<T> :
 }
 
 [DebuggerNonUserCode]
-public class GenericCollectionAssertions<TCollection, T> :
-    GenericCollectionAssertions<TCollection, T, GenericCollectionAssertions<TCollection, T>>
+public class GenericCollectionAssertions<TCollection, T>
+    : GenericCollectionAssertions<TCollection, T, GenericCollectionAssertions<TCollection, T>>
     where TCollection : IEnumerable<T>
 {
     public GenericCollectionAssertions(TCollection actualValue)
@@ -38,13 +37,12 @@ public class GenericCollectionAssertions<TCollection, T> :
 #pragma warning disable CS0659 // Ignore not overriding Object.GetHashCode()
 #pragma warning disable CA1065 // Ignore throwing NotSupportedException from Equals
 [DebuggerNonUserCode]
-public class GenericCollectionAssertions<TCollection, T, TAssertions> :
-    ReferenceTypeAssertions<TCollection, TAssertions>
+public class GenericCollectionAssertions<TCollection, T, TAssertions> : ReferenceTypeAssertions<TCollection, TAssertions>
     where TCollection : IEnumerable<T>
     where TAssertions : GenericCollectionAssertions<TCollection, T, TAssertions>
 {
     public GenericCollectionAssertions(TCollection actualValue)
-                : base(actualValue)
+        : base(actualValue)
     {
     }
 
@@ -64,12 +62,14 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndWhichConstraint<TAssertions, IEnumerable<TExpectation>> AllBeAssignableTo<TExpectation>(string because = "", params object[] becauseArgs)
+    public AndWhichConstraint<TAssertions, IEnumerable<TExpectation>> AllBeAssignableTo<TExpectation>(string because = "",
+        params object[] becauseArgs)
     {
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject is not null)
-            .FailWith("Expected type to be {0}{reason}, but found {context:the collection} is <null>.", typeof(TExpectation).FullName);
+            .FailWith("Expected type to be {0}{reason}, but found {context:the collection} is <null>.",
+                typeof(TExpectation).FullName);
 
         IEnumerable<TExpectation> matches = new TExpectation[0];
 
@@ -209,12 +209,14 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndWhichConstraint<TAssertions, IEnumerable<TExpectation>> AllBeOfType<TExpectation>(string because = "", params object[] becauseArgs)
+    public AndWhichConstraint<TAssertions, IEnumerable<TExpectation>> AllBeOfType<TExpectation>(string because = "",
+        params object[] becauseArgs)
     {
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject is not null)
-            .FailWith("Expected type to be {0}{reason}, but found {context:collection} is <null>.", typeof(TExpectation).FullName);
+            .FailWith("Expected type to be {0}{reason}, but found {context:collection} is <null>.",
+                typeof(TExpectation).FullName);
 
         IEnumerable<TExpectation> matches = new TExpectation[0];
 
@@ -355,13 +357,16 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     {
         Guard.ThrowIfArgumentIsNull(config);
 
-        EquivalencyAssertionOptions<IEnumerable<TExpectation>> options = config(AssertionOptions.CloneDefaults<TExpectation>()).AsCollection();
+        EquivalencyAssertionOptions<IEnumerable<TExpectation>> options =
+            config(AssertionOptions.CloneDefaults<TExpectation>()).AsCollection();
 
-        var context = new EquivalencyValidationContext(Node.From<IEnumerable<TExpectation>>(() => AssertionScope.Current.CallerIdentity), options)
-        {
-            Reason = new Reason(because, becauseArgs),
-            TraceWriter = options.TraceWriter,
-        };
+        var context =
+            new EquivalencyValidationContext(Node.From<IEnumerable<TExpectation>>(() => AssertionScope.Current.CallerIdentity),
+                options)
+            {
+                Reason = new Reason(because, becauseArgs),
+                TraceWriter = options.TraceWriter,
+            };
 
         var comparands = new Comparands
         {
@@ -419,7 +424,9 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<SubsequentOrderingAssertions<T>> BeInAscendingOrder(
         IComparer<T> comparer, string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer), "Cannot assert collection ordering without specifying a comparer.");
+        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer),
+            "Cannot assert collection ordering without specifying a comparer.");
+
         return BeInOrder(comparer, SortOrder.Ascending, because, becauseArgs);
     }
 
@@ -445,9 +452,12 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<SubsequentOrderingAssertions<T>> BeInAscendingOrder<TSelector>(
-        Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
+        Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "",
+        params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer), "Cannot assert collection ordering without specifying a comparer.");
+        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer),
+            "Cannot assert collection ordering without specifying a comparer.");
+
         return BeOrderedBy(propertyExpression, comparer, SortOrder.Ascending, because, becauseArgs);
     }
 
@@ -487,7 +497,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <remarks>
     /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
     /// </remarks>
-    public AndConstraint<SubsequentOrderingAssertions<T>> BeInAscendingOrder(Func<T, T, int> comparison, string because = "", params object[] becauseArgs)
+    public AndConstraint<SubsequentOrderingAssertions<T>> BeInAscendingOrder(Func<T, T, int> comparison, string because = "",
+        params object[] becauseArgs)
     {
         return BeInOrder(Comparer<T>.Create((x, y) => comparison(x, y)), SortOrder.Ascending, because, becauseArgs);
     }
@@ -536,7 +547,9 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<SubsequentOrderingAssertions<T>> BeInDescendingOrder(
         IComparer<T> comparer, string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer), "Cannot assert collection ordering without specifying a comparer.");
+        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer),
+            "Cannot assert collection ordering without specifying a comparer.");
+
         return BeInOrder(comparer, SortOrder.Descending, because, becauseArgs);
     }
 
@@ -562,9 +575,12 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(
-        Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
+        Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "",
+        params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer), "Cannot assert collection ordering without specifying a comparer.");
+        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer),
+            "Cannot assert collection ordering without specifying a comparer.");
+
         return BeOrderedBy(propertyExpression, comparer, SortOrder.Descending, because, becauseArgs);
     }
 
@@ -604,7 +620,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <remarks>
     /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
     /// </remarks>
-    public AndConstraint<SubsequentOrderingAssertions<T>> BeInDescendingOrder(Func<T, T, int> comparison, string because = "", params object[] becauseArgs)
+    public AndConstraint<SubsequentOrderingAssertions<T>> BeInDescendingOrder(Func<T, T, int> comparison, string because = "",
+        params object[] becauseArgs)
     {
         return BeInOrder(Comparer<T>.Create((x, y) => comparison(x, y)), SortOrder.Descending, because, becauseArgs);
     }
@@ -647,7 +664,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<TAssertions> BeSubsetOf(IEnumerable<T> expectedSuperset, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(expectedSuperset, nameof(expectedSuperset), "Cannot verify a subset against a <null> collection.");
+        Guard.ThrowIfArgumentIsNull(expectedSuperset, nameof(expectedSuperset),
+            "Cannot verify a subset against a <null> collection.");
 
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -688,6 +706,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         if (success)
         {
             ICollection<T> collection = Subject.ConvertOrCastToCollection();
+
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(collection.Contains(expected))
@@ -711,7 +730,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
-    public AndWhichConstraint<TAssertions, T> Contain(Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
+    public AndWhichConstraint<TAssertions, T> Contain(Expression<Func<T, bool>> predicate, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(predicate);
 
@@ -766,6 +786,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         if (success)
         {
             IEnumerable<T> missingItems = expectedObjects.Except(Subject);
+
             if (missingItems.Any())
             {
                 if (expectedObjects.Count > 1)
@@ -835,7 +856,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="config"/> is <see langword="null"/>.</exception>
-    public AndWhichConstraint<TAssertions, T> ContainEquivalentOf<TExpectation>(TExpectation expectation, Func<EquivalencyAssertionOptions<TExpectation>,
+    public AndWhichConstraint<TAssertions, T> ContainEquivalentOf<TExpectation>(TExpectation expectation,
+        Func<EquivalencyAssertionOptions<TExpectation>,
             EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(config);
@@ -854,11 +876,13 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
 
             foreach (T actualItem in Subject)
             {
-                var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => AssertionScope.Current.CallerIdentity), options)
-                {
-                    Reason = new Reason(because, becauseArgs),
-                    TraceWriter = options.TraceWriter
-                };
+                var context =
+                    new EquivalencyValidationContext(Node.From<TExpectation>(() => AssertionScope.Current.CallerIdentity),
+                        options)
+                    {
+                        Reason = new Reason(because, becauseArgs),
+                        TraceWriter = options.TraceWriter
+                    };
 
                 var comparands = new Comparands
                 {
@@ -870,6 +894,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                 new EquivalencyValidator().AssertEquality(comparands, context);
 
                 string[] failures = scope.Discard();
+
                 if (!failures.Any())
                 {
                     return new AndWhichConstraint<TAssertions, T>((TAssertions)this, actualItem);
@@ -1074,12 +1099,14 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         if (success)
         {
             ICollection<T> actualItems = Subject.ConvertOrCastToCollection();
+
             switch (actualItems.Count)
             {
                 case 0: // Fail, Collection is empty
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:collection} to contain a single item{reason}, but the collection is empty.");
+
                     break;
                 case 1: // Success Condition
                     match = actualItems.Single();
@@ -1088,6 +1115,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:collection} to contain a single item{reason}, but found {0}.", Subject);
+
                     break;
             }
         }
@@ -1125,6 +1153,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         if (success)
         {
             ICollection<T> actualItems = Subject.ConvertOrCastToCollection();
+
             Execute.Assertion
                 .ForCondition(actualItems.Any())
                 .BecauseOf(because, becauseArgs)
@@ -1132,20 +1161,24 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
 
             matches = actualItems.Where(predicate.Compile()).ToArray();
             int count = matches.Length;
-            switch (count)
+
+            if (count == 0)
             {
-                case 0:
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith(expectationPrefix + "but no such item was found.", predicate);
-                    break;
-                case > 1:
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith(expectationPrefix + "but " + count.ToString(CultureInfo.InvariantCulture) + " such items were found.", predicate);
-                    break;
-                default:
-                    break;
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(expectationPrefix + "but no such item was found.", predicate);
+            }
+            else if (count > 1)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        expectationPrefix + "but " + count.ToString(CultureInfo.InvariantCulture) + " such items were found.",
+                        predicate);
+            }
+            else
+            {
+                // Can never happen
             }
         }
 
@@ -1190,7 +1223,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="expectation"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> EndWith<TExpectation>(
-        IEnumerable<TExpectation> expectation, Func<T, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs)
+        IEnumerable<TExpectation> expectation, Func<T, TExpectation, bool> equalityComparison, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(expectation, nameof(expectation), "Cannot compare collection with <null>.");
 
@@ -1247,7 +1281,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     public AndConstraint<TAssertions> Equal<TExpectation>(
-        IEnumerable<TExpectation> expectation, Func<T, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs)
+        IEnumerable<TExpectation> expectation, Func<T, TExpectation, bool> equalityComparison, string because = "",
+        params object[] becauseArgs)
     {
         AssertSubjectEquality(expectation, equalityComparison, because, becauseArgs);
 
@@ -1321,7 +1356,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<TAssertions> HaveCount(Expression<Func<int, bool>> countPredicate, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(countPredicate, nameof(countPredicate), "Cannot compare collection count against a <null> predicate.");
+        Guard.ThrowIfArgumentIsNull(countPredicate, nameof(countPredicate),
+            "Cannot compare collection count against a <null> predicate.");
 
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -1357,7 +1393,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TAssertions> HaveCountGreaterThanOrEqualTo(int expected, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> HaveCountGreaterThanOrEqualTo(int expected, string because = "",
+        params object[] becauseArgs)
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -1376,7 +1413,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) => HaveCountGreaterThanOrEqualTo(expected, because, becauseArgs);
+    public AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) =>
+        HaveCountGreaterThanOrEqualTo(expected, because, becauseArgs);
 
     /// <summary>
     /// Asserts that the number of items in the collection is greater than the supplied <paramref name="expected" /> amount.
@@ -1437,7 +1475,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) => HaveCountLessThanOrEqualTo(expected, because, becauseArgs);
+    public AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) =>
+        HaveCountLessThanOrEqualTo(expected, because, becauseArgs);
 
     /// <summary>
     /// Asserts that the number of items in the collection is less than the supplied <paramref name="expected" /> amount.
@@ -1525,7 +1564,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "",
+        params object[] becauseArgs)
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -1561,7 +1601,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "",
+        params object[] becauseArgs)
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -1633,7 +1674,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<TAssertions> IntersectWith(IEnumerable<T> otherCollection, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify intersection against a <null> collection.");
+        Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection),
+            "Cannot verify intersection against a <null> collection.");
 
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -1711,7 +1753,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} {0} not to be equivalent with collection {1}{reason}, but they both reference the same object.",
+                .FailWith(
+                    "Expected {context:collection} {0} not to be equivalent with collection {1}{reason}, but they both reference the same object.",
                     Subject,
                     unexpected);
         }
@@ -1812,7 +1855,9 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<TAssertions> NotBeInAscendingOrder(
         IComparer<T> comparer, string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer), "Cannot assert collection ordering without specifying a comparer.");
+        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer),
+            "Cannot assert collection ordering without specifying a comparer.");
+
         return NotBeInOrder(comparer, SortOrder.Ascending, because, becauseArgs);
     }
 
@@ -1838,9 +1883,12 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(
-        Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
+        Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "",
+        params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer), "Cannot assert collection ordering without specifying a comparer.");
+        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer),
+            "Cannot assert collection ordering without specifying a comparer.");
+
         return NotBeOrderedBy(propertyExpression, comparer, SortOrder.Ascending, because, becauseArgs);
     }
 
@@ -1879,7 +1927,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <remarks>
     /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
     /// </remarks>
-    public AndConstraint<TAssertions> NotBeInAscendingOrder(Func<T, T, int> comparison, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> NotBeInAscendingOrder(Func<T, T, int> comparison, string because = "",
+        params object[] becauseArgs)
     {
         return NotBeInOrder(Comparer<T>.Create((x, y) => comparison(x, y)), SortOrder.Ascending, because, becauseArgs);
     }
@@ -1928,7 +1977,9 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<TAssertions> NotBeInDescendingOrder(
         IComparer<T> comparer, string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer), "Cannot assert collection ordering without specifying a comparer.");
+        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer),
+            "Cannot assert collection ordering without specifying a comparer.");
+
         return NotBeInOrder(comparer, SortOrder.Descending, because, becauseArgs);
     }
 
@@ -1954,9 +2005,12 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(
-        Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
+        Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "",
+        params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer), "Cannot assert collection ordering without specifying a comparer.");
+        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer),
+            "Cannot assert collection ordering without specifying a comparer.");
+
         return NotBeOrderedBy(propertyExpression, comparer, SortOrder.Descending, because, becauseArgs);
     }
 
@@ -1995,7 +2049,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// <remarks>
     /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
     /// </remarks>
-    public AndConstraint<TAssertions> NotBeInDescendingOrder(Func<T, T, int> comparison, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> NotBeInDescendingOrder(Func<T, T, int> comparison, string because = "",
+        params object[] becauseArgs)
     {
         return NotBeInOrder(Comparer<T>.Create((x, y) => comparison(x, y)), SortOrder.Descending, because, becauseArgs);
     }
@@ -2041,7 +2096,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Did not expect {context:collection} {0} to be a subset of {1}{reason}, but they both reference the same object.",
+                    .FailWith(
+                        "Did not expect {context:collection} {0} to be a subset of {1}{reason}, but they both reference the same object.",
                         Subject,
                         unexpectedSuperset);
             }
@@ -2052,7 +2108,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Did not expect {context:collection} {0} to be a subset of {1}{reason}.", actualItems, unexpectedSuperset);
+                    .FailWith("Did not expect {context:collection} {0} to be a subset of {1}{reason}.", actualItems,
+                        unexpectedSuperset);
             }
         }
 
@@ -2082,6 +2139,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         if (success)
         {
             ICollection<T> collection = Subject.ConvertOrCastToCollection();
+
             if (collection.Contains(unexpected))
             {
                 Execute.Assertion
@@ -2107,7 +2165,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> NotContain(Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> NotContain(Expression<Func<T, bool>> predicate, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(predicate);
 
@@ -2150,7 +2209,9 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify non-containment against a <null> collection");
 
         ICollection<T> unexpectedObjects = unexpected.ConvertOrCastToCollection();
-        Guard.ThrowIfArgumentIsEmpty(unexpectedObjects, nameof(unexpected), "Cannot verify non-containment against an empty collection");
+
+        Guard.ThrowIfArgumentIsEmpty(unexpectedObjects, nameof(unexpected),
+            "Cannot verify non-containment against an empty collection");
 
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -2160,6 +2221,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         if (success)
         {
             IEnumerable<T> foundItems = unexpectedObjects.Intersect(Subject);
+
             if (foundItems.Any())
             {
                 if (unexpectedObjects.Count > 1)
@@ -2229,31 +2291,37 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="config"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, Func<EquivalencyAssertionOptions<TExpectation>,
-        EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected,
+        Func<EquivalencyAssertionOptions<TExpectation>,
+            EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(config);
 
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject is not null)
-            .FailWith("Expected {context:collection} not to contain equivalent of {0}{reason}, but collection is <null>.", unexpected);
+            .FailWith("Expected {context:collection} not to contain equivalent of {0}{reason}, but collection is <null>.",
+                unexpected);
 
         if (success)
         {
             EquivalencyAssertionOptions<TExpectation> options = config(AssertionOptions.CloneDefaults<TExpectation>());
 
             var foundIndices = new List<int>();
+
             using (var scope = new AssertionScope())
             {
                 int index = 0;
+
                 foreach (T actualItem in Subject)
                 {
-                    var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => AssertionScope.Current.CallerIdentity), options)
-                    {
-                        Reason = new Reason(because, becauseArgs),
-                        TraceWriter = options.TraceWriter
-                    };
+                    var context =
+                        new EquivalencyValidationContext(Node.From<TExpectation>(() => AssertionScope.Current.CallerIdentity),
+                            options)
+                        {
+                            Reason = new Reason(because, becauseArgs),
+                            TraceWriter = options.TraceWriter
+                        };
 
                     var comparands = new Comparands
                     {
@@ -2281,7 +2349,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .WithExpectation("Expected {context:collection} {0} not to contain equivalent of {1}{reason}, ", Subject, unexpected)
+                        .WithExpectation("Expected {context:collection} {0} not to contain equivalent of {1}{reason}, ", Subject,
+                            unexpected)
                         .AddReportable("configuration", () => options.ToString());
 
                     if (foundIndices.Count == 1)
@@ -2332,7 +2401,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<TAssertions> NotContainInOrder(IEnumerable<T> unexpected, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify absence of ordered containment against a <null> collection.");
+        Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected),
+            "Cannot verify absence of ordered containment against a <null> collection.");
 
         if (Subject is null)
         {
@@ -2344,6 +2414,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         }
 
         IList<T> unexpectedItems = unexpected.ConvertOrCastToList();
+
         if (unexpectedItems.Any())
         {
             IList<T> actualItems = Subject.ConvertOrCastToList();
@@ -2401,7 +2472,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<TAssertions> NotContainInConsecutiveOrder(IEnumerable<T> unexpected, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify absence of ordered containment against a <null> collection.");
+        Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected),
+            "Cannot verify absence of ordered containment against a <null> collection.");
 
         if (Subject is null)
         {
@@ -2413,6 +2485,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         }
 
         IList<T> unexpectedItems = unexpected.ConvertOrCastToList();
+
         if (unexpectedItems.Any())
         {
             IList<T> actualItems = Subject.ConvertOrCastToList();
@@ -2439,7 +2512,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                             .FailWith(
                                 "Expected {context:collection} {0} to not contain items {1} in consecutive order{reason}, " +
                                 "but items appeared in order ending at index {2}.",
-                                Subject, unexpectedItems, subjectIndex + consecutiveItems - 2);
+                                Subject, unexpectedItems, (subjectIndex + consecutiveItems) - 2);
                     }
 
                     subjectIndex++;
@@ -2462,7 +2535,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> NotContainNulls<TKey>(Expression<Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> NotContainNulls<TKey>(Expression<Func<T, TKey>> predicate, string because = "",
+        params object[] becauseArgs)
         where TKey : class
     {
         Guard.ThrowIfArgumentIsNull(predicate);
@@ -2521,13 +2595,16 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} not to contain <null>s{reason}, but found several at indices {0}.", indices);
+                        .FailWith(
+                            "Expected {context:collection} not to contain <null>s{reason}, but found several at indices {0}.",
+                            indices);
                 }
                 else
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} not to contain <null>s{reason}, but found one at index {0}.", indices[0]);
+                        .FailWith("Expected {context:collection} not to contain <null>s{reason}, but found one at index {0}.",
+                            indices[0]);
                 }
             }
         }
@@ -2612,7 +2689,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> NotHaveSameCount<TExpectation>(IEnumerable<TExpectation> otherCollection, string because = "",
+    public AndConstraint<TAssertions> NotHaveSameCount<TExpectation>(IEnumerable<TExpectation> otherCollection,
+        string because = "",
         params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify count against a <null> collection.");
@@ -2654,7 +2732,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     public AndConstraint<TAssertions> NotIntersectWith(IEnumerable<T> otherCollection, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify intersection against a <null> collection.");
+        Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection),
+            "Cannot verify intersection against a <null> collection.");
 
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -2729,7 +2808,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(Expression<Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(Expression<Func<T, TKey>> predicate, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(predicate);
 
@@ -2753,7 +2833,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} to only have unique items on {0}{reason}, but items {1} are not unique.",
+                        .FailWith(
+                            "Expected {context:collection} to only have unique items on {0}{reason}, but items {1} are not unique.",
                             predicate.Body,
                             groupWithMultipleItems.SelectMany(g => g));
                 }
@@ -2761,7 +2842,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} to only have unique items on {0}{reason}, but item {1} is not unique.",
+                        .FailWith(
+                            "Expected {context:collection} to only have unique items on {0}{reason}, but item {1} is not unique.",
                             predicate.Body,
                             groupWithMultipleItems[0].First());
                 }
@@ -2801,7 +2883,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} to only have unique items{reason}, but items {0} are not unique.",
+                        .FailWith(
+                            "Expected {context:collection} to only have unique items{reason}, but items {0} are not unique.",
                             groupWithMultipleItems);
                 }
                 else
@@ -2909,12 +2992,15 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="expected"/> is empty.</exception>
-    public AndConstraint<TAssertions> SatisfyRespectively(IEnumerable<Action<T>> expected, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> SatisfyRespectively(IEnumerable<Action<T>> expected, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify against a <null> collection of inspectors");
 
         ICollection<Action<T>> elementInspectors = expected.ConvertOrCastToCollection();
-        Guard.ThrowIfArgumentIsEmpty(elementInspectors, nameof(expected), "Cannot verify against an empty collection of inspectors");
+
+        Guard.ThrowIfArgumentIsEmpty(elementInspectors, nameof(expected),
+            "Cannot verify against an empty collection of inspectors");
 
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -2950,7 +3036,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
 
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .WithExpectation("Expected {context:collection} to satisfy all inspectors{reason}, but some inspectors are not satisfied:")
+                    .WithExpectation(
+                        "Expected {context:collection} to satisfy all inspectors{reason}, but some inspectors are not satisfied:")
                     .FailWithPreFormatted(failureMessage)
                     .Then
                     .ClearExpectation();
@@ -2995,12 +3082,15 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="predicates"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="predicates"/> is empty.</exception>
-    public AndConstraint<TAssertions> Satisfy(IEnumerable<Expression<Func<T, bool>>> predicates, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> Satisfy(IEnumerable<Expression<Func<T, bool>>> predicates, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(predicates, nameof(predicates), "Cannot verify against a <null> collection of predicates");
 
         IList<Expression<Func<T, bool>>> predicatesList = predicates.ConvertOrCastToList();
-        Guard.ThrowIfArgumentIsEmpty(predicatesList, nameof(predicates), "Cannot verify against an empty collection of predicates");
+
+        Guard.ThrowIfArgumentIsEmpty(predicatesList, nameof(predicates),
+            "Cannot verify against an empty collection of predicates");
 
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -3021,21 +3111,25 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                 var doubleNewLine = Environment.NewLine + Environment.NewLine;
 
                 List<MaximumMatching.Predicate<T>> unmatchedPredicates = maximumMatchingSolution.GetUnmatchedPredicates();
+
                 if (unmatchedPredicates.Any())
                 {
                     message += doubleNewLine + "The following predicates did not have matching elements:";
+
                     message += doubleNewLine +
                         string.Join(Environment.NewLine,
                             unmatchedPredicates.Select(predicate => Formatter.ToString(predicate.Expression)));
                 }
 
                 List<Element<T>> unmatchedElements = maximumMatchingSolution.GetUnmatchedElements();
+
                 if (unmatchedElements.Any())
                 {
                     message += doubleNewLine + "The following elements did not match any predicate:";
 
                     IEnumerable<string> elementDescriptions = unmatchedElements
                         .Select(element => $"Index: {element.Index}, Element: {Formatter.ToString(element.Value)}");
+
                     message += doubleNewLine + string.Join(doubleNewLine, elementDescriptions);
                 }
 
@@ -3088,7 +3182,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="expectation"/> is <see langword="null"/>.</exception>
     public AndConstraint<TAssertions> StartWith<TExpectation>(
-        IEnumerable<TExpectation> expectation, Func<T, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs)
+        IEnumerable<TExpectation> expectation, Func<T, TExpectation, bool> equalityComparison, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(expectation, nameof(expectation), "Cannot compare collection with <null>.");
 
@@ -3154,7 +3249,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     {
         Func<T, TSelector> keySelector = propertyExpression.Compile();
 
-        IOrderedEnumerable<T> expectation = (direction == SortOrder.Ascending)
+        IOrderedEnumerable<T> expectation = direction == SortOrder.Ascending
             ? unordered.OrderBy(keySelector, comparer)
             : unordered.OrderByDescending(keySelector, comparer);
 
@@ -3171,7 +3266,9 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         return RepeatAsManyAsIterator(value, enumerable);
     }
 
-    protected void AssertCollectionEndsWith<TActual, TExpectation>(IEnumerable<TActual> actual, ICollection<TExpectation> expected, Func<TActual, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs)
+    protected void AssertCollectionEndsWith<TActual, TExpectation>(IEnumerable<TActual> actual,
+        ICollection<TExpectation> expected, Func<TActual, TExpectation, bool> equalityComparison, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(equalityComparison);
 
@@ -3193,7 +3290,9 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
             .ClearExpectation();
     }
 
-    protected void AssertCollectionStartsWith<TActual, TExpectation>(IEnumerable<TActual> actualItems, ICollection<TExpectation> expected, Func<TActual, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs)
+    protected void AssertCollectionStartsWith<TActual, TExpectation>(IEnumerable<TActual> actualItems,
+        ICollection<TExpectation> expected, Func<TActual, TExpectation, bool> equalityComparison, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(equalityComparison);
 
@@ -3210,13 +3309,14 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
             .ClearExpectation();
     }
 
-    protected void AssertSubjectEquality<TExpectation>(IEnumerable<TExpectation> expectation, Func<T, TExpectation, bool> equalityComparison,
-        string because = "", params object[] becauseArgs)
+    protected void AssertSubjectEquality<TExpectation>(IEnumerable<TExpectation> expectation,
+        Func<T, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(equalityComparison);
 
         bool subjectIsNull = Subject is null;
         bool expectationIsNull = expectation is null;
+
         if (subjectIsNull && expectationIsNull)
         {
             return;
@@ -3227,6 +3327,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         ICollection<TExpectation> expectedItems = expectation.ConvertOrCastToCollection();
 
         AssertionScope assertion = Execute.Assertion.BecauseOf(because, becauseArgs);
+
         if (subjectIsNull)
         {
             assertion.FailWith("Expected {context:collection} to be equal to {0}{reason}, but found <null>.", expectedItems);
@@ -3270,12 +3371,13 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     {
         IList<T> collection = subject.ConvertOrCastToList();
         int index = collection.IndexOf(successor);
-        return (index > 0) ? collection[index - 1] : default;
+        return index > 0 ? collection[index - 1] : default;
     }
 
     private static IEnumerable<TExpectation> RepeatAsManyAsIterator<TExpectation>(TExpectation value, IEnumerable<T> enumerable)
     {
         using IEnumerator<T> enumerator = enumerable.GetEnumerator();
+
         while (enumerator.MoveNext())
         {
             yield return value;
@@ -3286,18 +3388,22 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     {
         IList<T> collection = subject.ConvertOrCastToList();
         int index = collection.IndexOf(predecessor);
-        return (index < (collection.Count - 1)) ? collection[index + 1] : default;
+        return index < (collection.Count - 1) ? collection[index + 1] : default;
     }
 
     private string[] CollectFailuresFromInspectors(IEnumerable<Action<T>> elementInspectors)
     {
         string[] collectionFailures;
+
         using (var collectionScope = new AssertionScope())
         {
             int index = 0;
-            foreach ((T element, Action<T> inspector) in Subject.Zip(elementInspectors, (element, inspector) => (element, inspector)))
+
+            foreach ((T element, Action<T> inspector) in Subject.Zip(elementInspectors,
+                         (element, inspector) => (element, inspector)))
             {
                 string[] inspectorFailures;
+
                 using (var itemScope = new AssertionScope())
                 {
                     inspector(element);
@@ -3307,7 +3413,9 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                 if (inspectorFailures.Length > 0)
                 {
                     // Adding one tab and removing trailing dot to allow nested SatisfyRespectively
-                    string failures = string.Join(Environment.NewLine, inspectorFailures.Select(x => x.IndentLines().TrimEnd('.')));
+                    string failures = string.Join(Environment.NewLine,
+                        inspectorFailures.Select(x => x.IndentLines().TrimEnd('.')));
+
                     collectionScope.AddPreFormattedFailure($"At index {index}:{Environment.NewLine}{failures}");
                 }
 
@@ -3320,7 +3428,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         return collectionFailures;
     }
 
-    private bool IsValidProperty<TSelector>(Expression<Func<T, TSelector>> propertyExpression, string because, object[] becauseArgs)
+    private bool IsValidProperty<TSelector>(Expression<Func<T, TSelector>> propertyExpression, string because,
+        object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(propertyExpression, nameof(propertyExpression),
             "Cannot assert collection ordering without specifying a property.");
@@ -3368,7 +3477,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     private AndConstraint<SubsequentOrderingAssertions<T>> BeInOrder(
         IComparer<T> comparer, SortOrder expectedOrder, string because = "", params object[] becauseArgs)
     {
-        string sortOrder = (expectedOrder == SortOrder.Ascending) ? "ascending" : "descending";
+        string sortOrder = expectedOrder == SortOrder.Ascending ? "ascending" : "descending";
 
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -3381,7 +3490,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         {
             IList<T> actualItems = Subject.ConvertOrCastToList();
 
-            ordering = (expectedOrder == SortOrder.Ascending)
+            ordering = expectedOrder == SortOrder.Ascending
                 ? actualItems.OrderBy(item => item, comparer)
                 : actualItems.OrderByDescending(item => item, comparer);
 
@@ -3395,7 +3504,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:collection} to be in " + sortOrder +
-                                  " order{reason}, but found {0} where item at index {1} is in wrong order.",
+                            " order{reason}, but found {0} where item at index {1} is in wrong order.",
                             actualItems, index);
 
                     return new AndConstraint<SubsequentOrderingAssertions<T>>(
@@ -3411,9 +3520,10 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     /// Asserts the current collection does not have all elements in ascending order. Elements are compared
     /// using their <see cref="object.Equals(object)" /> implementation.
     /// </summary>
-    private AndConstraint<TAssertions> NotBeInOrder(IComparer<T> comparer, SortOrder order, string because = "", params object[] becauseArgs)
+    private AndConstraint<TAssertions> NotBeInOrder(IComparer<T> comparer, SortOrder order, string because = "",
+        params object[] becauseArgs)
     {
-        string sortOrder = (order == SortOrder.Ascending) ? "ascending" : "descending";
+        string sortOrder = order == SortOrder.Ascending ? "ascending" : "descending";
 
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -3424,11 +3534,12 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
         {
             IList<T> actualItems = Subject.ConvertOrCastToList();
 
-            T[] orderedItems = (order == SortOrder.Ascending)
+            T[] orderedItems = order == SortOrder.Ascending
                 ? actualItems.OrderBy(item => item, comparer).ToArray()
                 : actualItems.OrderByDescending(item => item, comparer).ToArray();
 
             Func<T, T, bool> areSameOrEqual = ObjectExtensions.GetComparer<T>();
+
             bool itemsAreUnordered = actualItems
                 .Where((actualItem, index) => !areSameOrEqual(actualItem, orderedItems[index]))
                 .Any();
@@ -3446,11 +3557,13 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-        throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean BeSameAs(), Equal(), or BeEquivalentTo() instead?");
+        throw new NotSupportedException(
+            "Equals is not part of Fluent Assertions. Did you mean BeSameAs(), Equal(), or BeEquivalentTo() instead?");
 
     private static int IndexOf(IList<T> items, T item, int startIndex)
     {
         Func<T, T, bool> comparer = ObjectExtensions.GetComparer<T>();
+
         for (; startIndex < items.Count; startIndex++)
         {
             if (comparer(items[startIndex], item))
@@ -3482,5 +3595,5 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> :
     }
 
     private protected static IComparer<TItem> GetComparer<TItem>() =>
-        typeof(TItem) == typeof(string) ? (IComparer<TItem>)(object)StringComparer.Ordinal : Comparer<TItem>.Default;
+        typeof(TItem) == typeof(string) ? (IComparer<TItem>)StringComparer.Ordinal : Comparer<TItem>.Default;
 }

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -12,8 +12,8 @@ namespace FluentAssertions.Collections;
 /// Contains a number of methods to assert that a <typeparamref name="TCollection"/> is in the expected state.
 /// </summary>
 [DebuggerNonUserCode]
-public class GenericDictionaryAssertions<TCollection, TKey, TValue> :
-    GenericDictionaryAssertions<TCollection, TKey, TValue, GenericDictionaryAssertions<TCollection, TKey, TValue>>
+public class GenericDictionaryAssertions<TCollection, TKey, TValue>
+    : GenericDictionaryAssertions<TCollection, TKey, TValue, GenericDictionaryAssertions<TCollection, TKey, TValue>>
     where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
 {
     public GenericDictionaryAssertions(TCollection keyValuePairs)
@@ -26,8 +26,8 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue> :
 /// Contains a number of methods to assert that a <typeparamref name="TCollection"/> is in the expected state.
 /// </summary>
 [DebuggerNonUserCode]
-public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions> :
-    GenericCollectionAssertions<TCollection, KeyValuePair<TKey, TValue>, TAssertions>
+public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
+    : GenericCollectionAssertions<TCollection, KeyValuePair<TKey, TValue>, TAssertions>
     where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
     where TAssertions : GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
 {
@@ -87,13 +87,14 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         }
 
         Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
+
         foreach (var key in expectedKeys)
         {
             Execute.Assertion
                 .ForCondition(areSameOrEqual(GetValue(Subject, key), GetValue(expected, key)))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but {1} differs at key {2}.",
-                expected, Subject, key);
+                    expected, Subject, key);
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -139,6 +140,7 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         IEnumerable<TKey> additionalKeys = subjectKeys.Except(unexpectedKeys);
 
         Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
+
         bool foundDifference = missingKeys.Any()
             || additionalKeys.Any()
             || subjectKeys.Any(key => !areSameOrEqual(GetValue(Subject, key), GetValue(unexpected, key)));
@@ -214,11 +216,12 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
 
         EquivalencyAssertionOptions<TExpectation> options = config(AssertionOptions.CloneDefaults<TExpectation>());
 
-        var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => AssertionScope.Current.CallerIdentity), options)
-        {
-            Reason = new Reason(because, becauseArgs),
-            TraceWriter = options.TraceWriter
-        };
+        var context =
+            new EquivalencyValidationContext(Node.From<TExpectation>(() => AssertionScope.Current.CallerIdentity), options)
+            {
+                Reason = new Reason(because, becauseArgs),
+                TraceWriter = options.TraceWriter
+            };
 
         var comparands = new Comparands
         {
@@ -283,7 +286,8 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     public AndConstraint<TAssertions> ContainKeys(IEnumerable<TKey> expected,
         string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify key containment against a <null> collection of keys");
+        Guard.ThrowIfArgumentIsNull(expected, nameof(expected),
+            "Cannot verify key containment against a <null> collection of keys");
 
         ICollection<TKey> expectedKeys = expected.ConvertOrCastToCollection();
         Guard.ThrowIfArgumentIsEmpty(expectedKeys, nameof(expected), "Cannot verify key containment against an empty sequence");
@@ -348,7 +352,8 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} {0} not to contain key {1}{reason}, but found it anyhow.", Subject, unexpected);
+                .FailWith("Expected {context:dictionary} {0} not to contain key {1}{reason}, but found it anyhow.", Subject,
+                    unexpected);
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -381,10 +386,13 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     public AndConstraint<TAssertions> NotContainKeys(IEnumerable<TKey> unexpected,
         string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify key containment against a <null> collection of keys");
+        Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected),
+            "Cannot verify key containment against a <null> collection of keys");
 
         ICollection<TKey> unexpectedKeys = unexpected.ConvertOrCastToCollection();
-        Guard.ThrowIfArgumentIsEmpty(unexpectedKeys, nameof(unexpected), "Cannot verify key containment against an empty sequence");
+
+        Guard.ThrowIfArgumentIsEmpty(unexpectedKeys, nameof(unexpected),
+            "Cannot verify key containment against an empty sequence");
 
         if (Subject is null)
         {
@@ -436,7 +444,7 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         string because = "", params object[] becauseArgs)
     {
         AndWhichConstraint<TAssertions, IEnumerable<TValue>> innerConstraint =
-                ContainValuesAndWhich(new[] { expected }, because, becauseArgs);
+            ContainValuesAndWhich(new[] { expected }, because, becauseArgs);
 
         return
             new AndWhichConstraint<TAssertions, TValue>(
@@ -470,15 +478,20 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     public AndConstraint<TAssertions> ContainValues(IEnumerable<TValue> expected,
         string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify value containment against a <null> collection of values");
+        Guard.ThrowIfArgumentIsNull(expected, nameof(expected),
+            "Cannot verify value containment against a <null> collection of values");
+
         return ContainValuesAndWhich(expected, because, becauseArgs);
     }
 
-    private AndWhichConstraint<TAssertions, IEnumerable<TValue>> ContainValuesAndWhich(IEnumerable<TValue> expected, string because = "",
+    private AndWhichConstraint<TAssertions, IEnumerable<TValue>> ContainValuesAndWhich(IEnumerable<TValue> expected,
+        string because = "",
         params object[] becauseArgs)
     {
         ICollection<TValue> expectedValues = expected.ConvertOrCastToCollection();
-        Guard.ThrowIfArgumentIsEmpty(expectedValues, nameof(expected), "Cannot verify value containment against an empty sequence");
+
+        Guard.ThrowIfArgumentIsEmpty(expectedValues, nameof(expected),
+            "Cannot verify value containment against an empty sequence");
 
         if (Subject is null)
         {
@@ -510,8 +523,8 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
 
         return
             new AndWhichConstraint<TAssertions,
-                    IEnumerable<TValue>>((TAssertions)this,
-                        RepetitionPreservingIntersect(subjectValues, expectedValues));
+                IEnumerable<TValue>>((TAssertions)this,
+                RepetitionPreservingIntersect(subjectValues, expectedValues));
     }
 
     /// <summary>
@@ -555,7 +568,8 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} {0} not to contain value {1}{reason}, but found it anyhow.", Subject, unexpected);
+                .FailWith("Expected {context:dictionary} {0} not to contain value {1}{reason}, but found it anyhow.", Subject,
+                    unexpected);
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -588,11 +602,13 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     public AndConstraint<TAssertions> NotContainValues(IEnumerable<TValue> unexpected,
         string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify value containment against a <null> collection of values");
+        Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected),
+            "Cannot verify value containment against a <null> collection of values");
 
         ICollection<TValue> unexpectedValues = unexpected.ConvertOrCastToCollection();
 
-        Guard.ThrowIfArgumentIsEmpty(unexpectedValues, nameof(unexpected), "Cannot verify value containment with an empty sequence");
+        Guard.ThrowIfArgumentIsEmpty(unexpectedValues, nameof(unexpected),
+            "Cannot verify value containment with an empty sequence");
 
         if (Subject is null)
         {
@@ -660,13 +676,16 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare dictionary with <null>.");
 
         ICollection<KeyValuePair<TKey, TValue>> expectedKeyValuePairs = expected.ConvertOrCastToCollection();
-        Guard.ThrowIfArgumentIsEmpty(expectedKeyValuePairs, nameof(expected), "Cannot verify key containment against an empty collection of key/value pairs");
+
+        Guard.ThrowIfArgumentIsEmpty(expectedKeyValuePairs, nameof(expected),
+            "Cannot verify key containment against an empty collection of key/value pairs");
 
         if (Subject is null)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to contain key/value pairs {0}{reason}, but dictionary is {1}.", expected, Subject);
+                .FailWith("Expected {context:dictionary} to contain key/value pairs {0}{reason}, but dictionary is {1}.",
+                    expected, Subject);
         }
 
         TKey[] expectedKeys = expectedKeyValuePairs.Select(keyValuePair => keyValuePair.Key).ToArray();
@@ -678,7 +697,8 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to contain key(s) {1}{reason}, but could not find keys {2}.", Subject,
+                    .FailWith("Expected {context:dictionary} {0} to contain key(s) {1}{reason}, but could not find keys {2}.",
+                        Subject,
                         expectedKeys, missingKeys);
             }
             else
@@ -691,7 +711,9 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         }
 
         Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
-        KeyValuePair<TKey, TValue>[] keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs.Where(keyValuePair => !areSameOrEqual(GetValue(Subject, keyValuePair.Key), keyValuePair.Value)).ToArray();
+
+        KeyValuePair<TKey, TValue>[] keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs
+            .Where(keyValuePair => !areSameOrEqual(GetValue(Subject, keyValuePair.Key), keyValuePair.Value)).ToArray();
 
         if (keyValuePairsNotSameOrEqualInSubject.Any())
         {
@@ -699,7 +721,8 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} to contain {0}{reason}, but {context:dictionary} differs at keys {1}.",
+                    .FailWith(
+                        "Expected {context:dictionary} to contain {0}{reason}, but {context:dictionary} differs at keys {1}.",
                         expectedKeyValuePairs, keyValuePairsNotSameOrEqualInSubject.Select(keyValuePair => keyValuePair.Key));
             }
             else
@@ -709,7 +732,8 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
 
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.", expectedKeyValuePair.Value, expectedKeyValuePair.Key, actual);
+                    .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.",
+                        expectedKeyValuePair.Value, expectedKeyValuePair.Key, actual);
             }
         }
 
@@ -757,23 +781,27 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but dictionary is {2}.", value, key,
+                .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but dictionary is {2}.", value,
+                    key,
                     Subject);
         }
 
         if (TryGetValue(Subject, key, out TValue actual))
         {
             Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
+
             Execute.Assertion
                 .ForCondition(areSameOrEqual(actual, value))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.", value, key, actual);
+                .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.", value, key,
+                    actual);
         }
         else
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but the key was not found.", value,
+                .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but the key was not found.",
+                    value,
                     key);
         }
 
@@ -816,20 +844,25 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         Guard.ThrowIfArgumentIsNull(items, nameof(items), "Cannot compare dictionary with <null>.");
 
         ICollection<KeyValuePair<TKey, TValue>> keyValuePairs = items.ConvertOrCastToCollection();
-        Guard.ThrowIfArgumentIsEmpty(keyValuePairs, nameof(items), "Cannot verify key containment against an empty collection of key/value pairs");
+
+        Guard.ThrowIfArgumentIsEmpty(keyValuePairs, nameof(items),
+            "Cannot verify key containment against an empty collection of key/value pairs");
 
         if (Subject is null)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but dictionary is {1}.", items, Subject);
+                .FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but dictionary is {1}.",
+                    items, Subject);
         }
 
-        KeyValuePair<TKey, TValue>[] keyValuePairsFound = keyValuePairs.Where(keyValuePair => ContainsKey(Subject, keyValuePair.Key)).ToArray();
+        KeyValuePair<TKey, TValue>[] keyValuePairsFound =
+            keyValuePairs.Where(keyValuePair => ContainsKey(Subject, keyValuePair.Key)).ToArray();
 
         if (keyValuePairsFound.Any())
         {
             Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
+
             KeyValuePair<TKey, TValue>[] keyValuePairsSameOrEqualInSubject = keyValuePairsFound
                 .Where(keyValuePair => areSameOrEqual(GetValue(Subject, keyValuePair.Key), keyValuePair.Value)).ToArray();
 
@@ -839,7 +872,9 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but found them anyhow.", keyValuePairs);
+                        .FailWith(
+                            "Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but found them anyhow.",
+                            keyValuePairs);
                 }
                 else
                 {
@@ -847,7 +882,9 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
 
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:dictionary} to not contain value {0} at key {1}{reason}, but found it anyhow.", keyValuePair.Value, keyValuePair.Key);
+                        .FailWith(
+                            "Expected {context:dictionary} to not contain value {0} at key {1}{reason}, but found it anyhow.",
+                            keyValuePair.Value, keyValuePair.Key);
                 }
             }
         }
@@ -896,7 +933,8 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but dictionary is {2}.", value,
+                .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but dictionary is {2}.",
+                    value,
                     key, Subject);
         }
 
@@ -905,7 +943,8 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
             Execute.Assertion
                 .ForCondition(!ObjectExtensions.GetComparer<TValue>()(actual, value))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but found it anyhow.", value, key);
+                .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but found it anyhow.",
+                    value, key);
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolver.cs
+++ b/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolver.cs
@@ -57,7 +57,8 @@ internal class MaximumMatchingSolver<TValue>
 
         while (breadthFirstSearchTracker.TryDequeueUnMatchedPredicate(out var unmatchedPredicate))
         {
-            var notVisitedMatchingElements = GetMatchingElements(unmatchedPredicate).Where(element => !visitedElements.Contains(element));
+            var notVisitedMatchingElements =
+                GetMatchingElements(unmatchedPredicate).Where(element => !visitedElements.Contains(element));
 
             foreach (var element in notVisitedMatchingElements)
             {
@@ -148,7 +149,10 @@ internal class MaximumMatchingSolver<TValue>
         public void ReassignElement(Element<TValue> element, Predicate<TValue> newMatchedPredicate)
         {
             var previouslyMatchedPredicate = originalMatches.GetMatchedPredicate(element);
-            previousMatchByPredicate.Add(previouslyMatchedPredicate, new Match { Predicate = newMatchedPredicate, Element = element });
+
+            previousMatchByPredicate.Add(previouslyMatchedPredicate,
+                new Match { Predicate = newMatchedPredicate, Element = element });
+
             unmatchedPredicatesQueue.Enqueue(previouslyMatchedPredicate);
         }
 

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -7,8 +7,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Collections;
 
-public class StringCollectionAssertions :
-    StringCollectionAssertions<IEnumerable<string>>
+public class StringCollectionAssertions : StringCollectionAssertions<IEnumerable<string>>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="StringCollectionAssertions"/> class.
@@ -19,8 +18,8 @@ public class StringCollectionAssertions :
     }
 }
 
-public class StringCollectionAssertions<TCollection> :
-    StringCollectionAssertions<TCollection, StringCollectionAssertions<TCollection>>
+public class StringCollectionAssertions<TCollection>
+    : StringCollectionAssertions<TCollection, StringCollectionAssertions<TCollection>>
     where TCollection : IEnumerable<string>
 {
     /// <summary>
@@ -32,8 +31,7 @@ public class StringCollectionAssertions<TCollection> :
     }
 }
 
-public class StringCollectionAssertions<TCollection, TAssertions> :
-    GenericCollectionAssertions<TCollection, string, TAssertions>
+public class StringCollectionAssertions<TCollection, TAssertions> : GenericCollectionAssertions<TCollection, string, TAssertions>
     where TCollection : IEnumerable<string>
     where TAssertions : StringCollectionAssertions<TCollection, TAssertions>
 {
@@ -94,7 +92,8 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<TAssertions> BeEquivalentTo(IEnumerable<string> expectation, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> BeEquivalentTo(IEnumerable<string> expectation, string because = "",
+        params object[] becauseArgs)
     {
         return BeEquivalentTo(expectation, config => config, because, becauseArgs);
     }
@@ -127,13 +126,15 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     {
         Guard.ThrowIfArgumentIsNull(config);
 
-        EquivalencyAssertionOptions<IEnumerable<string>> options = config(AssertionOptions.CloneDefaults<string>()).AsCollection();
+        EquivalencyAssertionOptions<IEnumerable<string>>
+            options = config(AssertionOptions.CloneDefaults<string>()).AsCollection();
 
-        var context = new EquivalencyValidationContext(Node.From<IEnumerable<string>>(() => AssertionScope.Current.CallerIdentity), options)
-        {
-            Reason = new Reason(because, becauseArgs),
-            TraceWriter = options.TraceWriter
-        };
+        var context =
+            new EquivalencyValidationContext(Node.From<IEnumerable<string>>(() => AssertionScope.Current.CallerIdentity), options)
+            {
+                Reason = new Reason(because, becauseArgs),
+                TraceWriter = options.TraceWriter
+            };
 
         var comparands = new Comparands
         {
@@ -241,8 +242,11 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     public AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match strings in collection against <null>. Provide a wildcard pattern or use the Contain method.");
-        Guard.ThrowIfArgumentIsEmpty(wildcardPattern, nameof(wildcardPattern), "Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the Contain method.");
+        Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern),
+            "Cannot match strings in collection against <null>. Provide a wildcard pattern or use the Contain method.");
+
+        Guard.ThrowIfArgumentIsEmpty(wildcardPattern, nameof(wildcardPattern),
+            "Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the Contain method.");
 
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -267,6 +271,7 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     private bool ContainsMatch(string wildcardPattern)
     {
         using var scope = new AssertionScope();
+
         return Subject.Any(item =>
         {
             item.Should().Match(wildcardPattern);
@@ -322,13 +327,17 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     public AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match strings in collection against <null>. Provide a wildcard pattern or use the NotContain method.");
-        Guard.ThrowIfArgumentIsEmpty(wildcardPattern, nameof(wildcardPattern), "Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the NotContain method.");
+        Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern),
+            "Cannot match strings in collection against <null>. Provide a wildcard pattern or use the NotContain method.");
+
+        Guard.ThrowIfArgumentIsEmpty(wildcardPattern, nameof(wildcardPattern),
+            "Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the NotContain method.");
 
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject is not null)
-            .FailWith("Did not expect {context:collection} to contain a match of {0}{reason}, but found <null>.", wildcardPattern);
+            .FailWith("Did not expect {context:collection} to contain a match of {0}{reason}, but found <null>.",
+                wildcardPattern);
 
         if (success)
         {
@@ -344,6 +353,7 @@ public class StringCollectionAssertions<TCollection, TAssertions> :
     private bool NotContainsMatch(string wildcardPattern)
     {
         using var scope = new AssertionScope();
+
         return Subject.All(item =>
         {
             item.Should().NotMatch(wildcardPattern);

--- a/Src/FluentAssertions/Collections/SubsequentOrderingAssertions.cs
+++ b/Src/FluentAssertions/Collections/SubsequentOrderingAssertions.cs
@@ -8,8 +8,8 @@ using FluentAssertions.Common;
 namespace FluentAssertions.Collections;
 
 [DebuggerNonUserCode]
-public class SubsequentOrderingAssertions<T> :
-    SubsequentOrderingGenericCollectionAssertions<IEnumerable<T>, T, SubsequentOrderingAssertions<T>>
+public class SubsequentOrderingAssertions<T>
+    : SubsequentOrderingGenericCollectionAssertions<IEnumerable<T>, T, SubsequentOrderingAssertions<T>>
 {
     public SubsequentOrderingAssertions(IEnumerable<T> actualValue, IOrderedEnumerable<T> previousOrderedEnumerable)
         : base(actualValue, previousOrderedEnumerable)
@@ -18,8 +18,8 @@ public class SubsequentOrderingAssertions<T> :
 }
 
 [DebuggerNonUserCode]
-public class SubsequentOrderingGenericCollectionAssertions<TCollection, T> :
-    SubsequentOrderingGenericCollectionAssertions<TCollection, T, SubsequentOrderingGenericCollectionAssertions<TCollection, T>>
+public class SubsequentOrderingGenericCollectionAssertions<TCollection, T>
+    : SubsequentOrderingGenericCollectionAssertions<TCollection, T, SubsequentOrderingGenericCollectionAssertions<TCollection, T>>
     where TCollection : IEnumerable<T>
 {
     public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, IOrderedEnumerable<T> previousOrderedEnumerable)
@@ -29,8 +29,8 @@ public class SubsequentOrderingGenericCollectionAssertions<TCollection, T> :
 }
 
 [DebuggerNonUserCode]
-public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions> :
-    GenericCollectionAssertions<TCollection, T, TAssertions>
+public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions>
+    : GenericCollectionAssertions<TCollection, T, TAssertions>
     where TCollection : IEnumerable<T>
     where TAssertions : SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions>
 {
@@ -88,9 +88,12 @@ public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAsse
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<SubsequentOrderingAssertions<T>> ThenBeInAscendingOrder<TSelector>(
-        Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
+        Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "",
+        params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer), "Cannot assert collection ordering without specifying a comparer.");
+        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer),
+            "Cannot assert collection ordering without specifying a comparer.");
+
         return ThenBeOrderedBy(propertyExpression, comparer, SortOrder.Ascending, because, becauseArgs);
     }
 
@@ -139,9 +142,12 @@ public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAsse
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
     public AndConstraint<SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(
-        Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
+        Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "",
+        params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer), "Cannot assert collection ordering without specifying a comparer.");
+        Guard.ThrowIfArgumentIsNull(comparer, nameof(comparer),
+            "Cannot assert collection ordering without specifying a comparer.");
+
         return ThenBeOrderedBy(propertyExpression, comparer, SortOrder.Descending, because, becauseArgs);
     }
 
@@ -166,7 +172,7 @@ public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAsse
         {
             Func<T, TSelector> keySelector = propertyExpression.Compile();
 
-            IOrderedEnumerable<T> expectation = (direction == SortOrder.Ascending)
+            IOrderedEnumerable<T> expectation = direction == SortOrder.Ascending
                 ? previousOrderedEnumerable.ThenBy(keySelector, comparer)
                 : previousOrderedEnumerable.ThenByDescending(keySelector, comparer);
 

--- a/Src/FluentAssertions/Common/Configuration.cs
+++ b/Src/FluentAssertions/Common/Configuration.cs
@@ -63,6 +63,7 @@ public class Configuration
         }
 
         string setting = store.GetSetting("valueFormatters");
+
         if (!string.IsNullOrEmpty(setting))
         {
             try
@@ -90,6 +91,7 @@ public class Configuration
             if (valueFormatterAssembly is null)
             {
                 string assemblyName = store.GetSetting("valueFormattersAssembly");
+
                 if (!string.IsNullOrEmpty(assemblyName))
                 {
                     valueFormatterAssembly = assemblyName;

--- a/Src/FluentAssertions/Common/DictionaryHelpers.cs
+++ b/Src/FluentAssertions/Common/DictionaryHelpers.cs
@@ -58,6 +58,7 @@ internal static class DictionaryHelpers
         static bool TryGetValue(TCollection collection, TKey key, out TValue value)
         {
             Func<TKey, TKey, bool> areSameOrEqual = ObjectExtensions.GetComparer<TKey>();
+
             foreach (var kvp in collection)
             {
                 if (areSameOrEqual(kvp.Key, key))

--- a/Src/FluentAssertions/Common/EnumerableExtensions.cs
+++ b/Src/FluentAssertions/Common/EnumerableExtensions.cs
@@ -8,12 +8,12 @@ internal static class EnumerableExtensions
 {
     public static ICollection<T> ConvertOrCastToCollection<T>(this IEnumerable<T> source)
     {
-        return (source as ICollection<T>) ?? source.ToList();
+        return source as ICollection<T> ?? source.ToList();
     }
 
     public static IList<T> ConvertOrCastToList<T>(this IEnumerable<T> source)
     {
-        return (source as IList<T>) ?? source.ToList();
+        return source as IList<T> ?? source.ToList();
     }
 
     /// <summary>
@@ -25,11 +25,13 @@ internal static class EnumerableExtensions
     /// <param name="second">The second sequence to compare.</param>
     /// <param name="equalityComparison">Method that is used to compare 2 elements with the same index.</param>
     /// <returns>Index at which two sequences have elements that are not equal, or -1 if enumerables are equal</returns>
-    public static int IndexOfFirstDifferenceWith<TFirst, TSecond>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second, Func<TFirst, TSecond, bool> equalityComparison)
+    public static int IndexOfFirstDifferenceWith<TFirst, TSecond>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second,
+        Func<TFirst, TSecond, bool> equalityComparison)
     {
         using IEnumerator<TFirst> firstEnumerator = first.GetEnumerator();
         using IEnumerator<TSecond> secondEnumerator = second.GetEnumerator();
         int index = 0;
+
         while (true)
         {
             bool isFirstCompleted = !firstEnumerator.MoveNext();

--- a/Src/FluentAssertions/Common/ExceptionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExceptionExtensions.cs
@@ -9,6 +9,7 @@ internal static class ExceptionExtensions
     public static ExceptionDispatchInfo Unwrap(this TargetInvocationException exception)
     {
         Exception result = exception;
+
         while (result is TargetInvocationException)
         {
             result = result.InnerException;

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -84,7 +84,9 @@ internal static class ExpressionExtensions
 
                 case ExpressionType.Call:
                     var methodCallExpression = (MethodCallExpression)node;
-                    if (methodCallExpression.Method.Name != "get_Item" || methodCallExpression.Arguments.Count != 1 || methodCallExpression.Arguments[0] is not ConstantExpression)
+
+                    if (methodCallExpression.Method.Name != "get_Item" || methodCallExpression.Arguments.Count != 1 ||
+                        methodCallExpression.Arguments[0] is not ConstantExpression)
                     {
                         throw new ArgumentException(GetUnsupportedExpressionMessage(expression.Body), nameof(expression));
                     }
@@ -153,7 +155,9 @@ internal static class ExpressionExtensions
 
                 case ExpressionType.Call:
                     var methodCallExpression = (MethodCallExpression)node;
-                    if (methodCallExpression.Method.Name != "get_Item" || methodCallExpression.Arguments.Count != 1 || methodCallExpression.Arguments[0] is not ConstantExpression)
+
+                    if (methodCallExpression.Method.Name != "get_Item" || methodCallExpression.Arguments.Count != 1 ||
+                        methodCallExpression.Arguments[0] is not ConstantExpression)
                     {
                         throw new ArgumentException(GetUnsupportedExpressionMessage(expression.Body), nameof(expression));
                     }

--- a/Src/FluentAssertions/Common/FullFrameworkReflector.cs
+++ b/Src/FluentAssertions/Common/FullFrameworkReflector.cs
@@ -20,17 +20,19 @@ internal class FullFrameworkReflector : IReflector
     {
         string assemblyName = ass.GetName().Name;
 
-        return !assemblyName.StartsWith("microsoft.", StringComparison.OrdinalIgnoreCase) &&
-               !assemblyName.StartsWith("xunit", StringComparison.OrdinalIgnoreCase) &&
-               !assemblyName.StartsWith("jetbrains.", StringComparison.OrdinalIgnoreCase) &&
-               !assemblyName.StartsWith("system", StringComparison.OrdinalIgnoreCase) &&
-               !assemblyName.StartsWith("mscorlib", StringComparison.OrdinalIgnoreCase) &&
-               !assemblyName.StartsWith("newtonsoft", StringComparison.OrdinalIgnoreCase);
+        return
+            !assemblyName.StartsWith("microsoft.", StringComparison.OrdinalIgnoreCase) &&
+            !assemblyName.StartsWith("xunit", StringComparison.OrdinalIgnoreCase) &&
+            !assemblyName.StartsWith("jetbrains.", StringComparison.OrdinalIgnoreCase) &&
+            !assemblyName.StartsWith("system", StringComparison.OrdinalIgnoreCase) &&
+            !assemblyName.StartsWith("mscorlib", StringComparison.OrdinalIgnoreCase) &&
+            !assemblyName.StartsWith("newtonsoft", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsDynamic(Assembly assembly)
     {
-        return assembly.GetType().FullName is "System.Reflection.Emit.AssemblyBuilder" or "System.Reflection.Emit.InternalAssemblyBuilder";
+        return assembly.GetType().FullName is "System.Reflection.Emit.AssemblyBuilder"
+            or "System.Reflection.Emit.InternalAssemblyBuilder";
     }
 
     private static IEnumerable<Type> GetExportedTypes(Assembly assembly)

--- a/Src/FluentAssertions/Common/Guard.cs
+++ b/Src/FluentAssertions/Common/Guard.cs
@@ -7,7 +7,9 @@ namespace FluentAssertions.Common;
 
 internal static class Guard
 {
-    public static void ThrowIfArgumentIsNull<T>([ValidatedNotNull] T obj, [CallerArgumentExpression(nameof(obj))] string paramName = "")
+    public static void ThrowIfArgumentIsNull<T>([ValidatedNotNull] T obj,
+        [CallerArgumentExpression(nameof(obj))]
+        string paramName = "")
     {
         if (obj is null)
         {
@@ -23,7 +25,9 @@ internal static class Guard
         }
     }
 
-    public static void ThrowIfArgumentIsNullOrEmpty([ValidatedNotNull] string str, [CallerArgumentExpression(nameof(str))] string paramName = "")
+    public static void ThrowIfArgumentIsNullOrEmpty([ValidatedNotNull] string str,
+        [CallerArgumentExpression(nameof(str))]
+        string paramName = "")
     {
         if (string.IsNullOrEmpty(str))
         {
@@ -50,7 +54,9 @@ internal static class Guard
         }
     }
 
-    public static void ThrowIfArgumentContainsNull<T>(IEnumerable<T> values, [CallerArgumentExpression(nameof(values))] string paramName = "")
+    public static void ThrowIfArgumentContainsNull<T>(IEnumerable<T> values,
+        [CallerArgumentExpression(nameof(values))]
+        string paramName = "")
     {
         if (values.Any(t => t is null))
         {
@@ -74,7 +80,9 @@ internal static class Guard
         }
     }
 
-    public static void ThrowIfArgumentIsNegative(TimeSpan timeSpan, [CallerArgumentExpression(nameof(timeSpan))] string paramName = "")
+    public static void ThrowIfArgumentIsNegative(TimeSpan timeSpan,
+        [CallerArgumentExpression(nameof(timeSpan))]
+        string paramName = "")
     {
         if (timeSpan < TimeSpan.Zero)
         {

--- a/Src/FluentAssertions/Common/ICollectionWrapper.cs
+++ b/Src/FluentAssertions/Common/ICollectionWrapper.cs
@@ -1,15 +1,14 @@
 ﻿using System.Collections;
 
-namespace FluentAssertions.Common
+namespace FluentAssertions.Common;
+
+/// <summary>
+/// Used to provide access to the underlying <typeparamref name="TCollection"/> for an object that wraps an underlying
+/// collection.
+/// </summary>
+/// <typeparam name="TCollection">Collection type.</typeparam>
+public interface ICollectionWrapper<TCollection>
+    where TCollection : ICollection
 {
-    /// <summary>
-    /// Used to provide access to the underlying <typeparamref name="TCollection"/> for an object that wraps an underlying
-    /// collection.
-    /// </summary>
-    /// <typeparam name="TCollection">Collection type.</typeparam>
-    public interface ICollectionWrapper<TCollection>
-        where TCollection : ICollection
-    {
-        TCollection UnderlyingCollection { get; }
-    }
+    TCollection UnderlyingCollection { get; }
 }

--- a/Src/FluentAssertions/Common/IntegerExtensions.cs
+++ b/Src/FluentAssertions/Common/IntegerExtensions.cs
@@ -4,5 +4,5 @@ internal static class IntegerExtensions
 {
     public static string Times(this int count) => count == 1 ? "1 time" : $"{count} times";
 
-    internal static bool IsConsecutiveTo(this int startNumber, int endNumber) => endNumber == startNumber + 1;
+    internal static bool IsConsecutiveTo(this int startNumber, int endNumber) => endNumber == (startNumber + 1);
 }

--- a/Src/FluentAssertions/Common/MemberPath.cs
+++ b/Src/FluentAssertions/Common/MemberPath.cs
@@ -59,7 +59,7 @@ internal class MemberPath
 
     public bool IsSameAs(MemberPath candidate)
     {
-        if ((declaringType == candidate.declaringType) || declaringType?.IsAssignableFrom(candidate.reflectedType) == true)
+        if (declaringType == candidate.declaringType || declaringType?.IsAssignableFrom(candidate.reflectedType) == true)
         {
             string[] candidateSegments = candidate.Segments;
 
@@ -74,7 +74,7 @@ internal class MemberPath
         string[] candidateSegments = candidate.Segments;
 
         return candidateSegments.Length > Segments.Length &&
-               candidateSegments.Take(Segments.Length).SequenceEqual(Segments, MemberPathSegmentEqualityComparer);
+            candidateSegments.Take(Segments.Length).SequenceEqual(Segments, MemberPathSegmentEqualityComparer);
     }
 
     private bool IsChildOf(MemberPath candidate)
@@ -82,8 +82,8 @@ internal class MemberPath
         string[] candidateSegments = candidate.Segments;
 
         return candidateSegments.Length < Segments.Length
-               && candidateSegments.SequenceEqual(Segments.Take(candidateSegments.Length),
-                   MemberPathSegmentEqualityComparer);
+            && candidateSegments.SequenceEqual(Segments.Take(candidateSegments.Length),
+                MemberPathSegmentEqualityComparer);
     }
 
     public MemberPath AsParentCollectionOf(MemberPath nextPath)
@@ -103,7 +103,7 @@ internal class MemberPath
     public bool HasSameParentAs(MemberPath path)
     {
         return Segments.Length == path.Segments.Length
-               && GetParentSegments().SequenceEqual(path.GetParentSegments(), MemberPathSegmentEqualityComparer);
+            && GetParentSegments().SequenceEqual(path.GetParentSegments(), MemberPathSegmentEqualityComparer);
     }
 
     private IEnumerable<string> GetParentSegments() => Segments.Take(Segments.Length - 1);

--- a/Src/FluentAssertions/Common/MemberPathSegmentEqualityComparer.cs
+++ b/Src/FluentAssertions/Common/MemberPathSegmentEqualityComparer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace FluentAssertions.Common;
@@ -34,13 +35,13 @@ internal class MemberPathSegmentEqualityComparer : IEqualityComparer<string>
         return x == y;
     }
 
-    private static bool IsIndexQualifier(string segment)
-        => segment == AnyIndexQualifier || IndexQualifierRegex.IsMatch(segment);
+    private static bool IsIndexQualifier(string segment) =>
+        segment == AnyIndexQualifier || IndexQualifierRegex.IsMatch(segment);
 
     public int GetHashCode(string obj)
     {
 #if NETCOREAPP2_1_OR_GREATER
-        return obj.GetHashCode(System.StringComparison.Ordinal);
+        return obj.GetHashCode(StringComparison.Ordinal);
 #else
         return obj.GetHashCode();
 #endif

--- a/Src/FluentAssertions/Common/MethodInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/MethodInfoExtensions.cs
@@ -14,14 +14,15 @@ internal static class MethodInfoExtensions
     /// They are a subset of <see cref="MethodImplAttributes"/> which can be checked on a type and therefore this mask has to be applied to check only for options.
     /// </summary>
     private static readonly Lazy<int> ImplementationOptionsMask =
-        new Lazy<int>(() => Enum.GetValues(typeof(MethodImplOptions)).Cast<int>().Sum(x => x));
+        new(() => Enum.GetValues(typeof(MethodImplOptions)).Cast<int>().Sum(x => x));
 
     internal static bool IsAsync(this MethodInfo methodInfo)
     {
         return methodInfo.IsDecoratedWith<AsyncStateMachineAttribute>();
     }
 
-    internal static IEnumerable<TAttribute> GetMatchingAttributes<TAttribute>(this MemberInfo memberInfo, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
+    internal static IEnumerable<TAttribute> GetMatchingAttributes<TAttribute>(this MemberInfo memberInfo,
+        Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
         where TAttribute : Attribute
     {
         var customAttributes = memberInfo.GetCustomAttributes<TAttribute>(inherit: false).ToList();

--- a/Src/FluentAssertions/Common/ObjectExtensions.cs
+++ b/Src/FluentAssertions/Common/ObjectExtensions.cs
@@ -23,9 +23,9 @@ internal static class ObjectExtensions
         }
 
         return (actual, expected) => actual is null
-                ? expected is null
-                : expected is not null
-                    && (EqualityComparer<T>.Default.Equals(actual, expected) || CompareNumerics(actual, expected));
+            ? expected is null
+            : expected is not null
+            && (EqualityComparer<T>.Default.Equals(actual, expected) || CompareNumerics(actual, expected));
     }
 
     private static bool CompareNumerics(object actual, object expected)
@@ -47,7 +47,7 @@ internal static class ObjectExtensions
             var converted = source.ConvertTo(targetType);
 
             return source.Equals(converted.ConvertTo(sourceType))
-                 && converted.Equals(target);
+                && converted.Equals(target);
         }
         catch
         {

--- a/Src/FluentAssertions/Common/ReadOnlyNonGenericCollectionWrapper.cs
+++ b/Src/FluentAssertions/Common/ReadOnlyNonGenericCollectionWrapper.cs
@@ -11,25 +11,25 @@ internal static class ReadOnlyNonGenericCollectionWrapper
     public static ReadOnlyNonGenericCollectionWrapper<DataTableCollection, DataTable> Create(DataTableCollection collection)
     {
         return
-            (collection != null)
-            ? new ReadOnlyNonGenericCollectionWrapper<DataTableCollection, DataTable>(collection)
-            : null;
+            collection != null
+                ? new ReadOnlyNonGenericCollectionWrapper<DataTableCollection, DataTable>(collection)
+                : null;
     }
 
     public static ReadOnlyNonGenericCollectionWrapper<DataColumnCollection, DataColumn> Create(DataColumnCollection collection)
     {
         return
-            (collection != null)
-            ? new ReadOnlyNonGenericCollectionWrapper<DataColumnCollection, DataColumn>(collection)
-            : null;
+            collection != null
+                ? new ReadOnlyNonGenericCollectionWrapper<DataColumnCollection, DataColumn>(collection)
+                : null;
     }
 
     public static ReadOnlyNonGenericCollectionWrapper<DataRowCollection, DataRow> Create(DataRowCollection collection)
     {
         return
-            (collection != null)
-            ? new ReadOnlyNonGenericCollectionWrapper<DataRowCollection, DataRow>(collection)
-            : null;
+            collection != null
+                ? new ReadOnlyNonGenericCollectionWrapper<DataRowCollection, DataRow>(collection)
+                : null;
     }
 }
 

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -17,7 +17,7 @@ internal static class StringExtensions
 
         for (int index = 0; index < value.Length; index++)
         {
-            if ((index >= expected.Length) || !comparer(value[index], expected[index]))
+            if (index >= expected.Length || !comparer(value[index], expected[index]))
             {
                 return index;
             }
@@ -28,7 +28,7 @@ internal static class StringExtensions
 
     private static Func<char, char, bool> GetCharComparer(StringComparison stringComparison) =>
         stringComparison == StringComparison.Ordinal
-            ? ((x, y) => x == y)
+            ? (x, y) => x == y
             : (x, y) => char.ToUpperInvariant(x) == char.ToUpperInvariant(y);
 
     /// <summary>
@@ -80,7 +80,7 @@ internal static class StringExtensions
     {
         if (@this.Length == 0)
         {
-            return (other.Length != 0) ? other : string.Empty;
+            return other.Length != 0 ? other : string.Empty;
         }
 
         if (other.Length == 0)
@@ -124,8 +124,8 @@ internal static class StringExtensions
     public static string RemoveNewLines(this string @this)
     {
         return @this.Replace("\n", string.Empty, StringComparison.Ordinal)
-                    .Replace("\r", string.Empty, StringComparison.Ordinal)
-                    .Replace("\\r\\n", string.Empty, StringComparison.Ordinal);
+            .Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Replace("\\r\\n", string.Empty, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Common/TimeOnlyExtensions.cs
+++ b/Src/FluentAssertions/Common/TimeOnlyExtensions.cs
@@ -1,5 +1,4 @@
 #if NET6_0_OR_GREATER
-
 using System;
 
 namespace FluentAssertions.Common;

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -23,8 +23,12 @@ internal static class TypeExtensions
 
     private static readonly ConcurrentDictionary<Type, bool> HasValueSemanticsCache = new();
     private static readonly ConcurrentDictionary<Type, bool> TypeIsRecordCache = new();
-    private static readonly ConcurrentDictionary<(Type Type, MemberVisibility Visibility), IEnumerable<PropertyInfo>> NonPrivatePropertiesCache = new();
-    private static readonly ConcurrentDictionary<(Type Type, MemberVisibility Visibility), IEnumerable<FieldInfo>> NonPrivateFieldsCache = new();
+
+    private static readonly ConcurrentDictionary<(Type Type, MemberVisibility Visibility), IEnumerable<PropertyInfo>>
+        NonPrivatePropertiesCache = new();
+
+    private static readonly ConcurrentDictionary<(Type Type, MemberVisibility Visibility), IEnumerable<FieldInfo>>
+        NonPrivateFieldsCache = new();
 
     public static bool IsDecoratedWith<TAttribute>(this Type type)
         where TAttribute : Attribute
@@ -142,7 +146,7 @@ internal static class TypeExtensions
     {
         return (property.DeclaringType.IsSameOrInherits(otherProperty.DeclaringType) ||
                 otherProperty.DeclaringType.IsSameOrInherits(property.DeclaringType)) &&
-               property.Name == otherProperty.Name;
+            property.Name == otherProperty.Name;
     }
 
     /// <summary>
@@ -157,6 +161,7 @@ internal static class TypeExtensions
         }
 
         Type[] interfaces = type.GetInterfaces();
+
         return
             interfaces
                 .Where(t => t.IsGenericType && t.GetGenericTypeDefinition() == openGenericType)
@@ -169,7 +174,7 @@ internal static class TypeExtensions
             .GetMethod("Equals", new[] { typeof(object) });
 
         return method is not null
-               && method.GetBaseDefinition().DeclaringType != method.DeclaringType;
+            && method.GetBaseDefinition().DeclaringType != method.DeclaringType;
     }
 
     /// <summary>
@@ -245,7 +250,7 @@ internal static class TypeExtensions
             return type
                 .GetProperties(AllInstanceMembersFlag | BindingFlags.DeclaredOnly)
                 .Where(property => property.GetMethod?.IsPrivate == false)
-                .Where(property => includeInternals || (property.GetMethod is { IsAssembly: false, IsFamilyOrAssembly: false }))
+                .Where(property => includeInternals || property.GetMethod is { IsAssembly: false, IsFamilyOrAssembly: false })
                 .ToArray();
         });
     }
@@ -293,7 +298,8 @@ internal static class TypeExtensions
         }
     }
 
-    private static List<TMemberInfo> GetInterfaceMembers<TMemberInfo>(Type typeToReflect, Func<Type, IEnumerable<TMemberInfo>> getMembers)
+    private static List<TMemberInfo> GetInterfaceMembers<TMemberInfo>(Type typeToReflect,
+        Func<Type, IEnumerable<TMemberInfo>> getMembers)
         where TMemberInfo : MemberInfo
     {
         List<TMemberInfo> members = new();
@@ -306,6 +312,7 @@ internal static class TypeExtensions
         while (queue.Count > 0)
         {
             Type subType = queue.Dequeue();
+
             foreach (Type subInterface in subType.GetInterfaces())
             {
                 if (considered.Contains(subInterface))
@@ -327,7 +334,8 @@ internal static class TypeExtensions
         return members;
     }
 
-    private static List<TMemberInfo> GetClassMembers<TMemberInfo>(Type typeToReflect, Func<Type, IEnumerable<TMemberInfo>> getMembers)
+    private static List<TMemberInfo> GetClassMembers<TMemberInfo>(Type typeToReflect,
+        Func<Type, IEnumerable<TMemberInfo>> getMembers)
         where TMemberInfo : MemberInfo
     {
         List<TMemberInfo> members = new();
@@ -411,6 +419,7 @@ internal static class TypeExtensions
     public static bool HasExplicitlyImplementedProperty(this Type type, Type interfaceType, string propertyName)
     {
         bool hasGetter = type.HasParameterlessMethod($"{interfaceType.FullName}.get_{propertyName}");
+
         bool hasSetter = type.GetMethods(AllStaticAndInstanceMembersFlag)
             .SingleOrDefault(m =>
                 m.Name == $"{interfaceType.FullName}.set_{propertyName}" &&
@@ -494,8 +503,8 @@ internal static class TypeExtensions
 
         // check subject and its base types against definition
         for (Type baseType = type;
-            baseType is not null;
-            baseType = baseType.BaseType)
+             baseType is not null;
+             baseType = baseType.BaseType)
         {
             if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == definition)
             {
@@ -509,8 +518,8 @@ internal static class TypeExtensions
     public static bool IsUnderNamespace(this Type type, string @namespace)
     {
         return IsGlobalNamespace()
-               || IsExactNamespace()
-               || IsParentNamespace();
+            || IsExactNamespace()
+            || IsParentNamespace();
 
         bool IsGlobalNamespace() => @namespace is null;
         bool IsExactNamespace() => IsNamespacePrefix() && type.Namespace.Length == @namespace.Length;
@@ -521,7 +530,7 @@ internal static class TypeExtensions
     public static bool IsSameOrInherits(this Type actualType, Type expectedType)
     {
         return actualType == expectedType ||
-               expectedType.IsAssignableFrom(actualType);
+            expectedType.IsAssignableFrom(actualType);
     }
 
     public static MethodInfo GetExplicitConversionOperator(this Type type, Type sourceType, Type targetType)
@@ -558,22 +567,23 @@ internal static class TypeExtensions
         return typeof(ITuple).IsAssignableFrom(type);
 #else
         Type openType = type.GetGenericTypeDefinition();
+
         return openType == typeof(ValueTuple<>)
-               || openType == typeof(ValueTuple<,>)
-               || openType == typeof(ValueTuple<,,>)
-               || openType == typeof(ValueTuple<,,,>)
-               || openType == typeof(ValueTuple<,,,,>)
-               || openType == typeof(ValueTuple<,,,,,>)
-               || openType == typeof(ValueTuple<,,,,,,>)
-               || (openType == typeof(ValueTuple<,,,,,,,>) && IsTuple(type.GetGenericArguments()[7]))
-               || openType == typeof(Tuple<>)
-               || openType == typeof(Tuple<,>)
-               || openType == typeof(Tuple<,,>)
-               || openType == typeof(Tuple<,,,>)
-               || openType == typeof(Tuple<,,,,>)
-               || openType == typeof(Tuple<,,,,,>)
-               || openType == typeof(Tuple<,,,,,,>)
-               || (openType == typeof(Tuple<,,,,,,,>) && IsTuple(type.GetGenericArguments()[7]));
+            || openType == typeof(ValueTuple<,>)
+            || openType == typeof(ValueTuple<,,>)
+            || openType == typeof(ValueTuple<,,,>)
+            || openType == typeof(ValueTuple<,,,,>)
+            || openType == typeof(ValueTuple<,,,,,>)
+            || openType == typeof(ValueTuple<,,,,,,>)
+            || (openType == typeof(ValueTuple<,,,,,,,>) && IsTuple(type.GetGenericArguments()[7]))
+            || openType == typeof(Tuple<>)
+            || openType == typeof(Tuple<,>)
+            || openType == typeof(Tuple<,,>)
+            || openType == typeof(Tuple<,,,>)
+            || openType == typeof(Tuple<,,,,>)
+            || openType == typeof(Tuple<,,,,,>)
+            || openType == typeof(Tuple<,,,,,,>)
+            || (openType == typeof(Tuple<,,,,,,,>) && IsTuple(type.GetGenericArguments()[7]));
 #endif
     }
 
@@ -600,8 +610,8 @@ internal static class TypeExtensions
     private static bool IsRecordClass(this Type type)
     {
         return type.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly) is { } &&
-               type.GetProperty("EqualityContract", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)?
-                   .GetMethod?.IsDecoratedWith<CompilerGeneratedAttribute>() == true;
+            type.GetProperty("EqualityContract", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)?
+                .GetMethod?.IsDecoratedWith<CompilerGeneratedAttribute>() == true;
     }
 
     private static bool IsRecordStruct(this Type type)
@@ -610,9 +620,11 @@ internal static class TypeExtensions
         // recognizing record structs from metadata is an open point. The following check is based on common sense
         // and heuristic testing, apparently giving good results but not supported by official documentation.
         return type.BaseType == typeof(ValueType) &&
-               type.GetMethod("PrintMembers", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly, null, new[] { typeof(StringBuilder) }, null) is { } &&
-               type.GetMethod("op_Equality", BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly, null, new[] { type, type }, null)?
-                   .IsDecoratedWith<CompilerGeneratedAttribute>() == true;
+            type.GetMethod("PrintMembers", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly, null,
+                new[] { typeof(StringBuilder) }, null) is { } &&
+            type.GetMethod("op_Equality", BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly, null,
+                    new[] { type, type }, null)?
+                .IsDecoratedWith<CompilerGeneratedAttribute>() == true;
     }
 
     private static bool IsKeyValuePair(Type type)

--- a/Src/FluentAssertions/CustomAssertionAttribute.cs
+++ b/Src/FluentAssertions/CustomAssertionAttribute.cs
@@ -6,7 +6,7 @@ namespace FluentAssertions;
 /// Marks a method as an extension to Fluent Assertions that either uses the built-in assertions
 /// internally, or directly uses the <c>Execute.Assertion</c>.
 /// </summary>
-[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Method)]
 public class CustomAssertionAttribute : Attribute
 {
 }

--- a/Src/FluentAssertions/Data/DataColumnAssertions.cs
+++ b/Src/FluentAssertions/Data/DataColumnAssertions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Data;
 using System.Diagnostics;
-
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
@@ -54,7 +53,8 @@ public class DataColumnAssertions : ReferenceTypeAssertions<DataColumn, DataColu
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<DataColumnAssertions> BeEquivalentTo(DataColumn expectation, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataColumnAssertions> BeEquivalentTo(DataColumn expectation, string because = "",
+        params object[] becauseArgs)
     {
         return BeEquivalentTo(
             expectation,
@@ -110,17 +110,22 @@ public class DataColumnAssertions : ReferenceTypeAssertions<DataColumn, DataColu
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="config"/> is <see langword="null"/>.</exception>
-    public AndConstraint<DataColumnAssertions> BeEquivalentTo(DataColumn expectation, Func<IDataEquivalencyAssertionOptions<DataColumn>, IDataEquivalencyAssertionOptions<DataColumn>> config, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataColumnAssertions> BeEquivalentTo(DataColumn expectation,
+        Func<IDataEquivalencyAssertionOptions<DataColumn>, IDataEquivalencyAssertionOptions<DataColumn>> config,
+        string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(config);
 
-        IDataEquivalencyAssertionOptions<DataColumn> options = config(AssertionOptions.CloneDefaults<DataColumn, DataEquivalencyAssertionOptions<DataColumn>>(e => new(e)));
+        IDataEquivalencyAssertionOptions<DataColumn> options =
+            config(AssertionOptions.CloneDefaults<DataColumn, DataEquivalencyAssertionOptions<DataColumn>>(e =>
+                new DataEquivalencyAssertionOptions<DataColumn>(e)));
 
-        var context = new EquivalencyValidationContext(Node.From<DataColumn>(() => AssertionScope.Current.CallerIdentity), options)
-        {
-            Reason = new Reason(because, becauseArgs),
-            TraceWriter = options.TraceWriter
-        };
+        var context =
+            new EquivalencyValidationContext(Node.From<DataColumn>(() => AssertionScope.Current.CallerIdentity), options)
+            {
+                Reason = new Reason(because, becauseArgs),
+                TraceWriter = options.TraceWriter
+            };
 
         var comparands = new Comparands
         {

--- a/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq.Expressions;
 using System.Reflection;
-
 using FluentAssertions.Equivalency;
 
 namespace FluentAssertions.Data;
@@ -14,18 +13,13 @@ internal class DataEquivalencyAssertionOptions<T> : EquivalencyAssertionOptions<
     private readonly HashSet<string> excludeColumnNames = new();
     private readonly Dictionary<string, HashSet<string>> excludeColumnNamesByTableName = new();
 
-    private bool allowMismatchedTypes;
-    private bool ignoreUnmatchedColumns;
-    private RowMatchMode rowMatchMode;
-    private bool excludeOriginalData;
+    public bool AllowMismatchedTypes { get; private set; }
 
-    public bool AllowMismatchedTypes => allowMismatchedTypes;
+    public bool IgnoreUnmatchedColumns { get; private set; }
 
-    public bool IgnoreUnmatchedColumns => ignoreUnmatchedColumns;
+    public bool ExcludeOriginalData { get; private set; }
 
-    public bool ExcludeOriginalData => excludeOriginalData;
-
-    public RowMatchMode RowMatchMode => rowMatchMode;
+    public RowMatchMode RowMatchMode { get; private set; }
 
     public ISet<string> ExcludeTableNames => excludeTableNames;
 
@@ -38,25 +32,25 @@ internal class DataEquivalencyAssertionOptions<T> : EquivalencyAssertionOptions<
 
     public IDataEquivalencyAssertionOptions<T> AllowingMismatchedTypes()
     {
-        allowMismatchedTypes = true;
+        AllowMismatchedTypes = true;
         return this;
     }
 
     public IDataEquivalencyAssertionOptions<T> IgnoringUnmatchedColumns()
     {
-        ignoreUnmatchedColumns = true;
+        IgnoreUnmatchedColumns = true;
         return this;
     }
 
     public IDataEquivalencyAssertionOptions<T> UsingRowMatchMode(RowMatchMode rowMatchMode)
     {
-        this.rowMatchMode = rowMatchMode;
+        RowMatchMode = rowMatchMode;
         return this;
     }
 
     public IDataEquivalencyAssertionOptions<T> ExcludingOriginalData()
     {
-        excludeOriginalData = true;
+        ExcludeOriginalData = true;
         return this;
     }
 
@@ -109,7 +103,8 @@ internal class DataEquivalencyAssertionOptions<T> : EquivalencyAssertionOptions<
         return this;
     }
 
-    private void ExcludeMemberOfRelatedTypeByGeneratedPredicate<TDeclaringType, TPropertyType>(Expression<Func<TDeclaringType, TPropertyType>> expression)
+    private void ExcludeMemberOfRelatedTypeByGeneratedPredicate<TDeclaringType, TPropertyType>(
+        Expression<Func<TDeclaringType, TPropertyType>> expression)
     {
         Expression<Func<IMemberInfo, bool>> predicate = BuildMemberSelectionPredicate(
             typeof(TDeclaringType),
@@ -118,7 +113,8 @@ internal class DataEquivalencyAssertionOptions<T> : EquivalencyAssertionOptions<
         Excluding(predicate);
     }
 
-    private void ExcludeMemberOfSubtypeOfRelatedTypeByGeneratedPredicate<TDeclaringType, TInheritingType, TPropertyType>(Expression<Func<TDeclaringType, TPropertyType>> expression)
+    private void ExcludeMemberOfSubtypeOfRelatedTypeByGeneratedPredicate<TDeclaringType, TInheritingType, TPropertyType>(
+        Expression<Func<TDeclaringType, TPropertyType>> expression)
         where TInheritingType : TDeclaringType
     {
         Expression<Func<IMemberInfo, bool>> predicate = BuildMemberSelectionPredicate(
@@ -130,8 +126,8 @@ internal class DataEquivalencyAssertionOptions<T> : EquivalencyAssertionOptions<
 
     private static MemberInfo GetMemberAccessTargetMember(Expression expression)
     {
-        if ((expression is UnaryExpression unaryExpression)
-         && (unaryExpression.NodeType == ExpressionType.Convert))
+        if (expression is UnaryExpression unaryExpression
+            && unaryExpression.NodeType == ExpressionType.Convert)
         {
             // If the expression is a value type, then accessing it will involve an
             // implicit boxing conversion to type object that we need to ignore.
@@ -146,7 +142,8 @@ internal class DataEquivalencyAssertionOptions<T> : EquivalencyAssertionOptions<
         throw new ArgumentException("Expression must be a simple member access", nameof(expression));
     }
 
-    private static Expression<Func<IMemberInfo, bool>> BuildMemberSelectionPredicate(Type relatedSubjectType, MemberInfo referencedMember)
+    private static Expression<Func<IMemberInfo, bool>> BuildMemberSelectionPredicate(Type relatedSubjectType,
+        MemberInfo referencedMember)
     {
         ParameterExpression predicateMemberInfoArgument = Expression.Parameter(typeof(IMemberInfo));
 
@@ -260,7 +257,7 @@ internal class DataEquivalencyAssertionOptions<T> : EquivalencyAssertionOptions<
         }
 
         if (excludeColumnNamesByTableName.TryGetValue(column.Table.TableName, out HashSet<string> excludeColumnsForTable)
-         && excludeColumnsForTable.Contains(column.ColumnName))
+            && excludeColumnsForTable.Contains(column.ColumnName))
         {
             return true;
         }

--- a/Src/FluentAssertions/Data/DataRowAssertions.cs
+++ b/Src/FluentAssertions/Data/DataRowAssertions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Linq;
-
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
@@ -35,7 +34,8 @@ public class DataRowAssertions<TDataRow> : ReferenceTypeAssertions<TDataRow, Dat
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndWhichConstraint<DataRowAssertions<TDataRow>, DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs)
+    public AndWhichConstraint<DataRowAssertions<TDataRow>, DataColumn> HaveColumn(string expectedColumnName, string because = "",
+        params object[] becauseArgs)
     {
         var subjectColumn = default(DataColumn);
 
@@ -43,13 +43,15 @@ public class DataRowAssertions<TDataRow> : ReferenceTypeAssertions<TDataRow, Dat
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataRow} to contain a column named {0}{reason}, but found <null>.", expectedColumnName);
+                .FailWith("Expected {context:DataRow} to contain a column named {0}{reason}, but found <null>.",
+                    expectedColumnName);
         }
         else if (!Subject.Table.Columns.Contains(expectedColumnName))
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataRow} to contain a column named {0}{reason}, but it does not.", expectedColumnName);
+                .FailWith("Expected {context:DataRow} to contain a column named {0}{reason}, but it does not.",
+                    expectedColumnName);
         }
         else
         {
@@ -79,13 +81,16 @@ public class DataRowAssertions<TDataRow> : ReferenceTypeAssertions<TDataRow, Dat
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<DataRowAssertions<TDataRow>> HaveColumns(IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataRowAssertions<TDataRow>> HaveColumns(IEnumerable<string> expectedColumnNames, string because = "",
+        params object[] becauseArgs)
     {
         if (Subject is null)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataRow} to be in a table containing {0} column(s) with specific names{reason}, but found <null>.", expectedColumnNames.Count());
+                .FailWith(
+                    "Expected {context:DataRow} to be in a table containing {0} column(s) with specific names{reason}, but found <null>.",
+                    expectedColumnNames.Count());
         }
 
         foreach (var expectedColumnName in expectedColumnNames)
@@ -93,7 +98,8 @@ public class DataRowAssertions<TDataRow> : ReferenceTypeAssertions<TDataRow, Dat
             Execute.Assertion
                 .ForCondition(Subject.Table.Columns.Contains(expectedColumnName))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected table containing {context:DataRow} to contain a column named {0}{reason}, but it does not.", expectedColumnName);
+                .FailWith("Expected table containing {context:DataRow} to contain a column named {0}{reason}, but it does not.",
+                    expectedColumnName);
         }
 
         return new AndConstraint<DataRowAssertions<TDataRow>>(this);
@@ -114,8 +120,7 @@ public class DataRowAssertions<TDataRow> : ReferenceTypeAssertions<TDataRow, Dat
     /// The <see cref="DataRow"/> objects must be of the same type; if two <see cref="DataRow"/> objects
     /// are equivalent in all ways, except that one is part of a typed <see cref="DataTable"/> and is of a subclass
     /// of <see cref="DataRow"/>, then by default, they will not be considered equivalent. This can be overridden
-    /// with the <see cref="BeEquivalentTo(DataRow, Func{IDataEquivalencyAssertionOptions{DataRow}, IDataEquivalencyAssertionOptions{DataRow}}, string, object[])"/>
-    /// overload.
+    /// by using the overload that takes <see cref="IDataEquivalencyAssertionOptions{DataSet}"/>.
     /// </remarks>
     /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
     /// <param name="because">
@@ -125,7 +130,8 @@ public class DataRowAssertions<TDataRow> : ReferenceTypeAssertions<TDataRow, Dat
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<DataRowAssertions<TDataRow>> BeEquivalentTo(DataRow expectation, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataRowAssertions<TDataRow>> BeEquivalentTo(DataRow expectation, string because = "",
+        params object[] becauseArgs)
     {
         return BeEquivalentTo(
             expectation,
@@ -175,11 +181,15 @@ public class DataRowAssertions<TDataRow> : ReferenceTypeAssertions<TDataRow, Dat
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="config"/> is <see langword="null"/>.</exception>
-    public AndConstraint<DataRowAssertions<TDataRow>> BeEquivalentTo(DataRow expectation, Func<IDataEquivalencyAssertionOptions<DataRow>, IDataEquivalencyAssertionOptions<DataRow>> config, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataRowAssertions<TDataRow>> BeEquivalentTo(DataRow expectation,
+        Func<IDataEquivalencyAssertionOptions<DataRow>, IDataEquivalencyAssertionOptions<DataRow>> config, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(config);
 
-        IDataEquivalencyAssertionOptions<DataRow> options = config(AssertionOptions.CloneDefaults<DataRow, DataEquivalencyAssertionOptions<DataRow>>(e => new(e)));
+        IDataEquivalencyAssertionOptions<DataRow> options =
+            config(AssertionOptions.CloneDefaults<DataRow, DataEquivalencyAssertionOptions<DataRow>>(e =>
+                new DataEquivalencyAssertionOptions<DataRow>(e)));
 
         var context = new EquivalencyValidationContext(Node.From<DataRow>(() => AssertionScope.Current.CallerIdentity), options)
         {

--- a/Src/FluentAssertions/Data/DataSetAssertions.cs
+++ b/Src/FluentAssertions/Data/DataSetAssertions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Linq;
-
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
@@ -35,7 +34,8 @@ public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, Data
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<DataSetAssertions<TDataSet>> HaveTableCount(int expected, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataSetAssertions<TDataSet>> HaveTableCount(int expected, string because = "",
+        params object[] becauseArgs)
     {
         if (Subject is null)
         {
@@ -49,7 +49,8 @@ public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, Data
         Execute.Assertion
             .ForCondition(actualCount == expected)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:DataSet} to contain exactly {0} table(s){reason}, but found {1}.", expected, actualCount);
+            .FailWith("Expected {context:DataSet} to contain exactly {0} table(s){reason}, but found {1}.", expected,
+                actualCount);
 
         return new AndConstraint<DataSetAssertions<TDataSet>>(this);
     }
@@ -65,7 +66,8 @@ public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, Data
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndWhichConstraint<DataSetAssertions<TDataSet>, DataTable> HaveTable(string expectedTableName, string because = "", params object[] becauseArgs)
+    public AndWhichConstraint<DataSetAssertions<TDataSet>, DataTable> HaveTable(string expectedTableName, string because = "",
+        params object[] becauseArgs)
     {
         var subjectTable = default(DataTable);
 
@@ -73,7 +75,8 @@ public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, Data
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataSet} to contain a table named {0}{reason}, but found <null>.", expectedTableName);
+                .FailWith("Expected {context:DataSet} to contain a table named {0}{reason}, but found <null>.",
+                    expectedTableName);
         }
         else if (!Subject.Tables.Contains(expectedTableName))
         {
@@ -109,13 +112,15 @@ public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, Data
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<DataSetAssertions<TDataSet>> HaveTables(IEnumerable<string> expectedTableNames, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataSetAssertions<TDataSet>> HaveTables(IEnumerable<string> expectedTableNames, string because = "",
+        params object[] becauseArgs)
     {
         if (Subject is null)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataSet} to contain {0} table(s) with specific names{reason}, but found <null>.", expectedTableNames.Count());
+                .FailWith("Expected {context:DataSet} to contain {0} table(s) with specific names{reason}, but found <null>.",
+                    expectedTableNames.Count());
         }
 
         foreach (var expectedTableName in expectedTableNames)
@@ -151,9 +156,8 @@ public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, Data
     /// The <see cref="DataSet"/> objects must be of the same type; if two <see cref="DataSet"/> objects
     /// are equivalent in all ways, except that one is a custom subclass of <see cref="DataSet"/> (e.g. to provide
     /// typed accessors for <see cref="DataTable"/> values contained by the <see cref="DataSet"/>), then by default,
-    /// they will not be considered equivalent. This can be overridden with the
-    /// <see cref="BeEquivalentTo(DataSet, Func{IDataEquivalencyAssertionOptions{DataSet}, IDataEquivalencyAssertionOptions{DataSet}}, string, object[])"/>
-    /// overload.
+    /// they will not be considered equivalent. This can be overridden by using the overload that takes
+    /// <see cref="IDataEquivalencyAssertionOptions{DataSet}"/>.
     /// </remarks>
     /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
     /// <param name="because">
@@ -163,7 +167,8 @@ public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, Data
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<DataSetAssertions<TDataSet>> BeEquivalentTo(DataSet expectation, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataSetAssertions<TDataSet>> BeEquivalentTo(DataSet expectation, string because = "",
+        params object[] becauseArgs)
     {
         return BeEquivalentTo(
             expectation,
@@ -227,11 +232,15 @@ public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, Data
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="config"/> is <see langword="null"/>.</exception>
-    public AndConstraint<DataSetAssertions<TDataSet>> BeEquivalentTo(DataSet expectation, Func<IDataEquivalencyAssertionOptions<DataSet>, IDataEquivalencyAssertionOptions<DataSet>> config, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataSetAssertions<TDataSet>> BeEquivalentTo(DataSet expectation,
+        Func<IDataEquivalencyAssertionOptions<DataSet>, IDataEquivalencyAssertionOptions<DataSet>> config, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(config);
 
-        IDataEquivalencyAssertionOptions<DataSet> options = config(AssertionOptions.CloneDefaults<DataSet, DataEquivalencyAssertionOptions<DataSet>>(e => new(e)));
+        IDataEquivalencyAssertionOptions<DataSet> options =
+            config(AssertionOptions.CloneDefaults<DataSet, DataEquivalencyAssertionOptions<DataSet>>(e =>
+                new DataEquivalencyAssertionOptions<DataSet>(e)));
 
         var comparands = new Comparands
         {

--- a/Src/FluentAssertions/Data/DataTableAssertions.cs
+++ b/Src/FluentAssertions/Data/DataTableAssertions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Linq;
-
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
@@ -35,7 +34,8 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<DataTableAssertions<TDataTable>> HaveRowCount(int expected, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataTableAssertions<TDataTable>> HaveRowCount(int expected, string because = "",
+        params object[] becauseArgs)
     {
         if (Subject is null)
         {
@@ -49,7 +49,8 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
         Execute.Assertion
             .ForCondition(actualCount == expected)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:DataTable} to contain exactly {0} row(s){reason}, but found {1}.", expected, actualCount);
+            .FailWith("Expected {context:DataTable} to contain exactly {0} row(s){reason}, but found {1}.", expected,
+                actualCount);
 
         return new AndConstraint<DataTableAssertions<TDataTable>>(this);
     }
@@ -65,7 +66,8 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndWhichConstraint<DataTableAssertions<TDataTable>, DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs)
+    public AndWhichConstraint<DataTableAssertions<TDataTable>, DataColumn> HaveColumn(string expectedColumnName,
+        string because = "", params object[] becauseArgs)
     {
         var subjectColumn = default(DataColumn);
 
@@ -73,13 +75,15 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataTable} to contain a column named {0}{reason}, but found <null>.", expectedColumnName);
+                .FailWith("Expected {context:DataTable} to contain a column named {0}{reason}, but found <null>.",
+                    expectedColumnName);
         }
         else if (!Subject.Columns.Contains(expectedColumnName))
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataTable} to contain a column named {0}{reason}, but it does not.", expectedColumnName);
+                .FailWith("Expected {context:DataTable} to contain a column named {0}{reason}, but it does not.",
+                    expectedColumnName);
         }
         else
         {
@@ -109,13 +113,15 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<DataTableAssertions<TDataTable>> HaveColumns(IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataTableAssertions<TDataTable>> HaveColumns(IEnumerable<string> expectedColumnNames,
+        string because = "", params object[] becauseArgs)
     {
         if (Subject is null)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataTable} to contain {0} column(s) with specific names{reason}, but found <null>.", expectedColumnNames.Count());
+                .FailWith("Expected {context:DataTable} to contain {0} column(s) with specific names{reason}, but found <null>.",
+                    expectedColumnNames.Count());
         }
 
         foreach (var expectedColumnName in expectedColumnNames)
@@ -123,7 +129,8 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
             Execute.Assertion
                 .ForCondition(Subject.Columns.Contains(expectedColumnName))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataTable} to contain a column named {0}{reason}, but it does not.", expectedColumnName);
+                .FailWith("Expected {context:DataTable} to contain a column named {0}{reason}, but it does not.",
+                    expectedColumnName);
         }
 
         return new AndConstraint<DataTableAssertions<TDataTable>>(this);
@@ -160,9 +167,8 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
     ///
     /// The <see cref="DataTable"/> objects must be of the same type; if two <see cref="DataTable"/> objects
     /// are equivalent in all ways, except that one is a typed <see cref="DataTable"/> that is a subclass
-    /// of <see cref="DataTable"/>, then by default, they will not be considered equivalent. This can be overridden
-    /// with the <see cref="BeEquivalentTo(DataTable, Func{IDataEquivalencyAssertionOptions{DataTable}, IDataEquivalencyAssertionOptions{DataTable}}, string, object[])"/>
-    /// overload.
+    /// of <see cref="DataTable"/>, then by default, they will not be considered equivalent. This can be overridden by
+    /// using the overload that takes <see cref="IDataEquivalencyAssertionOptions{DataSet}"/>.
     /// </remarks>
     /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
     /// <param name="because">
@@ -172,7 +178,8 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<DataTableAssertions<TDataTable>> BeEquivalentTo(DataTable expectation, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataTableAssertions<TDataTable>> BeEquivalentTo(DataTable expectation, string because = "",
+        params object[] becauseArgs)
     {
         return BeEquivalentTo(
             expectation,
@@ -240,11 +247,15 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="config"/> is <see langword="null"/>.</exception>
-    public AndConstraint<DataTableAssertions<TDataTable>> BeEquivalentTo(DataTable expectation, Func<IDataEquivalencyAssertionOptions<DataTable>, IDataEquivalencyAssertionOptions<DataTable>> config, string because = "", params object[] becauseArgs)
+    public AndConstraint<DataTableAssertions<TDataTable>> BeEquivalentTo(DataTable expectation,
+        Func<IDataEquivalencyAssertionOptions<DataTable>, IDataEquivalencyAssertionOptions<DataTable>> config,
+        string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(config);
 
-        IDataEquivalencyAssertionOptions<DataTable> options = config(AssertionOptions.CloneDefaults<DataTable, DataEquivalencyAssertionOptions<DataTable>>(e => new(e)));
+        IDataEquivalencyAssertionOptions<DataTable> options =
+            config(AssertionOptions.CloneDefaults<DataTable, DataEquivalencyAssertionOptions<DataTable>>(e =>
+                new DataEquivalencyAssertionOptions<DataTable>(e)));
 
         var context = new EquivalencyValidationContext(Node.From<DataTable>(() => AssertionScope.Current.CallerIdentity), options)
         {

--- a/Src/FluentAssertions/Data/IDataEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Data/IDataEquivalencyAssertionOptions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq.Expressions;
-
 using FluentAssertions.Equivalency;
 
 namespace FluentAssertions.Data;

--- a/Src/FluentAssertions/DataColumnCollectionAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataColumnCollectionAssertionExtensions.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Globalization;
 using System.Linq;
-
 using FluentAssertions.Collections;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
@@ -124,7 +121,7 @@ public static class DataColumnCollectionAssertionExtensions
             .ForCondition(subject => subject is not null)
             .FailWith("the same count as {0}{reason}, but found <null>.", otherCollection)
             .Then
-            .Given((subject) => (actual: subject.Count(), expected: otherCollection.Count))
+            .Given(subject => (actual: subject.Count(), expected: otherCollection.Count))
             .ForCondition(count => count.actual == count.expected)
             .FailWith("{0} column(s){reason}, but found {1}.", count => count.expected, count => count.actual)
             .Then
@@ -161,7 +158,7 @@ public static class DataColumnCollectionAssertionExtensions
             .ForCondition(subject => subject is not null)
             .FailWith("the same count as {0}{reason}, but found <null>.", otherCollection)
             .Then
-            .Given((subject) => (actual: subject.Count(), expected: otherCollection.Count))
+            .Given(subject => (actual: subject.Count(), expected: otherCollection.Count))
             .ForCondition(count => count.actual != count.expected)
             .FailWith("{0} column(s){reason}, but found {1}.", count => count.expected, count => count.actual)
             .Then

--- a/Src/FluentAssertions/DataRowAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataRowAssertionExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System.Data;
 using System.Diagnostics;
-
 using FluentAssertions.Data;
-
 using JetBrains.Annotations;
 
 namespace FluentAssertions;

--- a/Src/FluentAssertions/DataRowCollectionAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataRowCollectionAssertionExtensions.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-
 using FluentAssertions.Collections;
 using FluentAssertions.Common;
-using FluentAssertions.Data;
-using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions;
@@ -118,7 +114,7 @@ public static class DataRowCollectionAssertionExtensions
             .ForCondition(subject => subject is not null)
             .FailWith("the same count as {0}{reason}, but found <null>.", otherCollection)
             .Then
-            .Given((subject) => (actual: subject.Count(), expected: otherCollection.Count))
+            .Given(subject => (actual: subject.Count(), expected: otherCollection.Count))
             .ForCondition(count => count.actual == count.expected)
             .FailWith("{0} row(s){reason}, but found {1}.", count => count.expected, count => count.actual)
             .Then
@@ -154,7 +150,7 @@ public static class DataRowCollectionAssertionExtensions
             .ForCondition(subject => subject is not null)
             .FailWith("the same count as {0}{reason}, but found <null>.", otherCollection)
             .Then
-            .Given((subject) => (actual: subject.Count(), expected: otherCollection.Count))
+            .Given(subject => (actual: subject.Count(), expected: otherCollection.Count))
             .ForCondition(count => count.actual != count.expected)
             .FailWith("{0} row(s){reason}, but found {1}.", count => count.expected, count => count.actual)
             .Then

--- a/Src/FluentAssertions/DataSetAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataSetAssertionExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System.Data;
 using System.Diagnostics;
-
 using FluentAssertions.Data;
-
 using JetBrains.Annotations;
 
 namespace FluentAssertions;

--- a/Src/FluentAssertions/DataTableAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataTableAssertionExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System.Data;
 using System.Diagnostics;
-
 using FluentAssertions.Data;
-
 using JetBrains.Annotations;
 
 namespace FluentAssertions;

--- a/Src/FluentAssertions/DataTableCollectionAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataTableCollectionAssertionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Data;
 using System.Linq;
-
 using FluentAssertions.Collections;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
@@ -153,7 +152,7 @@ public static class DataTableCollectionAssertionExtensions
             .ForCondition(subject => subject is not null)
             .FailWith("the same count as {0}{reason}, but found <null>.", otherCollection)
             .Then
-            .Given((subject) => (actual: subject.Count(), expected: otherCollection.Count))
+            .Given(subject => (actual: subject.Count(), expected: otherCollection.Count))
             .ForCondition(count => count.actual == count.expected)
             .FailWith("{0} table(s){reason}, but found {1}.", count => count.expected, count => count.actual)
             .Then
@@ -189,7 +188,7 @@ public static class DataTableCollectionAssertionExtensions
             .ForCondition(subject => subject is not null)
             .FailWith("the same count as {0}{reason}, but found <null>.", otherCollection)
             .Then
-            .Given((subject) => (actual: subject.Count(), expected: otherCollection.Count))
+            .Given(subject => (actual: subject.Count(), expected: otherCollection.Count))
             .ForCondition(count => count.actual != count.expected)
             .FailWith("{0} table(s){reason}, but found {1}.", count => count.expected, count => count.actual)
             .Then

--- a/Src/FluentAssertions/Equivalency/Comparands.cs
+++ b/Src/FluentAssertions/Equivalency/Comparands.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using FluentAssertions.Common;
 using static System.FormattableString;
 
@@ -34,7 +33,7 @@ public class Comparands
     {
         get
         {
-            return ((compileTimeType != typeof(object)) || Expectation is null) ? compileTimeType : RuntimeType;
+            return compileTimeType != typeof(object) || Expectation is null ? compileTimeType : RuntimeType;
         }
 
         // SMELL: Do we really need this? Can we replace it by making Comparands generic or take a constructor parameter?

--- a/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
@@ -18,8 +18,8 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Represents the run-time type-specific behavior of a structural equivalency assertion.
 /// </summary>
-public class EquivalencyAssertionOptions<TExpectation> :
-    SelfReferenceEquivalencyAssertionOptions<EquivalencyAssertionOptions<TExpectation>>
+public class EquivalencyAssertionOptions<TExpectation>
+    : SelfReferenceEquivalencyAssertionOptions<EquivalencyAssertionOptions<TExpectation>>
 {
     public EquivalencyAssertionOptions()
     {
@@ -43,7 +43,8 @@ public class EquivalencyAssertionOptions<TExpectation> :
     /// Selects a collection to define exclusions at.
     /// Allows to navigate deeper by using <see cref="For{TNext}"/>.
     /// </summary>
-    public NestedExclusionOptionBuilder<TExpectation, TNext> For<TNext>(Expression<Func<TExpectation, IEnumerable<TNext>>> expression)
+    public NestedExclusionOptionBuilder<TExpectation, TNext> For<TNext>(
+        Expression<Func<TExpectation, IEnumerable<TNext>>> expression)
     {
         var selectionRule = new ExcludeMemberByPathSelectionRule(expression.GetMemberPath());
         AddSelectionRule(selectionRule);

--- a/Src/FluentAssertions/Equivalency/EquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyStep.cs
@@ -5,7 +5,8 @@
 /// </summary>
 public abstract class EquivalencyStep<T> : IEquivalencyStep
 {
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         if (!typeof(T).IsAssignableFrom(comparands.GetExpectedType(context.Options)))
         {
@@ -18,5 +19,6 @@ public abstract class EquivalencyStep<T> : IEquivalencyStep
     /// <summary>
     /// Implements <see cref="IEquivalencyStep.Handle"/>, but only gets called when the expected type matches <typeparamref name="T"/>.
     /// </summary>
-    protected abstract EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator);
+    protected abstract EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator);
 }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -46,6 +46,7 @@ public class EquivalencyValidator : IEquivalencyValidator
         AssertionScope assertionScope)
     {
         bool shouldRecurse = options.AllowInfiniteRecursion || currentNode.Depth < MaxDepth;
+
         if (!shouldRecurse)
         {
             assertionScope.FailWith("The maximum recursion depth was reached.  ");
@@ -66,9 +67,11 @@ public class EquivalencyValidator : IEquivalencyValidator
         using var _ = context.Tracer.WriteBlock(node => node.Description);
 
         Func<IEquivalencyStep, GetTraceMessage> getMessage = step => _ => $"Equivalency was proven by {step.GetType().Name}";
+
         foreach (IEquivalencyStep step in AssertionOptions.EquivalencyPlan)
         {
             var result = step.Handle(comparands, context, this);
+
             if (result == EquivalencyResult.AssertionCompleted)
             {
                 context.Tracer.WriteLine(getMessage(step));

--- a/Src/FluentAssertions/Equivalency/Execution/CollectionMemberAssertionOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CollectionMemberAssertionOptionsDecorator.cs
@@ -36,7 +36,8 @@ internal class CollectionMemberAssertionOptionsDecorator : IEquivalencyAssertion
     {
         get
         {
-            return new OrderingRuleCollection(inner.OrderingRules.Select(rule => new CollectionMemberOrderingRuleDecorator(rule)));
+            return new OrderingRuleCollection(inner.OrderingRules.Select(rule =>
+                new CollectionMemberOrderingRuleDecorator(rule)));
         }
     }
 

--- a/Src/FluentAssertions/Equivalency/Execution/CyclicReferenceDetector.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CyclicReferenceDetector.cs
@@ -30,7 +30,7 @@ internal class CyclicReferenceDetector : ICloneable2
         {
             isCyclic = !observedReferences.Add(reference);
 
-            if (isCyclic && (handling == CyclicReferenceHandling.ThrowException))
+            if (isCyclic && handling == CyclicReferenceHandling.ThrowException)
             {
                 AssertionScope.Current
                     .BecauseOf(reason)

--- a/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs
@@ -39,7 +39,7 @@ internal class ObjectReference
 
     private string[] GetPathElements() => pathElements
         ??= path.ToUpperInvariant().Replace("][", "].[", StringComparison.Ordinal)
-                .Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+            .Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
 
     private bool IsParentOrChildOf(ObjectReference other)
     {
@@ -49,7 +49,7 @@ internal class ObjectReference
         int commonElements = Math.Min(path.Length, otherPath.Length);
         int longerPathAdditionalElements = Math.Max(path.Length, otherPath.Length) - commonElements;
 
-        return (longerPathAdditionalElements > 0) && otherPath.Take(commonElements).SequenceEqual(path.Take(commonElements));
+        return longerPathAdditionalElements > 0 && otherPath.Take(commonElements).SequenceEqual(path.Take(commonElements));
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-
 using FluentAssertions.Equivalency.Tracing;
 
 namespace FluentAssertions.Equivalency;

--- a/Src/FluentAssertions/Equivalency/IEquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyValidationContext.cs
@@ -1,4 +1,3 @@
-using System;
 using FluentAssertions.Equivalency.Tracing;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Equivalency/IMember.cs
+++ b/Src/FluentAssertions/Equivalency/IMember.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency;

--- a/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
@@ -20,7 +20,7 @@ internal class MappedMemberMatchingRule<TExpectation, TSubject> : IMemberMatchin
             throw new ArgumentException("The expectation's member name cannot be a nested path");
         }
 
-        if (Regex.IsMatch(subjectMemberName, $@"[\.\[\]]"))
+        if (Regex.IsMatch(subjectMemberName, @"[\.\[\]]"))
         {
             throw new ArgumentException("The subject's member name cannot be a nested path");
         }
@@ -36,6 +36,7 @@ internal class MappedMemberMatchingRule<TExpectation, TSubject> : IMemberMatchin
             if (expectedMember.Name == expectationMemberName)
             {
                 var member = MemberFactory.Find(subject, subjectMemberName, parent);
+
                 if (member is null)
                 {
                     throw new ArgumentException(

--- a/Src/FluentAssertions/Equivalency/Matching/MappedPathMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedPathMatchingRule.cs
@@ -23,6 +23,7 @@ internal class MappedPathMatchingRule : IMemberMatchingRule
     {
         Guard.ThrowIfArgumentIsNullOrEmpty(expectationMemberPath,
             nameof(expectationMemberPath), "A member path cannot be null");
+
         Guard.ThrowIfArgumentIsNullOrEmpty(subjectMemberPath,
             nameof(subjectMemberPath), "A member path cannot be null");
 
@@ -31,7 +32,8 @@ internal class MappedPathMatchingRule : IMemberMatchingRule
 
         if (expectationPath.GetContainsSpecificCollectionIndex() || subjectPath.GetContainsSpecificCollectionIndex())
         {
-            throw new ArgumentException("Mapping properties containing a collection index must use the [] format without specific index.");
+            throw new ArgumentException(
+                "Mapping properties containing a collection index must use the [] format without specific index.");
         }
 
         if (!expectationPath.HasSameParentAs(subjectPath))
@@ -43,6 +45,7 @@ internal class MappedPathMatchingRule : IMemberMatchingRule
     public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions options)
     {
         MemberPath path = expectationPath;
+
         if (expectedMember.RootIsCollection)
         {
             path = path.WithCollectionAsRoot();
@@ -51,6 +54,7 @@ internal class MappedPathMatchingRule : IMemberMatchingRule
         if (path.IsEquivalentTo(expectedMember.PathAndName))
         {
             var member = MemberFactory.Find(subject, subjectPath.MemberName, parent);
+
             if (member is null)
             {
                 throw new ArgumentException(

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -16,13 +16,13 @@ internal class MustMatchByNameRule : IMemberMatchingRule
         if (config.IncludedProperties != MemberVisibility.None)
         {
             PropertyInfo propertyInfo = subject.GetType().FindProperty(expectedMember.Name);
-            subjectMember = (propertyInfo is not null) && !propertyInfo.IsIndexer() ? new Property(propertyInfo, parent) : null;
+            subjectMember = propertyInfo is not null && !propertyInfo.IsIndexer() ? new Property(propertyInfo, parent) : null;
         }
 
-        if ((subjectMember is null) && config.IncludedFields != MemberVisibility.None)
+        if (subjectMember is null && config.IncludedFields != MemberVisibility.None)
         {
             FieldInfo fieldInfo = subject.GetType().FindField(expectedMember.Name);
-            subjectMember = (fieldInfo is not null) ? new Field(fieldInfo, parent) : null;
+            subjectMember = fieldInfo is not null ? new Field(fieldInfo, parent) : null;
         }
 
         if ((subjectMember is null || !config.UseRuntimeTyping) && ExpectationImplementsMemberExplicitly(subject, expectedMember))

--- a/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
@@ -11,13 +11,14 @@ internal class TryMatchByNameRule : IMemberMatchingRule
     public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions config)
     {
         PropertyInfo property = subject.GetType().FindProperty(expectedMember.Name);
-        if ((property is not null) && !property.IsIndexer())
+
+        if (property is not null && !property.IsIndexer())
         {
             return new Property(property, parent);
         }
 
         FieldInfo field = subject.GetType().FindField(expectedMember.Name);
-        return (field is not null) ? new Field(field, parent) : null;
+        return field is not null ? new Field(field, parent) : null;
     }
 
     /// <inheritdoc />

--- a/Src/FluentAssertions/Equivalency/MemberFactory.cs
+++ b/Src/FluentAssertions/Equivalency/MemberFactory.cs
@@ -24,12 +24,13 @@ public static class MemberFactory
     internal static IMember Find(object target, string memberName, INode parent)
     {
         PropertyInfo property = target.GetType().FindProperty(memberName);
-        if ((property is not null) && !property.IsIndexer())
+
+        if (property is not null && !property.IsIndexer())
         {
             return new Property(property, parent);
         }
 
         FieldInfo field = target.GetType().FindField(memberName);
-        return (field is not null) ? new Field(field, parent) : null;
+        return field is not null ? new Field(field, parent) : null;
     }
 }

--- a/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -11,7 +11,8 @@ namespace FluentAssertions.Equivalency;
 /// </summary>
 internal class MultiDimensionalArrayEquivalencyStep : IEquivalencyStep
 {
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         if (comparands.Expectation is not Array expectationAsArray || expectationAsArray.Rank == 1)
         {
@@ -116,6 +117,7 @@ internal class Digit
         var indices = new List<int>();
 
         Digit digit = this;
+
         while (digit is not null)
         {
             indices.Add(digit.index);
@@ -128,6 +130,7 @@ internal class Digit
     public bool Increment()
     {
         bool success = nextDigit?.Increment() == true;
+
         if (!success)
         {
             if (index < (length - 1))

--- a/Src/FluentAssertions/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Equivalency/Node.cs
@@ -123,7 +123,7 @@ public class Node : INode
             return true;
         }
 
-        if (obj.GetType() != this.GetType())
+        if (obj.GetType() != GetType())
         {
             return false;
         }

--- a/Src/FluentAssertions/Equivalency/Ordering/ByteArrayOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/ByteArrayOrderingRule.cs
@@ -11,7 +11,9 @@ internal class ByteArrayOrderingRule : IOrderingRule
 {
     public OrderStrictness Evaluate(IObjectInfo memberInfo)
     {
-        return memberInfo.CompileTimeType.IsSameOrInherits(typeof(IEnumerable<byte>)) ? OrderStrictness.Strict : OrderStrictness.Irrelevant;
+        return memberInfo.CompileTimeType.IsSameOrInherits(typeof(IEnumerable<byte>))
+            ? OrderStrictness.Strict
+            : OrderStrictness.Irrelevant;
     }
 
     public override string ToString()

--- a/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
@@ -22,6 +22,7 @@ internal class PathBasedOrderingRule : IOrderingRule
     public OrderStrictness Evaluate(IObjectInfo objectInfo)
     {
         string currentPropertyPath = objectInfo.Path;
+
         if (!ContainsIndexingQualifiers(path))
         {
             currentPropertyPath = RemoveInitialIndexQualifier(currentPropertyPath);
@@ -49,6 +50,7 @@ internal class PathBasedOrderingRule : IOrderingRule
         if (!indexQualifierRegex.IsMatch(path))
         {
             Match match = indexQualifierRegex.Match(sourcePath);
+
             if (match.Success)
             {
                 sourcePath = sourcePath.Substring(match.Length);

--- a/Src/FluentAssertions/Equivalency/Property.cs
+++ b/Src/FluentAssertions/Equivalency/Property.cs
@@ -51,10 +51,8 @@ public class Property : Node, IMember
     {
         get
         {
-            if (isBrowsable == null)
-            {
-                isBrowsable = propertyInfo.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
-            }
+            isBrowsable ??=
+                propertyInfo.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
 
             return isBrowsable.Value;
         }

--- a/Src/FluentAssertions/Equivalency/Selection/ExcludeNonBrowsableMembersRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/ExcludeNonBrowsableMembersRule.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace FluentAssertions.Equivalency.Selection;
@@ -8,7 +7,8 @@ internal class ExcludeNonBrowsableMembersRule : IMemberSelectionRule
 {
     public bool IncludesMembers => false;
 
-    public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers, MemberSelectionContext context)
+    public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
+        MemberSelectionContext context)
     {
         return selectedMembers.Where(member => member.IsBrowsable).ToList();
     }

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
@@ -19,11 +19,13 @@ internal class IncludeMemberByPathSelectionRule : SelectMemberByPathSelectionRul
 
     public override bool IncludesMembers => true;
 
-    protected override void AddOrRemoveMembersFrom(List<IMember> selectedMembers, INode parent, string parentPath, MemberSelectionContext context)
+    protected override void AddOrRemoveMembersFrom(List<IMember> selectedMembers, INode parent, string parentPath,
+        MemberSelectionContext context)
     {
         foreach (MemberInfo memberInfo in context.Type.GetNonPrivateMembers(MemberVisibility.Public | MemberVisibility.Internal))
         {
             var memberPath = new MemberPath(context.Type, memberInfo.DeclaringType, parentPath.Combine(memberInfo.Name));
+
             if (memberToInclude.IsSameAs(memberPath) || memberToInclude.IsParentOrChildOf(memberPath))
             {
                 selectedMembers.Add(MemberFactory.Create(memberInfo, parent));

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPredicateSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPredicateSelectionRule.cs
@@ -28,9 +28,11 @@ internal class IncludeMemberByPredicateSelectionRule : IMemberSelectionRule
     {
         var members = new List<IMember>(selectedMembers);
 
-        foreach (MemberInfo memberInfo in currentNode.Type.GetNonPrivateMembers(MemberVisibility.Public | MemberVisibility.Internal))
+        foreach (MemberInfo memberInfo in currentNode.Type.GetNonPrivateMembers(MemberVisibility.Public |
+                     MemberVisibility.Internal))
         {
             IMember member = MemberFactory.Create(memberInfo, currentNode);
+
             if (predicate(new MemberToMemberInfoAdapter(member)))
             {
                 if (!members.Any(p => p.IsEquivalentTo(member)))

--- a/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
@@ -18,7 +18,7 @@ internal abstract class SelectMemberByPathSelectionRule : IMemberSelectionRule
 
     protected void SetSelectedPath(string path)
     {
-        this.selectedPath = path;
+        selectedPath = path;
     }
 
     public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
@@ -51,6 +51,7 @@ internal abstract class SelectMemberByPathSelectionRule : IMemberSelectionRule
     private static string RemoveIndexQualifiers(string path)
     {
         Match match = new Regex(@"^\[\d+]").Match(path);
+
         if (match.Success)
         {
             path = path.Substring(match.Length);

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -759,8 +759,8 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
             builder.AppendLine("- Ignoring cyclic references");
         }
 
-        builder.AppendLine($"- Compare tuples by their properties");
-        builder.AppendLine($"- Compare anonymous types by their properties");
+        builder.AppendLine("- Compare tuples by their properties");
+        builder.AppendLine("- Compare anonymous types by their properties");
 
         if (compareRecordsByValue is true)
         {

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionContext.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionContext.cs
@@ -3,7 +3,7 @@ namespace FluentAssertions.Equivalency.Steps;
 internal class AssertionContext<TSubject> : IAssertionContext<TSubject>
 {
     private AssertionContext(INode currentNode, TSubject subject, TSubject expectation, string because,
-                            object[] becauseArgs)
+        object[] becauseArgs)
     {
         SelectedNode = currentNode;
         Subject = subject;
@@ -24,7 +24,7 @@ internal class AssertionContext<TSubject> : IAssertionContext<TSubject>
 
     internal static AssertionContext<TSubject> CreateFrom(Comparands comparands, IEquivalencyValidationContext context)
     {
-        return new(
+        return new AssertionContext<TSubject>(
             context.CurrentNode,
             (TSubject)comparands.Subject,
             (TSubject)comparands.Expectation,

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
@@ -22,9 +22,11 @@ public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
         description = predicate.ToString();
     }
 
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         bool success = false;
+
         using (var scope = new AssertionScope())
         {
             // Try without conversion
@@ -34,6 +36,7 @@ public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
             }
 
             bool converted = false;
+
             if (!success && context.Options.ConversionSelector.RequiresConversion(comparands, context.CurrentNode))
             {
                 // Convert into a child context
@@ -46,6 +49,7 @@ public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
             {
                 // Try again after conversion
                 success = ExecuteAssertion(comparands, context);
+
                 if (success)
                 {
                     // If the assertion succeeded after conversion, discard the failures from
@@ -75,7 +79,8 @@ public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
         bool expectationIsValidType =
             AssertionScope.Current
                 .ForCondition(expectationIsNull || comparands.Expectation.GetType().IsSameOrInherits(typeof(TSubject)))
-                .FailWith("Expected " + context.CurrentNode.Description + " from expectation to be a {0}{reason}, but found a {1}.",
+                .FailWith(
+                    "Expected " + context.CurrentNode.Description + " from expectation to be a {0}{reason}, but found a {1}.",
                     typeof(TSubject), comparands.Expectation?.GetType());
 
         if (subjectIsValidType && expectationIsValidType)

--- a/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
@@ -13,14 +13,15 @@ namespace FluentAssertions.Equivalency.Steps;
 /// </remarks>
 public class AutoConversionStep : IEquivalencyStep
 {
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         if (!context.Options.ConversionSelector.RequiresConversion(comparands, context.CurrentNode))
         {
             return EquivalencyResult.ContinueWithNext;
         }
 
-        if ((comparands.Expectation is null) || (comparands.Subject is null))
+        if (comparands.Expectation is null || comparands.Subject is null)
         {
             return EquivalencyResult.ContinueWithNext;
         }
@@ -35,13 +36,15 @@ public class AutoConversionStep : IEquivalencyStep
 
         if (TryChangeType(comparands.Subject, expectationType, out object convertedSubject))
         {
-            context.Tracer.WriteLine(member => Invariant($"Converted subject {comparands.Subject} at {member.Description} to {expectationType}"));
+            context.Tracer.WriteLine(member =>
+                Invariant($"Converted subject {comparands.Subject} at {member.Description} to {expectationType}"));
 
             comparands.Subject = convertedSubject;
         }
         else
         {
-            context.Tracer.WriteLine(member => Invariant($"Subject {comparands.Subject} at {member.Description} could not be converted to {expectationType}"));
+            context.Tracer.WriteLine(member =>
+                Invariant($"Subject {comparands.Subject} at {member.Description} could not be converted to {expectationType}"));
         }
 
         return EquivalencyResult.ContinueWithNext;
@@ -50,6 +53,7 @@ public class AutoConversionStep : IEquivalencyStep
     private static bool TryChangeType(object subject, Type expectationType, out object conversionResult)
     {
         conversionResult = null;
+
         try
         {
             conversionResult = Convert.ChangeType(subject, expectationType, CultureInfo.InvariantCulture);

--- a/Src/FluentAssertions/Equivalency/Steps/ConstraintCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ConstraintCollectionEquivalencyStep.cs
@@ -7,12 +7,14 @@ namespace FluentAssertions.Equivalency.Steps;
 
 public class ConstraintCollectionEquivalencyStep : EquivalencyStep<ConstraintCollection>
 {
-    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         if (comparands.Subject is not ConstraintCollection)
         {
             AssertionScope.Current
-                .FailWith("Expected a value of type ConstraintCollection at {context:Constraints}, but found {0}", comparands.Subject.GetType());
+                .FailWith("Expected a value of type ConstraintCollection at {context:Constraints}, but found {0}",
+                    comparands.Subject.GetType());
         }
         else
         {
@@ -28,13 +30,14 @@ public class ConstraintCollectionEquivalencyStep : EquivalencyStep<ConstraintCol
             {
                 AssertionScope.Current
                     .ForCondition(subjectConstraints.TryGetValue(constraintName, out Constraint subjectConstraint))
-                    .FailWith("Expected constraint named {0} in {context:Constraints collection}{reason}, but did not find one", constraintName);
+                    .FailWith("Expected constraint named {0} in {context:Constraints collection}{reason}, but did not find one",
+                        constraintName);
 
                 AssertionScope.Current
                     .ForCondition(expectationConstraints.TryGetValue(constraintName, out Constraint expectationConstraint))
                     .FailWith("Found unexpected constraint named {0} in {context:Constraints collection}", constraintName);
 
-                if ((subjectConstraint is not null) && (expectationConstraint is not null))
+                if (subjectConstraint is not null && expectationConstraint is not null)
                 {
                     Comparands newComparands = new()
                     {

--- a/Src/FluentAssertions/Equivalency/Steps/ConstraintEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ConstraintEquivalencyStep.cs
@@ -9,7 +9,8 @@ namespace FluentAssertions.Equivalency.Steps;
 
 public class ConstraintEquivalencyStep : EquivalencyStep<Constraint>
 {
-    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         if (comparands.Subject is not Constraint)
         {
@@ -36,14 +37,14 @@ public class ConstraintEquivalencyStep : EquivalencyStep<Constraint>
 
             if (matchingType)
             {
-                if ((subject is UniqueConstraint subjectUniqueConstraint)
-                    && (expectation is UniqueConstraint expectationUniqueConstraint))
+                if (subject is UniqueConstraint subjectUniqueConstraint
+                    && expectation is UniqueConstraint expectationUniqueConstraint)
                 {
                     CompareConstraints(nestedValidator, context, subjectUniqueConstraint, expectationUniqueConstraint,
                         selectedMembers);
                 }
-                else if ((subject is ForeignKeyConstraint subjectForeignKeyConstraint)
-                         && (expectation is ForeignKeyConstraint expectationForeignKeyConstraint))
+                else if (subject is ForeignKeyConstraint subjectForeignKeyConstraint
+                         && expectation is ForeignKeyConstraint expectationForeignKeyConstraint)
                 {
                     CompareConstraints(nestedValidator, context, subjectForeignKeyConstraint, expectationForeignKeyConstraint,
                         selectedMembers);
@@ -83,6 +84,7 @@ public class ConstraintEquivalencyStep : EquivalencyStep<Constraint>
         if (selectedMembers.TryGetValue("ExtendedProperties", out IMember expectationMember))
         {
             IMember matchingMember = FindMatchFor(expectationMember, context.CurrentNode, subject, options);
+
             if (matchingMember is not null)
             {
                 var nestedComparands = new Comparands
@@ -222,7 +224,8 @@ public class ConstraintEquivalencyStep : EquivalencyStep<Constraint>
             }
 
             failureMessage.Append("{reason}, but constraint does not include ");
-            failureMessage.Append((missingColumnNames.Count == 1)
+
+            failureMessage.Append(missingColumnNames.Count == 1
                 ? "that column. "
                 : "these columns. ");
         }

--- a/Src/FluentAssertions/Equivalency/Steps/DataColumnEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataColumnEquivalencyStep.cs
@@ -10,7 +10,8 @@ namespace FluentAssertions.Equivalency.Steps;
 public class DataColumnEquivalencyStep : EquivalencyStep<DataColumn>
 {
     [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
-    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         var subject = comparands.Subject as DataColumn;
         var expectation = comparands.Expectation as DataColumn;
@@ -54,9 +55,9 @@ public class DataColumnEquivalencyStep : EquivalencyStep<DataColumn>
         var dataTableConfig = context.Options as DataEquivalencyAssertionOptions<DataTable>;
         var dataColumnConfig = context.Options as DataEquivalencyAssertionOptions<DataColumn>;
 
-        if ((dataSetConfig?.ShouldExcludeColumn(subject) == true)
-            || (dataTableConfig?.ShouldExcludeColumn(subject) == true)
-            || (dataColumnConfig?.ShouldExcludeColumn(subject) == true))
+        if (dataSetConfig?.ShouldExcludeColumn(subject) == true
+            || dataTableConfig?.ShouldExcludeColumn(subject) == true
+            || dataColumnConfig?.ShouldExcludeColumn(subject) == true)
         {
             compareColumn = false;
         }
@@ -77,6 +78,7 @@ public class DataColumnEquivalencyStep : EquivalencyStep<DataColumn>
         IEquivalencyValidationContext context)
     {
         IMember matchingMember = FindMatchFor(expectationMember, comparands.Subject, context);
+
         if (matchingMember is not null)
         {
             var nestedComparands = new Comparands
@@ -108,7 +110,7 @@ public class DataColumnEquivalencyStep : EquivalencyStep<DataColumn>
     // DataColumn.BeEquivalentTo extension method in DataColumnAssertions.cs. If this ever
     // needs to change, keep them in sync.
     private static readonly ISet<string> CandidateMembers =
-        new HashSet<string>()
+        new HashSet<string>
         {
             nameof(DataColumn.AllowDBNull),
             nameof(DataColumn.AutoIncrement),

--- a/Src/FluentAssertions/Equivalency/Steps/DataRelationEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRelationEquivalencyStep.cs
@@ -10,7 +10,8 @@ namespace FluentAssertions.Equivalency.Steps;
 public class DataRelationEquivalencyStep : EquivalencyStep<DataRelation>
 {
     [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
-    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         var subject = comparands.Subject as DataRelation;
         var expectation = comparands.Expectation as DataRelation;
@@ -89,6 +90,7 @@ public class DataRelationEquivalencyStep : EquivalencyStep<DataRelation>
         if (selectedMembers.TryGetValue(nameof(DataRelation.ExtendedProperties), out IMember expectationMember))
         {
             IMember matchingMember = FindMatchFor(expectationMember, context.CurrentNode, comparands.Subject, config);
+
             if (matchingMember is not null)
             {
                 var nestedComparands = new Comparands
@@ -171,8 +173,8 @@ public class DataRelationEquivalencyStep : EquivalencyStep<DataRelation>
                 DataColumn expectationColumn = expectationColumns[i];
 
                 bool columnsAreEquivalent =
-                    (subjectColumn.Table.TableName == expectationColumn.Table.TableName) &&
-                    (subjectColumn.ColumnName == expectationColumn.ColumnName);
+                    subjectColumn.Table.TableName == expectationColumn.Table.TableName &&
+                    subjectColumn.ColumnName == expectationColumn.ColumnName;
 
                 AssertionScope.Current
                     .ForCondition(columnsAreEquivalent)

--- a/Src/FluentAssertions/Equivalency/Steps/DataRowCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRowCollectionEquivalencyStep.cs
@@ -8,7 +8,8 @@ namespace FluentAssertions.Equivalency.Steps;
 
 public class DataRowCollectionEquivalencyStep : EquivalencyStep<DataRowCollection>
 {
-    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         if (comparands.Subject is not DataRowCollection)
         {
@@ -52,6 +53,7 @@ public class DataRowCollectionEquivalencyStep : EquivalencyStep<DataRowCollectio
                     default:
                         AssertionScope.Current.FailWith(
                             "Unknown RowMatchMode {0} when trying to compare {context:DataRowCollection}", rowMatchMode);
+
                         break;
                 }
             }
@@ -60,7 +62,8 @@ public class DataRowCollectionEquivalencyStep : EquivalencyStep<DataRowCollectio
         return EquivalencyResult.AssertionCompleted;
     }
 
-    private static void MatchRowsByIndexAndCompare(IEquivalencyValidationContext context, IEquivalencyValidator parent, DataRowCollection subject, DataRowCollection expectation)
+    private static void MatchRowsByIndexAndCompare(IEquivalencyValidationContext context, IEquivalencyValidator parent,
+        DataRowCollection subject, DataRowCollection expectation)
     {
         for (int index = 0; index < expectation.Count; index++)
         {
@@ -69,7 +72,8 @@ public class DataRowCollectionEquivalencyStep : EquivalencyStep<DataRowCollectio
         }
     }
 
-    private static void MatchRowsByPrimaryKeyAndCompare(IEquivalencyValidator parent, IEquivalencyValidationContext context, DataRowCollection subject, DataRowCollection expectation)
+    private static void MatchRowsByPrimaryKeyAndCompare(IEquivalencyValidator parent, IEquivalencyValidationContext context,
+        DataRowCollection subject, DataRowCollection expectation)
     {
         Type[] subjectPrimaryKeyTypes = null;
         Type[] expectationPrimaryKeyTypes = null;
@@ -99,7 +103,9 @@ public class DataRowCollectionEquivalencyStep : EquivalencyStep<DataRowCollectio
         if (table.PrimaryKey is null or { Length: 0 })
         {
             AssertionScope.Current
-                .FailWith("Table {0} containing {1} {context:DataRowCollection} does not have a primary key. RowMatchMode.PrimaryKey cannot be applied.", table.TableName, comparisonTerm);
+                .FailWith(
+                    "Table {0} containing {1} {context:DataRowCollection} does not have a primary key. RowMatchMode.PrimaryKey cannot be applied.",
+                    table.TableName, comparisonTerm);
         }
         else
         {
@@ -118,11 +124,11 @@ public class DataRowCollectionEquivalencyStep : EquivalencyStep<DataRowCollectio
     {
         bool matchingTypes = false;
 
-        if ((subjectPrimaryKeyTypes is not null) && (expectationPrimaryKeyTypes is not null))
+        if (subjectPrimaryKeyTypes is not null && expectationPrimaryKeyTypes is not null)
         {
             matchingTypes = subjectPrimaryKeyTypes.Length == expectationPrimaryKeyTypes.Length;
 
-            for (int i = 0; matchingTypes && (i < subjectPrimaryKeyTypes.Length); i++)
+            for (int i = 0; matchingTypes && i < subjectPrimaryKeyTypes.Length; i++)
             {
                 if (subjectPrimaryKeyTypes[i] != expectationPrimaryKeyTypes[i])
                 {
@@ -133,14 +139,16 @@ public class DataRowCollectionEquivalencyStep : EquivalencyStep<DataRowCollectio
             if (!matchingTypes)
             {
                 AssertionScope.Current
-                    .FailWith("Subject and expectation primary keys of table containing {context:DataRowCollection} do not have the same schema and cannot be compared. RowMatchMode.PrimaryKey cannot be applied.");
+                    .FailWith(
+                        "Subject and expectation primary keys of table containing {context:DataRowCollection} do not have the same schema and cannot be compared. RowMatchMode.PrimaryKey cannot be applied.");
             }
         }
 
         return matchingTypes;
     }
 
-    private static void GatherRowsByPrimaryKeyAndCompareData(IEquivalencyValidator parent, IEquivalencyValidationContext context, DataRowCollection subject, DataRowCollection expectation)
+    private static void GatherRowsByPrimaryKeyAndCompareData(IEquivalencyValidator parent, IEquivalencyValidationContext context,
+        DataRowCollection subject, DataRowCollection expectation)
     {
         var expectationRowByKey = expectation.Cast<DataRow>()
             .ToDictionary(row => ExtractPrimaryKey(row));
@@ -173,7 +181,9 @@ public class DataRowCollectionEquivalencyStep : EquivalencyStep<DataRowCollectio
             else
             {
                 AssertionScope.Current
-                    .FailWith("Expected to find a row with key {0} in {context:DataRowCollection}{reason}, but no such row was found", expectationRowByKey.Keys.Single());
+                    .FailWith(
+                        "Expected to find a row with key {0} in {context:DataRowCollection}{reason}, but no such row was found",
+                        expectationRowByKey.Keys.Single());
             }
         }
     }
@@ -218,7 +228,7 @@ public class DataRowCollectionEquivalencyStep : EquivalencyStep<DataRowCollectio
 
             for (int i = 0; i < values.Length; i++)
             {
-                hash = (hash * 389) ^ values[i].GetHashCode();
+                hash = hash * 389 ^ values[i].GetHashCode();
             }
 
             return hash;

--- a/Src/FluentAssertions/Equivalency/Steps/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRowEquivalencyStep.cs
@@ -12,7 +12,8 @@ namespace FluentAssertions.Equivalency.Steps;
 public class DataRowEquivalencyStep : EquivalencyStep<DataRow>
 {
     [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
-    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         var subject = comparands.Subject as DataRow;
         var expectation = comparands.Expectation as DataRow;
@@ -54,7 +55,8 @@ public class DataRowEquivalencyStep : EquivalencyStep<DataRow>
                             expectation.GetType(), subject.GetType());
                 }
 
-                SelectedDataRowMembers selectedMembers = GetMembersFromExpectation(comparands, context.CurrentNode, context.Options);
+                SelectedDataRowMembers selectedMembers =
+                    GetMembersFromExpectation(comparands, context.CurrentNode, context.Options);
 
                 CompareScalarProperties(subject, expectation, selectedMembers);
 
@@ -98,26 +100,26 @@ public class DataRowEquivalencyStep : EquivalencyStep<DataRow>
             .Select(col => col.ColumnName);
 
         bool ignoreUnmatchedColumns =
-            (dataSetConfig?.IgnoreUnmatchedColumns == true) ||
-            (dataTableConfig?.IgnoreUnmatchedColumns == true) ||
-            (dataRowConfig?.IgnoreUnmatchedColumns == true);
+            dataSetConfig?.IgnoreUnmatchedColumns == true ||
+            dataTableConfig?.IgnoreUnmatchedColumns == true ||
+            dataRowConfig?.IgnoreUnmatchedColumns == true;
 
         DataRowVersion subjectVersion =
-            (subject.RowState == DataRowState.Deleted)
+            subject.RowState == DataRowState.Deleted
                 ? DataRowVersion.Original
                 : DataRowVersion.Current;
 
         DataRowVersion expectationVersion =
-            (expectation.RowState == DataRowState.Deleted)
+            expectation.RowState == DataRowState.Deleted
                 ? DataRowVersion.Original
                 : DataRowVersion.Current;
 
         bool compareOriginalVersions =
-            (subject.RowState == DataRowState.Modified) && (expectation.RowState == DataRowState.Modified);
+            subject.RowState == DataRowState.Modified && expectation.RowState == DataRowState.Modified;
 
-        if ((dataSetConfig?.ExcludeOriginalData == true)
-            || (dataTableConfig?.ExcludeOriginalData == true)
-            || (dataRowConfig?.ExcludeOriginalData == true))
+        if (dataSetConfig?.ExcludeOriginalData == true
+            || dataTableConfig?.ExcludeOriginalData == true
+            || dataRowConfig?.ExcludeOriginalData == true)
         {
             compareOriginalVersions = false;
         }
@@ -128,9 +130,9 @@ public class DataRowEquivalencyStep : EquivalencyStep<DataRow>
             DataColumn subjectColumn = subject.Table.Columns[columnName];
 
             if (subjectColumn is not null
-                && ((dataSetConfig?.ShouldExcludeColumn(subjectColumn) == true)
-                    || (dataTableConfig?.ShouldExcludeColumn(subjectColumn) == true)
-                    || (dataRowConfig?.ShouldExcludeColumn(subjectColumn) == true)))
+                && (dataSetConfig?.ShouldExcludeColumn(subjectColumn) == true
+                    || dataTableConfig?.ShouldExcludeColumn(subjectColumn) == true
+                    || dataRowConfig?.ShouldExcludeColumn(subjectColumn) == true))
             {
                 continue;
             }
@@ -146,7 +148,7 @@ public class DataRowEquivalencyStep : EquivalencyStep<DataRow>
                     .FailWith("Found unexpected column {0} in {context:DataRow}", columnName);
             }
 
-            if ((subjectColumn is not null) && (expectationColumn is not null))
+            if (subjectColumn is not null && expectationColumn is not null)
             {
                 CompareFieldValue(context, parent, subject, expectation, subjectColumn, subjectVersion, expectationColumn,
                     expectationVersion);
@@ -172,7 +174,8 @@ public class DataRowEquivalencyStep : EquivalencyStep<DataRow>
         if (nestedContext is not null)
         {
             parent.RecursivelyAssertEquality(
-                new Comparands(subject[subjectColumn, subjectVersion], expectation[expectationColumn, expectationVersion], typeof(object)),
+                new Comparands(subject[subjectColumn, subjectVersion], expectation[expectationColumn, expectationVersion],
+                    typeof(object)),
                 nestedContext);
         }
     }
@@ -185,7 +188,7 @@ public class DataRowEquivalencyStep : EquivalencyStep<DataRow>
     }
 
     private static readonly ConcurrentDictionary<(Type CompileTimeType, Type RuntimeType, IEquivalencyAssertionOptions Config),
-            SelectedDataRowMembers> SelectedMembersCache = new();
+        SelectedDataRowMembers> SelectedMembersCache = new();
 
     private static SelectedDataRowMembers GetMembersFromExpectation(Comparands comparands, INode currentNode,
         IEquivalencyAssertionOptions config)

--- a/Src/FluentAssertions/Equivalency/Steps/DataSetEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataSetEquivalencyStep.cs
@@ -8,7 +8,8 @@ namespace FluentAssertions.Equivalency.Steps;
 
 public class DataSetEquivalencyStep : EquivalencyStep<DataSet>
 {
-    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         var subject = comparands.Subject as DataSet;
 
@@ -29,7 +30,8 @@ public class DataSetEquivalencyStep : EquivalencyStep<DataSet>
                 }
                 else
                 {
-                    AssertionScope.Current.FailWith("Expected {context:DataSet} to be of type {0}, but found {1} instead", expectation.GetType(), comparands.Subject.GetType());
+                    AssertionScope.Current.FailWith("Expected {context:DataSet} to be of type {0}, but found {1} instead",
+                        expectation.GetType(), comparands.Subject.GetType());
                 }
             }
             else
@@ -40,7 +42,8 @@ public class DataSetEquivalencyStep : EquivalencyStep<DataSet>
                 {
                     AssertionScope.Current
                         .ForCondition(subject.GetType() == expectation.GetType())
-                        .FailWith("Expected {context:DataSet} to be of type {0}{reason}, but found {1}", expectation.GetType(), subject.GetType());
+                        .FailWith("Expected {context:DataSet} to be of type {0}{reason}, but found {1}", expectation.GetType(),
+                            subject.GetType());
                 }
 
                 var selectedMembers = GetMembersFromExpectation(comparands, context.CurrentNode, context.Options)
@@ -63,82 +66,97 @@ public class DataSetEquivalencyStep : EquivalencyStep<DataSet>
         {
             AssertionScope.Current
                 .ForCondition(subject.DataSetName == expectation.DataSetName)
-                .FailWith("Expected {context:DataSet} to have DataSetName {0}{reason}, but found {1} instead", expectation.DataSetName, subject.DataSetName);
+                .FailWith("Expected {context:DataSet} to have DataSetName {0}{reason}, but found {1} instead",
+                    expectation.DataSetName, subject.DataSetName);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.CaseSensitive)))
         {
             AssertionScope.Current
                 .ForCondition(subject.CaseSensitive == expectation.CaseSensitive)
-                .FailWith("Expected {context:DataSet} to have CaseSensitive value of {0}{reason}, but found {1} instead", expectation.CaseSensitive, subject.CaseSensitive);
+                .FailWith("Expected {context:DataSet} to have CaseSensitive value of {0}{reason}, but found {1} instead",
+                    expectation.CaseSensitive, subject.CaseSensitive);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.EnforceConstraints)))
         {
             AssertionScope.Current
                 .ForCondition(subject.EnforceConstraints == expectation.EnforceConstraints)
-                .FailWith("Expected {context:DataSet} to have EnforceConstraints value of {0}{reason}, but found {1} instead", expectation.EnforceConstraints, subject.EnforceConstraints);
+                .FailWith("Expected {context:DataSet} to have EnforceConstraints value of {0}{reason}, but found {1} instead",
+                    expectation.EnforceConstraints, subject.EnforceConstraints);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.HasErrors)))
         {
             AssertionScope.Current
                 .ForCondition(subject.HasErrors == expectation.HasErrors)
-                .FailWith("Expected {context:DataSet} to have HasErrors value of {0}{reason}, but found {1} instead", expectation.HasErrors, subject.HasErrors);
+                .FailWith("Expected {context:DataSet} to have HasErrors value of {0}{reason}, but found {1} instead",
+                    expectation.HasErrors, subject.HasErrors);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.Locale)))
         {
             AssertionScope.Current
                 .ForCondition(subject.Locale == expectation.Locale)
-                .FailWith("Expected {context:DataSet} to have Locale value of {0}{reason}, but found {1} instead", expectation.Locale, subject.Locale);
+                .FailWith("Expected {context:DataSet} to have Locale value of {0}{reason}, but found {1} instead",
+                    expectation.Locale, subject.Locale);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.Namespace)))
         {
             AssertionScope.Current
                 .ForCondition(subject.Namespace == expectation.Namespace)
-                .FailWith("Expected {context:DataSet} to have Namespace value of {0}{reason}, but found {1} instead", expectation.Namespace, subject.Namespace);
+                .FailWith("Expected {context:DataSet} to have Namespace value of {0}{reason}, but found {1} instead",
+                    expectation.Namespace, subject.Namespace);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.Prefix)))
         {
             AssertionScope.Current
                 .ForCondition(subject.Prefix == expectation.Prefix)
-                .FailWith("Expected {context:DataSet} to have Prefix value of {0}{reason}, but found {1} instead", expectation.Prefix, subject.Prefix);
+                .FailWith("Expected {context:DataSet} to have Prefix value of {0}{reason}, but found {1} instead",
+                    expectation.Prefix, subject.Prefix);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.RemotingFormat)))
         {
             AssertionScope.Current
                 .ForCondition(subject.RemotingFormat == expectation.RemotingFormat)
-                .FailWith("Expected {context:DataSet} to have RemotingFormat value of {0}{reason}, but found {1} instead", expectation.RemotingFormat, subject.RemotingFormat);
+                .FailWith("Expected {context:DataSet} to have RemotingFormat value of {0}{reason}, but found {1} instead",
+                    expectation.RemotingFormat, subject.RemotingFormat);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.SchemaSerializationMode)))
         {
             AssertionScope.Current
                 .ForCondition(subject.SchemaSerializationMode == expectation.SchemaSerializationMode)
-                .FailWith("Expected {context:DataSet} to have SchemaSerializationMode value of {0}{reason}, but found {1} instead", expectation.SchemaSerializationMode, subject.SchemaSerializationMode);
+                .FailWith(
+                    "Expected {context:DataSet} to have SchemaSerializationMode value of {0}{reason}, but found {1} instead",
+                    expectation.SchemaSerializationMode, subject.SchemaSerializationMode);
         }
     }
 
-    private static void CompareCollections(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, DataSet subject, DataSet expectation, DataEquivalencyAssertionOptions<DataSet> dataConfig, Dictionary<string, IMember> selectedMembers)
+    private static void CompareCollections(IEquivalencyValidationContext context, IEquivalencyValidator parent,
+        IEquivalencyAssertionOptions config, DataSet subject, DataSet expectation,
+        DataEquivalencyAssertionOptions<DataSet> dataConfig, Dictionary<string, IMember> selectedMembers)
     {
         // Note: The collections here are listed in the XML documentation for the DataSet.BeEquivalentTo extension
         // method in DataSetAssertions.cs. If this ever needs to change, keep them in sync.
-        CompareExtendedProperties(new Comparands(subject, expectation, typeof(DataSet)), context, parent, config, selectedMembers);
+        CompareExtendedProperties(new Comparands(subject, expectation, typeof(DataSet)), context, parent, config,
+            selectedMembers);
 
         CompareTables(context, parent, subject, expectation, dataConfig, selectedMembers);
     }
 
-    private static void CompareExtendedProperties(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, Dictionary<string, IMember> selectedMembers)
+    private static void CompareExtendedProperties(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator parent, IEquivalencyAssertionOptions config, Dictionary<string, IMember> selectedMembers)
     {
         foreach (var collectionName in new[] { nameof(DataSet.ExtendedProperties), nameof(DataSet.Relations) })
         {
             if (selectedMembers.TryGetValue(collectionName, out IMember expectationMember))
             {
                 IMember matchingMember = FindMatchFor(expectationMember, comparands.Subject, context.CurrentNode, config);
+
                 if (matchingMember is not null)
                 {
                     var nestedComparands = new Comparands
@@ -155,13 +173,15 @@ public class DataSetEquivalencyStep : EquivalencyStep<DataSet>
         }
     }
 
-    private static void CompareTables(IEquivalencyValidationContext context, IEquivalencyValidator parent, DataSet subject, DataSet expectation, DataEquivalencyAssertionOptions<DataSet> dataConfig, Dictionary<string, IMember> selectedMembers)
+    private static void CompareTables(IEquivalencyValidationContext context, IEquivalencyValidator parent, DataSet subject,
+        DataSet expectation, DataEquivalencyAssertionOptions<DataSet> dataConfig, Dictionary<string, IMember> selectedMembers)
     {
         if (selectedMembers.ContainsKey(nameof(expectation.Tables)))
         {
             bool success = AssertionScope.Current
                 .ForCondition(subject.Tables.Count == expectation.Tables.Count)
-                .FailWith("Expected {context:DataSet} to contain {0}, but found {1} table(s)", expectation.Tables.Count, subject.Tables.Count);
+                .FailWith("Expected {context:DataSet} to contain {0}, but found {1} table(s)", expectation.Tables.Count,
+                    subject.Tables.Count);
 
             if (!success)
             {
@@ -175,17 +195,18 @@ public class DataSetEquivalencyStep : EquivalencyStep<DataSet>
 
                 if (excludeCaseSensitive || excludeLocale)
                 {
-                    dataConfig.Excluding((IMemberInfo memberInfo) =>
-                            (memberInfo.DeclaringType == typeof(DataTable)) &&
+                    dataConfig.Excluding(memberInfo =>
+                        memberInfo.DeclaringType == typeof(DataTable) &&
                         (
-                                (excludeCaseSensitive && (memberInfo.Name == nameof(DataTable.CaseSensitive)))
-                        ||
-                                (excludeLocale && (memberInfo.Name == nameof(DataTable.Locale)))));
+                            (excludeCaseSensitive && memberInfo.Name == nameof(DataTable.CaseSensitive))
+                            ||
+                            (excludeLocale && memberInfo.Name == nameof(DataTable.Locale))));
                 }
             }
 
             IEnumerable<string> expectationTableNames = expectation.Tables.Cast<DataTable>()
                 .Select(table => table.TableName);
+
             IEnumerable<string> subjectTableNames = subject.Tables.Cast<DataTable>()
                 .Select(table => table.TableName);
 
@@ -221,7 +242,8 @@ public class DataSetEquivalencyStep : EquivalencyStep<DataSet>
         }
     }
 
-    private static IMember FindMatchFor(IMember selectedMemberInfo, object subject, INode currentNode, IEquivalencyAssertionOptions options)
+    private static IMember FindMatchFor(IMember selectedMemberInfo, object subject, INode currentNode,
+        IEquivalencyAssertionOptions options)
     {
         IEnumerable<IMember> query =
             from rule in options.MatchingRules

--- a/Src/FluentAssertions/Equivalency/Steps/DataTableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataTableEquivalencyStep.cs
@@ -10,7 +10,8 @@ namespace FluentAssertions.Equivalency.Steps;
 public class DataTableEquivalencyStep : EquivalencyStep<DataTable>
 {
     [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
-    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         var subject = comparands.Subject as DataTable;
         var expectation = comparands.Expectation as DataTable;
@@ -32,7 +33,8 @@ public class DataTableEquivalencyStep : EquivalencyStep<DataTable>
                 }
                 else
                 {
-                    AssertionScope.Current.FailWith("Expected {context:DataTable} to be of type {0}, but found {1} instead", expectation.GetType(), comparands.Subject.GetType());
+                    AssertionScope.Current.FailWith("Expected {context:DataTable} to be of type {0}, but found {1} instead",
+                        expectation.GetType(), comparands.Subject.GetType());
                 }
             }
             else
@@ -41,11 +43,12 @@ public class DataTableEquivalencyStep : EquivalencyStep<DataTable>
                 var dataTableConfig = context.Options as DataEquivalencyAssertionOptions<DataTable>;
 
                 if (dataSetConfig?.AllowMismatchedTypes != true
-                 && dataTableConfig?.AllowMismatchedTypes != true)
+                    && dataTableConfig?.AllowMismatchedTypes != true)
                 {
                     AssertionScope.Current
                         .ForCondition(subject.GetType() == expectation.GetType())
-                        .FailWith("Expected {context:DataTable} to be of type {0}{reason}, but found {1}", expectation.GetType(), subject.GetType());
+                        .FailWith("Expected {context:DataTable} to be of type {0}{reason}, but found {1}", expectation.GetType(),
+                            subject.GetType());
                 }
 
                 var selectedMembers = GetMembersFromExpectation(context.CurrentNode, comparands, context.Options)
@@ -60,7 +63,8 @@ public class DataTableEquivalencyStep : EquivalencyStep<DataTable>
         return EquivalencyResult.AssertionCompleted;
     }
 
-    private static void CompareScalarProperties(DataTable subject, DataTable expectation, Dictionary<string, IMember> selectedMembers)
+    private static void CompareScalarProperties(DataTable subject, DataTable expectation,
+        Dictionary<string, IMember> selectedMembers)
     {
         // Note: The members here are listed in the XML documentation for the DataTable.BeEquivalentTo extension
         // method in DataTableAssertions.cs. If this ever needs to change, keep them in sync.
@@ -68,60 +72,69 @@ public class DataTableEquivalencyStep : EquivalencyStep<DataTable>
         {
             AssertionScope.Current
                 .ForCondition(subject.TableName == expectation.TableName)
-                .FailWith("Expected {context:DataTable} to have TableName {0}{reason}, but found {1} instead", expectation.TableName, subject.TableName);
+                .FailWith("Expected {context:DataTable} to have TableName {0}{reason}, but found {1} instead",
+                    expectation.TableName, subject.TableName);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.CaseSensitive)))
         {
             AssertionScope.Current
                 .ForCondition(subject.CaseSensitive == expectation.CaseSensitive)
-                .FailWith("Expected {context:DataTable} to have CaseSensitive value of {0}{reason}, but found {1} instead", expectation.CaseSensitive, subject.CaseSensitive);
+                .FailWith("Expected {context:DataTable} to have CaseSensitive value of {0}{reason}, but found {1} instead",
+                    expectation.CaseSensitive, subject.CaseSensitive);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.DisplayExpression)))
         {
             AssertionScope.Current
                 .ForCondition(subject.DisplayExpression == expectation.DisplayExpression)
-                .FailWith("Expected {context:DataTable} to have DisplayExpression value of {0}{reason}, but found {1} instead", expectation.DisplayExpression, subject.DisplayExpression);
+                .FailWith("Expected {context:DataTable} to have DisplayExpression value of {0}{reason}, but found {1} instead",
+                    expectation.DisplayExpression, subject.DisplayExpression);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.HasErrors)))
         {
             AssertionScope.Current
                 .ForCondition(subject.HasErrors == expectation.HasErrors)
-                .FailWith("Expected {context:DataTable} to have HasErrors value of {0}{reason}, but found {1} instead", expectation.HasErrors, subject.HasErrors);
+                .FailWith("Expected {context:DataTable} to have HasErrors value of {0}{reason}, but found {1} instead",
+                    expectation.HasErrors, subject.HasErrors);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.Locale)))
         {
             AssertionScope.Current
                 .ForCondition(subject.Locale == expectation.Locale)
-                .FailWith("Expected {context:DataTable} to have Locale value of {0}{reason}, but found {1} instead", expectation.Locale, subject.Locale);
+                .FailWith("Expected {context:DataTable} to have Locale value of {0}{reason}, but found {1} instead",
+                    expectation.Locale, subject.Locale);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.Namespace)))
         {
             AssertionScope.Current
                 .ForCondition(subject.Namespace == expectation.Namespace)
-                .FailWith("Expected {context:DataTable} to have Namespace value of {0}{reason}, but found {1} instead", expectation.Namespace, subject.Namespace);
+                .FailWith("Expected {context:DataTable} to have Namespace value of {0}{reason}, but found {1} instead",
+                    expectation.Namespace, subject.Namespace);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.Prefix)))
         {
             AssertionScope.Current
                 .ForCondition(subject.Prefix == expectation.Prefix)
-                .FailWith("Expected {context:DataTable} to have Prefix value of {0}{reason}, but found {1} instead", expectation.Prefix, subject.Prefix);
+                .FailWith("Expected {context:DataTable} to have Prefix value of {0}{reason}, but found {1} instead",
+                    expectation.Prefix, subject.Prefix);
         }
 
         if (selectedMembers.ContainsKey(nameof(expectation.RemotingFormat)))
         {
             AssertionScope.Current
                 .ForCondition(subject.RemotingFormat == expectation.RemotingFormat)
-                .FailWith("Expected {context:DataTable} to have RemotingFormat value of {0}{reason}, but found {1} instead", expectation.RemotingFormat, subject.RemotingFormat);
+                .FailWith("Expected {context:DataTable} to have RemotingFormat value of {0}{reason}, but found {1} instead",
+                    expectation.RemotingFormat, subject.RemotingFormat);
         }
     }
 
-    private static void CompareCollections(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, Dictionary<string, IMember> selectedMembers)
+    private static void CompareCollections(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator parent, IEquivalencyAssertionOptions config, Dictionary<string, IMember> selectedMembers)
     {
         // Note: The collections here are listed in the XML documentation for the DataTable.BeEquivalentTo extension
         // method in DataTableAssertions.cs. If this ever needs to change, keep them in sync.
@@ -141,6 +154,7 @@ public class DataTableEquivalencyStep : EquivalencyStep<DataTable>
             if (selectedMembers.TryGetValue(collectionName, out IMember expectationMember))
             {
                 IMember matchingMember = FindMatchFor(expectationMember, comparands.Subject, context.CurrentNode, config);
+
                 if (matchingMember is not null)
                 {
                     IEquivalencyValidationContext nestedContext = context.AsNestedMember(expectationMember);
@@ -158,7 +172,8 @@ public class DataTableEquivalencyStep : EquivalencyStep<DataTable>
         }
     }
 
-    private static IMember FindMatchFor(IMember selectedMemberInfo, object subject, INode currentNode, IEquivalencyAssertionOptions config)
+    private static IMember FindMatchFor(IMember selectedMemberInfo, object subject, INode currentNode,
+        IEquivalencyAssertionOptions config)
     {
         IEnumerable<IMember> query =
             from rule in config.MatchingRules
@@ -169,7 +184,8 @@ public class DataTableEquivalencyStep : EquivalencyStep<DataTable>
         return query.FirstOrDefault();
     }
 
-    private static IEnumerable<IMember> GetMembersFromExpectation(INode currentNode, Comparands comparands, IEquivalencyAssertionOptions config)
+    private static IEnumerable<IMember> GetMembersFromExpectation(INode currentNode, Comparands comparands,
+        IEquivalencyAssertionOptions config)
     {
         IEnumerable<IMember> members = Enumerable.Empty<IMember>();
 

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
@@ -8,7 +8,8 @@ namespace FluentAssertions.Equivalency.Steps;
 public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
 {
     [SuppressMessage("ReSharper", "PossibleNullReferenceException")]
-    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         var subject = comparands.Subject as IDictionary;
         var expectation = comparands.Expectation as IDictionary;
@@ -21,13 +22,18 @@ public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
                 {
                     if (context.Options.IsRecursive)
                     {
-                        context.Tracer.WriteLine(member => Invariant($"Recursing into dictionary item {key} at {member.Description}"));
-                        nestedValidator.RecursivelyAssertEquality(new Comparands(subject[key], expectation[key], typeof(object)), context.AsDictionaryItem<object, IDictionary>(key));
+                        context.Tracer.WriteLine(member =>
+                            Invariant($"Recursing into dictionary item {key} at {member.Description}"));
+
+                        nestedValidator.RecursivelyAssertEquality(new Comparands(subject[key], expectation[key], typeof(object)),
+                            context.AsDictionaryItem<object, IDictionary>(key));
                     }
                     else
                     {
                         context.Tracer.WriteLine(member =>
-                            Invariant($"Comparing dictionary item {key} at {member.Description} between subject and expectation"));
+                            Invariant(
+                                $"Comparing dictionary item {key} at {member.Description} between subject and expectation"));
+
                         subject[key].Should().Be(expectation[key], context.Reason.FormattedMessage, context.Reason.Arguments);
                     }
                 }
@@ -40,14 +46,14 @@ public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
     private static bool PreconditionsAreMet(IDictionary expectation, IDictionary subject)
     {
         return AssertIsDictionary(subject)
-               && AssertEitherIsNotNull(expectation, subject)
-               && AssertSameLength(expectation, subject);
+            && AssertEitherIsNotNull(expectation, subject)
+            && AssertSameLength(expectation, subject);
     }
 
     private static bool AssertEitherIsNotNull(IDictionary expectation, IDictionary subject)
     {
         return AssertionScope.Current
-            .ForCondition(((expectation is null) && (subject is null)) || (expectation is not null))
+            .ForCondition((expectation is null && subject is null) || expectation is not null)
             .FailWith("Expected {context:subject} to be {0}{reason}, but found {1}.", null, subject);
     }
 
@@ -61,7 +67,7 @@ public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
     private static bool AssertSameLength(IDictionary expectation, IDictionary subject)
     {
         return AssertionScope.Current
-            .ForCondition((expectation is null) || (subject.Keys.Count == expectation.Keys.Count))
+            .ForCondition(expectation is null || subject.Keys.Count == expectation.Keys.Count)
             .FailWith("Expected {context:subject} to be a dictionary with {0} item(s), but it only contains {1} item(s).",
                 expectation?.Keys.Count, subject?.Keys.Count);
     }

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -42,6 +42,7 @@ internal class DictionaryInterfaceInfo
         result = null;
 
         var interfaces = GetDictionaryInterfacesFrom(target);
+
         if (interfaces.Length > 1)
         {
             throw new ArgumentException(

--- a/Src/FluentAssertions/Equivalency/Steps/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumEqualityStep.cs
@@ -10,7 +10,8 @@ namespace FluentAssertions.Equivalency.Steps;
 
 public class EnumEqualityStep : IEquivalencyStep
 {
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         if (!comparands.GetExpectedType(context.Options).IsEnum)
         {
@@ -24,7 +25,9 @@ public class EnumEqualityStep : IEquivalencyStep
                 decimal? expectationsUnderlyingValue = ExtractDecimal(comparands.Expectation);
                 string expectationName = GetDisplayNameForEnumComparison(comparands.Expectation, expectationsUnderlyingValue);
 
-                return new FailReason($"Expected {{context:enum}} to be equivalent to {expectationName}{{reason}}, but found {{0}}.", comparands.Subject);
+                return new FailReason(
+                    $"Expected {{context:enum}} to be equivalent to {expectationName}{{reason}}, but found {{0}}.",
+                    comparands.Subject);
             });
 
         if (succeeded)
@@ -59,7 +62,8 @@ public class EnumEqualityStep : IEquivalencyStep
                 string subjectsName = GetDisplayNameForEnumComparison(comparands.Subject, subjectsUnderlyingValue);
                 string expectationName = GetDisplayNameForEnumComparison(comparands.Expectation, expectationsUnderlyingValue);
 
-                return new FailReason($"Expected {{context:enum}} to equal {expectationName} by value{{reason}}, but found {subjectsName}.");
+                return new FailReason(
+                    $"Expected {{context:enum}} to equal {expectationName} by value{{reason}}, but found {subjectsName}.");
             });
     }
 
@@ -77,8 +81,9 @@ public class EnumEqualityStep : IEquivalencyStep
 
                 string subjectsName = GetDisplayNameForEnumComparison(comparands.Subject, subjectsUnderlyingValue);
                 string expectationName = GetDisplayNameForEnumComparison(comparands.Expectation, expectationsUnderlyingValue);
+
                 return new FailReason(
-                        $"Expected {{context:enum}} to equal {expectationName} by name{{reason}}, but found {subjectsName}.");
+                    $"Expected {{context:enum}} to equal {expectationName} by name{{reason}}, but found {subjectsName}.");
             });
     }
 

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -7,7 +7,8 @@ namespace FluentAssertions.Equivalency.Steps;
 
 public class EnumerableEquivalencyStep : IEquivalencyStep
 {
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         if (!IsCollection(comparands.GetExpectedType(context.Options)))
         {
@@ -37,8 +38,8 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
         if (conditionMet)
         {
             conditionMet = AssertionScope.Current
-            .ForCondition(IsCollection(subject.GetType()))
-            .FailWith("Expected a collection, but {context:Subject} is of a non-collection type.");
+                .ForCondition(IsCollection(subject.GetType()))
+                .FailWith("Expected a collection, but {context:Subject} is of a non-collection type.");
         }
 
         return conditionMet;

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -40,12 +40,15 @@ internal class EnumerableEquivalencyValidator
             {
                 using var _ = context.Tracer.WriteBlock(member =>
                     Invariant($"Structurally comparing {subject} and expectation {expectation} at {member.Description}"));
+
                 AssertElementGraphEquivalency(subject, expectation, context.CurrentNode);
             }
             else
             {
                 using var _ = context.Tracer.WriteBlock(member =>
-                    Invariant($"Comparing subject {subject} and expectation {expectation} at {member.Description} using simple value equality"));
+                    Invariant(
+                        $"Comparing subject {subject} and expectation {expectation} at {member.Description} using simple value equality"));
+
                 subject.Should().BeEquivalentTo(expectation);
             }
         }
@@ -89,20 +92,26 @@ internal class EnumerableEquivalencyValidator
     private void AssertElementGraphEquivalencyWithStrictOrdering<T>(object[] subjects, T[] expectations)
     {
         int failedCount = 0;
+
         foreach (int index in Enumerable.Range(0, expectations.Length))
         {
             T expectation = expectations[index];
 
             using var _ = context.Tracer.WriteBlock(member =>
-                Invariant($"Strictly comparing expectation {expectation} at {member.Description} to item with index {index} in {subjects}"));
+                Invariant(
+                    $"Strictly comparing expectation {expectation} at {member.Description} to item with index {index} in {subjects}"));
+
             bool succeeded = StrictlyMatchAgainst(subjects, expectation, index);
+
             if (!succeeded)
             {
                 failedCount++;
+
                 if (failedCount >= FailedItemsFastFailThreshold)
                 {
                     context.Tracer.WriteLine(member =>
                         $"Aborting strict order comparison of collections after {FailedItemsFastFailThreshold} items failed at {member.Description}");
+
                     break;
                 }
             }
@@ -112,20 +121,26 @@ internal class EnumerableEquivalencyValidator
     private void AssertElementGraphEquivalencyWithLooseOrdering<T>(object[] subjects, T[] expectations)
     {
         int failedCount = 0;
+
         foreach (int index in Enumerable.Range(0, expectations.Length))
         {
             T expectation = expectations[index];
 
             using var _ = context.Tracer.WriteBlock(member =>
-                Invariant($"Finding the best match of {expectation} within all items in {subjects} at {member.Description}[{index}]"));
+                Invariant(
+                    $"Finding the best match of {expectation} within all items in {subjects} at {member.Description}[{index}]"));
+
             bool succeeded = LooselyMatchAgainst(subjects, expectation, index);
+
             if (!succeeded)
             {
                 failedCount++;
+
                 if (failedCount >= FailedItemsFastFailThreshold)
                 {
                     context.Tracer.WriteLine(member =>
                         $"Fail failing loose order comparison of collection after {FailedItemsFastFailThreshold} items failed at {member.Description}");
+
                     break;
                 }
             }
@@ -138,7 +153,10 @@ internal class EnumerableEquivalencyValidator
     {
         var results = new AssertionResultSet();
         int index = 0;
-        GetTraceMessage getMessage = member => $"Comparing subject at {member.Description}[{index}] with the expectation at {member.Description}[{expectationIndex}]";
+
+        GetTraceMessage getMessage = member =>
+            $"Comparing subject at {member.Description}[{index}] with the expectation at {member.Description}[{expectationIndex}]";
+
         int indexToBeRemoved = -1;
 
         for (var metaIndex = 0; metaIndex < unmatchedSubjectIndexes.Count; metaIndex++)
@@ -150,6 +168,7 @@ internal class EnumerableEquivalencyValidator
             string[] failures = TryToMatch(subject, expectation, expectationIndex);
 
             results.AddSet(index, failures);
+
             if (results.ContainsSuccessfulSet())
             {
                 context.Tracer.WriteLine(_ => "It's a match");
@@ -178,7 +197,9 @@ internal class EnumerableEquivalencyValidator
     private string[] TryToMatch<T>(object subject, T expectation, int expectationIndex)
     {
         using var scope = new AssertionScope();
-        parent.RecursivelyAssertEquality(new Comparands(subject, expectation, typeof(T)), context.AsCollectionItem<T>(expectationIndex));
+
+        parent.RecursivelyAssertEquality(new Comparands(subject, expectation, typeof(T)),
+            context.AsCollectionItem<T>(expectationIndex));
 
         return scope.Discard();
     }

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidatorExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidatorExtensions.cs
@@ -6,20 +6,22 @@ namespace FluentAssertions.Equivalency.Steps;
 
 internal static class EnumerableEquivalencyValidatorExtensions
 {
-    public static Continuation AssertEitherCollectionIsNotEmpty<T>(this IAssertionScope scope, ICollection<object> subject, ICollection<T> expectation)
+    public static Continuation AssertEitherCollectionIsNotEmpty<T>(this IAssertionScope scope, ICollection<object> subject,
+        ICollection<T> expectation)
     {
         return scope
-            .ForCondition((subject.Count > 0) || (expectation.Count == 0))
+            .ForCondition(subject.Count > 0 || expectation.Count == 0)
             .FailWith(", but found an empty collection.")
             .Then
-            .ForCondition((subject.Count == 0) || (expectation.Count > 0))
+            .ForCondition(subject.Count == 0 || expectation.Count > 0)
             .FailWith(", but {0}{2}contains {1} item(s).",
                 subject,
                 subject.Count,
                 Environment.NewLine);
     }
 
-    public static Continuation AssertCollectionHasEnoughItems<T>(this IAssertionScope scope, ICollection<object> subject, ICollection<T> expectation)
+    public static Continuation AssertCollectionHasEnoughItems<T>(this IAssertionScope scope, ICollection<object> subject,
+        ICollection<T> expectation)
     {
         return scope
             .ForCondition(subject.Count >= expectation.Count)
@@ -30,7 +32,8 @@ internal static class EnumerableEquivalencyValidatorExtensions
                 Environment.NewLine);
     }
 
-    public static Continuation AssertCollectionHasNotTooManyItems<T>(this IAssertionScope scope, ICollection<object> subject, ICollection<T> expectation)
+    public static Continuation AssertCollectionHasNotTooManyItems<T>(this IAssertionScope scope, ICollection<object> subject,
+        ICollection<T> expectation)
     {
         return scope
             .ForCondition(subject.Count <= expectation.Count)

--- a/Src/FluentAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
@@ -13,7 +13,8 @@ public class EqualityComparerEquivalencyStep<T> : IEquivalencyStep
         this.comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
     }
 
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         if (comparands.GetExpectedType(context.Options) != typeof(T))
         {

--- a/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -27,6 +27,7 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
         {
             Type expectationType = comparands.GetExpectedType(context.Options);
             bool isDictionary = DictionaryInterfaceInfo.TryGetFrom(expectationType, "expectation", out var expectedDictionary);
+
             if (isDictionary)
             {
                 Handle(comparands, expectedDictionary, context, nestedValidator);
@@ -46,6 +47,7 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
             && AssertExpectationIsNotNull(comparands.Subject, comparands.Expectation))
         {
             var (isDictionary, actualDictionary) = EnsureSubjectIsDictionary(comparands, expectedDictionary);
+
             if (isDictionary)
             {
                 if (AssertSameLength(comparands, actualDictionary, expectedDictionary))
@@ -111,7 +113,7 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
     }
 
     private static bool AssertSameLength<TSubjectKey, TSubjectValue, TExpectedKey, TExpectedValue>(
-        IDictionary<TSubjectKey, TSubjectValue> subject, IDictionary<TExpectedKey, TExpectedValue> expectation)
+            IDictionary<TSubjectKey, TSubjectValue> subject, IDictionary<TExpectedKey, TExpectedValue> expectation)
 
         // Type constraint of TExpectedKey is asymmetric in regards to TSubjectKey
         // but it is valid. This constraint is implicitly enforced by the dictionary interface info which is called before
@@ -164,6 +166,7 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
         }
 
         var additionalKeys = new List<TSubjectKey>();
+
         foreach (TSubjectKey subjectKey in subject.Keys)
         {
             if (!presentKeys.Contains(subjectKey))

--- a/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
@@ -15,9 +15,11 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
         (HandleImpl).GetMethodInfo().GetGenericMethodDefinition();
 #pragma warning restore SA1110
 
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         Type expectedType = comparands.GetExpectedType(context.Options);
+
         if (comparands.Expectation is null || !IsGenericCollection(expectedType))
         {
             return EquivalencyResult.ContinueWithNext;
@@ -45,7 +47,8 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
 
             try
             {
-                HandleMethod.MakeGenericMethod(typeOfEnumeration).Invoke(null, new[] { validator, subjectAsArray, comparands.Expectation });
+                HandleMethod.MakeGenericMethod(typeOfEnumeration)
+                    .Invoke(null, new[] { validator, subjectAsArray, comparands.Expectation });
             }
             catch (TargetInvocationException e)
             {
@@ -56,8 +59,8 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
         return EquivalencyResult.AssertionCompleted;
     }
 
-    private static void HandleImpl<T>(EnumerableEquivalencyValidator validator, object[] subject, IEnumerable<T> expectation)
-        => validator.Execute(subject, ToArray(expectation));
+    private static void HandleImpl<T>(EnumerableEquivalencyValidator validator, object[] subject, IEnumerable<T> expectation) =>
+        validator.Execute(subject, ToArray(expectation));
 
     private static bool AssertSubjectIsCollection(object subject)
     {
@@ -84,7 +87,7 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
     {
         Type[] enumerableInterfaces = GetIEnumerableInterfaces(type);
 
-        return (!typeof(string).IsAssignableFrom(type)) && enumerableInterfaces.Any();
+        return !typeof(string).IsAssignableFrom(type) && enumerableInterfaces.Any();
     }
 
     private static Type[] GetIEnumerableInterfaces(Type type)
@@ -97,7 +100,7 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
 
         Type soughtType = typeof(IEnumerable<>);
 
-        return Common.TypeExtensions.GetClosedGenericInterfaces(type, soughtType);
+        return type.GetClosedGenericInterfaces(soughtType);
     }
 
     private static Type GetTypeOfEnumeration(Type enumerableType)

--- a/Src/FluentAssertions/Equivalency/Steps/ReferenceEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ReferenceEqualityEquivalencyStep.cs
@@ -2,8 +2,11 @@
 
 public class ReferenceEqualityEquivalencyStep : IEquivalencyStep
 {
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
-        return ReferenceEquals(comparands.Subject, comparands.Expectation) ? EquivalencyResult.AssertionCompleted : EquivalencyResult.ContinueWithNext;
+        return ReferenceEquals(comparands.Subject, comparands.Expectation)
+            ? EquivalencyResult.AssertionCompleted
+            : EquivalencyResult.ContinueWithNext;
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/RunAllUserStepsEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/RunAllUserStepsEquivalencyStep.cs
@@ -6,7 +6,8 @@
 /// </summary>
 public class RunAllUserStepsEquivalencyStep : IEquivalencyStep
 {
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         foreach (IEquivalencyStep step in context.Options.UserEquivalencySteps)
         {

--- a/Src/FluentAssertions/Equivalency/Steps/SimpleEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/SimpleEqualityEquivalencyStep.cs
@@ -2,7 +2,8 @@ namespace FluentAssertions.Equivalency.Steps;
 
 public class SimpleEqualityEquivalencyStep : IEquivalencyStep
 {
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         if (!context.Options.IsRecursive && !context.CurrentNode.IsRoot)
         {

--- a/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -5,7 +5,8 @@ namespace FluentAssertions.Equivalency.Steps;
 
 public class StringEqualityEquivalencyStep : IEquivalencyStep
 {
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         Type expectationType = comparands.GetExpectedType(context.Options);
 
@@ -20,6 +21,7 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         }
 
         bool subjectIsString = ValidateSubjectIsString(comparands, context.CurrentNode);
+
         if (subjectIsString)
         {
             string subject = (string)comparands.Subject;
@@ -37,7 +39,7 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         object expected = comparands.Expectation;
         object subject = comparands.Subject;
 
-        bool onlyOneNull = (expected is null) != (subject is null);
+        bool onlyOneNull = expected is null != subject is null;
 
         if (onlyOneNull)
         {

--- a/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
@@ -18,23 +18,24 @@ public class StructuralEqualityEquivalencyStep : IEquivalencyStep
         if (comparands.Expectation is null)
         {
             AssertionScope.Current
-            .BecauseOf(context.Reason)
-            .FailWith(
-                "Expected {context:subject} to be <null>{reason}, but found {0}.",
-                comparands.Subject);
+                .BecauseOf(context.Reason)
+                .FailWith(
+                    "Expected {context:subject} to be <null>{reason}, but found {0}.",
+                    comparands.Subject);
         }
         else if (comparands.Subject is null)
         {
             AssertionScope.Current
-            .BecauseOf(context.Reason)
-            .FailWith(
-                "Expected {context:object} to be {0}{reason}, but found {1}.",
-                comparands.Expectation,
-                comparands.Subject);
+                .BecauseOf(context.Reason)
+                .FailWith(
+                    "Expected {context:object} to be {0}{reason}, but found {1}.",
+                    comparands.Expectation,
+                    comparands.Subject);
         }
         else
         {
             IMember[] selectedMembers = GetMembersFromExpectation(context.CurrentNode, comparands, context.Options).ToArray();
+
             if (context.CurrentNode.IsRoot && !selectedMembers.Any())
             {
                 throw new InvalidOperationException(
@@ -55,6 +56,7 @@ public class StructuralEqualityEquivalencyStep : IEquivalencyStep
         IEquivalencyValidator parent, IMember selectedMember, IEquivalencyAssertionOptions options)
     {
         IMember matchingMember = FindMatchFor(selectedMember, context.CurrentNode, comparands.Subject, options);
+
         if (matchingMember is not null)
         {
             var nestedComparands = new Comparands

--- a/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
@@ -7,18 +7,21 @@ namespace FluentAssertions.Equivalency.Steps;
 /// </summary>
 public class ValueTypeEquivalencyStep : IEquivalencyStep
 {
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         Type expectationType = comparands.GetExpectedType(context.Options);
         EqualityStrategy strategy = context.Options.GetEqualityStrategy(expectationType);
 
         bool canHandle = strategy is EqualityStrategy.Equals or EqualityStrategy.ForceEquals;
+
         if (canHandle)
         {
             context.Tracer.WriteLine(member =>
             {
-                string strategyName = (strategy == EqualityStrategy.Equals)
-                    ? $"{expectationType} overrides Equals" : "we are forced to use Equals";
+                string strategyName = strategy == EqualityStrategy.Equals
+                    ? $"{expectationType} overrides Equals"
+                    : "we are forced to use Equals";
 
                 return $"Treating {member.Description} as a value type because {strategyName}.";
             });

--- a/Src/FluentAssertions/Equivalency/Steps/XAttributeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/XAttributeEquivalencyStep.cs
@@ -4,7 +4,8 @@ namespace FluentAssertions.Equivalency.Steps;
 
 public class XAttributeEquivalencyStep : EquivalencyStep<XAttribute>
 {
-    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         var subject = (XAttribute)comparands.Subject;
         var expectation = (XAttribute)comparands.Expectation;

--- a/Src/FluentAssertions/Equivalency/Steps/XDocumentEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/XDocumentEquivalencyStep.cs
@@ -4,7 +4,8 @@ namespace FluentAssertions.Equivalency.Steps;
 
 public class XDocumentEquivalencyStep : EquivalencyStep<XDocument>
 {
-    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         var subject = (XDocument)comparands.Subject;
         var expectation = (XDocument)comparands.Expectation;

--- a/Src/FluentAssertions/Equivalency/Steps/XElementEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/XElementEquivalencyStep.cs
@@ -4,7 +4,8 @@ namespace FluentAssertions.Equivalency.Steps;
 
 public class XElementEquivalencyStep : EquivalencyStep<XElement>
 {
-    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    protected override EquivalencyResult OnHandle(Comparands comparands, IEquivalencyValidationContext context,
+        IEquivalencyValidator nestedValidator)
     {
         var subject = (XElement)comparands.Subject;
         var expectation = (XElement)comparands.Expectation;

--- a/Src/FluentAssertions/Equivalency/Tracing/Tracer.cs
+++ b/Src/FluentAssertions/Equivalency/Tracing/Tracer.cs
@@ -47,5 +47,5 @@ public class Tracer
         }
     }
 
-    public override string ToString() => (traceWriter is not null) ? traceWriter.ToString() : string.Empty;
+    public override string ToString() => traceWriter is not null ? traceWriter.ToString() : string.Empty;
 }

--- a/Src/FluentAssertions/EquivalencyPlan.cs
+++ b/Src/FluentAssertions/EquivalencyPlan.cs
@@ -53,6 +53,7 @@ public class EquivalencyPlan : IEnumerable<IEquivalencyStep>
         int insertIndex = Math.Max(steps.Count - 1, 0);
 
         IEquivalencyStep predecessor = steps.LastOrDefault(s => s is TPredecessor);
+
         if (predecessor is not null)
         {
             insertIndex = Math.Min(insertIndex, steps.LastIndexOf(predecessor) + 1);
@@ -79,6 +80,7 @@ public class EquivalencyPlan : IEnumerable<IEquivalencyStep>
         int insertIndex = Math.Max(steps.Count - 1, 0);
 
         IEquivalencyStep equalityStep = steps.LastOrDefault(s => s is TSuccessor);
+
         if (equalityStep is not null)
         {
             insertIndex = steps.LastIndexOf(equalityStep);
@@ -111,7 +113,7 @@ public class EquivalencyPlan : IEnumerable<IEquivalencyStep>
 
     private static List<IEquivalencyStep> GetDefaultSteps()
     {
-        return new(18)
+        return new List<IEquivalencyStep>(18)
         {
             new RunAllUserStepsEquivalencyStep(),
             new AutoConversionStep(),

--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -29,11 +29,12 @@ public static class EventRaisingExtensions
             bool hasSender = Execute.Assertion
                 .ForCondition(@event.Parameters.Any())
                 .FailWith("Expected event from sender {0}, " +
-                          $"but event {eventRecording.EventName} does not have any parameters", expectedSender);
+                    $"but event {eventRecording.EventName} does not have any parameters", expectedSender);
 
             if (hasSender)
             {
                 object sender = @event.Parameters.First();
+
                 if (ReferenceEquals(sender, expectedSender))
                 {
                     eventsForSender.Add(@event);
@@ -119,6 +120,7 @@ public static class EventRaisingExtensions
             }
 
             bool isMatch = hasArgumentOfRightType;
+
             for (int index = 0; index < predicates.Length && isMatch; index++)
             {
                 isMatch = compiledPredicates[index]?.Invoke(typedParameters[index]) ?? true;
@@ -135,7 +137,8 @@ public static class EventRaisingExtensions
         if (!foundMatchingEvent)
         {
             Execute.Assertion
-                .FailWith("Expected at least one event with some arguments of type <{0}> that pairwise match {1}, but found none.",
+                .FailWith(
+                    "Expected at least one event with some arguments of type <{0}> that pairwise match {1}, but found none.",
                     typeof(T),
                     string.Join(" | ", predicates.Where(p => p is not null).Select(p => p.Body.ToString())));
         }

--- a/Src/FluentAssertions/Events/EventAssertions.cs
+++ b/Src/FluentAssertions/Events/EventAssertions.cs
@@ -19,7 +19,7 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
     protected internal EventAssertions(IMonitor<T> monitor)
         : base(monitor.Subject)
     {
-        this.Monitor = monitor;
+        Monitor = monitor;
     }
 
     /// <summary>
@@ -43,6 +43,7 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
     public IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs)
     {
         IEventRecording recording = Monitor.GetRecordingFor(eventName);
+
         if (!recording.Any())
         {
             Execute.Assertion
@@ -69,6 +70,7 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
     public void NotRaise(string eventName, string because = "", params object[] becauseArgs)
     {
         IEventRecording events = Monitor.GetRecordingFor(eventName);
+
         if (events.Any())
         {
             Execute.Assertion
@@ -102,7 +104,8 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected object {0} to raise event {1} for property {2}{reason}, but it did not raise that event at all.",
+                .FailWith(
+                    "Expected object {0} to raise event {1} for property {2}{reason}, but it did not raise that event at all.",
                     Monitor.Subject, PropertyChangedEventName, propertyName);
         }
 

--- a/Src/FluentAssertions/Events/EventMonitor.cs
+++ b/Src/FluentAssertions/Events/EventMonitor.cs
@@ -88,6 +88,7 @@ internal class EventMonitor<T> : IMonitor<T>
         }
 
         EventInfo[] events = GetPublicEvents(typeDefiningEventsToMonitor);
+
         if (!events.Any())
         {
             throw new InvalidOperationException($"Type {typeDefiningEventsToMonitor.Name} does not expose any events.");
@@ -127,6 +128,7 @@ internal class EventMonitor<T> : IMonitor<T>
         if (!recorderMap.TryGetValue(eventInfo.Name, out _))
         {
             var recorder = new EventRecorder(subject.Target, eventInfo.Name, utcNow, threadSafeSequenceGenerator);
+
             if (recorderMap.TryAdd(eventInfo.Name, recorder))
             {
                 recorder.Attach(subject, eventInfo);

--- a/Src/FluentAssertions/Events/EventRecorder.cs
+++ b/Src/FluentAssertions/Events/EventRecorder.cs
@@ -26,7 +26,8 @@ internal sealed class EventRecorder : IEventRecording, IDisposable
     /// <param name="eventName">The name of the event that's recorded</param>
     /// <param name="utcNow">A delegate to get the current date and time in UTC format.</param>
     /// <param name="sequenceGenerator">Class used to generate a sequence in a thread-safe manner.</param>
-    public EventRecorder(object eventRaiser, string eventName, Func<DateTime> utcNow, ThreadSafeSequenceGenerator sequenceGenerator)
+    public EventRecorder(object eventRaiser, string eventName, Func<DateTime> utcNow,
+        ThreadSafeSequenceGenerator sequenceGenerator)
     {
         this.utcNow = utcNow;
         EventObject = eventRaiser;

--- a/Src/FluentAssertions/Execution/AssertionFailedException.cs
+++ b/Src/FluentAssertions/Execution/AssertionFailedException.cs
@@ -1,5 +1,4 @@
 using System;
-
 using System.Runtime.Serialization;
 
 namespace FluentAssertions.Execution;
@@ -8,7 +7,6 @@ namespace FluentAssertions.Execution;
 /// Represents the default exception in case no test framework is configured.
 /// </summary>
 [Serializable]
-
 #pragma warning disable CA1032, RCS1194 // AssertionFailedException should never be constructed with an empty message
 public class AssertionFailedException : Exception
 #pragma warning restore CA1032, RCS1194

--- a/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Execution;

--- a/Src/FluentAssertions/Execution/ContextDataItems.cs
+++ b/Src/FluentAssertions/Execution/ContextDataItems.cs
@@ -19,6 +19,7 @@ internal class ContextDataItems
     public string AsStringOrDefault(string key)
     {
         DataItem item = items.SingleOrDefault(i => i.Key == key);
+
         if (item is not null)
         {
             if (item.RequiresFormatting)
@@ -80,7 +81,7 @@ internal class ContextDataItems
 
         public DataItem Clone()
         {
-            object value = (Value is ICloneable2 cloneable) ? cloneable.Clone() : Value;
+            object value = Value is ICloneable2 cloneable ? cloneable.Clone() : Value;
             return new DataItem(Key, value, Reportable, RequiresFormatting);
         }
     }

--- a/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
+++ b/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
@@ -5,19 +5,18 @@ namespace FluentAssertions.Execution;
 /// </summary>
 public class ContinuationOfGiven<TSubject>
 {
-    private readonly GivenSelector<TSubject> parent;
     private readonly bool succeeded;
 
     internal ContinuationOfGiven(GivenSelector<TSubject> parent, bool succeeded)
     {
         this.succeeded = succeeded;
-        this.parent = parent;
+        Then = parent;
     }
 
     /// <summary>
     /// Continuous the assertion chain if the previous assertion was successful.
     /// </summary>
-    public GivenSelector<TSubject> Then => parent;
+    public GivenSelector<TSubject> Then { get; }
 
     /// <summary>
     /// Provides back-wards compatibility for code that expects <see cref="AssertionScope.FailWith(string, object[])"/> to return a boolean.

--- a/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Execution;

--- a/Src/FluentAssertions/Execution/GivenSelectorExtensions.cs
+++ b/Src/FluentAssertions/Execution/GivenSelectorExtensions.cs
@@ -19,38 +19,39 @@ internal static class GivenSelectorExtensions
         this GivenSelector<ICollection<T>> givenSelector, int length)
     {
         return givenSelector
-            .ForCondition(items => (items.Count > 0) || (length == 0))
+            .ForCondition(items => items.Count > 0 || length == 0)
             .FailWith("but found empty collection.")
             .Then
-            .ForCondition(items => (items.Count == 0) || (length > 0))
+            .ForCondition(items => items.Count == 0 || length > 0)
             .FailWith("but found {0}.", items => items);
     }
 
-    public static ContinuationOfGiven<ICollection<T>> AssertCollectionHasEnoughItems<T>(this GivenSelector<IEnumerable<T>> givenSelector,
-        int length)
+    public static ContinuationOfGiven<ICollection<T>> AssertCollectionHasEnoughItems<T>(
+        this GivenSelector<IEnumerable<T>> givenSelector, int length)
     {
         return givenSelector
             .Given(items => items.ConvertOrCastToCollection())
             .AssertCollectionHasEnoughItems(length);
     }
 
-    public static ContinuationOfGiven<ICollection<T>> AssertCollectionHasEnoughItems<T>(this GivenSelector<ICollection<T>> givenSelector, int length)
+    public static ContinuationOfGiven<ICollection<T>> AssertCollectionHasEnoughItems<T>(
+        this GivenSelector<ICollection<T>> givenSelector, int length)
     {
         return givenSelector
             .ForCondition(items => items.Count >= length)
             .FailWith("but {0} contains {1} item(s) less.", items => items, items => length - items.Count);
     }
 
-    public static ContinuationOfGiven<ICollection<T>> AssertCollectionHasNotTooManyItems<T>(this GivenSelector<ICollection<T>> givenSelector,
-        int length)
+    public static ContinuationOfGiven<ICollection<T>> AssertCollectionHasNotTooManyItems<T>(
+        this GivenSelector<ICollection<T>> givenSelector, int length)
     {
         return givenSelector
             .ForCondition(items => items.Count <= length)
             .FailWith("but {0} contains {1} item(s) too many.", items => items, items => items.Count - length);
     }
 
-    public static ContinuationOfGiven<ICollection<T>> AssertCollectionsHaveSameCount<T>(this GivenSelector<ICollection<T>> givenSelector,
-        int length)
+    public static ContinuationOfGiven<ICollection<T>> AssertCollectionsHaveSameCount<T>(
+        this GivenSelector<ICollection<T>> givenSelector, int length)
     {
         return givenSelector
             .AssertEitherCollectionIsNotEmpty(length)
@@ -60,7 +61,8 @@ internal static class GivenSelectorExtensions
             .AssertCollectionHasNotTooManyItems(length);
     }
 
-    public static ContinuationOfGiven<ICollection<TActual>> AssertCollectionsHaveSameItems<TActual, TExpected>(this GivenSelector<ICollection<TActual>> givenSelector,
+    public static ContinuationOfGiven<ICollection<TActual>> AssertCollectionsHaveSameItems<TActual, TExpected>(
+        this GivenSelector<ICollection<TActual>> givenSelector,
         ICollection<TExpected> expected, Func<ICollection<TActual>, ICollection<TExpected>, int> findIndex)
     {
         return givenSelector

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -13,6 +13,7 @@ internal abstract class LateBoundTestFramework : ITestFramework
     public void Throw(string message)
     {
         Type exceptionType = assembly.GetType(ExceptionFullName);
+
         if (exceptionType is null)
         {
             throw new Exception(

--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -30,7 +30,8 @@ internal class MessageBuilder
     }
 
     // SMELL: Too many parameters.
-    public string Build(string message, object[] messageArgs, string reason, ContextDataItems contextData, string identifier, string fallbackIdentifier)
+    public string Build(string message, object[] messageArgs, string reason, ContextDataItems contextData, string identifier,
+        string fallbackIdentifier)
     {
         message = Regex.Replace(message, "{reason}", SanitizeReason(reason));
 
@@ -50,6 +51,7 @@ internal class MessageBuilder
         message = Regex.Replace(message, pattern, match =>
         {
             const string result = " ";
+
             if (!string.IsNullOrEmpty(identifier))
             {
                 return result + identifier;
@@ -97,7 +99,8 @@ internal class MessageBuilder
         }
         catch (FormatException formatException)
         {
-            return $"**WARNING** failure message '{failureMessage}' could not be formatted with string.Format{Environment.NewLine}{formatException.StackTrace}";
+            return
+                $"**WARNING** failure message '{failureMessage}' could not be formatted with string.Format{Environment.NewLine}{formatException.StackTrace}";
         }
     }
 
@@ -135,6 +138,6 @@ internal class MessageBuilder
 
     private bool StartsWithBlank(string text)
     {
-        return (text.Length > 0) && blanks.Contains(text[0]);
+        return text.Length > 0 && blanks.Contains(text[0]);
     }
 }

--- a/Src/FluentAssertions/Execution/NSpecFramework.cs
+++ b/Src/FluentAssertions/Execution/NSpecFramework.cs
@@ -32,6 +32,7 @@ internal class NSpecFramework : ITestFramework
     public void Throw(string message)
     {
         Type exceptionType = assembly.GetType("NSpec.Domain.AssertionException");
+
         if (exceptionType is null)
         {
             throw new Exception("Failed to create the NSpec assertion type");

--- a/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
+++ b/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
@@ -52,6 +52,7 @@ internal class TestFrameworkProvider
     private ITestFramework AttemptToDetectUsingAppSetting()
     {
         string frameworkName = configuration.TestFrameworkName;
+
         if (string.IsNullOrEmpty(frameworkName))
         {
             return null;
@@ -60,7 +61,9 @@ internal class TestFrameworkProvider
         if (!Frameworks.TryGetValue(frameworkName, out ITestFramework framework))
         {
             string frameworks = string.Join(", ", Frameworks.Keys);
-            var message = $"FluentAssertions was configured to use the test framework '{frameworkName}' but this is not supported. " +
+
+            var message =
+                $"FluentAssertions was configured to use the test framework '{frameworkName}' but this is not supported. " +
                 $"Please use one of the supported frameworks: {frameworks}.";
 
             throw new InvalidOperationException(message);
@@ -69,9 +72,11 @@ internal class TestFrameworkProvider
         if (!framework.IsAvailable)
         {
             string frameworks = string.Join(", ", Frameworks.Keys);
+
             var innerMessage = framework is LateBoundTestFramework lateBoundTestFramework
                 ? $"the required assembly '{lateBoundTestFramework.AssemblyName}' could not be found"
                 : "it could not be found";
+
             var message =
                 $"FluentAssertions was configured to use the test framework '{frameworkName}' but {innerMessage}. " +
                 $"Please use one of the supported frameworks: {frameworks}.";

--- a/Src/FluentAssertions/Execution/XUnit2TestFramework.cs
+++ b/Src/FluentAssertions/Execution/XUnit2TestFramework.cs
@@ -33,6 +33,7 @@ internal class XUnit2TestFramework : ITestFramework
     public void Throw(string message)
     {
         Type exceptionType = assembly.GetType("Xunit.Sdk.XunitException");
+
         if (exceptionType is null)
         {
             throw new Exception("Failed to create the XUnit assertion type");

--- a/Src/FluentAssertions/Extensions/FluentDateTimeExtensions.cs
+++ b/Src/FluentAssertions/Extensions/FluentDateTimeExtensions.cs
@@ -142,7 +142,8 @@ public static class FluentDateTimeExtensions
     /// Returns a new <see cref="DateTime"/> value for the specified <paramref name="date"/> and time with the specified
     /// <paramref name="hours"/>, <paramref name="minutes"/> and optionally <paramref name="seconds"/>.
     /// </summary>
-    public static DateTime At(this DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0)
+    public static DateTime At(this DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0,
+        int microseconds = 0, int nanoseconds = 0)
     {
         if (microseconds is < 0 or > 999)
         {
@@ -173,7 +174,8 @@ public static class FluentDateTimeExtensions
     /// Returns a new <see cref="DateTimeOffset"/> value for the specified <paramref name="date"/> and time with the specified
     /// <paramref name="hours"/>, <paramref name="minutes"/> and optionally <paramref name="seconds"/>.
     /// </summary>
-    public static DateTimeOffset At(this DateTimeOffset date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0)
+    public static DateTimeOffset At(this DateTimeOffset date, int hours, int minutes, int seconds = 0, int milliseconds = 0,
+        int microseconds = 0, int nanoseconds = 0)
     {
         if (microseconds is < 0 or > 999)
         {

--- a/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
@@ -20,6 +20,7 @@ public class AggregateExceptionValueFormatter : IValueFormatter
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         var exception = (AggregateException)value;
+
         if (exception.InnerExceptions.Count == 1)
         {
             formattedGraph.AddFragment("(aggregated) ");

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting;
@@ -25,7 +24,7 @@ public class AttributeBasedFormatter : IValueFormatter
     /// </returns>
     public bool CanHandle(object value)
     {
-        return IsScanningEnabled && (value is not null) && (GetFormatter(value) is not null);
+        return IsScanningEnabled && value is not null && GetFormatter(value) is not null;
     }
 
     private static bool IsScanningEnabled
@@ -37,7 +36,7 @@ public class AttributeBasedFormatter : IValueFormatter
     {
         MethodInfo method = GetFormatter(value);
 
-        object[] parameters = new[] { value, formattedGraph };
+        object[] parameters = { value, formattedGraph };
 
         method.Invoke(null, parameters);
     }
@@ -45,6 +44,7 @@ public class AttributeBasedFormatter : IValueFormatter
     private MethodInfo GetFormatter(object value)
     {
         Type valueType = value.GetType();
+
         do
         {
             if (Formatters.TryGetValue(valueType, out var formatter))
@@ -89,8 +89,10 @@ public class AttributeBasedFormatter : IValueFormatter
             where method.IsDecoratedWithOrInherit<ValueFormatterAttribute>()
             let methodParameters = method.GetParameters()
             where methodParameters.Length == 2
-            select new { Type = methodParameters.First().ParameterType, Method = method } into formatter
-            group formatter by formatter.Type into formatterGroup
+            select new { Type = methodParameters.First().ParameterType, Method = method }
+            into formatter
+            group formatter by formatter.Type
+            into formatterGroup
             select formatterGroup.First();
 
         return query.ToDictionary(f => f.Type, f => f.Method);
@@ -101,8 +103,8 @@ public class AttributeBasedFormatter : IValueFormatter
         Configuration configuration = Configuration.Current;
         ValueFormatterDetectionMode mode = configuration.ValueFormatterDetectionMode;
 
-        return (mode == ValueFormatterDetectionMode.Scan) || (
-            (mode == ValueFormatterDetectionMode.Specific) &&
+        return mode == ValueFormatterDetectionMode.Scan || (
+            mode == ValueFormatterDetectionMode.Specific &&
             assembly.FullName.Split(',')[0].Equals(configuration.ValueFormatterAssembly, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/Src/FluentAssertions/Formatting/DateOnlyValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateOnlyValueFormatter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Globalization;
 
 #if NET6_0_OR_GREATER
-
 namespace FluentAssertions.Formatting;
 
 public class DateOnlyValueFormatter : IValueFormatter

--- a/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
@@ -36,12 +36,14 @@ public class DateTimeOffsetValueFormatter : IValueFormatter
         formattedGraph.AddFragment("<");
 
         bool hasDate = HasDate(dateTimeOffset);
+
         if (hasDate)
         {
             formattedGraph.AddFragment(dateTimeOffset.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
         }
 
         bool hasTime = HasTime(dateTimeOffset);
+
         if (hasTime)
         {
             if (hasDate)
@@ -103,9 +105,9 @@ public class DateTimeOffsetValueFormatter : IValueFormatter
 
     private static bool HasTime(DateTimeOffset dateTime)
     {
-        return (dateTime.Hour != 0)
-            || (dateTime.Minute != 0)
-            || (dateTime.Second != 0)
+        return dateTime.Hour != 0
+            || dateTime.Minute != 0
+            || dateTime.Second != 0
             || HasMilliSeconds(dateTime)
             || HasMicroSeconds(dateTime)
             || HasNanoSeconds(dateTime);
@@ -113,7 +115,7 @@ public class DateTimeOffsetValueFormatter : IValueFormatter
 
     private static bool HasDate(DateTimeOffset dateTime)
     {
-        return (dateTime.Day != 1) || (dateTime.Month != 1) || (dateTime.Year != 1);
+        return dateTime.Day != 1 || dateTime.Month != 1 || dateTime.Year != 1;
     }
 
     private static bool HasMilliSeconds(DateTimeOffset dateTime)

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -77,6 +77,7 @@ public class DefaultValueFormatter : IValueFormatter
 
         MemberInfo[] members = GetMembers(type);
         using var iterator = new Iterator<MemberInfo>(members.OrderBy(mi => mi.Name, StringComparer.Ordinal));
+
         while (iterator.MoveNext())
         {
             WriteMemberValueTextFor(obj, iterator.Current, formattedGraph, formatChild);
@@ -98,7 +99,8 @@ public class DefaultValueFormatter : IValueFormatter
     /// <remarks>The default is <see cref="System.Type.FullName"/>.</remarks>
     protected virtual string TypeDisplayName(Type type) => type.FullName;
 
-    private static void WriteMemberValueTextFor(object value, MemberInfo member, FormattedObjectGraph formattedGraph, FormatChild formatChild)
+    private static void WriteMemberValueTextFor(object value, MemberInfo member, FormattedObjectGraph formattedGraph,
+        FormatChild formatChild)
     {
         object memberValue;
 

--- a/Src/FluentAssertions/Formatting/DictionaryValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DictionaryValueFormatter.cs
@@ -33,6 +33,7 @@ public class DictionaryValueFormatter : IValueFormatter
         IEnumerable<KeyValuePair<object, object>> collection = AsEnumerable((IDictionary)value);
 
         using var iterator = new Iterator<KeyValuePair<object, object>>(collection, MaxItems);
+
         while (iterator.MoveNext())
         {
             if (iterator.IsFirst)
@@ -86,6 +87,7 @@ public class DictionaryValueFormatter : IValueFormatter
     private static IEnumerable<KeyValuePair<object, object>> AsEnumerable(IDictionary dictionary)
     {
         IDictionaryEnumerator iterator = dictionary.GetEnumerator();
+
         using (iterator as IDisposable)
         {
             while (iterator.MoveNext())

--- a/Src/FluentAssertions/Formatting/EnumValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumValueFormatter.cs
@@ -22,6 +22,7 @@ public class EnumValueFormatter : IValueFormatter
     {
         string typePart = value.GetType().Name;
         string namePart = value.ToString().Replace(", ", "|", StringComparison.Ordinal);
+
         string valuePart = Convert.ToDecimal(value, CultureInfo.InvariantCulture)
             .ToString(CultureInfo.InvariantCulture);
 

--- a/Src/FluentAssertions/Formatting/EnumerableExtensions.cs
+++ b/Src/FluentAssertions/Formatting/EnumerableExtensions.cs
@@ -9,7 +9,7 @@ internal static class EnumerableExtensions
     {
         var buffer = new StringBuilder();
 
-        T lastItem = default(T);
+        T lastItem = default;
         bool first = true;
 
         foreach (var item in items)

--- a/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
@@ -33,6 +33,7 @@ public class EnumerableValueFormatter : IValueFormatter
         IEnumerable<object> collection = ((IEnumerable)value).Cast<object>();
 
         using var iterator = new Iterator<object>(collection, MaxItems);
+
         while (iterator.MoveNext())
         {
             if (iterator.IsFirst)

--- a/Src/FluentAssertions/Formatting/FormattedObjectGraph.cs
+++ b/Src/FluentAssertions/Formatting/FormattedObjectGraph.cs
@@ -36,7 +36,7 @@ public class FormattedObjectGraph
     /// <summary>
     /// Returns the number of lines of text currently in the graph.
     /// </summary>
-    public int LineCount => lines.Count + ((lineBuilder.Length > 0) ? 1 : 0);
+    public int LineCount => lines.Count + (lineBuilder.Length > 0 ? 1 : 0);
 
     /// <summary>
     /// Starts a new line with the provided text fragment. Additional text can be added to
@@ -90,6 +90,7 @@ public class FormattedObjectGraph
         if (lines.Count == maxLines)
         {
             lines.Add(string.Empty);
+
             lines.Add(
                 $"(Output has exceeded the maximum of {maxLines} lines. " +
                 $"Increase {nameof(FormattingOptions)}.{nameof(FormattingOptions.MaxLines)} on {nameof(AssertionScope)} or {nameof(AssertionOptions)} to include more lines.)");
@@ -109,6 +110,7 @@ public class FormattedObjectGraph
     public IDisposable WithIndentation()
     {
         indentation++;
+
         return new Disposable(() =>
         {
             if (indentation > 0)

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -122,7 +122,8 @@ public static class Formatter
         }
     }
 
-    private static void FormatChild(string path, object value, FormattedObjectGraph output, FormattingContext context, FormattingOptions options, ObjectGraph graph)
+    private static void FormatChild(string path, object value, FormattedObjectGraph output, FormattingContext context,
+        FormattingOptions options, ObjectGraph graph)
     {
         try
         {
@@ -135,7 +136,7 @@ public static class Formatter
             else if (graph.Depth > options.MaxDepth)
             {
                 output.AddLine($"Maximum recursion depth of {options.MaxDepth} was reached. " +
-                       $" Increase {nameof(FormattingOptions.MaxDepth)} on {nameof(AssertionScope)} or {nameof(AssertionOptions)} to get more details.");
+                    $" Increase {nameof(FormattingOptions.MaxDepth)} on {nameof(AssertionScope)} or {nameof(AssertionOptions)} to get more details.");
             }
             else
             {

--- a/Src/FluentAssertions/Formatting/FormattingOptions.cs
+++ b/Src/FluentAssertions/Formatting/FormattingOptions.cs
@@ -25,7 +25,7 @@ public class FormattingOptions
 
     internal FormattingOptions Clone()
     {
-        return new()
+        return new FormattingOptions
         {
             UseLineBreaks = UseLineBreaks,
             MaxDepth = MaxDepth,

--- a/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
+++ b/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
@@ -47,6 +47,7 @@ public class MultidimensionalArrayFormatter : IValueFormatter
             {
                 enumerator.MoveNext();
                 formatChild(string.Join("-", dimensionIndices), enumerator.Current, formattedGraph);
+
                 if (!IsLastIteration(arr, currentDimensionIndex, currentLoopIndex))
                 {
                     formattedGraph.AddFragment(", ");
@@ -74,6 +75,7 @@ public class MultidimensionalArrayFormatter : IValueFormatter
                 }
 
                 currentDimensionIndex = dimensionIndices[currentLoopIndex];
+
                 if (!IsLastIteration(arr, currentDimensionIndex, currentLoopIndex))
                 {
                     formattedGraph.AddFragment(", ");
@@ -91,7 +93,7 @@ public class MultidimensionalArrayFormatter : IValueFormatter
 
     private static bool IsInnerMostLoop(Array arr, int index)
     {
-        return index == arr.Rank - 1;
+        return index == (arr.Rank - 1);
     }
 
     private static bool IsLastIteration(Array arr, int index, int dimension)

--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -116,7 +116,7 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
     /// </summary>
     private sealed class AndOperatorChainExtractor : ExpressionVisitor
     {
-        public List<Expression> AndChain { get; } = new List<Expression>();
+        public List<Expression> AndChain { get; } = new();
 
         public override Expression Visit(Expression node)
         {

--- a/Src/FluentAssertions/Formatting/TimeOnlyValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TimeOnlyValueFormatter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Globalization;
 
 #if NET6_0_OR_GREATER
-
 namespace FluentAssertions.Formatting;
 
 public class TimeOnlyValueFormatter : IValueFormatter

--- a/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
@@ -42,7 +42,7 @@ public class TimeSpanValueFormatter : IValueFormatter
             formattedGraph.AddFragment("default");
         }
 
-        string sign = (timeSpan.Ticks >= 0) ? string.Empty : "-";
+        string sign = timeSpan.Ticks >= 0 ? string.Empty : "-";
 
         if (fragments.Count == 1)
         {
@@ -73,9 +73,10 @@ public class TimeSpanValueFormatter : IValueFormatter
     private static void AddMicrosecondsIfNotZero(TimeSpan timeSpan, List<string> fragments)
     {
         var ticks = timeSpan.Ticks % TimeSpan.TicksPerMillisecond;
+
         if (ticks > 0)
         {
-            var microSeconds = ticks / (double)TimeSpan.TicksPerMillisecond * 1000;
+            var microSeconds = ticks * (1000.0 / TimeSpan.TicksPerMillisecond);
             fragments.Add(microSeconds.ToString("0.0", CultureInfo.InvariantCulture) + "µs");
         }
     }

--- a/Src/FluentAssertions/Formatting/ValueFormatterAttribute.cs
+++ b/Src/FluentAssertions/Formatting/ValueFormatterAttribute.cs
@@ -5,7 +5,7 @@ namespace FluentAssertions.Formatting;
 /// <summary>
 /// Marks a static method as a kind of <see cref="IValueFormatter"/> for a particular type.
 /// </summary>
-[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Method)]
 public class ValueFormatterAttribute : Attribute
 {
 }

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -248,7 +248,8 @@ public class ComparableTypeAssertions<T, TAssertions> : ReferenceTypeAssertions<
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) => BeLessThanOrEqualTo(expected, because, becauseArgs);
+    public AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) =>
+        BeLessThanOrEqualTo(expected, because, becauseArgs);
 
     /// <summary>
     /// Asserts that the subject is greater than another object according to its implementation of <see cref="IComparable{T}"/>.
@@ -297,7 +298,8 @@ public class ComparableTypeAssertions<T, TAssertions> : ReferenceTypeAssertions<
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) => BeGreaterThanOrEqualTo(expected, because, becauseArgs);
+    public AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) =>
+        BeGreaterThanOrEqualTo(expected, because, becauseArgs);
 
     /// <summary>
     /// Asserts that a value is within a range.
@@ -322,7 +324,7 @@ public class ComparableTypeAssertions<T, TAssertions> : ReferenceTypeAssertions<
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition((Subject.CompareTo(minimumValue) >= Equal) && (Subject.CompareTo(maximumValue) <= Equal))
+            .ForCondition(Subject.CompareTo(minimumValue) >= Equal && Subject.CompareTo(maximumValue) <= Equal)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:object} to be between {0} and {1}{reason}, but found {2}.",
                 minimumValue, maximumValue, Subject);
@@ -353,7 +355,7 @@ public class ComparableTypeAssertions<T, TAssertions> : ReferenceTypeAssertions<
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(!((Subject.CompareTo(minimumValue) >= Equal) && (Subject.CompareTo(maximumValue) <= Equal)))
+            .ForCondition(!(Subject.CompareTo(minimumValue) >= Equal && Subject.CompareTo(maximumValue) <= Equal))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:object} to not be between {0} and {1}{reason}, but found {2}.",
                 minimumValue, maximumValue, Subject);

--- a/Src/FluentAssertions/Numeric/DecimalAssertions.cs
+++ b/Src/FluentAssertions/Numeric/DecimalAssertions.cs
@@ -19,7 +19,7 @@ internal class DecimalAssertions : NumericAssertions<decimal>
     {
         try
         {
-            decimal difference = checked(subject - expected);
+            decimal difference = subject - expected;
             return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
         catch (OverflowException)

--- a/Src/FluentAssertions/Numeric/NullableDecimalAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableDecimalAssertions.cs
@@ -19,7 +19,7 @@ internal class NullableDecimalAssertions : NullableNumericAssertions<decimal>
     {
         try
         {
-            decimal difference = checked(subject - expected);
+            decimal difference = subject - expected;
             return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
         }
         catch (OverflowException)

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -60,7 +60,8 @@ public class NumericAssertions<T, TAssertions>
         Execute.Assertion
             .ForCondition(Subject?.CompareTo(expected) == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to be {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected, Subject);
+            .FailWith("Expected {context:value} to be {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected,
+                Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -81,7 +82,8 @@ public class NumericAssertions<T, TAssertions>
         Execute.Assertion
             .ForCondition(expected is T value ? Subject?.CompareTo(value) == 0 : !Subject.HasValue)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to be {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected, Subject);
+            .FailWith("Expected {context:value} to be {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected,
+                Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -141,7 +143,7 @@ public class NumericAssertions<T, TAssertions>
     public AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject?.CompareTo(default(T)) > 0)
+            .ForCondition(Subject?.CompareTo(default) > 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be positive{reason}, but found {0}.", Subject);
 
@@ -161,7 +163,7 @@ public class NumericAssertions<T, TAssertions>
     public AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject is T value && !IsNaN(value) && value.CompareTo(default(T)) < 0)
+            .ForCondition(Subject is T value && !IsNaN(value) && value.CompareTo(default) < 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be negative{reason}, but found {0}.", Subject);
 
@@ -189,7 +191,8 @@ public class NumericAssertions<T, TAssertions>
         Execute.Assertion
             .ForCondition(Subject is T value && !IsNaN(value) && value.CompareTo(expected) < 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to be less than {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected, Subject);
+            .FailWith("Expected {context:value} to be less than {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected),
+                expected, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -216,13 +219,16 @@ public class NumericAssertions<T, TAssertions>
         Execute.Assertion
             .ForCondition(Subject is T value && !IsNaN(value) && value.CompareTo(expected) <= 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to be less than or equal to {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected, Subject);
+            .FailWith(
+                "Expected {context:value} to be less than or equal to {0}{reason}, but found {1}" +
+                GenerateDifferenceMessage(expected), expected, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) => BeLessThanOrEqualTo(expected, because, becauseArgs);
+    public AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) =>
+        BeLessThanOrEqualTo(expected, because, becauseArgs);
 
     /// <summary>
     /// Asserts that the numeric value is greater than the specified <paramref name="expected"/> value.
@@ -246,7 +252,9 @@ public class NumericAssertions<T, TAssertions>
         Execute.Assertion
             .ForCondition(Subject?.CompareTo(expected) > 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to be greater than {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected, Subject);
+            .FailWith(
+                "Expected {context:value} to be greater than {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected),
+                expected, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -273,13 +281,16 @@ public class NumericAssertions<T, TAssertions>
         Execute.Assertion
             .ForCondition(Subject?.CompareTo(expected) >= 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to be greater than or equal to {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected, Subject);
+            .FailWith(
+                "Expected {context:value} to be greater than or equal to {0}{reason}, but found {1}" +
+                GenerateDifferenceMessage(expected), expected, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) => BeGreaterThanOrEqualTo(expected, because, becauseArgs);
+    public AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) =>
+        BeGreaterThanOrEqualTo(expected, because, becauseArgs);
 
     /// <summary>
     /// Asserts that a value is within a range.
@@ -309,7 +320,7 @@ public class NumericAssertions<T, TAssertions>
         }
 
         Execute.Assertion
-            .ForCondition(Subject is T value && (value.CompareTo(minimumValue) >= 0) && (value.CompareTo(maximumValue) <= 0))
+            .ForCondition(Subject is T value && value.CompareTo(minimumValue) >= 0 && value.CompareTo(maximumValue) <= 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be between {0} and {1}{reason}, but found {2}.",
                 minimumValue, maximumValue, Subject);
@@ -345,7 +356,7 @@ public class NumericAssertions<T, TAssertions>
         }
 
         Execute.Assertion
-            .ForCondition(Subject is T value && !((value.CompareTo(minimumValue) >= 0) && (value.CompareTo(maximumValue) <= 0)))
+            .ForCondition(Subject is T value && !(value.CompareTo(minimumValue) >= 0 && value.CompareTo(maximumValue) <= 0))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to not be between {0} and {1}{reason}, but found {2}.",
                 minimumValue, maximumValue, Subject);
@@ -407,6 +418,7 @@ public class NumericAssertions<T, TAssertions>
         Guard.ThrowIfArgumentIsNull(expectedType);
 
         Type subjectType = Subject?.GetType();
+
         if (expectedType.IsGenericTypeDefinition && subjectType?.IsGenericType == true)
         {
             (subjectType?.GetGenericTypeDefinition()).Should().Be(expectedType, because, becauseArgs);
@@ -495,6 +507,7 @@ public class NumericAssertions<T, TAssertions>
     private string GenerateDifferenceMessage(T? expected)
     {
         const string noDifferenceMessage = ".";
+
         if (Subject is not T subject || expected is not T expectedValue)
         {
             return noDifferenceMessage;

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 using FluentAssertions.Numeric;
-using FluentAssertions.Primitives;
 
 namespace FluentAssertions;
 
@@ -36,18 +35,21 @@ public static class NumericAssertionsExtensions
     {
         sbyte actualValue = parent.Subject.Value;
         sbyte minValue = (sbyte)(nearbyValue - delta);
+
         if (minValue > nearbyValue)
         {
             minValue = sbyte.MinValue;
         }
 
         sbyte maxValue = (sbyte)(nearbyValue + delta);
+
         if (maxValue < nearbyValue)
         {
             maxValue = sbyte.MaxValue;
         }
 
-        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
+        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<sbyte>>(parent);
     }
@@ -75,18 +77,21 @@ public static class NumericAssertionsExtensions
     {
         byte actualValue = parent.Subject.Value;
         byte minValue = (byte)(nearbyValue - delta);
+
         if (minValue > nearbyValue)
         {
             minValue = byte.MinValue;
         }
 
         byte maxValue = (byte)(nearbyValue + delta);
+
         if (maxValue < nearbyValue)
         {
             maxValue = byte.MaxValue;
         }
 
-        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
+        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<byte>>(parent);
     }
@@ -114,18 +119,21 @@ public static class NumericAssertionsExtensions
     {
         short actualValue = parent.Subject.Value;
         short minValue = (short)(nearbyValue - delta);
+
         if (minValue > nearbyValue)
         {
             minValue = short.MinValue;
         }
 
         short maxValue = (short)(nearbyValue + delta);
+
         if (maxValue < nearbyValue)
         {
             maxValue = short.MaxValue;
         }
 
-        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
+        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<short>>(parent);
     }
@@ -153,18 +161,21 @@ public static class NumericAssertionsExtensions
     {
         ushort actualValue = parent.Subject.Value;
         ushort minValue = (ushort)(nearbyValue - delta);
+
         if (minValue > nearbyValue)
         {
             minValue = ushort.MinValue;
         }
 
         ushort maxValue = (ushort)(nearbyValue + delta);
+
         if (maxValue < nearbyValue)
         {
             maxValue = ushort.MaxValue;
         }
 
-        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
+        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<ushort>>(parent);
     }
@@ -192,18 +203,21 @@ public static class NumericAssertionsExtensions
     {
         int actualValue = parent.Subject.Value;
         int minValue = (int)(nearbyValue - delta);
+
         if (minValue > nearbyValue)
         {
             minValue = int.MinValue;
         }
 
         int maxValue = (int)(nearbyValue + delta);
+
         if (maxValue < nearbyValue)
         {
             maxValue = int.MaxValue;
         }
 
-        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
+        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<int>>(parent);
     }
@@ -231,18 +245,21 @@ public static class NumericAssertionsExtensions
     {
         uint actualValue = parent.Subject.Value;
         uint minValue = nearbyValue - delta;
+
         if (minValue > nearbyValue)
         {
             minValue = uint.MinValue;
         }
 
         uint maxValue = nearbyValue + delta;
+
         if (maxValue < nearbyValue)
         {
             maxValue = uint.MaxValue;
         }
 
-        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
+        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<uint>>(parent);
     }
@@ -272,7 +289,8 @@ public static class NumericAssertionsExtensions
         long minValue = GetMinValue(nearbyValue, delta);
         long maxValue = GetMaxValue(nearbyValue, delta);
 
-        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
+        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<long>>(parent);
     }
@@ -300,18 +318,21 @@ public static class NumericAssertionsExtensions
     {
         ulong actualValue = parent.Subject.Value;
         ulong minValue = nearbyValue - delta;
+
         if (minValue > nearbyValue)
         {
             minValue = ulong.MinValue;
         }
 
         ulong maxValue = nearbyValue + delta;
+
         if (maxValue < nearbyValue)
         {
             maxValue = ulong.MaxValue;
         }
 
-        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
+        FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<ulong>>(parent);
     }
@@ -354,18 +375,21 @@ public static class NumericAssertionsExtensions
     {
         sbyte actualValue = parent.Subject.Value;
         sbyte minValue = (sbyte)(distantValue - delta);
+
         if (minValue > distantValue)
         {
             minValue = sbyte.MinValue;
         }
 
         sbyte maxValue = (sbyte)(distantValue + delta);
+
         if (maxValue < distantValue)
         {
             maxValue = sbyte.MaxValue;
         }
 
-        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
+        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<sbyte>>(parent);
     }
@@ -393,18 +417,21 @@ public static class NumericAssertionsExtensions
     {
         byte actualValue = parent.Subject.Value;
         byte minValue = (byte)(distantValue - delta);
+
         if (minValue > distantValue)
         {
             minValue = byte.MinValue;
         }
 
         byte maxValue = (byte)(distantValue + delta);
+
         if (maxValue < distantValue)
         {
             maxValue = byte.MaxValue;
         }
 
-        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
+        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<byte>>(parent);
     }
@@ -432,18 +459,21 @@ public static class NumericAssertionsExtensions
     {
         short actualValue = parent.Subject.Value;
         short minValue = (short)(distantValue - delta);
+
         if (minValue > distantValue)
         {
             minValue = short.MinValue;
         }
 
         short maxValue = (short)(distantValue + delta);
+
         if (maxValue < distantValue)
         {
             maxValue = short.MaxValue;
         }
 
-        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
+        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<short>>(parent);
     }
@@ -471,18 +501,21 @@ public static class NumericAssertionsExtensions
     {
         ushort actualValue = parent.Subject.Value;
         ushort minValue = (ushort)(distantValue - delta);
+
         if (minValue > distantValue)
         {
             minValue = ushort.MinValue;
         }
 
         ushort maxValue = (ushort)(distantValue + delta);
+
         if (maxValue < distantValue)
         {
             maxValue = ushort.MaxValue;
         }
 
-        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
+        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<ushort>>(parent);
     }
@@ -510,18 +543,21 @@ public static class NumericAssertionsExtensions
     {
         int actualValue = parent.Subject.Value;
         int minValue = (int)(distantValue - delta);
+
         if (minValue > distantValue)
         {
             minValue = int.MinValue;
         }
 
         int maxValue = (int)(distantValue + delta);
+
         if (maxValue < distantValue)
         {
             maxValue = int.MaxValue;
         }
 
-        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
+        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<int>>(parent);
     }
@@ -549,18 +585,21 @@ public static class NumericAssertionsExtensions
     {
         uint actualValue = parent.Subject.Value;
         uint minValue = distantValue - delta;
+
         if (minValue > distantValue)
         {
             minValue = uint.MinValue;
         }
 
         uint maxValue = distantValue + delta;
+
         if (maxValue < distantValue)
         {
             maxValue = uint.MaxValue;
         }
 
-        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
+        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<uint>>(parent);
     }
@@ -590,7 +629,8 @@ public static class NumericAssertionsExtensions
         long minValue = GetMinValue(distantValue, delta);
         long maxValue = GetMaxValue(distantValue, delta);
 
-        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
+        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<long>>(parent);
     }
@@ -618,18 +658,21 @@ public static class NumericAssertionsExtensions
     {
         ulong actualValue = parent.Subject.Value;
         ulong minValue = distantValue - delta;
+
         if (minValue > distantValue)
         {
             minValue = ulong.MinValue;
         }
 
         ulong maxValue = distantValue + delta;
+
         if (maxValue < distantValue)
         {
             maxValue = ulong.MaxValue;
         }
 
-        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
+        FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because,
+            becauseArgs);
 
         return new AndConstraint<NumericAssertions<ulong>>(parent);
     }
@@ -677,7 +720,8 @@ public static class NumericAssertionsExtensions
         bool success = Execute.Assertion
             .ForCondition(parent.Subject is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
+            .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue,
+                precision);
 
         if (success)
         {
@@ -721,7 +765,8 @@ public static class NumericAssertionsExtensions
         bool succeeded = Execute.Assertion
             .ForCondition(expectedValue is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was {2}.", expectedValue, precision, parent.Subject);
+            .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was {2}.", expectedValue, precision,
+                parent.Subject);
 
         if (succeeded)
         {
@@ -763,17 +808,20 @@ public static class NumericAssertionsExtensions
 
         if (float.IsPositiveInfinity(expectedValue))
         {
-            FailIfDifferenceOutsidePrecision(float.IsPositiveInfinity(parent.Subject.Value), parent, expectedValue, precision, float.NaN, because, becauseArgs);
+            FailIfDifferenceOutsidePrecision(float.IsPositiveInfinity(parent.Subject.Value), parent, expectedValue, precision,
+                float.NaN, because, becauseArgs);
         }
         else if (float.IsNegativeInfinity(expectedValue))
         {
-            FailIfDifferenceOutsidePrecision(float.IsNegativeInfinity(parent.Subject.Value), parent, expectedValue, precision, float.NaN, because, becauseArgs);
+            FailIfDifferenceOutsidePrecision(float.IsNegativeInfinity(parent.Subject.Value), parent, expectedValue, precision,
+                float.NaN, because, becauseArgs);
         }
         else
         {
             float actualDifference = Math.Abs(expectedValue - parent.Subject.Value);
 
-            FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
+            FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference,
+                because, becauseArgs);
         }
 
         return new AndConstraint<NumericAssertions<float>>(parent);
@@ -806,7 +854,8 @@ public static class NumericAssertionsExtensions
         bool success = Execute.Assertion
             .ForCondition(parent.Subject is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
+            .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue,
+                precision);
 
         if (success)
         {
@@ -850,7 +899,8 @@ public static class NumericAssertionsExtensions
         bool succeeded = Execute.Assertion
             .ForCondition(expectedValue is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was {2}.", expectedValue, precision, parent.Subject);
+            .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was {2}.", expectedValue, precision,
+                parent.Subject);
 
         if (succeeded)
         {
@@ -892,17 +942,20 @@ public static class NumericAssertionsExtensions
 
         if (double.IsPositiveInfinity(expectedValue))
         {
-            FailIfDifferenceOutsidePrecision(double.IsPositiveInfinity(parent.Subject.Value), parent, expectedValue, precision, double.NaN, because, becauseArgs);
+            FailIfDifferenceOutsidePrecision(double.IsPositiveInfinity(parent.Subject.Value), parent, expectedValue, precision,
+                double.NaN, because, becauseArgs);
         }
         else if (double.IsNegativeInfinity(expectedValue))
         {
-            FailIfDifferenceOutsidePrecision(double.IsNegativeInfinity(parent.Subject.Value), parent, expectedValue, precision, double.NaN, because, becauseArgs);
+            FailIfDifferenceOutsidePrecision(double.IsNegativeInfinity(parent.Subject.Value), parent, expectedValue, precision,
+                double.NaN, because, becauseArgs);
         }
         else
         {
             double actualDifference = Math.Abs(expectedValue - parent.Subject.Value);
 
-            FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
+            FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference,
+                because, becauseArgs);
         }
 
         return new AndConstraint<NumericAssertions<double>>(parent);
@@ -926,7 +979,8 @@ public static class NumericAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="precision"/> is negative.</exception>
-    public static AndConstraint<NullableNumericAssertions<decimal>> BeApproximately(this NullableNumericAssertions<decimal> parent,
+    public static AndConstraint<NullableNumericAssertions<decimal>> BeApproximately(
+        this NullableNumericAssertions<decimal> parent,
         decimal expectedValue, decimal precision, string because = "",
         params object[] becauseArgs)
     {
@@ -935,7 +989,8 @@ public static class NumericAssertionsExtensions
         bool success = Execute.Assertion
             .ForCondition(parent.Subject is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
+            .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue,
+                precision);
 
         if (success)
         {
@@ -965,7 +1020,8 @@ public static class NumericAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="precision"/> is negative.</exception>
-    public static AndConstraint<NullableNumericAssertions<decimal>> BeApproximately(this NullableNumericAssertions<decimal> parent,
+    public static AndConstraint<NullableNumericAssertions<decimal>> BeApproximately(
+        this NullableNumericAssertions<decimal> parent,
         decimal? expectedValue, decimal precision, string because = "",
         params object[] becauseArgs)
     {
@@ -979,7 +1035,8 @@ public static class NumericAssertionsExtensions
         bool succeeded = Execute.Assertion
             .ForCondition(expectedValue is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was {2}.", expectedValue, precision, parent.Subject);
+            .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was {2}.", expectedValue, precision,
+                parent.Subject);
 
         if (succeeded)
         {
@@ -1016,7 +1073,8 @@ public static class NumericAssertionsExtensions
 
         decimal actualDifference = Math.Abs(expectedValue - parent.Subject.Value);
 
-        FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
+        FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference,
+            because, becauseArgs);
 
         return new AndConstraint<NumericAssertions<decimal>>(parent);
     }
@@ -1096,7 +1154,7 @@ public static class NumericAssertionsExtensions
     {
         Guard.ThrowIfArgumentIsNegative(precision);
 
-        if ((parent.Subject is null) != (unexpectedValue is null))
+        if (parent.Subject is null != unexpectedValue is null)
         {
             return new AndConstraint<NullableNumericAssertions<float>>(parent);
         }
@@ -1104,7 +1162,8 @@ public static class NumericAssertionsExtensions
         bool succeeded = Execute.Assertion
             .ForCondition(parent.Subject is not null && unexpectedValue is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to not approximate {0} +/- {1}{reason}, but it was {2}.", unexpectedValue, precision, parent.Subject);
+            .FailWith("Expected {context:value} to not approximate {0} +/- {1}{reason}, but it was {2}.", unexpectedValue,
+                precision, parent.Subject);
 
         if (succeeded)
         {
@@ -1146,17 +1205,20 @@ public static class NumericAssertionsExtensions
 
         if (float.IsPositiveInfinity(unexpectedValue))
         {
-            FailIfDifferenceWithinPrecision(parent, !float.IsPositiveInfinity(parent.Subject.Value), unexpectedValue, precision, float.NaN, because, becauseArgs);
+            FailIfDifferenceWithinPrecision(parent, !float.IsPositiveInfinity(parent.Subject.Value), unexpectedValue, precision,
+                float.NaN, because, becauseArgs);
         }
         else if (float.IsNegativeInfinity(unexpectedValue))
         {
-            FailIfDifferenceWithinPrecision(parent, !float.IsNegativeInfinity(parent.Subject.Value), unexpectedValue, precision, float.NaN, because, becauseArgs);
+            FailIfDifferenceWithinPrecision(parent, !float.IsNegativeInfinity(parent.Subject.Value), unexpectedValue, precision,
+                float.NaN, because, becauseArgs);
         }
         else
         {
             float actualDifference = Math.Abs(unexpectedValue - parent.Subject.Value);
 
-            FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
+            FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference,
+                because, becauseArgs);
         }
 
         return new AndConstraint<NumericAssertions<float>>(parent);
@@ -1180,7 +1242,8 @@ public static class NumericAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="precision"/> is negative.</exception>
-    public static AndConstraint<NullableNumericAssertions<double>> NotBeApproximately(this NullableNumericAssertions<double> parent,
+    public static AndConstraint<NullableNumericAssertions<double>> NotBeApproximately(
+        this NullableNumericAssertions<double> parent,
         double unexpectedValue, double precision, string because = "",
         params object[] becauseArgs)
     {
@@ -1214,13 +1277,14 @@ public static class NumericAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="precision"/> is negative.</exception>
-    public static AndConstraint<NullableNumericAssertions<double>> NotBeApproximately(this NullableNumericAssertions<double> parent,
+    public static AndConstraint<NullableNumericAssertions<double>> NotBeApproximately(
+        this NullableNumericAssertions<double> parent,
         double? unexpectedValue, double precision, string because = "",
         params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNegative(precision);
 
-        if ((parent.Subject is null) != (unexpectedValue is null))
+        if (parent.Subject is null != unexpectedValue is null)
         {
             return new AndConstraint<NullableNumericAssertions<double>>(parent);
         }
@@ -1228,7 +1292,8 @@ public static class NumericAssertionsExtensions
         bool succeeded = Execute.Assertion
             .ForCondition(parent.Subject is not null && unexpectedValue is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to not approximate {0} +/- {1}{reason}, but it was {2}.", unexpectedValue, precision, parent.Subject);
+            .FailWith("Expected {context:value} to not approximate {0} +/- {1}{reason}, but it was {2}.", unexpectedValue,
+                precision, parent.Subject);
 
         if (succeeded)
         {
@@ -1270,17 +1335,20 @@ public static class NumericAssertionsExtensions
 
         if (double.IsPositiveInfinity(unexpectedValue))
         {
-            FailIfDifferenceWithinPrecision(parent, !double.IsPositiveInfinity(parent.Subject.Value), unexpectedValue, precision, double.NaN, because, becauseArgs);
+            FailIfDifferenceWithinPrecision(parent, !double.IsPositiveInfinity(parent.Subject.Value), unexpectedValue, precision,
+                double.NaN, because, becauseArgs);
         }
         else if (double.IsNegativeInfinity(unexpectedValue))
         {
-            FailIfDifferenceWithinPrecision(parent, !double.IsNegativeInfinity(parent.Subject.Value), unexpectedValue, precision, double.NaN, because, becauseArgs);
+            FailIfDifferenceWithinPrecision(parent, !double.IsNegativeInfinity(parent.Subject.Value), unexpectedValue, precision,
+                double.NaN, because, becauseArgs);
         }
         else
         {
             double actualDifference = Math.Abs(unexpectedValue - parent.Subject.Value);
 
-            FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
+            FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference,
+                because, becauseArgs);
         }
 
         return new AndConstraint<NumericAssertions<double>>(parent);
@@ -1304,7 +1372,8 @@ public static class NumericAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="precision"/> is negative.</exception>
-    public static AndConstraint<NullableNumericAssertions<decimal>> NotBeApproximately(this NullableNumericAssertions<decimal> parent,
+    public static AndConstraint<NullableNumericAssertions<decimal>> NotBeApproximately(
+        this NullableNumericAssertions<decimal> parent,
         decimal unexpectedValue, decimal precision, string because = "",
         params object[] becauseArgs)
     {
@@ -1338,13 +1407,14 @@ public static class NumericAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="precision"/> is negative.</exception>
-    public static AndConstraint<NullableNumericAssertions<decimal>> NotBeApproximately(this NullableNumericAssertions<decimal> parent,
+    public static AndConstraint<NullableNumericAssertions<decimal>> NotBeApproximately(
+        this NullableNumericAssertions<decimal> parent,
         decimal? unexpectedValue, decimal precision, string because = "",
         params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNegative(precision);
 
-        if ((parent.Subject is null) != (unexpectedValue is null))
+        if (parent.Subject is null != unexpectedValue is null)
         {
             return new AndConstraint<NullableNumericAssertions<decimal>>(parent);
         }
@@ -1352,7 +1422,8 @@ public static class NumericAssertionsExtensions
         bool succeeded = Execute.Assertion
             .ForCondition(parent.Subject is not null && unexpectedValue is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:value} to not approximate {0} +/- {1}{reason}, but it was {2}.", unexpectedValue, precision, parent.Subject);
+            .FailWith("Expected {context:value} to not approximate {0} +/- {1}{reason}, but it was {2}.", unexpectedValue,
+                precision, parent.Subject);
 
         if (succeeded)
         {
@@ -1389,7 +1460,8 @@ public static class NumericAssertionsExtensions
 
         decimal actualDifference = Math.Abs(unexpectedValue - parent.Subject.Value);
 
-        FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
+        FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference,
+            because, becauseArgs);
 
         return new AndConstraint<NumericAssertions<decimal>>(parent);
     }
@@ -1411,11 +1483,11 @@ public static class NumericAssertionsExtensions
 
     private static long GetMinValue(long value, ulong delta)
     {
-        long minValue = (delta <= ulong.MaxValue / 2)
-                        ? (value - (long)delta)
-                        : ((value < 0)
-                            ? long.MinValue
-                            : (-(long)(delta - (ulong)value)));
+        long minValue = delta <= (ulong.MaxValue / 2)
+            ? value - (long)delta
+            : value < 0
+                ? long.MinValue
+                : -(long)(delta - (ulong)value);
 
         if (minValue > value)
         {
@@ -1427,11 +1499,11 @@ public static class NumericAssertionsExtensions
 
     private static long GetMaxValue(long value, ulong delta)
     {
-        long maxValue = (delta <= ulong.MaxValue / 2)
-            ? (value + (long)delta)
-            : ((value >= 0)
+        long maxValue = delta <= (ulong.MaxValue / 2)
+            ? value + (long)delta
+            : value >= 0
                 ? long.MaxValue
-                : ((long)((ulong)value + delta)));
+                : (long)((ulong)value + delta);
 
         if (maxValue < value)
         {

--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -115,7 +115,8 @@ public static class ObjectAssertionsExtensions
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
     public static AndConstraint<ObjectAssertions> BeDataContractSerializable<T>(this ObjectAssertions assertions,
-        Func<EquivalencyAssertionOptions<T>, EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs)
+        Func<EquivalencyAssertionOptions<T>, EquivalencyAssertionOptions<T>> options, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(options);
 
@@ -144,6 +145,7 @@ public static class ObjectAssertionsExtensions
     private static object CreateCloneUsingBinarySerializer(object subject)
     {
         using var stream = new MemoryStream();
+
         var binaryFormatter = new BinaryFormatter
         {
             Binder = new SimpleBinder(subject.GetType())
@@ -167,7 +169,7 @@ public static class ObjectAssertionsExtensions
 
         public override Type BindToType(string assemblyName, string typeName)
         {
-            if ((type.FullName == typeName) && (type.Assembly.FullName == assemblyName))
+            if (type.FullName == typeName && type.Assembly.FullName == assemblyName)
             {
                 return type;
             }

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -145,7 +145,7 @@ public class BooleanAssertions<TAssertions>
             .FailWith("but it did not.")
             .Then
             .ClearExpectation();
-        
+
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 

--- a/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using FluentAssertions.Execution;
 
 #if NET6_0_OR_GREATER
-
 namespace FluentAssertions.Primitives;
 
 /// <summary>
@@ -330,7 +329,8 @@ public class DateOnlyAssertions<TAssertions>
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.HasValue)
-            .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but found a <null> DateOnly.", unexpected)
+            .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but found a <null> DateOnly.",
+                unexpected)
             .Then
             .ForCondition(Subject.Value.Year != unexpected)
             .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but it was.", unexpected,
@@ -500,7 +500,8 @@ public class DateOnlyAssertions<TAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateOnly?> validValues, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateOnly?> validValues, string because = "",
+        params object[] becauseArgs)
     {
         Execute.Assertion
             .ForCondition(validValues.Contains(Subject))

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -175,7 +175,7 @@ public class DateTimeAssertions<TAssertions>
             .ForCondition(Subject is not null)
             .FailWith(", but found <null>.")
             .Then
-            .ForCondition((Subject >= minimumValue) && (Subject <= maximumValue))
+            .ForCondition(Subject >= minimumValue && Subject <= maximumValue)
             .FailWith(", but {0} was off by {1}.", Subject, difference)
             .Then
             .ClearExpectation();
@@ -217,7 +217,7 @@ public class DateTimeAssertions<TAssertions>
         DateTime maximumValue = distantTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
         Execute.Assertion
-            .ForCondition((Subject < minimumValue) || (Subject > maximumValue))
+            .ForCondition(Subject < minimumValue || Subject > maximumValue)
             .BecauseOf(because, becauseArgs)
             .FailWith(
                 "Did not expect {context:the date and time} to be within {0} from {1}{reason}, but it was {2}.",
@@ -430,7 +430,8 @@ public class DateTimeAssertions<TAssertions>
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.HasValue)
-            .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but found a <null> DateTime.", unexpected)
+            .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but found a <null> DateTime.",
+                unexpected)
             .Then
             .ForCondition(Subject.Value.Year != unexpected)
             .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but it was.", unexpected,
@@ -887,7 +888,8 @@ public class DateTimeAssertions<TAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTime?> validValues, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTime?> validValues, string because = "",
+        params object[] becauseArgs)
     {
         Execute.Assertion
             .ForCondition(validValues.Contains(Subject))
@@ -914,12 +916,12 @@ public class DateTimeAssertions<TAssertions>
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {context:the date and time} to be in " + expectedKind.ToString() + "{reason}")
+            .WithExpectation("Expected {context:the date and time} to be in " + expectedKind + "{reason}")
             .ForCondition(Subject.HasValue)
             .FailWith(", but found a <null> DateTime.")
             .Then
             .ForCondition(Subject.Value.Kind == expectedKind)
-            .FailWith(", but found " + Subject.Value.Kind.ToString() + ".")
+            .FailWith(", but found " + Subject.Value.Kind + ".")
             .Then
             .ClearExpectation();
 

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -63,7 +63,8 @@ public class DateTimeOffsetAssertions<TAssertions>
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {context:the date and time} to represent the same point in time as {0}{reason}, ", expected)
+            .WithExpectation("Expected {context:the date and time} to represent the same point in time as {0}{reason}, ",
+                expected)
             .ForCondition(Subject.HasValue)
             .FailWith("but found a <null> DateTimeOffset.")
             .Then
@@ -92,15 +93,16 @@ public class DateTimeOffsetAssertions<TAssertions>
         if (!expected.HasValue)
         {
             Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(!Subject.HasValue)
-               .FailWith("Expected {context:the date and time} to be <null>{reason}, but it was {0}.", Subject);
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(!Subject.HasValue)
+                .FailWith("Expected {context:the date and time} to be <null>{reason}, but it was {0}.", Subject);
         }
         else
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:the date and time} to represent the same point in time as {0}{reason}, ", expected)
+                .WithExpectation("Expected {context:the date and time} to represent the same point in time as {0}{reason}, ",
+                    expected)
                 .ForCondition(Subject.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
@@ -130,7 +132,9 @@ public class DateTimeOffsetAssertions<TAssertions>
         Execute.Assertion
             .ForCondition(Subject != unexpected)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Did not expect {context:the date and time} to represent the same point in time as {0}{reason}, but it did.", unexpected);
+            .FailWith(
+                "Did not expect {context:the date and time} to represent the same point in time as {0}{reason}, but it did.",
+                unexpected);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -152,7 +156,9 @@ public class DateTimeOffsetAssertions<TAssertions>
         Execute.Assertion
             .ForCondition(Subject != unexpected)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Did not expect {context:the date and time} to represent the same point in time as {0}{reason}, but it did.", unexpected);
+            .FailWith(
+                "Did not expect {context:the date and time} to represent the same point in time as {0}{reason}, but it did.",
+                unexpected);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -203,9 +209,9 @@ public class DateTimeOffsetAssertions<TAssertions>
         if (!expected.HasValue)
         {
             Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(!Subject.HasValue)
-               .FailWith("Expected {context:the date and time} to be <null>{reason}, but it was {0}.", Subject);
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(!Subject.HasValue)
+                .FailWith("Expected {context:the date and time} to be <null>{reason}, but it was {0}.", Subject);
         }
         else
         {
@@ -262,7 +268,8 @@ public class DateTimeOffsetAssertions<TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(!((Subject == null && unexpected == null) || (Subject != null && unexpected != null && Subject.Value.EqualsExact(unexpected.Value))))
+            .ForCondition(!((Subject == null && unexpected == null) ||
+                (Subject != null && unexpected != null && Subject.Value.EqualsExact(unexpected.Value))))
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:the date and time} to be exactly {0}{reason}, but it was.", unexpected);
 
@@ -353,7 +360,7 @@ public class DateTimeOffsetAssertions<TAssertions>
         DateTimeOffset maximumValue = distantTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
         Execute.Assertion
-            .ForCondition((Subject < minimumValue) || (Subject > maximumValue))
+            .ForCondition(Subject < minimumValue || Subject > maximumValue)
             .BecauseOf(because, becauseArgs)
             .FailWith(
                 "Did not expect {context:the date and time} to be within {0} from {1}{reason}, but it was {2}.",
@@ -1067,7 +1074,8 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTimeOffset> validValues, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTimeOffset> validValues, string because = "",
+        params object[] becauseArgs)
     {
         return BeOneOf(validValues.Cast<DateTimeOffset?>(), because, becauseArgs);
     }
@@ -1085,7 +1093,8 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTimeOffset?> validValues, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTimeOffset?> validValues, string because = "",
+        params object[] becauseArgs)
     {
         Execute.Assertion
             .ForCondition(validValues.Contains(Subject))

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
@@ -24,8 +24,7 @@ public class DateTimeOffsetRangeAssertions<TAssertions>
     private readonly TAssertions parentAssertions;
     private readonly TimeSpanPredicate predicate;
 
-    private readonly Dictionary<TimeSpanCondition, TimeSpanPredicate> predicates = new Dictionary
-        <TimeSpanCondition, TimeSpanPredicate>
+    private readonly Dictionary<TimeSpanCondition, TimeSpanPredicate> predicates = new()
     {
         [TimeSpanCondition.MoreThan] = new TimeSpanPredicate((ts1, ts2) => ts1 > ts2, "more than"),
         [TimeSpanCondition.AtLeast] = new TimeSpanPredicate((ts1, ts2) => ts1 >= ts2, "at least"),
@@ -70,7 +69,7 @@ public class DateTimeOffsetRangeAssertions<TAssertions>
             .ForCondition(subject.HasValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time) to be " + predicate.DisplayText +
-                      " {0} before {1}{reason}, but found a <null> DateTime.", timeSpan, target);
+                " {0} before {1}{reason}, but found a <null> DateTime.", timeSpan, target);
 
         if (success)
         {
@@ -107,7 +106,7 @@ public class DateTimeOffsetRangeAssertions<TAssertions>
             .ForCondition(subject.HasValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be " + predicate.DisplayText +
-                      " {0} after {1}{reason}, but found a <null> DateTime.", timeSpan, target);
+                " {0} after {1}{reason}, but found a <null> DateTime.", timeSpan, target);
 
         if (success)
         {
@@ -127,7 +126,7 @@ public class DateTimeOffsetRangeAssertions<TAssertions>
 
     private static string PositionRelativeToTarget(DateTimeOffset actual, DateTimeOffset target)
     {
-        return actual - target >= TimeSpan.Zero ? "ahead" : "behind";
+        return (actual - target) >= TimeSpan.Zero ? "ahead" : "behind";
     }
 
     /// <inheritdoc/>

--- a/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
@@ -24,8 +24,7 @@ public class DateTimeRangeAssertions<TAssertions>
     private readonly TAssertions parentAssertions;
     private readonly TimeSpanPredicate predicate;
 
-    private readonly Dictionary<TimeSpanCondition, TimeSpanPredicate> predicates = new Dictionary
-        <TimeSpanCondition, TimeSpanPredicate>
+    private readonly Dictionary<TimeSpanCondition, TimeSpanPredicate> predicates = new()
     {
         [TimeSpanCondition.MoreThan] = new TimeSpanPredicate((ts1, ts2) => ts1 > ts2, "more than"),
         [TimeSpanCondition.AtLeast] = new TimeSpanPredicate((ts1, ts2) => ts1 >= ts2, "at least"),
@@ -70,7 +69,7 @@ public class DateTimeRangeAssertions<TAssertions>
             .ForCondition(subject.HasValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected date and/or time {0} to be " + predicate.DisplayText +
-                      " {1} before {2}{reason}, but found a <null> DateTime.",
+                " {1} before {2}{reason}, but found a <null> DateTime.",
                 subject, timeSpan, target);
 
         if (success)
@@ -109,7 +108,7 @@ public class DateTimeRangeAssertions<TAssertions>
             .ForCondition(subject.HasValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected date and/or time {0} to be " + predicate.DisplayText +
-                      " {1} after {2}{reason}, but found a <null> DateTime.",
+                " {1} after {2}{reason}, but found a <null> DateTime.",
                 subject, timeSpan, target);
 
         if (success)
@@ -130,7 +129,7 @@ public class DateTimeRangeAssertions<TAssertions>
 
     private static string PositionRelativeToTarget(DateTime actual, DateTime target)
     {
-        return actual - target >= TimeSpan.Zero ? "ahead" : "behind";
+        return (actual - target) >= TimeSpan.Zero ? "ahead" : "behind";
     }
 
     /// <inheritdoc/>

--- a/Src/FluentAssertions/Primitives/EnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/EnumAssertions.cs
@@ -195,7 +195,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> HaveValue(decimal expected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject is TEnum value && (GetValue(value) == expected))
+            .ForCondition(Subject is TEnum value && GetValue(value) == expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to have value {0}{reason}, but found {1}.",
                 expected, Subject);
@@ -217,7 +217,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> NotHaveValue(decimal unexpected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(!(Subject is TEnum value && (GetValue(value) == unexpected)))
+            .ForCondition(!(Subject is TEnum value && GetValue(value) == unexpected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to not have value {0}{reason}, but found {1}.",
                 unexpected, Subject);
@@ -240,7 +240,7 @@ public class EnumAssertions<TEnum, TAssertions>
         where T : struct, Enum
     {
         Execute.Assertion
-            .ForCondition(Subject is TEnum value && (GetValue(value) == GetValue(expected)))
+            .ForCondition(Subject is TEnum value && GetValue(value) == GetValue(expected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to have same value as {0}{reason}, but found {1}.",
                 expected, Subject);
@@ -263,7 +263,7 @@ public class EnumAssertions<TEnum, TAssertions>
         where T : struct, Enum
     {
         Execute.Assertion
-            .ForCondition(!(Subject is TEnum value && (GetValue(value) == GetValue(unexpected))))
+            .ForCondition(!(Subject is TEnum value && GetValue(value) == GetValue(unexpected)))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to not have same value as {0}{reason}, but found {1}.",
                 unexpected, Subject);
@@ -286,7 +286,7 @@ public class EnumAssertions<TEnum, TAssertions>
         where T : struct, Enum
     {
         Execute.Assertion
-            .ForCondition(Subject is TEnum value && (GetName(value) == GetName(expected)))
+            .ForCondition(Subject is TEnum value && GetName(value) == GetName(expected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to have same name as {0}{reason}, but found {1}.",
                 expected, Subject);
@@ -309,7 +309,7 @@ public class EnumAssertions<TEnum, TAssertions>
         where T : struct, Enum
     {
         Execute.Assertion
-            .ForCondition(!(Subject is TEnum value && (GetName(value) == GetName(unexpected))))
+            .ForCondition(!(Subject is TEnum value && GetName(value) == GetName(unexpected)))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to not have same name as {0}{reason}, but found {1}.",
                 unexpected, Subject);
@@ -417,8 +417,11 @@ public class EnumAssertions<TEnum, TAssertions>
     /// <exception cref="ArgumentException"><paramref name="validValues"/> is empty.</exception>
     public AndConstraint<TAssertions> BeOneOf(IEnumerable<TEnum> validValues, string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(validValues, nameof(validValues), "Cannot assert that an enum is one of a null list of enums");
-        Guard.ThrowIfArgumentIsEmpty(validValues, nameof(validValues), "Cannot assert that an enum is one of an empty list of enums");
+        Guard.ThrowIfArgumentIsNull(validValues, nameof(validValues),
+            "Cannot assert that an enum is one of a null list of enums");
+
+        Guard.ThrowIfArgumentIsEmpty(validValues, nameof(validValues),
+            "Cannot assert that an enum is one of an empty list of enums");
 
         Execute.Assertion
             .ForCondition(Subject is not null)

--- a/Src/FluentAssertions/Primitives/HttpResponseMessageAssertions.cs
+++ b/Src/FluentAssertions/Primitives/HttpResponseMessageAssertions.cs
@@ -209,7 +209,8 @@ public class HttpResponseMessageAssertions<TAssertions> : ObjectAssertions<HttpR
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<TAssertions> NotHaveStatusCode(HttpStatusCode unexpected, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> NotHaveStatusCode(HttpStatusCode unexpected, string because = "",
+        params object[] becauseArgs)
     {
         var success = Execute.Assertion
             .ForCondition(Subject is not null)

--- a/Src/FluentAssertions/Primitives/NegatedStringStartValidator.cs
+++ b/Src/FluentAssertions/Primitives/NegatedStringStartValidator.cs
@@ -33,6 +33,7 @@ internal class NegatedStringStartValidator : StringValidator
     protected override void ValidateAgainstMismatch()
     {
         bool isMatch = Subject.StartsWith(Expected, stringComparison);
+
         if (isMatch)
         {
             Assertion.FailWith(ExpectationDescription + "{0}{reason}, but found {1}.",

--- a/Src/FluentAssertions/Primitives/NullableDateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateOnlyAssertions.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using FluentAssertions.Execution;
 
 #if NET6_0_OR_GREATER
-
 namespace FluentAssertions.Primitives;
 
 /// <summary>

--- a/Src/FluentAssertions/Primitives/NullableTimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableTimeOnlyAssertions.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using FluentAssertions.Execution;
 
 #if NET6_0_OR_GREATER
-
 namespace FluentAssertions.Primitives;
 
 /// <summary>

--- a/Src/FluentAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ObjectAssertions.cs
@@ -210,6 +210,7 @@ public class ObjectAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
         Guard.ThrowIfArgumentIsNull(config);
 
         bool hasMismatches;
+
         using (var scope = new AssertionScope())
         {
             Subject.Should().BeEquivalentTo(unexpected, config);

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -128,7 +128,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
     {
         BeOfType(typeof(T), because, becauseArgs);
 
-        T typedSubject = (Subject is T type)
+        T typedSubject = Subject is T type
             ? type
             : default;
 
@@ -162,6 +162,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
         if (success)
         {
             Type subjectType = Subject.GetType();
+
             if (expectedType.IsGenericTypeDefinition && subjectType.IsGenericType)
             {
                 subjectType.GetGenericTypeDefinition().Should().Be(expectedType, because, becauseArgs);
@@ -220,6 +221,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
         if (success)
         {
             Type subjectType = Subject.GetType();
+
             if (unexpectedType.IsGenericTypeDefinition && subjectType.IsGenericType)
             {
                 subjectType.GetGenericTypeDefinition().Should().NotBe(unexpectedType, because, becauseArgs);
@@ -262,7 +264,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
                 .FailWith("Expected {context} to be assignable to {0}{reason}, but {1} is not.", typeof(T), Subject.GetType());
         }
 
-        T typedSubject = (Subject is T type)
+        T typedSubject = Subject is T type
             ? type
             : default;
 

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -166,7 +166,8 @@ public class SimpleTimeSpanAssertions<TAssertions>
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public AndConstraint<TAssertions> BeLessOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs) => BeLessThanOrEqualTo(expected, because, becauseArgs);
+    public AndConstraint<TAssertions> BeLessOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs) =>
+        BeLessThanOrEqualTo(expected, because, becauseArgs);
 
     /// <summary>
     /// Asserts that the time difference of the current <see cref="TimeSpan"/> is greater than the
@@ -214,7 +215,8 @@ public class SimpleTimeSpanAssertions<TAssertions>
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public AndConstraint<TAssertions> BeGreaterOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs) => BeGreaterThanOrEqualTo(expected, because, becauseArgs);
+    public AndConstraint<TAssertions> BeGreaterOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs) =>
+        BeGreaterThanOrEqualTo(expected, because, becauseArgs);
 
     /// <summary>
     /// Asserts that the current <see cref="TimeSpan"/> is within the specified time
@@ -247,7 +249,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
         TimeSpan maximumValue = nearbyTime + precision;
 
         Execute.Assertion
-            .ForCondition((Subject >= minimumValue) && (Subject.Value <= maximumValue))
+            .ForCondition(Subject >= minimumValue && Subject.Value <= maximumValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be within {0} from {1}{reason}, but found {2}.",
                 precision,

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -53,7 +53,9 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// </param>
     public AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs)
     {
-        var stringEqualityValidator = new StringEqualityValidator(Subject, expected, StringComparison.Ordinal, because, becauseArgs);
+        var stringEqualityValidator =
+            new StringEqualityValidator(Subject, expected, StringComparison.Ordinal, because, becauseArgs);
+
         stringEqualityValidator.Validate();
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -136,6 +138,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         params object[] becauseArgs)
     {
         bool notEquivalent;
+
         using (var scope = new AssertionScope())
         {
             Subject.Should().BeEquivalentTo(unexpected);
@@ -209,8 +212,11 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// <exception cref="ArgumentException"><paramref name="wildcardPattern"/> is empty.</exception>
     public AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match string against <null>. Provide a wildcard pattern or use the BeNull method.");
-        Guard.ThrowIfArgumentIsEmpty(wildcardPattern, nameof(wildcardPattern), "Cannot match string against an empty string. Provide a wildcard pattern or use the BeEmpty method.");
+        Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern),
+            "Cannot match string against <null>. Provide a wildcard pattern or use the BeNull method.");
+
+        Guard.ThrowIfArgumentIsEmpty(wildcardPattern, nameof(wildcardPattern),
+            "Cannot match string against an empty string. Provide a wildcard pattern or use the BeEmpty method.");
 
         var stringWildcardMatchingValidator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs);
         stringWildcardMatchingValidator.Validate();
@@ -255,8 +261,11 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// <exception cref="ArgumentException"><paramref name="wildcardPattern"/> is empty.</exception>
     public AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match string against <null>. Provide a wildcard pattern or use the NotBeNull method.");
-        Guard.ThrowIfArgumentIsEmpty(wildcardPattern, nameof(wildcardPattern), "Cannot match string against an empty string. Provide a wildcard pattern or use the NotBeEmpty method.");
+        Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern),
+            "Cannot match string against <null>. Provide a wildcard pattern or use the NotBeNull method.");
+
+        Guard.ThrowIfArgumentIsEmpty(wildcardPattern, nameof(wildcardPattern),
+            "Cannot match string against an empty string. Provide a wildcard pattern or use the NotBeEmpty method.");
 
         new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs)
         {
@@ -304,8 +313,11 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     public AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match string against <null>. Provide a wildcard pattern or use the BeNull method.");
-        Guard.ThrowIfArgumentIsEmpty(wildcardPattern, nameof(wildcardPattern), "Cannot match string against an empty string. Provide a wildcard pattern or use the BeEmpty method.");
+        Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern),
+            "Cannot match string against <null>. Provide a wildcard pattern or use the BeNull method.");
+
+        Guard.ThrowIfArgumentIsEmpty(wildcardPattern, nameof(wildcardPattern),
+            "Cannot match string against an empty string. Provide a wildcard pattern or use the BeEmpty method.");
 
         var validator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs)
         {
@@ -356,8 +368,11 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     public AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match string against <null>. Provide a wildcard pattern or use the NotBeNull method.");
-        Guard.ThrowIfArgumentIsEmpty(wildcardPattern, nameof(wildcardPattern), "Cannot match string against an empty string. Provide a wildcard pattern or use the NotBeEmpty method.");
+        Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern),
+            "Cannot match string against <null>. Provide a wildcard pattern or use the NotBeNull method.");
+
+        Guard.ThrowIfArgumentIsEmpty(wildcardPattern, nameof(wildcardPattern),
+            "Cannot match string against an empty string. Provide a wildcard pattern or use the NotBeEmpty method.");
 
         var validator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs)
         {
@@ -391,13 +406,14 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="regularExpression"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> MatchRegex([RegexPattern][StringSyntax("Regex")] string regularExpression,
+    public AndConstraint<TAssertions> MatchRegex([RegexPattern] [StringSyntax("Regex")] string regularExpression,
         OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression),
             "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
 
         Regex regex;
+
         try
         {
             regex = new Regex(regularExpression);
@@ -406,6 +422,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         {
             Execute.Assertion.FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.",
                 regularExpression);
+
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
@@ -426,12 +443,14 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="regularExpression"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> MatchRegex([RegexPattern][StringSyntax("Regex")] string regularExpression,
+    public AndConstraint<TAssertions> MatchRegex([RegexPattern] [StringSyntax("Regex")] string regularExpression,
         string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
+        Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression),
+            "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
 
         Regex regex;
+
         try
         {
             regex = new Regex(regularExpression);
@@ -440,6 +459,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         {
             Execute.Assertion.FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.",
                 regularExpression);
+
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
@@ -474,7 +494,9 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
 
         var regexStr = regularExpression.ToString();
-        Guard.ThrowIfArgumentIsEmpty(regexStr, nameof(regularExpression), "Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.");
+
+        Guard.ThrowIfArgumentIsEmpty(regexStr, nameof(regularExpression),
+            "Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.");
 
         bool success = Execute.Assertion
             .ForCondition(Subject is not null)
@@ -520,7 +542,9 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
 
         var regexStr = regularExpression.ToString();
-        Guard.ThrowIfArgumentIsEmpty(regexStr, nameof(regularExpression), "Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.");
+
+        Guard.ThrowIfArgumentIsEmpty(regexStr, nameof(regularExpression),
+            "Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.");
 
         bool success = Execute.Assertion
             .ForCondition(Subject is not null)
@@ -554,12 +578,14 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="regularExpression"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> NotMatchRegex([RegexPattern][StringSyntax("Regex")] string regularExpression,
+    public AndConstraint<TAssertions> NotMatchRegex([RegexPattern] [StringSyntax("Regex")] string regularExpression,
         string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.");
+        Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression),
+            "Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.");
 
         Regex regex;
+
         try
         {
             regex = new Regex(regularExpression);
@@ -568,6 +594,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         {
             Execute.Assertion.FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.",
                 regularExpression);
+
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
@@ -595,7 +622,9 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             "Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.");
 
         var regexStr = regularExpression.ToString();
-        Guard.ThrowIfArgumentIsEmpty(regexStr, nameof(regularExpression), "Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.");
+
+        Guard.ThrowIfArgumentIsEmpty(regexStr, nameof(regularExpression),
+            "Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.");
 
         bool success = Execute.Assertion
             .ForCondition(Subject is not null)
@@ -655,7 +684,9 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     {
         Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare start of string with <null>.");
 
-        var negatedStringStartValidator = new NegatedStringStartValidator(Subject, unexpected, StringComparison.Ordinal, because, becauseArgs);
+        var negatedStringStartValidator =
+            new NegatedStringStartValidator(Subject, unexpected, StringComparison.Ordinal, because, becauseArgs);
+
         negatedStringStartValidator.Validate();
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -679,7 +710,9 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     {
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare string start equivalence with <null>.");
 
-        var stringStartValidator = new StringStartValidator(Subject, expected, StringComparison.OrdinalIgnoreCase, because, becauseArgs);
+        var stringStartValidator =
+            new StringStartValidator(Subject, expected, StringComparison.OrdinalIgnoreCase, because, becauseArgs);
+
         stringStartValidator.Validate();
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -698,11 +731,14 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare start of string with <null>.");
 
-        var negatedStringStartValidator = new NegatedStringStartValidator(Subject, unexpected, StringComparison.OrdinalIgnoreCase, because, becauseArgs);
+        var negatedStringStartValidator =
+            new NegatedStringStartValidator(Subject, unexpected, StringComparison.OrdinalIgnoreCase, because, becauseArgs);
+
         negatedStringStartValidator.Validate();
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -914,7 +950,8 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="expected"/> is empty.</exception>
-    public AndConstraint<TAssertions> Contain(string expected, OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> Contain(string expected, OccurrenceConstraint occurrenceConstraint, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot assert string containment against <null>.");
         Guard.ThrowIfArgumentIsEmpty(expected, nameof(expected), "Cannot assert string containment against an empty string.");
@@ -980,7 +1017,8 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="expected"/> is empty.</exception>
-    public AndConstraint<TAssertions> ContainEquivalentOf(string expected, OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> ContainEquivalentOf(string expected, OccurrenceConstraint occurrenceConstraint,
+        string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot assert string containment against <null>.");
         Guard.ThrowIfArgumentIsEmpty(expected, nameof(expected), "Cannot assert string containment against an empty string.");
@@ -1015,6 +1053,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         ThrowIfValuesNullOrEmpty(values);
 
         IEnumerable<string> missing = values.Where(v => !Contains(Subject, v, StringComparison.Ordinal));
+
         Execute.Assertion
             .ForCondition(values.All(v => Contains(Subject, v, StringComparison.Ordinal)))
             .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Primitives/StringEqualityValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityValidator.cs
@@ -18,10 +18,10 @@ internal class StringEqualityValidator : StringValidator
     protected override bool ValidateAgainstSuperfluousWhitespace()
     {
         return Assertion
-            .ForCondition(!((Expected.Length > Subject.Length) && Expected.TrimEnd().Equals(Subject, comparisonMode)))
+            .ForCondition(!(Expected.Length > Subject.Length && Expected.TrimEnd().Equals(Subject, comparisonMode)))
             .FailWith(ExpectationDescription + "{0}{reason}, but it misses some extra whitespace at the end.", Expected)
             .Then
-            .ForCondition(!((Subject.Length > Expected.Length) && Subject.TrimEnd().Equals(Expected, comparisonMode)))
+            .ForCondition(!(Subject.Length > Expected.Length && Subject.TrimEnd().Equals(Expected, comparisonMode)))
             .FailWith(ExpectationDescription + "{0}{reason}, but it has unexpected whitespace at the end.", Expected);
     }
 
@@ -34,7 +34,7 @@ internal class StringEqualityValidator : StringValidator
                 string mismatchSegment = GetMismatchSegmentForStringsOfDifferentLengths();
 
                 string message = ExpectationDescription +
-                                    "{0} with a length of {1}{reason}, but {2} has a length of {3}, differs near " + mismatchSegment + ".";
+                    "{0} with a length of {1}{reason}, but {2} has a length of {3}, differs near " + mismatchSegment + ".";
 
                 return new FailReason(message, Expected, Expected.Length, Subject, Subject.Length);
             });
@@ -60,6 +60,7 @@ internal class StringEqualityValidator : StringValidator
     protected override void ValidateAgainstMismatch()
     {
         int indexOfMismatch = Subject.IndexOfFirstMismatch(Expected, comparisonMode);
+
         if (indexOfMismatch != -1)
         {
             Assertion.FailWith(

--- a/Src/FluentAssertions/Primitives/StringStartValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringStartValidator.cs
@@ -41,6 +41,7 @@ internal class StringStartValidator : StringValidator
     protected override void ValidateAgainstMismatch()
     {
         bool isMismatch = !Subject.StartsWith(Expected, stringComparison);
+
         if (isMismatch)
         {
             int indexOfMismatch = Subject.IndexOfFirstMismatch(Expected, stringComparison);

--- a/Src/FluentAssertions/Primitives/StringValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringValidator.cs
@@ -30,7 +30,7 @@ internal abstract class StringValidator
 
     public void Validate()
     {
-        if ((Expected is not null) || (Subject is not null))
+        if (Expected is not null || Subject is not null)
         {
             if (ValidateAgainstNulls())
             {
@@ -52,7 +52,7 @@ internal abstract class StringValidator
 
     private bool ValidateAgainstNulls()
     {
-        if ((Expected is null) != (Subject is null))
+        if (Expected is null != Subject is null)
         {
             Assertion.FailWith(ExpectationDescription + "{0}{reason}, but found {1}.", Expected, Subject);
             return false;
@@ -63,7 +63,7 @@ internal abstract class StringValidator
 
     private static bool IsLongOrMultiline(string value)
     {
-        return (value.Length > HumanReadableLength) || value.Contains(Environment.NewLine, StringComparison.Ordinal);
+        return value.Length > HumanReadableLength || value.Contains(Environment.NewLine, StringComparison.Ordinal);
     }
 
     protected virtual bool ValidateAgainstSuperfluousWhitespace()

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Text;
 using System.Text.RegularExpressions;
-
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Primitives;
@@ -30,7 +29,9 @@ internal class StringWildcardMatchingValidator : StringValidator
 
     private bool IsMatch()
     {
-        RegexOptions options = IgnoreCase ? (RegexOptions.IgnoreCase | RegexOptions.CultureInvariant) : RegexOptions.None;
+        RegexOptions options = IgnoreCase
+            ? RegexOptions.IgnoreCase | RegexOptions.CultureInvariant
+            : RegexOptions.None;
 
         string input = CleanNewLines(Subject);
         string pattern = ConvertWildcardToRegEx(CleanNewLines(Expected));
@@ -42,8 +43,8 @@ internal class StringWildcardMatchingValidator : StringValidator
     {
         return "^"
             + Regex.Escape(wildcardExpression)
-             .Replace("\\*", ".*", StringComparison.Ordinal)
-             .Replace("\\?", ".", StringComparison.Ordinal)
+                .Replace("\\*", ".*", StringComparison.Ordinal)
+                .Replace("\\?", ".", StringComparison.Ordinal)
             + "$";
     }
 

--- a/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
@@ -6,7 +6,6 @@ using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 #if NET6_0_OR_GREATER
-
 namespace FluentAssertions.Primitives;
 
 /// <summary>
@@ -151,7 +150,7 @@ public class TimeOnlyAssertions<TAssertions>
     {
         Guard.ThrowIfArgumentIsNegative(precision);
 
-        TimeSpan? difference = (Subject != null)
+        TimeSpan? difference = Subject != null
             ? MinimumDifference(Subject.Value, nearbyTime)
             : null;
 
@@ -417,7 +416,8 @@ public class TimeOnlyAssertions<TAssertions>
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.HasValue)
-            .FailWith("Did not expect the hours part of {context:the time} to be {0}{reason}, but found a <null> TimeOnly.", unexpected)
+            .FailWith("Did not expect the hours part of {context:the time} to be {0}{reason}, but found a <null> TimeOnly.",
+                unexpected)
             .Then
             .ForCondition(Subject.Value.Hour != unexpected)
             .FailWith("Did not expect the hours part of {context:the time} to be {0}{reason}, but it was.", unexpected,
@@ -641,7 +641,8 @@ public class TimeOnlyAssertions<TAssertions>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TAssertions> BeOneOf(IEnumerable<TimeOnly?> validValues, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> BeOneOf(IEnumerable<TimeOnly?> validValues, string because = "",
+        params object[] becauseArgs)
     {
         Execute.Assertion
             .ForCondition(validValues.Contains(Subject))

--- a/Src/FluentAssertions/Primitives/TimeSpanPredicate.cs
+++ b/Src/FluentAssertions/Primitives/TimeSpanPredicate.cs
@@ -7,16 +7,15 @@ namespace FluentAssertions.Primitives;
 /// </summary>
 internal class TimeSpanPredicate
 {
-    private readonly string displayText;
     private readonly Func<TimeSpan, TimeSpan, bool> lambda;
 
     public TimeSpanPredicate(Func<TimeSpan, TimeSpan, bool> lambda, string displayText)
     {
         this.lambda = lambda;
-        this.displayText = displayText;
+        DisplayText = displayText;
     }
 
-    public string DisplayText => displayText;
+    public string DisplayText { get; }
 
     public bool IsMatchedBy(TimeSpan actual, TimeSpan expected)
     {

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -52,9 +52,9 @@ public class AssemblyAssertions : ReferenceTypeAssertions<Assembly, AssemblyAsse
             IEnumerable<string> references = Subject.GetReferencedAssemblies().Select(x => x.Name);
 
             Execute.Assertion
-                   .BecauseOf(because, becauseArgs)
-                   .ForCondition(!references.Contains(assemblyName))
-                   .FailWith("Expected assembly {0} not to reference assembly {1}{reason}.", subjectName, assemblyName);
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(!references.Contains(assemblyName))
+                .FailWith("Expected assembly {0} not to reference assembly {1}{reason}.", subjectName, assemblyName);
         }
 
         return new AndConstraint<AssemblyAssertions>(this);
@@ -90,9 +90,9 @@ public class AssemblyAssertions : ReferenceTypeAssertions<Assembly, AssemblyAsse
             IEnumerable<string> references = Subject.GetReferencedAssemblies().Select(x => x.Name);
 
             Execute.Assertion
-                   .BecauseOf(because, becauseArgs)
-                   .ForCondition(references.Contains(assemblyName))
-                   .FailWith("Expected assembly {0} to reference assembly {1}{reason}, but it does not.", subjectName, assemblyName);
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(references.Contains(assemblyName))
+                .FailWith("Expected assembly {0} to reference assembly {1}{reason}, but it does not.", subjectName, assemblyName);
         }
 
         return new AndConstraint<AssemblyAssertions>(this);
@@ -112,7 +112,8 @@ public class AssemblyAssertions : ReferenceTypeAssertions<Assembly, AssemblyAsse
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
-    public AndWhichConstraint<AssemblyAssertions, Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs)
+    public AndWhichConstraint<AssemblyAssertions, Type> DefineType(string @namespace, string name, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNullOrEmpty(name);
 

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -60,6 +60,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
             if (success)
             {
                 bool completesWithinTimeout = await CompletesWithinTimeoutAsync(task, remainingTime);
+
                 Execute.Assertion
                     .ForCondition(completesWithinTimeout)
                     .BecauseOf(because, becauseArgs)
@@ -92,9 +93,11 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         if (success)
         {
             (Task task, TimeSpan remainingTime) = InvokeWithTimer(timeSpan);
+
             if (remainingTime >= TimeSpan.Zero)
             {
                 bool completesWithinTimeout = await CompletesWithinTimeoutAsync(task, remainingTime);
+
                 Execute.Assertion
                     .ForCondition(!completesWithinTimeout)
                     .BecauseOf(because, becauseArgs)
@@ -265,7 +268,8 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="waitTime"/> or <paramref name="pollInterval"/> are negative.</exception>
-    public Task<AndConstraint<TAssertions>> NotThrowAfterAsync(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
+    public Task<AndConstraint<TAssertions>> NotThrowAfterAsync(TimeSpan waitTime, TimeSpan pollInterval, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNegative(waitTime);
         Guard.ThrowIfArgumentIsNegative(pollInterval);
@@ -288,6 +292,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
                 while (invocationEndTime is null || invocationEndTime < waitTime)
                 {
                     exception = await InvokeWithInterceptionAsync(Subject);
+
                     if (exception is null)
                     {
                         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -353,8 +358,8 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
             // If an assertion failure occurs, we want the message to talk about "subject"
             // not "await action".
             using (CallerIdentifier.OnlyOneFluentAssertionScopeOnCallStack()
-                    ? CallerIdentifier.OverrideStackSearchUsingCurrentScope()
-                    : default)
+                       ? CallerIdentifier.OverrideStackSearchUsingCurrentScope()
+                       : default)
             {
                 await action();
             }

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -176,7 +176,8 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="waitTime"/> or <paramref name="pollInterval"/> are negative.</exception>
-    public AndConstraint<TAssertions> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNegative(waitTime);
         Guard.ThrowIfArgumentIsNegative(pollInterval);
@@ -197,6 +198,7 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
             while (invocationEndTime is null || invocationEndTime < waitTime)
             {
                 exception = InvokeSubjectWithInterception();
+
                 if (exception is null)
                 {
                     break;
@@ -232,8 +234,8 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
             // If an assertion failure occurs, we want the message to talk about "subject"
             // not "action".
             using (CallerIdentifier.OnlyOneFluentAssertionScopeOnCallStack()
-                ? CallerIdentifier.OverrideStackSearchUsingCurrentScope()
-                : default)
+                       ? CallerIdentifier.OverrideStackSearchUsingCurrentScope()
+                       : default)
             {
                 InvokeSubject();
             }
@@ -250,7 +252,8 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
     {
         if (Subject.GetMethodInfo().IsDecoratedWithOrInherit<AsyncStateMachineAttribute>())
         {
-            throw new InvalidOperationException("Cannot use action assertions on an async void method. Assign the async method to a variable of type Func<Task> instead of Action so that it can be awaited.");
+            throw new InvalidOperationException(
+                "Cannot use action assertions on an async void method. Assign the async method to a variable of type Func<Task> instead of Action so that it can be awaited.");
         }
     }
 }

--- a/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
@@ -12,7 +12,8 @@ namespace FluentAssertions.Specialized;
 /// Contains a number of methods to assert that a method yields the expected result.
 /// </summary>
 [DebuggerNonUserCode]
-public abstract class DelegateAssertionsBase<TDelegate, TAssertions> : ReferenceTypeAssertions<TDelegate, DelegateAssertionsBase<TDelegate, TAssertions>>
+public abstract class DelegateAssertionsBase<TDelegate, TAssertions>
+    : ReferenceTypeAssertions<TDelegate, DelegateAssertionsBase<TDelegate, TAssertions>>
     where TDelegate : Delegate
     where TAssertions : DelegateAssertionsBase<TDelegate, TAssertions>
 {
@@ -63,6 +64,7 @@ public abstract class DelegateAssertionsBase<TDelegate, TAssertions> : Reference
         where TException : Exception
     {
         IEnumerable<TException> exceptions = extractor.OfType<TException>(exception);
+
         Execute.Assertion
             .ForCondition(!exceptions.Any())
             .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -15,8 +15,7 @@ namespace FluentAssertions.Specialized;
 /// Contains a number of methods to assert that an <see cref="Exception" /> is in the correct state.
 /// </summary>
 [DebuggerNonUserCode]
-public class ExceptionAssertions<TException> :
-    ReferenceTypeAssertions<IEnumerable<TException>, ExceptionAssertions<TException>>
+public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerable<TException>, ExceptionAssertions<TException>>
     where TException : Exception
 {
     #region Private Definitions
@@ -183,6 +182,7 @@ public class ExceptionAssertions<TException> :
         Guard.ThrowIfArgumentIsNull(exceptionExpression);
 
         Func<TException, bool> condition = exceptionExpression.Compile();
+
         Execute.Assertion
             .ForCondition(condition(SingleSubject))
             .BecauseOf(because, becauseArgs)
@@ -247,6 +247,7 @@ public class ExceptionAssertions<TException> :
             if (Subject.Count() > 1)
             {
                 string thrownExceptions = BuildExceptionsString(Subject);
+
                 Services.ThrowException(
                     $"More than one exception was thrown.  FluentAssertions cannot determine which Exception was meant.{Environment.NewLine}{thrownExceptions}");
             }
@@ -270,7 +271,7 @@ public class ExceptionAssertions<TException> :
             Context = "exception message";
         }
 
-        public string Context { get; set; }
+        public string Context { get; }
 
         public void Execute(IEnumerable<string> messages, string expectation, string because, params object[] becauseArgs)
         {
@@ -298,6 +299,7 @@ public class ExceptionAssertions<TException> :
             {
                 string replacedCurlyBraces =
                     failure.EscapePlaceholders();
+
                 AssertionScope.Current.FailWith(replacedCurlyBraces);
             }
         }

--- a/Src/FluentAssertions/Specialized/ExecutionTime.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTime.cs
@@ -40,6 +40,7 @@ public class ExecutionTime
 
         ActionDescription = actionDescription;
         IsRunning = true;
+
         Task = Task.Run(() =>
         {
             // move stopwatch as close to action start as possible
@@ -80,6 +81,7 @@ public class ExecutionTime
 
         ActionDescription = actionDescription;
         IsRunning = true;
+
         Task = Task.Run(async () =>
         {
             // move stopwatch as close to action start as possible

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -69,7 +69,8 @@ public class ExecutionTimeAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<ExecutionTimeAssertions> BeLessThanOrEqualTo(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
+    public AndConstraint<ExecutionTimeAssertions> BeLessThanOrEqualTo(TimeSpan maxDuration, string because = "",
+        params object[] becauseArgs)
     {
         bool Condition(TimeSpan duration) => duration <= maxDuration;
         (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: false, rate: maxDuration);
@@ -78,8 +79,9 @@ public class ExecutionTimeAssertions
             .ForCondition(Condition(elapsed))
             .BecauseOf(because, becauseArgs)
             .FailWith("Execution of " +
-                      execution.ActionDescription.EscapePlaceholders() + " should be less than or equal to {0}{reason}, but it required " +
-                      (isRunning ? "more than " : "exactly ") + "{1}.",
+                execution.ActionDescription.EscapePlaceholders() +
+                " should be less than or equal to {0}{reason}, but it required " +
+                (isRunning ? "more than " : "exactly ") + "{1}.",
                 maxDuration,
                 elapsed);
 
@@ -87,7 +89,8 @@ public class ExecutionTimeAssertions
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public AndConstraint<ExecutionTimeAssertions> BeLessOrEqualTo(TimeSpan maxDuration, string because = "", params object[] becauseArgs) => BeLessThanOrEqualTo(maxDuration, because, becauseArgs);
+    public AndConstraint<ExecutionTimeAssertions> BeLessOrEqualTo(TimeSpan maxDuration, string because = "",
+        params object[] becauseArgs) => BeLessThanOrEqualTo(maxDuration, because, becauseArgs);
 
     /// <summary>
     /// Asserts that the execution time of the operation is less than a specified amount of time.
@@ -102,7 +105,8 @@ public class ExecutionTimeAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<ExecutionTimeAssertions> BeLessThan(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
+    public AndConstraint<ExecutionTimeAssertions> BeLessThan(TimeSpan maxDuration, string because = "",
+        params object[] becauseArgs)
     {
         bool Condition(TimeSpan duration) => duration < maxDuration;
         (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: false, rate: maxDuration);
@@ -111,8 +115,8 @@ public class ExecutionTimeAssertions
             .ForCondition(Condition(execution.ElapsedTime))
             .BecauseOf(because, becauseArgs)
             .FailWith("Execution of " +
-                      execution.ActionDescription.EscapePlaceholders() + " should be less than {0}{reason}, but it required " +
-                      (isRunning ? "more than " : "exactly ") + "{1}.",
+                execution.ActionDescription.EscapePlaceholders() + " should be less than {0}{reason}, but it required " +
+                (isRunning ? "more than " : "exactly ") + "{1}.",
                 maxDuration,
                 elapsed);
 
@@ -132,7 +136,8 @@ public class ExecutionTimeAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<ExecutionTimeAssertions> BeGreaterThanOrEqualTo(TimeSpan minDuration, string because = "", params object[] becauseArgs)
+    public AndConstraint<ExecutionTimeAssertions> BeGreaterThanOrEqualTo(TimeSpan minDuration, string because = "",
+        params object[] becauseArgs)
     {
         bool Condition(TimeSpan duration) => duration >= minDuration;
         (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: true, rate: minDuration);
@@ -141,8 +146,9 @@ public class ExecutionTimeAssertions
             .ForCondition(Condition(elapsed))
             .BecauseOf(because, becauseArgs)
             .FailWith("Execution of " +
-                      execution.ActionDescription.EscapePlaceholders() + " should be greater than or equal to {0}{reason}, but it required " +
-                      (isRunning ? "more than " : "exactly ") + "{1}.",
+                execution.ActionDescription.EscapePlaceholders() +
+                " should be greater than or equal to {0}{reason}, but it required " +
+                (isRunning ? "more than " : "exactly ") + "{1}.",
                 minDuration,
                 elapsed);
 
@@ -150,7 +156,8 @@ public class ExecutionTimeAssertions
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public AndConstraint<ExecutionTimeAssertions> BeGreaterOrEqualTo(TimeSpan minDuration, string because = "", params object[] becauseArgs) => BeGreaterThanOrEqualTo(minDuration, because, becauseArgs);
+    public AndConstraint<ExecutionTimeAssertions> BeGreaterOrEqualTo(TimeSpan minDuration, string because = "",
+        params object[] becauseArgs) => BeGreaterThanOrEqualTo(minDuration, because, becauseArgs);
 
     /// <summary>
     /// Asserts that the execution time of the operation is greater than a specified amount of time.
@@ -165,7 +172,8 @@ public class ExecutionTimeAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<ExecutionTimeAssertions> BeGreaterThan(TimeSpan minDuration, string because = "", params object[] becauseArgs)
+    public AndConstraint<ExecutionTimeAssertions> BeGreaterThan(TimeSpan minDuration, string because = "",
+        params object[] becauseArgs)
     {
         bool Condition(TimeSpan duration) => duration > minDuration;
         (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: true, rate: minDuration);
@@ -174,8 +182,8 @@ public class ExecutionTimeAssertions
             .ForCondition(Condition(elapsed))
             .BecauseOf(because, becauseArgs)
             .FailWith("Execution of " +
-                      execution.ActionDescription.EscapePlaceholders() + " should be greater than {0}{reason}, but it required " +
-                      (isRunning ? "more than " : "exactly ") + "{1}.",
+                execution.ActionDescription.EscapePlaceholders() + " should be greater than {0}{reason}, but it required " +
+                (isRunning ? "more than " : "exactly ") + "{1}.",
                 minDuration,
                 elapsed);
 
@@ -200,7 +208,8 @@ public class ExecutionTimeAssertions
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="precision"/> is negative.</exception>
-    public AndConstraint<ExecutionTimeAssertions> BeCloseTo(TimeSpan expectedDuration, TimeSpan precision, string because = "", params object[] becauseArgs)
+    public AndConstraint<ExecutionTimeAssertions> BeCloseTo(TimeSpan expectedDuration, TimeSpan precision, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNegative(precision);
 
@@ -218,8 +227,8 @@ public class ExecutionTimeAssertions
             .ForCondition(MinCondition(elapsed) && MaxCondition(elapsed))
             .BecauseOf(because, becauseArgs)
             .FailWith("Execution of " + execution.ActionDescription.EscapePlaceholders() +
-                      " should be within {0} from {1}{reason}, but it required " +
-                      (isRunning ? "more than " : "exactly ") + "{2}.",
+                " should be within {0} from {1}{reason}, but it required " +
+                (isRunning ? "more than " : "exactly ") + "{2}.",
                 precision,
                 expectedDuration,
                 elapsed);
@@ -229,5 +238,6 @@ public class ExecutionTimeAssertions
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-        throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean BeLessThanOrEqualTo() or BeGreaterThanOrEqualTo() instead?");
+        throw new NotSupportedException(
+            "Equals is not part of Fluent Assertions. Did you mean BeLessThanOrEqualTo() or BeGreaterThanOrEqualTo() instead?");
 }

--- a/Src/FluentAssertions/Specialized/FunctionAssertionHelpers.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertionHelpers.cs
@@ -15,15 +15,16 @@ internal static class FunctionAssertionHelpers
         catch (Exception exception)
         {
             Execute.Assertion
-            .ForCondition(exception is null)
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Did not expect any exception{reason}, but found {0}.", exception);
+                .ForCondition(exception is null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Did not expect any exception{reason}, but found {0}.", exception);
 
             return default;
         }
     }
 
-    internal static TResult NotThrowAfter<TResult>(Func<TResult> subject, IClock clock, TimeSpan waitTime, TimeSpan pollInterval, string because, object[] becauseArgs)
+    internal static TResult NotThrowAfter<TResult>(Func<TResult> subject, IClock clock, TimeSpan waitTime, TimeSpan pollInterval,
+        string because, object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNegative(waitTime);
         Guard.ThrowIfArgumentIsNegative(pollInterval);

--- a/Src/FluentAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Security;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
@@ -42,9 +41,9 @@ public class FunctionAssertions<T> : DelegateAssertions<Func<T>, FunctionAsserti
     public new AndWhichConstraint<FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs)
     {
         bool success = Execute.Assertion
-           .ForCondition(Subject is not null)
-           .BecauseOf(because, becauseArgs)
-           .FailWith("Expected {context} not to throw{reason}, but found <null>.");
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context} not to throw{reason}, but found <null>.");
 
         T result = default;
 
@@ -79,7 +78,8 @@ public class FunctionAssertions<T> : DelegateAssertions<Func<T>, FunctionAsserti
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="waitTime"/> or <paramref name="pollInterval"/> are negative.</exception>
-    public new AndWhichConstraint<FunctionAssertions<T>, T> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
+    public new AndWhichConstraint<FunctionAssertions<T>, T> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval,
+        string because = "", params object[] becauseArgs)
     {
         bool success = Execute.Assertion
             .ForCondition(Subject is not null)

--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -6,7 +6,8 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Specialized;
 
-public class GenericAsyncFunctionAssertions<TResult> : AsyncFunctionAssertions<Task<TResult>, GenericAsyncFunctionAssertions<TResult>>
+public class GenericAsyncFunctionAssertions<TResult>
+    : AsyncFunctionAssertions<Task<TResult>, GenericAsyncFunctionAssertions<TResult>>
 {
     public GenericAsyncFunctionAssertions(Func<Task<TResult>> subject, IExtractExceptions extractor)
         : this(subject, extractor, new Clock())
@@ -51,11 +52,12 @@ public class GenericAsyncFunctionAssertions<TResult> : AsyncFunctionAssertions<T
             if (success)
             {
                 bool completesWithinTimeout = await CompletesWithinTimeoutAsync(task, remainingTime);
+
                 success = Execute.Assertion
-                .ForCondition(completesWithinTimeout)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
-        }
+                    .ForCondition(completesWithinTimeout)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
+            }
 
             TResult result = success ? task.Result : default;
             return new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>(this, result);

--- a/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
+++ b/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
@@ -87,7 +87,6 @@ public class TaskCompletionSourceAssertions : TaskCompletionSourceAssertionsBase
         return new AndConstraint<TaskCompletionSourceAssertions>(this);
     }
 }
-
 #endif
 
 public class TaskCompletionSourceAssertions<T> : TaskCompletionSourceAssertionsBase
@@ -127,10 +126,12 @@ public class TaskCompletionSourceAssertions<T> : TaskCompletionSourceAssertionsB
         if (success)
         {
             bool completesWithinTimeout = await CompletesWithinTimeoutAsync(subject.Task, timeSpan);
+
             Execute.Assertion
                 .ForCondition(completesWithinTimeout)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
+
             T result = subject.Task.IsCompleted ? subject.Task.Result : default;
             return new AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>(this, result);
         }
@@ -160,6 +161,7 @@ public class TaskCompletionSourceAssertions<T> : TaskCompletionSourceAssertionsB
         if (success)
         {
             bool completesWithinTimeout = await CompletesWithinTimeoutAsync(subject.Task, timeSpan);
+
             Execute.Assertion
                 .ForCondition(!completesWithinTimeout)
                 .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Types/MethodBaseAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodBaseAssertions.cs
@@ -71,7 +71,8 @@ public abstract class MethodBaseAssertions<TSubject, TAssertions> : MemberInfoAs
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="accessModifier"/>
     /// is not a <see cref="CSharpAccessModifier"/> value.</exception>
-    public AndConstraint<TAssertions> NotHaveAccessModifier(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
+    public AndConstraint<TAssertions> NotHaveAccessModifier(CSharpAccessModifier accessModifier, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsOutOfRange(accessModifier);
 

--- a/Src/FluentAssertions/Types/MethodInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoAssertions.cs
@@ -37,9 +37,9 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
         if (success)
         {
             Execute.Assertion
-            .ForCondition(!Subject.IsNonVirtual())
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Expected method " + SubjectDescription + " to be virtual{reason}, but it is not virtual.");
+                .ForCondition(!Subject.IsNonVirtual())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected method " + SubjectDescription + " to be virtual{reason}, but it is not virtual.");
         }
 
         return new AndConstraint<MethodInfoAssertions>(this);
@@ -93,9 +93,9 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
         if (success)
         {
             Execute.Assertion
-            .ForCondition(Subject.IsAsync())
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Expected method " + SubjectDescription + " to be async{reason}, but it is not.");
+                .ForCondition(Subject.IsAsync())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected method " + SubjectDescription + " to be async{reason}, but it is not.");
         }
 
         return new AndConstraint<MethodInfoAssertions>(this);
@@ -139,7 +139,8 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs)
+    public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> ReturnVoid(string because = "",
+        params object[] becauseArgs)
     {
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -170,7 +171,8 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="returnType"/> is <see langword="null"/>.</exception>
-    public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> Return(Type returnType, string because = "", params object[] becauseArgs)
+    public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> Return(Type returnType, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(returnType);
 
@@ -202,7 +204,8 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] becauseArgs)
+    public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> Return<TReturn>(string because = "",
+        params object[] becauseArgs)
     {
         return Return(typeof(TReturn), because, becauseArgs);
     }
@@ -217,7 +220,8 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> NotReturnVoid(string because = "", params object[] becauseArgs)
+    public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> NotReturnVoid(string because = "",
+        params object[] becauseArgs)
     {
         bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -247,7 +251,8 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="returnType"/> is <see langword="null"/>.</exception>
-    public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> NotReturn(Type returnType, string because = "", params object[] becauseArgs)
+    public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> NotReturn(Type returnType, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(returnType);
 
@@ -260,10 +265,10 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
         if (success)
         {
             Execute.Assertion
-            .ForCondition(returnType != Subject.ReturnType)
-            .BecauseOf(because, becauseArgs)
-            .FailWith(
-                "Expected the return type of method " + Subject.Name + " not to be {0}{reason}, but it is.", returnType);
+                .ForCondition(returnType != Subject.ReturnType)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected the return type of method " + Subject.Name + " not to be {0}{reason}, but it is.", returnType);
         }
 
         return new AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>>(this);
@@ -280,7 +285,8 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> NotReturn<TReturn>(string because = "", params object[] becauseArgs)
+    public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> NotReturn<TReturn>(string because = "",
+        params object[] becauseArgs)
     {
         return NotReturn(typeof(TReturn), because, becauseArgs);
     }

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Common;
+using static System.Reflection.BindingFlags;
 
 namespace FluentAssertions.Types;
 
@@ -35,7 +36,7 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
         Guard.ThrowIfArgumentContainsNull(types);
 
         selectedMethods = types.SelectMany(t => t
-            .GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+            .GetMethods(DeclaredOnly | Instance | Static | Public | NonPublic)
             .Where(method => !HasSpecialName(method)));
     }
 
@@ -152,7 +153,7 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
     }
 
     /// <summary>
-    /// Only return methods that are async. 
+    /// Only return methods that are async.
     /// </summary>
     public MethodInfoSelector ThatAreAsync()
     {
@@ -161,7 +162,7 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
     }
 
     /// <summary>
-    /// Only return methods that are not async. 
+    /// Only return methods that are not async.
     /// </summary>
     public MethodInfoSelector ThatAreNotAsync()
     {
@@ -170,7 +171,7 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
     }
 
     /// <summary>
-    /// Only return methods that are static. 
+    /// Only return methods that are static.
     /// </summary>
     public MethodInfoSelector ThatAreStatic()
     {
@@ -179,7 +180,7 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
     }
 
     /// <summary>
-    /// Only return methods that are not static. 
+    /// Only return methods that are not static.
     /// </summary>
     public MethodInfoSelector ThatAreNotStatic()
     {
@@ -188,7 +189,7 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
     }
 
     /// <summary>
-    /// Only return methods that are virtual. 
+    /// Only return methods that are virtual.
     /// </summary>
     public MethodInfoSelector ThatAreVirtual()
     {
@@ -197,7 +198,7 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
     }
 
     /// <summary>
-    /// Only return methods that are not virtual. 
+    /// Only return methods that are not virtual.
     /// </summary>
     public MethodInfoSelector ThatAreNotVirtual()
     {

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -162,7 +162,8 @@ public class MethodInfoSelectorAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+    public AndConstraint<MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "",
+        params object[] becauseArgs)
         where TAttribute : Attribute
     {
         return BeDecoratedWith<TAttribute>(_ => true, because, becauseArgs);
@@ -214,7 +215,8 @@ public class MethodInfoSelectorAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+    public AndConstraint<MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "",
+        params object[] becauseArgs)
         where TAttribute : Attribute
     {
         return NotBeDecoratedWith<TAttribute>(_ => true, because, becauseArgs);
@@ -267,10 +269,13 @@ public class MethodInfoSelectorAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<MethodInfoSelectorAssertions> Be(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
+    public AndConstraint<MethodInfoSelectorAssertions> Be(CSharpAccessModifier accessModifier, string because = "",
+        params object[] becauseArgs)
     {
         var methods = SubjectMethods.Where(pi => pi.GetCSharpAccessModifier() != accessModifier).ToArray();
-        var message = $"Expected all selected methods to be {accessModifier}{{reason}}, but the following methods are not:" + Environment.NewLine + GetDescriptionsFor(methods);
+
+        var message = $"Expected all selected methods to be {accessModifier}{{reason}}, but the following methods are not:" +
+            Environment.NewLine + GetDescriptionsFor(methods);
 
         Execute.Assertion
             .ForCondition(!methods.Any())
@@ -291,10 +296,13 @@ public class MethodInfoSelectorAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<MethodInfoSelectorAssertions> NotBe(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
+    public AndConstraint<MethodInfoSelectorAssertions> NotBe(CSharpAccessModifier accessModifier, string because = "",
+        params object[] becauseArgs)
     {
         var methods = SubjectMethods.Where(pi => pi.GetCSharpAccessModifier() == accessModifier).ToArray();
-        var message = $"Expected all selected methods to not be {accessModifier}{{reason}}, but the following methods are:" + Environment.NewLine + GetDescriptionsFor(methods);
+
+        var message = $"Expected all selected methods to not be {accessModifier}{{reason}}, but the following methods are:" +
+            Environment.NewLine + GetDescriptionsFor(methods);
 
         Execute.Assertion
             .ForCondition(!methods.Any())

--- a/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
@@ -10,8 +10,7 @@ namespace FluentAssertions.Types;
 /// Contains a number of methods to assert that a <see cref="PropertyInfo"/> is in the expected state.
 /// </summary>
 [DebuggerNonUserCode]
-public class PropertyInfoAssertions :
-    MemberInfoAssertions<PropertyInfo, PropertyInfoAssertions>
+public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, PropertyInfoAssertions>
 {
     public PropertyInfoAssertions(PropertyInfo propertyInfo)
         : base(propertyInfo)
@@ -67,9 +66,9 @@ public class PropertyInfoAssertions :
         if (success)
         {
             Execute.Assertion
-            .ForCondition(!Subject.IsVirtual())
-            .BecauseOf(because, becauseArgs)
-            .FailWith($"Expected property {GetDescriptionFor(Subject)} not to be virtual{{reason}}, but it is.");
+                .ForCondition(!Subject.IsVirtual())
+                .BecauseOf(because, becauseArgs)
+                .FailWith($"Expected property {GetDescriptionFor(Subject)} not to be virtual{{reason}}, but it is.");
         }
 
         return new AndConstraint<PropertyInfoAssertions>(this);
@@ -96,11 +95,11 @@ public class PropertyInfoAssertions :
         if (success)
         {
             Execute.Assertion
-            .ForCondition(Subject.CanWrite)
-            .BecauseOf(because, becauseArgs)
-            .FailWith(
-                "Expected {context:property} {0} to have a setter{reason}.",
-                Subject);
+                .ForCondition(Subject.CanWrite)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected {context:property} {0} to have a setter{reason}.",
+                    Subject);
         }
 
         return new AndConstraint<PropertyInfoAssertions>(this);
@@ -119,14 +118,15 @@ public class PropertyInfoAssertions :
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="accessModifier"/>
     /// is not a <see cref="CSharpAccessModifier"/> value.</exception>
-    public AndConstraint<PropertyInfoAssertions> BeWritable(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
+    public AndConstraint<PropertyInfoAssertions> BeWritable(CSharpAccessModifier accessModifier, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsOutOfRange(accessModifier);
 
         bool success = Execute.Assertion
-          .BecauseOf(because, becauseArgs)
-          .ForCondition(Subject is not null)
-          .FailWith($"Expected {Identifier} to be {accessModifier}{{reason}}, but {{context:property}} is <null>.");
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject is not null)
+            .FailWith($"Expected {Identifier} to be {accessModifier}{{reason}}, but {{context:property}} is <null>.");
 
         if (success)
         {
@@ -159,11 +159,11 @@ public class PropertyInfoAssertions :
         if (success)
         {
             Execute.Assertion
-            .ForCondition(!Subject.CanWrite)
-            .BecauseOf(because, becauseArgs)
-            .FailWith(
-                "Expected {context:property} {0} not to have a setter{reason}.",
-                Subject);
+                .ForCondition(!Subject.CanWrite)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected {context:property} {0} not to have a setter{reason}.",
+                    Subject);
         }
 
         return new AndConstraint<PropertyInfoAssertions>(this);
@@ -189,8 +189,8 @@ public class PropertyInfoAssertions :
         if (success)
         {
             Execute.Assertion.ForCondition(Subject.CanRead)
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Expected property " + Subject.Name + " to have a getter{reason}, but it does not.");
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected property " + Subject.Name + " to have a getter{reason}, but it does not.");
         }
 
         return new AndConstraint<PropertyInfoAssertions>(this);
@@ -209,14 +209,15 @@ public class PropertyInfoAssertions :
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="accessModifier"/>
     /// is not a <see cref="CSharpAccessModifier"/> value.</exception>
-    public AndConstraint<PropertyInfoAssertions> BeReadable(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
+    public AndConstraint<PropertyInfoAssertions> BeReadable(CSharpAccessModifier accessModifier, string because = "",
+        params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsOutOfRange(accessModifier);
 
         bool success = Execute.Assertion
-           .BecauseOf(because, becauseArgs)
-           .ForCondition(Subject is not null)
-           .FailWith($"Expected {Identifier} to be {accessModifier}{{reason}}, but {{context:property}} is <null>.");
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject is not null)
+            .FailWith($"Expected {Identifier} to be {accessModifier}{{reason}}, but {{context:property}} is <null>.");
 
         if (success)
         {
@@ -249,11 +250,11 @@ public class PropertyInfoAssertions :
         if (success)
         {
             Execute.Assertion
-            .ForCondition(!Subject.CanRead)
-            .BecauseOf(because, becauseArgs)
-            .FailWith(
-                "Expected {context:property} {0} not to have a getter{reason}.",
-                Subject);
+                .ForCondition(!Subject.CanRead)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected {context:property} {0} not to have a getter{reason}.",
+                    Subject);
         }
 
         return new AndConstraint<PropertyInfoAssertions>(this);
@@ -277,16 +278,16 @@ public class PropertyInfoAssertions :
         Guard.ThrowIfArgumentIsNull(propertyType);
 
         bool success = Execute.Assertion
-           .BecauseOf(because, becauseArgs)
-           .ForCondition(Subject is not null)
-           .FailWith("Expected type of property to be {0}{reason}, but {context:property} is <null>.", propertyType);
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject is not null)
+            .FailWith("Expected type of property to be {0}{reason}, but {context:property} is <null>.", propertyType);
 
         if (success)
         {
             Execute.Assertion.ForCondition(Subject.PropertyType == propertyType)
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Expected Type of property " + Subject.Name + " to be {0}{reason}, but it is {1}.",
-            propertyType, Subject.PropertyType);
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected Type of property " + Subject.Name + " to be {0}{reason}, but it is {1}.",
+                    propertyType, Subject.PropertyType);
         }
 
         return new AndConstraint<PropertyInfoAssertions>(this);
@@ -325,16 +326,16 @@ public class PropertyInfoAssertions :
         Guard.ThrowIfArgumentIsNull(propertyType);
 
         bool success = Execute.Assertion
-           .BecauseOf(because, becauseArgs)
-           .ForCondition(Subject is not null)
-           .FailWith("Expected type of property not to be {0}{reason}, but {context:property} is <null>.", propertyType);
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject is not null)
+            .FailWith("Expected type of property not to be {0}{reason}, but {context:property} is <null>.", propertyType);
 
         if (success)
         {
             Execute.Assertion
-            .ForCondition(Subject.PropertyType != propertyType)
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Expected Type of property " + Subject.Name + " not to be {0}{reason}, but it is.", propertyType);
+                .ForCondition(Subject.PropertyType != propertyType)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected Type of property " + Subject.Name + " not to be {0}{reason}, but it is.", propertyType);
         }
 
         return new AndConstraint<PropertyInfoAssertions>(this);

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -36,7 +36,7 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
 
         selectedProperties = types.SelectMany(t => t
             .GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance
-                            | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static));
+                | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static));
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -159,7 +159,8 @@ public class PropertyInfoSelectorAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+    public AndConstraint<PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "",
+        params object[] becauseArgs)
         where TAttribute : Attribute
     {
         PropertyInfo[] propertiesWithoutAttribute = GetPropertiesWithout<TAttribute>();
@@ -185,7 +186,8 @@ public class PropertyInfoSelectorAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+    public AndConstraint<PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "",
+        params object[] becauseArgs)
         where TAttribute : Attribute
     {
         PropertyInfo[] propertiesWithAttribute = GetPropertiesWith<TAttribute>();

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -207,7 +207,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// </param>
     public AndConstraint<TypeAssertions> NotBe(Type unexpected, string because = "", params object[] becauseArgs)
     {
-        string nameOfUnexpectedType = (unexpected is not null) ? $"[{unexpected.AssemblyQualifiedName}]" : "<null>";
+        string nameOfUnexpectedType = unexpected is not null ? $"[{unexpected.AssemblyQualifiedName}]" : "<null>";
 
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -789,9 +789,9 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     public AndConstraint<TypeAssertions> BeStatic(string because = "", params object[] becauseArgs)
     {
         bool success = Execute.Assertion
-           .BecauseOf(because, becauseArgs)
-           .ForCondition(Subject is not null)
-           .FailWith("Expected type to be static{reason}, but {context:type} is <null>.");
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject is not null)
+            .FailWith("Expected type to be static{reason}, but {context:type} is <null>.");
 
         if (success)
         {
@@ -1541,9 +1541,9 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
         Guard.ThrowIfArgumentIsOutOfRange(accessModifier);
 
         bool success = Execute.Assertion
-           .BecauseOf(because, becauseArgs)
-           .ForCondition(Subject is not null)
-           .FailWith($"Expected {{context:type}} to be {accessModifier}{{reason}}, but {{context:type}} is <null>.");
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject is not null)
+            .FailWith($"Expected {{context:type}} to be {accessModifier}{{reason}}, but {{context:type}} is <null>.");
 
         if (success)
         {

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -63,7 +63,7 @@ public class TypeSelector : IEnumerable<Type>
     public TypeSelector ThatImplement<TInterface>()
     {
         types = types
-            .Where(t => typeof(TInterface).IsAssignableFrom(t) && (t != typeof(TInterface)))
+            .Where(t => typeof(TInterface).IsAssignableFrom(t) && t != typeof(TInterface))
             .ToList();
 
         return this;
@@ -75,7 +75,7 @@ public class TypeSelector : IEnumerable<Type>
     public TypeSelector ThatDoNotImplement<TInterface>()
     {
         types = types
-            .Where(t => !typeof(TInterface).IsAssignableFrom(t) && (t != typeof(TInterface)))
+            .Where(t => !typeof(TInterface).IsAssignableFrom(t) && t != typeof(TInterface))
             .ToList();
 
         return this;
@@ -315,6 +315,7 @@ public class TypeSelector : IEnumerable<Type>
     public TypeSelector UnwrapEnumerableTypes()
     {
         var unwrappedTypes = new List<Type>();
+
         foreach (Type type in types)
         {
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -111,7 +111,8 @@ public class TypeSelectorAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+    public AndConstraint<TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "",
+        params object[] becauseArgs)
         where TAttribute : Attribute
     {
         Type[] typesWithoutAttribute = Subject
@@ -245,7 +246,8 @@ public class TypeSelectorAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+    public AndConstraint<TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "",
+        params object[] becauseArgs)
         where TAttribute : Attribute
     {
         Type[] typesWithAttribute = Subject
@@ -318,7 +320,8 @@ public class TypeSelectorAssertions
 
         Execute.Assertion.ForCondition(!notSealedTypes.Any())
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types to be sealed{reason}, but the following types are not:{0}{1}.", Environment.NewLine, GetDescriptionsFor(notSealedTypes));
+            .FailWith("Expected all types to be sealed{reason}, but the following types are not:{0}{1}.", Environment.NewLine,
+                GetDescriptionsFor(notSealedTypes));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -339,7 +342,8 @@ public class TypeSelectorAssertions
 
         Execute.Assertion.ForCondition(!sealedTypes.Any())
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types not to be sealed{reason}, but the following types are:{0}{1}.", Environment.NewLine, GetDescriptionsFor(sealedTypes));
+            .FailWith("Expected all types not to be sealed{reason}, but the following types are:{0}{1}.", Environment.NewLine,
+                GetDescriptionsFor(sealedTypes));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -357,7 +361,8 @@ public class TypeSelectorAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TypeSelectorAssertions> BeInNamespace(string @namespace, string because = "", params object[] becauseArgs)
+    public AndConstraint<TypeSelectorAssertions> BeInNamespace(string @namespace, string because = "",
+        params object[] becauseArgs)
     {
         Type[] typesNotInNamespace = Subject
             .Where(t => t.Namespace != @namespace)
@@ -367,7 +372,7 @@ public class TypeSelectorAssertions
             .ForCondition(!typesNotInNamespace.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be in namespace {0}{reason}," +
-                      " but the following types are in a different namespace:{1}{2}.",
+                " but the following types are in a different namespace:{1}{2}.",
                 @namespace,
                 Environment.NewLine,
                 GetDescriptionsFor(typesNotInNamespace));
@@ -388,7 +393,8 @@ public class TypeSelectorAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TypeSelectorAssertions> NotBeInNamespace(string @namespace, string because = "", params object[] becauseArgs)
+    public AndConstraint<TypeSelectorAssertions> NotBeInNamespace(string @namespace, string because = "",
+        params object[] becauseArgs)
     {
         Type[] typesInNamespace = Subject
             .Where(t => t.Namespace == @namespace)
@@ -398,7 +404,7 @@ public class TypeSelectorAssertions
             .ForCondition(!typesInNamespace.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected no types to be in namespace {0}{reason}," +
-                      " but the following types are in the namespace:{1}{2}.",
+                " but the following types are in the namespace:{1}{2}.",
                 @namespace,
                 Environment.NewLine,
                 GetDescriptionsFor(typesInNamespace));
@@ -419,7 +425,8 @@ public class TypeSelectorAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TypeSelectorAssertions> BeUnderNamespace(string @namespace, string because = "", params object[] becauseArgs)
+    public AndConstraint<TypeSelectorAssertions> BeUnderNamespace(string @namespace, string because = "",
+        params object[] becauseArgs)
     {
         Type[] typesNotUnderNamespace = Subject
             .Where(t => !t.IsUnderNamespace(@namespace))
@@ -429,7 +436,7 @@ public class TypeSelectorAssertions
             .ForCondition(!typesNotUnderNamespace.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected the namespaces of all types to start with {0}{reason}," +
-                      " but the namespaces of the following types do not start with it:{1}{2}.",
+                " but the namespaces of the following types do not start with it:{1}{2}.",
                 @namespace,
                 Environment.NewLine,
                 GetDescriptionsFor(typesNotUnderNamespace));
@@ -451,7 +458,8 @@ public class TypeSelectorAssertions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TypeSelectorAssertions> NotBeUnderNamespace(string @namespace, string because = "", params object[] becauseArgs)
+    public AndConstraint<TypeSelectorAssertions> NotBeUnderNamespace(string @namespace, string because = "",
+        params object[] becauseArgs)
     {
         Type[] typesUnderNamespace = Subject
             .Where(t => t.IsUnderNamespace(@namespace))
@@ -461,7 +469,7 @@ public class TypeSelectorAssertions
             .ForCondition(!typesUnderNamespace.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected the namespaces of all types to not start with {0}{reason}," +
-                      " but the namespaces of the following types start with it:{1}{2}.",
+                " but the namespaces of the following types start with it:{1}{2}.",
                 @namespace,
                 Environment.NewLine,
                 GetDescriptionsFor(typesUnderNamespace));
@@ -482,5 +490,6 @@ public class TypeSelectorAssertions
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-        throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean BeInNamespace() or BeDecoratedWith() instead?");
+        throw new NotSupportedException(
+            "Equals is not part of Fluent Assertions. Did you mean BeInNamespace() or BeDecoratedWith() instead?");
 }

--- a/Src/FluentAssertions/Xml/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/Node.cs
@@ -11,7 +11,7 @@ internal sealed class Node
     private readonly string name;
     private int count;
 
-    public static Node CreateRoot() => new Node(null, null);
+    public static Node CreateRoot() => new(null, null);
 
     private Node(Node parent, string name)
     {
@@ -46,6 +46,7 @@ internal sealed class Node
     private IEnumerable<Node> GetPath()
     {
         Node current = this;
+
         while (current.Parent is not null)
         {
             yield return current;
@@ -58,7 +59,7 @@ internal sealed class Node
     public Node Push(string localName)
     {
         Node node = children.Find(e => e.name == localName)
-                    ?? AddChildNode(localName);
+            ?? AddChildNode(localName);
 
         node.count++;
 

--- a/Src/FluentAssertions/Xml/Equivalency/XmlIterator.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/XmlIterator.cs
@@ -44,6 +44,7 @@ internal class XmlIterator
     public void MoveToEndElement()
     {
         reader.Read();
+
         if (reader.NodeType != XmlNodeType.EndElement)
         {
             // advancing failed

--- a/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
@@ -62,9 +62,11 @@ internal class XmlReaderValidator
                 var expectation = expectationIterator.NodeType == XmlNodeType.Text
                     ? $"content \"{expectationIterator.Value}\""
                     : $"{expectationIterator.NodeType} \"{expectationIterator.LocalName}\"";
+
                 var subject = subjectIterator.NodeType == XmlNodeType.Text
                     ? $"content \"{subjectIterator.Value}\""
                     : $"{subjectIterator.NodeType} \"{subjectIterator.LocalName}\"";
+
                 return new Failure(
                     $"Expected {expectation} in {{context:subject}} at {{0}}{{reason}}, but found {subject}.",
                     currentNode.GetXPath());
@@ -78,6 +80,7 @@ internal class XmlReaderValidator
             {
                 case XmlNodeType.Element:
                     failure = ValidateStartElement();
+
                     if (failure is not null)
                     {
                         return failure;
@@ -160,7 +163,7 @@ internal class XmlReaderValidator
         {
             AttributeData expectedAttribute = expectedAttributes.SingleOrDefault(
                 ea => ea.NamespaceUri == subjectAttribute.NamespaceUri
-                      && ea.LocalName == subjectAttribute.LocalName);
+                    && ea.LocalName == subjectAttribute.LocalName);
 
             if (expectedAttribute is null)
             {
@@ -229,7 +232,7 @@ internal class XmlReaderValidator
 
     private Failure ValidateAgainstNulls()
     {
-        if ((expectationReader is null) != (subjectReader is null))
+        if (expectationReader is null != subjectReader is null)
         {
             return new Failure(
                 "Expected {context:subject} to be equivalent to {0}{reason}, but found {1}.",

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
-
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
@@ -106,7 +105,8 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<XDocumentAssertions> NotBeEquivalentTo(XDocument unexpected, string because = "", params object[] becauseArgs)
+    public AndConstraint<XDocumentAssertions> NotBeEquivalentTo(XDocument unexpected, string because = "",
+        params object[] becauseArgs)
     {
         using (XmlReader subjectReader = Subject?.CreateReader())
         using (XmlReader otherReader = unexpected?.CreateReader())
@@ -153,11 +153,13 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
-    public AndWhichConstraint<XDocumentAssertions, XElement> HaveRoot(XName expected, string because = "", params object[] becauseArgs)
+    public AndWhichConstraint<XDocumentAssertions, XElement> HaveRoot(XName expected, string because = "",
+        params object[] becauseArgs)
     {
         if (Subject is null)
         {
-            throw new InvalidOperationException("Cannot assert the document has a root element if the document itself is <null>.");
+            throw new InvalidOperationException(
+                "Cannot assert the document has a root element if the document itself is <null>.");
         }
 
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected),
@@ -166,7 +168,7 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
         XElement root = Subject.Root;
 
         Execute.Assertion
-            .ForCondition((root is not null) && (root.Name == expected))
+            .ForCondition(root is not null && root.Name == expected)
             .BecauseOf(because, becauseArgs)
             .FailWith(
                 "Expected {context:subject} to have root element {0}{reason}, but found {1}.",
@@ -250,7 +252,7 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
         }
 
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected),
-                "Cannot assert the document has an element if the expected name is <null>.");
+            "Cannot assert the document has an element if the expected name is <null>.");
 
         Execute.Assertion
             .ForCondition(Subject.Root is not null)
@@ -260,6 +262,7 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
                 expected.ToString());
 
         XElement xElement = Subject.Root.Element(expected);
+
         Execute.Assertion
             .ForCondition(xElement is not null)
             .BecauseOf(because, becauseArgs)
@@ -293,7 +296,7 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
         params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected),
-                "Cannot assert the document has an element count if the element name is <null>.");
+            "Cannot assert the document has an element count if the element name is <null>.");
 
         bool success = Execute.Assertion
             .ForCondition(Subject is not null)
@@ -305,6 +308,7 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
         if (success)
         {
             var root = Subject.Root;
+
             success = Execute.Assertion
                 .ForCondition(root is not null)
                 .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -315,7 +315,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
         params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected),
-                "Cannot assert the element has an element count if the element name is <null>.");
+            "Cannot assert the element has an element count if the element name is <null>.");
 
         bool success = Execute.Assertion
             .ForCondition(Subject is not null)

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -146,4 +146,7 @@ dotnet_diagnostic.SA1615.severity = none
 dotnet_diagnostic.SA1005.severity = suggestion
 
 # ReSharper/Rider
-resharper_expression_is_always_null_highlighting=none
+resharper_expression_is_always_null_highlighting = none
+
+# ReSharper properties
+resharper_keep_user_linebreaks = true

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -192,7 +192,7 @@ namespace FluentAssertions
         public static System.Action<string> Logger { get; set; }
         public static string DetermineCallerIdentity() { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method)]
     public class CustomAssertionAttribute : System.Attribute
     {
         public CustomAssertionAttribute() { }
@@ -1700,7 +1700,7 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method)]
     public class ValueFormatterAttribute : System.Attribute
     {
         public ValueFormatterAttribute() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -205,7 +205,7 @@ namespace FluentAssertions
         public static System.Action<string> Logger { get; set; }
         public static string DetermineCallerIdentity() { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method)]
     public class CustomAssertionAttribute : System.Attribute
     {
         public CustomAssertionAttribute() { }
@@ -1725,7 +1725,7 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method)]
     public class ValueFormatterAttribute : System.Attribute
     {
         public ValueFormatterAttribute() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -192,7 +192,7 @@ namespace FluentAssertions
         public static System.Action<string> Logger { get; set; }
         public static string DetermineCallerIdentity() { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method)]
     public class CustomAssertionAttribute : System.Attribute
     {
         public CustomAssertionAttribute() { }
@@ -1700,7 +1700,7 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method)]
     public class ValueFormatterAttribute : System.Attribute
     {
         public ValueFormatterAttribute() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -192,7 +192,7 @@ namespace FluentAssertions
         public static System.Action<string> Logger { get; set; }
         public static string DetermineCallerIdentity() { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method)]
     public class CustomAssertionAttribute : System.Attribute
     {
         public CustomAssertionAttribute() { }
@@ -1700,7 +1700,7 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method)]
     public class ValueFormatterAttribute : System.Attribute
     {
         public ValueFormatterAttribute() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -191,7 +191,7 @@ namespace FluentAssertions
         public static System.Action<string> Logger { get; set; }
         public static string DetermineCallerIdentity() { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method)]
     public class CustomAssertionAttribute : System.Attribute
     {
         public CustomAssertionAttribute() { }
@@ -1651,7 +1651,7 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method)]
     public class ValueFormatterAttribute : System.Attribute
     {
         public ValueFormatterAttribute() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -192,7 +192,7 @@ namespace FluentAssertions
         public static System.Action<string> Logger { get; set; }
         public static string DetermineCallerIdentity() { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method)]
     public class CustomAssertionAttribute : System.Attribute
     {
         public CustomAssertionAttribute() { }
@@ -1700,7 +1700,7 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method)]
     public class ValueFormatterAttribute : System.Attribute
     {
         public ValueFormatterAttribute() { }

--- a/Tests/Benchmarks/CheckIfMemberIsBrowsable.cs
+++ b/Tests/Benchmarks/CheckIfMemberIsBrowsable.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel;
 using System.Reflection;
-
 using BenchmarkDotNet.Attributes;
 
 namespace Benchmarks;
@@ -12,6 +11,7 @@ public class CheckIfMemberIsBrowsableBenchmarks
     public bool IsBrowsable { get; set; }
 
     public int BrowsableField;
+
     [EditorBrowsable(EditorBrowsableState.Never)]
     public int NonBrowsableField;
 

--- a/Tests/Benchmarks/LargeDataTableEquivalency.cs
+++ b/Tests/Benchmarks/LargeDataTableEquivalency.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Data;
 using System.Linq;
-
 using BenchmarkDotNet.Attributes;
-
 using Bogus;
-
 using FluentAssertions;
 using FluentAssertions.Data;
 
@@ -48,7 +45,7 @@ public class LargeDataTableEquivalencyBenchmarks
 
     private static object GetData(Faker faker, Type columnType)
     {
-        return (Type.GetTypeCode(columnType)) switch
+        return Type.GetTypeCode(columnType) switch
         {
             TypeCode.Empty or TypeCode.DBNull => null,
             TypeCode.Boolean => faker.Random.Bool(),
@@ -73,9 +70,13 @@ public class LargeDataTableEquivalencyBenchmarks
     private static object GetDefault(Faker faker, Type columnType)
     {
         if (columnType == typeof(TimeSpan))
+        {
             return faker.Date.Future() - faker.Date.Future();
+        }
         else if (columnType == typeof(Guid))
+        {
             return faker.Random.Guid();
+        }
 
         throw new Exception("Unable to populate column of type " + columnType);
     }

--- a/Tests/Benchmarks/LargeObjectGraph.cs
+++ b/Tests/Benchmarks/LargeObjectGraph.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-
 using BenchmarkDotNet.Attributes;
-
 using FluentAssertions;
 using FluentAssertions.Primitives;
 
@@ -31,6 +29,6 @@ public class LargeObjectGraphBenchmarks
     }
 
     [Benchmark]
-    public AndConstraint<ObjectAssertions> BeEquivalentTo()
-        => copy1.Should().BeEquivalentTo(copy2, config => config.AllowingInfiniteRecursion());
+    public AndConstraint<ObjectAssertions> BeEquivalentTo() =>
+        copy1.Should().BeEquivalentTo(copy2, config => config.AllowingInfiniteRecursion());
 }

--- a/Tests/Benchmarks/Program.cs
+++ b/Tests/Benchmarks/Program.cs
@@ -1,8 +1,10 @@
-﻿using BenchmarkDotNet.Columns;
+﻿using System.Globalization;
+using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Exporters.Csv;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
+using Perfolizer.Horology;
 
 namespace Benchmarks;
 
@@ -13,10 +15,10 @@ internal static class Program
         var exporter = new CsvExporter(
             CsvSeparator.CurrentCulture,
             new SummaryStyle(
-                cultureInfo: System.Globalization.CultureInfo.GetCultureInfo("nl-NL"),
+                cultureInfo: CultureInfo.GetCultureInfo("nl-NL"),
                 printUnitsInHeader: true,
                 printUnitsInContent: false,
-                timeUnit: Perfolizer.Horology.TimeUnit.Microsecond,
+                timeUnit: TimeUnit.Microsecond,
                 sizeUnit: SizeUnit.KB
             ));
 

--- a/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
+++ b/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using Bogus;
-
 using FluentAssertions.Equivalency;
 using FluentAssertions.Equivalency.Steps;
 using FluentAssertions.Equivalency.Tracing;
@@ -37,7 +36,8 @@ public class UsersOfGetClosedGenericInterfaces
 
         public IEquivalencyValidationContext AsCollectionItem<TItem>(string index) => throw new NotImplementedException();
 
-        public IEquivalencyValidationContext AsDictionaryItem<TKey, TExpectation>(TKey key) => throw new NotImplementedException();
+        public IEquivalencyValidationContext AsDictionaryItem<TKey, TExpectation>(TKey key) =>
+            throw new NotImplementedException();
 
         public IEquivalencyValidationContext Clone() => throw new NotImplementedException();
     }
@@ -85,7 +85,7 @@ public class UsersOfGetClosedGenericInterfaces
     public Type DataType { get; set; }
 
     [GlobalSetup]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0055:Fix formatting", Justification = "Big long list of one-liners")]
+    [SuppressMessage("Style", "IDE0055:Fix formatting", Justification = "Big long list of one-liners")]
     public void GlobalSetup()
     {
         dictionaryStep = new GenericDictionaryEquivalencyStep();
@@ -151,24 +151,35 @@ public class UsersOfGetClosedGenericInterfaces
                     break;
 
                 default:
+                {
+                    if (DataType == typeof(TimeSpan))
                     {
-                        if (DataType == typeof(TimeSpan))
-                            values[i] = faker.Date.Future() - faker.Date.Future();
-                        else if (DataType == typeof(Guid))
-                            values[i] = faker.Random.Guid();
-                        else if (DataType == typeof(Dictionary<int, int>))
-                            values[i] = new Dictionary<int, int>() { { faker.Random.Int(), faker.Random.Int() } };
-                        else if (DataType == typeof(IEnumerable<int>))
-                            values[i] = new int[] { faker.Random.Int(), faker.Random.Int() };
-                        else
-                            throw new Exception("Unable to populate data of type " + DataType);
-
-                        break;
+                        values[i] = faker.Date.Future() - faker.Date.Future();
                     }
+                    else if (DataType == typeof(Guid))
+                    {
+                        values[i] = faker.Random.Guid();
+                    }
+                    else if (DataType == typeof(Dictionary<int, int>))
+                    {
+                        values[i] = new Dictionary<int, int>
+                            { { faker.Random.Int(), faker.Random.Int() } };
+                    }
+                    else if (DataType == typeof(IEnumerable<int>))
+                    {
+                        values[i] = new[] { faker.Random.Int(), faker.Random.Int() };
+                    }
+                    else
+                    {
+                        throw new Exception("Unable to populate data of type " + DataType);
+                    }
+
+                    break;
+                }
             }
         }
 
-        context = new Context()
+        context = new Context
         {
             Options = new Config()
         };

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -166,7 +166,7 @@ public class BasicSpecs
 
         public new virtual bool Equals(object obj)
         {
-            return (obj is VirtualClass other) && other.Property == Property;
+            return obj is VirtualClass other && other.Property == Property;
         }
     }
 

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -36,7 +36,7 @@ public class CollectionSpecs
         public override bool Equals(object obj)
         {
             return obj is SubDummy subDummy
-                   && Id == subDummy.Id;
+                && Id == subDummy.Id;
         }
 
         public override int GetHashCode()
@@ -86,8 +86,8 @@ public class CollectionSpecs
 
     private class MultiEnumerable : IEnumerable<int>, IEnumerable<long>
     {
-        private readonly List<int> ints = new List<int>();
-        private readonly List<long> longs = new List<long>();
+        private readonly List<int> ints = new();
+        private readonly List<long> longs = new();
 
         IEnumerator<int> IEnumerable<int>.GetEnumerator()
         {
@@ -175,7 +175,7 @@ public class CollectionSpecs
 
     public class UserRolesLookupElement
     {
-        private readonly Dictionary<Guid, List<string>> innerRoles = new Dictionary<Guid, List<string>>();
+        private readonly Dictionary<Guid, List<string>> innerRoles = new();
 
         public virtual Dictionary<Guid, IEnumerable<string>> Roles
         {
@@ -199,8 +199,15 @@ public class CollectionSpecs
     public void When_the_expectation_is_an_array_of_interface_type_it_should_respect_declared_types()
     {
         // Arrange
-        var actual = new IInterface[] { new MyClass() { InterfaceProperty = 1, ClassProperty = 42 } };
-        var expected = new IInterface[] { new MyClass() { InterfaceProperty = 1, ClassProperty = 1337 } };
+        var actual = new IInterface[]
+        {
+            new MyClass { InterfaceProperty = 1, ClassProperty = 42 }
+        };
+
+        var expected = new IInterface[]
+        {
+            new MyClass { InterfaceProperty = 1, ClassProperty = 1337 }
+        };
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
@@ -213,10 +220,10 @@ public class CollectionSpecs
     public void When_the_expectation_has_fewer_dimensions_than_a_multi_dimensional_subject_it_should_fail()
     {
         // Arrange
-        object objectA = new object();
-        object objectB = new object();
+        object objectA = new();
+        object objectB = new();
 
-        var actual = new object[][] { new object[] { objectA, objectB } };
+        var actual = new[] { new[] { objectA, objectB } };
         var expected = actual[0];
 
         // Act
@@ -295,9 +302,9 @@ public class CollectionSpecs
     public void When_a_collection_does_not_match_it_should_include_items_in_message()
     {
         // Arrange
-        var subject = new int[] { 1, 2 };
+        var subject = new[] { 1, 2 };
 
-        var expectation = new int[] { 3, 2, 1 };
+        var expectation = new[] { 3, 2, 1 };
 
         // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation);
@@ -329,12 +336,12 @@ public class CollectionSpecs
     public void When_a_nullable_collection_does_not_match_it_should_throw()
     {
         // Arrange
-        var subject = new { Values = (ImmutableArray<int>?)ImmutableArray.Create<int>(1, 2, 3) };
+        var subject = new { Values = (ImmutableArray<int>?)ImmutableArray.Create(1, 2, 3) };
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(new
         {
-            Values = (ImmutableArray<int>?)ImmutableArray.Create<int>(1, 2, 4)
+            Values = (ImmutableArray<int>?)ImmutableArray.Create(1, 2, 4)
         });
 
         // Assert
@@ -453,11 +460,11 @@ public class CollectionSpecs
     public void When_two_deeply_nested_collections_are_equivalent_while_ignoring_the_order_it_should_not_throw()
     {
         // Arrange
-        var items = new[] { new int[0], new int[] { 42 } };
+        var items = new[] { new int[0], new[] { 42 } };
 
         // Act / Assert
         items.Should().BeEquivalentTo(
-            new[] { new int[] { 42 }, new int[0] }
+            new[] { new[] { 42 }, new int[0] }
         );
     }
 
@@ -484,8 +491,8 @@ public class CollectionSpecs
     public void When_the_subject_is_a_non_generic_collection_it_should_still_work()
     {
         // Arrange
-        object item = new object();
-        object[] array = new[] { item };
+        object item = new();
+        object[] array = { item };
         IList readOnlyList = ArrayList.ReadOnly(array);
 
         // Act / Assert
@@ -1091,8 +1098,8 @@ public class CollectionSpecs
         When_a_strongly_typed_collection_is_declared_as_an_untyped_collection_and_runtime_checking_is_configured_is_should_use_the_runtime_type()
     {
         // Arrange
-        ICollection collection1 = new List<Car> { new Car() };
-        ICollection collection2 = new List<Customer> { new Customer() };
+        ICollection collection1 = new List<Car> { new() };
+        ICollection collection2 = new List<Customer> { new() };
 
         // Act
         Action act =
@@ -1180,6 +1187,7 @@ public class CollectionSpecs
         // Arrange
         const int N = 100000;
         var subject = new List<string>(N) { "one" };
+
         for (int i = 1; i < N; i++)
         {
             subject.Add("two");
@@ -1208,9 +1216,9 @@ public class CollectionSpecs
         // Arrange
         var subject = new List<SomeDto>
         {
-            new SomeDto { Name = "someDto", Age = 1 },
-            new SomeDto { Name = "someDto", Age = 1 },
-            new SomeDto { Name = "someDto", Age = 1 }
+            new() { Name = "someDto", Age = 1 },
+            new() { Name = "someDto", Age = 1 },
+            new() { Name = "someDto", Age = 1 }
         };
 
         // Act
@@ -1231,18 +1239,18 @@ public class CollectionSpecs
         // Arrange
         var subject = new List<SomeDto>
         {
-            new SomeDto { Name = "someDto", Age = 1 },
-            new SomeDto { Name = "someDto", Age = 1 },
-            new SomeDto { Name = "someDto", Age = 1 }
+            new() { Name = "someDto", Age = 1 },
+            new() { Name = "someDto", Age = 1 },
+            new() { Name = "someDto", Age = 1 }
         };
 
         // Act
         Action action = () => subject.Should().AllBeEquivalentTo(new
-        {
-            Name = "someDto",
-            Age = 1,
-            Birthdate = default(DateTime)
-        })
+            {
+                Name = "someDto",
+                Age = 1,
+                Birthdate = default(DateTime)
+            })
             .And.HaveCount(3);
 
         // Assert
@@ -1285,6 +1293,7 @@ public class CollectionSpecs
         // Arrange
         const int N = 100000;
         var subject = new List<int>(N) { 1 };
+
         for (int i = 1; i < N; i++)
         {
             subject.Add(2);
@@ -1421,7 +1430,7 @@ public class CollectionSpecs
         };
 
         // Act
-        Action action = () => subject.Should().BeEquivalentTo(expectation,  options => options
+        Action action = () => subject.Should().BeEquivalentTo(expectation, options => options
             .WithStrictOrderingFor(oi => oi.ParentType == expectation[0].GetType()));
 
         // Assert
@@ -1536,7 +1545,7 @@ public class CollectionSpecs
     {
         // Arrange
         var collection1 = new Collection<CustomerType> { new DerivedCustomerType("123") };
-        var collection2 = new Collection<CustomerType> { new CustomerType("123") };
+        var collection2 = new Collection<CustomerType> { new("123") };
 
         // Act
         Action act = () => collection1.Should().BeEquivalentTo(collection2);
@@ -1632,12 +1641,14 @@ public class CollectionSpecs
         // Arrange
         var subject = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 30, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 30, Id = 2 }
         };
 
         var expectation = new List<Customer>
         {
-            new Customer { Name = "Jane", Age = 30, Id = 2 }, new Customer { Name = "John", Age = 28, Id = 1 }
+            new() { Name = "Jane", Age = 30, Id = 2 },
+            new() { Name = "John", Age = 28, Id = 1 }
         };
 
         // Act
@@ -1878,8 +1889,8 @@ public class CollectionSpecs
         // Arrange
         var actual = new[,]
         {
-        { 1, 2, 3 },
-        { 4, 5, 6 }
+            { 1, 2, 3 },
+            { 4, 5, 6 }
         };
 
         // Act
@@ -1978,7 +1989,7 @@ public class CollectionSpecs
     public void When_the_number_of_dimensions_of_the_arrays_are_not_the_same_it_should_throw()
     {
         // Arrange
-        var actual = new[, ,]
+        var actual = new[,,]
         {
             {
                 { 1 },
@@ -2066,11 +2077,15 @@ public class CollectionSpecs
     public void When_the_subject_contains_less_items_than_expected_it_should_throw()
     {
         // Arrange
-        var subject = new List<Customer> { new Customer { Name = "John", Age = 27, Id = 1 } };
+        var subject = new List<Customer>
+        {
+            new() { Name = "John", Age = 27, Id = 1 }
+        };
 
         var expectation = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         };
 
         // Act
@@ -2089,10 +2104,14 @@ public class CollectionSpecs
         // Arrange
         var subject = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         };
 
-        var expectation = new List<Customer> { new Customer { Name = "John", Age = 27, Id = 1 } };
+        var expectation = new List<Customer>
+        {
+            new() { Name = "John", Age = 27, Id = 1 }
+        };
 
         // Act
         Action action =
@@ -2110,16 +2129,16 @@ public class CollectionSpecs
         // Arrange
         var subject = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 },
-            new Customer { Name = "John", Age = 27, Id = 1 },
-            new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         };
 
         var expectation = new List<Customer>
         {
-            new Customer { Name = "Jane", Age = 24, Id = 2 },
-            new Customer { Name = "John", Age = 27, Id = 1 },
-            new Customer { Name = "John", Age = 27, Id = 1 }
+            new() { Name = "Jane", Age = 24, Id = 2 },
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "John", Age = 27, Id = 1 }
         };
 
         // Act
@@ -2136,12 +2155,14 @@ public class CollectionSpecs
         // Arrange
         var subject = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         };
 
         var expectation = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "John", Age = 27, Id = 1 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "John", Age = 27, Id = 1 }
         };
 
         // Act
@@ -2160,12 +2181,14 @@ public class CollectionSpecs
         // Arrange
         var subject = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "John", Age = 27, Id = 1 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "John", Age = 27, Id = 1 }
         };
 
         var expectation = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         };
 
         // Act
@@ -2249,12 +2272,14 @@ public class CollectionSpecs
         // Arrange
         var subject = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         };
 
         var expectation = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 30, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 30, Id = 2 }
         };
 
         // Act
@@ -2272,12 +2297,14 @@ public class CollectionSpecs
         // Arrange
         var subject = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         };
 
         var expectation = new List<CustomerDto>
         {
-            new CustomerDto { Name = "John", Age = 27 }, new CustomerDto { Name = "Jane", Age = 30 }
+            new() { Name = "John", Age = 27 },
+            new() { Name = "Jane", Age = 30 }
         };
 
         // Act
@@ -2426,12 +2453,14 @@ public class CollectionSpecs
         // Arrange
         var subject = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         };
 
         var expectation = new List<Customer>
         {
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         };
 
         // Act
@@ -2453,7 +2482,8 @@ public class CollectionSpecs
 
         var expectation = new Collection<Customer>
         {
-            new Customer { Name = "Jane", Age = 24, Id = 2 }, new Customer { Name = "John", Age = 27, Id = 1 }
+            new() { Name = "Jane", Age = 24, Id = 2 },
+            new() { Name = "John", Age = 27, Id = 1 }
         };
 
         // Act
@@ -2476,7 +2506,8 @@ public class CollectionSpecs
 
         var expectation = new Collection<Customer>
         {
-            new Customer { Name = "Jane", Age = 24, Id = 2 }, new Customer { Name = "John", Age = 27, Id = 1 }
+            new() { Name = "Jane", Age = 24, Id = 2 },
+            new() { Name = "John", Age = 27, Id = 1 }
         };
 
         // Act
@@ -2504,7 +2535,8 @@ public class CollectionSpecs
 
         var expectation = new Collection<Customer>
         {
-            new Customer { Name = "Jane", Age = 24, Id = 2 }, new Customer { Name = "John", Age = 27, Id = 1 }
+            new() { Name = "Jane", Age = 24, Id = 2 },
+            new() { Name = "John", Age = 27, Id = 1 }
         };
 
         // Act
@@ -2526,7 +2558,8 @@ public class CollectionSpecs
 
         var expectation = new Collection<Customer>
         {
-            new Customer { Name = "Jane", Age = 24, Id = 2 }, new Customer { Name = "John", Age = 27, Id = 1 }
+            new() { Name = "Jane", Age = 24, Id = 2 },
+            new() { Name = "John", Age = 27, Id = 1 }
         };
 
         // Act
@@ -2541,8 +2574,8 @@ public class CollectionSpecs
     public void When_two_unordered_lists_contain_empty_different_objects_it_should_throw()
     {
         // Arrange
-        var actual = new object[] { new object() };
-        var expected = new object[] { new object() };
+        var actual = new object[] { new() };
+        var expected = new object[] { new() };
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
@@ -2556,7 +2589,7 @@ public class CollectionSpecs
     {
         // Arrange
         var actual = new object[] { null };
-        var expected = new object[] { new object() };
+        var expected = new object[] { new() };
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
@@ -2569,7 +2602,7 @@ public class CollectionSpecs
     public void When_two_unordered_lists_contain_null_in_expectation_it_should_throw()
     {
         // Arrange
-        var actual = new object[] { new object() };
+        var actual = new object[] { new() };
         var expected = new object[] { null };
 
         // Act
@@ -2595,8 +2628,9 @@ public class CollectionSpecs
     public void When_an_exception_is_thrown_during_data_access_the_stack_trace_contains_the_original_site()
     {
         // Arrange
-        var genericCollectionA = new List<ExceptionThrowingClass>() { new ExceptionThrowingClass() };
-        var genericCollectionB = new List<ExceptionThrowingClass>() { new ExceptionThrowingClass() };
+        var genericCollectionA = new List<ExceptionThrowingClass> { new() };
+
+        var genericCollectionB = new List<ExceptionThrowingClass> { new() };
 
         var expectedTargetSite = typeof(ExceptionThrowingClass)
             .GetProperty(nameof(ExceptionThrowingClass.ExceptionThrowingProperty)).GetMethod;
@@ -2616,8 +2650,8 @@ public class CollectionSpecs
         };
 
         return from x in arrays
-               from y in arrays
-               select new object[] { x, y };
+            from y in arrays
+            select new[] { x, y };
     }
 
     [Fact]
@@ -2650,6 +2684,7 @@ public class CollectionSpecs
         var expectation = new List<ClassWithLotsOfProperties>();
 
         var maxAmount = 100;
+
         for (var i = 0; i < maxAmount; i++)
         {
             actual.Add(GetObject(i));
@@ -2711,6 +2746,6 @@ public class CollectionSpecs
             Key = key;
         }
 
-        public string Key { get; protected set; }
+        public string Key { get; }
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
@@ -12,13 +12,27 @@ public class CyclicReferencesSpecs
     public void When_validating_nested_properties_that_have_cyclic_references_it_should_throw()
     {
         // Arrange
-        var cyclicRoot = new CyclicRoot { Text = "Root" };
+        var cyclicRoot = new CyclicRoot
+        {
+            Text = "Root"
+        };
 
-        cyclicRoot.Level = new CyclicLevel1 { Text = "Level1", Root = cyclicRoot };
+        cyclicRoot.Level = new CyclicLevel1
+        {
+            Text = "Level1",
+            Root = cyclicRoot
+        };
 
-        var cyclicRootDto = new CyclicRootDto { Text = "Root" };
+        var cyclicRootDto = new CyclicRootDto
+        {
+            Text = "Root"
+        };
 
-        cyclicRootDto.Level = new CyclicLevel1Dto { Text = "Level1", Root = cyclicRootDto };
+        cyclicRootDto.Level = new CyclicLevel1Dto
+        {
+            Text = "Level1",
+            Root = cyclicRootDto
+        };
 
         // Act
         Action act = () => cyclicRoot.Should().BeEquivalentTo(cyclicRootDto);
@@ -33,11 +47,27 @@ public class CyclicReferencesSpecs
     public void When_validating_nested_properties_and_ignoring_cyclic_references_it_should_succeed()
     {
         // Arrange
-        var cyclicRoot = new CyclicRoot { Text = "Root" };
-        cyclicRoot.Level = new CyclicLevel1 { Text = "Level1", Root = cyclicRoot };
+        var cyclicRoot = new CyclicRoot
+        {
+            Text = "Root"
+        };
 
-        var cyclicRootDto = new CyclicRootDto { Text = "Root" };
-        cyclicRootDto.Level = new CyclicLevel1Dto { Text = "Level1", Root = cyclicRootDto };
+        cyclicRoot.Level = new CyclicLevel1
+        {
+            Text = "Level1",
+            Root = cyclicRoot
+        };
+
+        var cyclicRootDto = new CyclicRootDto
+        {
+            Text = "Root"
+        };
+
+        cyclicRootDto.Level = new CyclicLevel1Dto
+        {
+            Text = "Level1",
+            Root = cyclicRootDto
+        };
 
         // Act
         Action act = () =>
@@ -92,13 +122,27 @@ public class CyclicReferencesSpecs
     public void When_validating_nested_properties_that_are_null_it_should_not_throw_on_cyclic_references()
     {
         // Arrange
-        var actual = new CyclicRoot { Text = null };
+        var actual = new CyclicRoot
+        {
+            Text = null
+        };
 
-        actual.Level = new CyclicLevel1 { Text = null, Root = null };
+        actual.Level = new CyclicLevel1
+        {
+            Text = null,
+            Root = null
+        };
 
-        var expectation = new CyclicRootDto { Text = null };
+        var expectation = new CyclicRootDto
+        {
+            Text = null
+        };
 
-        expectation.Level = new CyclicLevel1Dto { Text = null, Root = null };
+        expectation.Level = new CyclicLevel1Dto
+        {
+            Text = null,
+            Root = null
+        };
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation);
@@ -111,13 +155,27 @@ public class CyclicReferencesSpecs
     public void When_the_graph_contains_the_same_value_object_it_should_not_be_treated_as_a_cyclic_reference()
     {
         // Arrange
-        var actual = new CyclicRootWithValueObject { Object = new ValueObject("MyValue") };
+        var actual = new CyclicRootWithValueObject
+        {
+            Object = new ValueObject("MyValue")
+        };
 
-        actual.Level = new CyclicLevelWithValueObject { Object = new ValueObject("MyValue"), Root = null };
+        actual.Level = new CyclicLevelWithValueObject
+        {
+            Object = new ValueObject("MyValue"),
+            Root = null
+        };
 
-        var expectation = new CyclicRootWithValueObject { Object = new ValueObject("MyValue") };
+        var expectation = new CyclicRootWithValueObject
+        {
+            Object = new ValueObject("MyValue")
+        };
 
-        expectation.Level = new CyclicLevelWithValueObject { Object = new ValueObject("MyValue"), Root = null };
+        expectation.Level = new CyclicLevelWithValueObject
+        {
+            Object = new ValueObject("MyValue"),
+            Root = null
+        };
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation);
@@ -227,7 +285,12 @@ public class CyclicReferencesSpecs
         // Act
         var instance1 = new SelfReturningEnumerable();
         var instance2 = new SelfReturningEnumerable();
-        var actual = new List<SelfReturningEnumerable> { instance1, instance2 };
+
+        var actual = new List<SelfReturningEnumerable>
+        {
+            instance1,
+            instance2
+        };
 
         // Assert
         Action act = () => actual.Should().BeEquivalentTo(
@@ -277,14 +340,44 @@ public class CyclicReferencesSpecs
     public void When_the_root_object_is_referenced_from_a_nested_object_it_should_treat_it_as_a_cyclic_reference()
     {
         // Arrange
-        var company1 = new MyCompany { Name = "Company" };
-        var user1 = new MyUser { Name = "User", Company = company1 };
-        var logo1 = new MyCompanyLogo { Url = "blank", Company = company1, CreatedBy = user1 };
+        var company1 = new MyCompany
+        {
+            Name = "Company"
+        };
+
+        var user1 = new MyUser
+        {
+            Name = "User",
+            Company = company1
+        };
+
+        var logo1 = new MyCompanyLogo
+        {
+            Url = "blank",
+            Company = company1,
+            CreatedBy = user1
+        };
+
         company1.Logo = logo1;
 
-        var company2 = new MyCompany { Name = "Company" };
-        var user2 = new MyUser { Name = "User", Company = company2 };
-        var logo2 = new MyCompanyLogo { Url = "blank", Company = company2, CreatedBy = user2 };
+        var company2 = new MyCompany
+        {
+            Name = "Company"
+        };
+
+        var user2 = new MyUser
+        {
+            Name = "User",
+            Company = company2
+        };
+
+        var logo2 = new MyCompanyLogo
+        {
+            Url = "blank",
+            Company = company2,
+            CreatedBy = user2
+        };
+
         company2.Logo = logo2;
 
         // Act
@@ -298,15 +391,29 @@ public class CyclicReferencesSpecs
     public void Allow_ignoring_cyclic_references_in_value_types_compared_by_members()
     {
         // Arrange
-        var expectation = new ValueTypeCircularDependency() { Title = "First" };
+        var expectation = new ValueTypeCircularDependency
+        {
+            Title = "First"
+        };
 
-        var second = new ValueTypeCircularDependency() { Title = "Second", Previous = expectation };
+        var second = new ValueTypeCircularDependency
+        {
+            Title = "Second",
+            Previous = expectation
+        };
 
         expectation.Next = second;
 
-        var subject = new ValueTypeCircularDependency() { Title = "First" };
+        var subject = new ValueTypeCircularDependency
+        {
+            Title = "First"
+        };
 
-        var secondCopy = new ValueTypeCircularDependency() { Title = "SecondDifferent", Previous = subject };
+        var secondCopy = new ValueTypeCircularDependency
+        {
+            Title = "SecondDifferent",
+            Previous = subject
+        };
 
         subject.Next = secondCopy;
 
@@ -337,7 +444,7 @@ public class CyclicReferencesSpecs
                 return true;
             }
 
-            return (obj is ValueTypeCircularDependency baseObj) && baseObj.Title == Title;
+            return obj is ValueTypeCircularDependency baseObj && baseObj.Title == Title;
         }
 
         public override int GetHashCode()

--- a/Tests/FluentAssertions.Equivalency.Specs/DataColumnSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataColumnSpecs.cs
@@ -111,6 +111,7 @@ public class DataColumnSpecs : DataSpecs
 
         // Act & Assert
         IEnumerable<DataColumn> excludedColumns = new[] { dataColumn2 };
+
         dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
             .ExcludingColumns(excludedColumns));
     }
@@ -131,7 +132,7 @@ public class DataColumnSpecs : DataSpecs
         // Act & Assert
         dataTable1.Should().BeEquivalentTo(dataTable2, options => options
             .ExcludingColumn(dataTable2.DecimalColumn)
-            .ExcludingRelated((DataTable dataTable) => dataTable.Constraints));
+            .ExcludingRelated(dataTable => dataTable.Constraints));
     }
 
     [Fact]
@@ -149,7 +150,7 @@ public class DataColumnSpecs : DataSpecs
         // Act & Assert
         dataSet1.Should().BeEquivalentTo(dataSet2, options => options
             .ExcludingColumn(dataTable2.DecimalColumn)
-            .ExcludingRelated((DataTable dataTable) => dataTable.Constraints));
+            .ExcludingRelated(dataTable => dataTable.Constraints));
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRelationSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRelationSpecs.cs
@@ -42,7 +42,7 @@ public class DataRelationSpecs : DataSpecs
         dataTable1.Should().BeEquivalentTo(
             dataTable2,
             options => options
-                .ExcludingRelated((DataRelation dataRelation) => dataRelation.RelationName));
+                .ExcludingRelated(dataRelation => dataRelation.RelationName));
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public class DataRelationSpecs : DataSpecs
         dataTable1.Should().BeEquivalentTo(
             dataTable2,
             options => options
-                .ExcludingRelated((DataRelation dataRelation) => dataRelation.Nested));
+                .ExcludingRelated(dataRelation => dataRelation.Nested));
     }
 
     [Fact]
@@ -204,9 +204,9 @@ public class DataRelationSpecs : DataSpecs
         dataTable1.Should().BeEquivalentTo(dataTable2, options => options
             .Excluding(dataTable => dataTable.ChildRelations)
             .Excluding(dataTable => dataTable.Constraints)
-            .ExcludingRelated((DataRelation dataRelation) => dataRelation.ParentColumns)
-            .ExcludingRelated((DataRelation dataRelation) => dataRelation.ParentKeyConstraint)
-            .ExcludingRelated((DataRelation dataRelation) => dataRelation.ChildKeyConstraint));
+            .ExcludingRelated(dataRelation => dataRelation.ParentColumns)
+            .ExcludingRelated(dataRelation => dataRelation.ParentKeyConstraint)
+            .ExcludingRelated(dataRelation => dataRelation.ChildKeyConstraint));
     }
 
     [Fact]
@@ -250,9 +250,9 @@ public class DataRelationSpecs : DataSpecs
         dataTable1.Should().BeEquivalentTo(dataTable2, options => options
             .Excluding(dataTable => dataTable.ParentRelations)
             .Excluding(dataTable => dataTable.Constraints)
-            .ExcludingRelated((DataRelation dataRelation) => dataRelation.ChildColumns)
-            .ExcludingRelated((DataRelation dataRelation) => dataRelation.ParentKeyConstraint)
-            .ExcludingRelated((DataRelation dataRelation) => dataRelation.ChildKeyConstraint));
+            .ExcludingRelated(dataRelation => dataRelation.ChildColumns)
+            .ExcludingRelated(dataRelation => dataRelation.ParentKeyConstraint)
+            .ExcludingRelated(dataRelation => dataRelation.ChildKeyConstraint));
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-
 using Xunit;
 using Xunit.Sdk;
 
@@ -63,7 +62,8 @@ public class DataRowSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_row_subject_is_deleted_and_expectation_is_not_but_the_row_state_is_excluded_equivalency_test_should_succeed()
+    public void
+        When_data_row_subject_is_deleted_and_expectation_is_not_but_the_row_state_is_excluded_equivalency_test_should_succeed()
     {
         // Arrange
         var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -83,7 +83,8 @@ public class DataRowSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_row_expectation_is_deleted_and_subject_is_not_but_the_row_state_is_excluded_equivalency_test_should_succeed()
+    public void
+        When_data_row_expectation_is_deleted_and_subject_is_not_but_the_row_state_is_excluded_equivalency_test_should_succeed()
     {
         // Arrange
         var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -147,11 +148,13 @@ public class DataRowSpecs : DataSpecs
         Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataRow1[Decimal, DataRowVersion.Original] to be *, but found *");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataRow1[Decimal, DataRowVersion.Original] to be *, but found *");
     }
 
     [Fact]
-    public void When_data_row_is_modified_and_original_data_differs_but_original_data_is_excluded_then_equivalency_test_should_succeed()
+    public void
+        When_data_row_is_modified_and_original_data_differs_but_original_data_is_excluded_then_equivalency_test_should_succeed()
     {
         // Arrange
         var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -196,7 +199,8 @@ public class DataRowSpecs : DataSpecs
         Action action = () => dataTable[0].Should().BeEquivalentTo(dataTableOfMismatchedType[0]);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataTable[0] to be of type *TypedDataRow2, but found *TypedDataRow1*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataTable[0] to be of type *TypedDataRow2, but found *TypedDataRow1*");
     }
 
     [Fact]
@@ -217,7 +221,8 @@ public class DataRowSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_one_data_row_has_errors_and_the_other_does_not_and_the_corresponding_property_is_not_excluded_then_equivalency_test_should_fail()
+    public void
+        When_one_data_row_has_errors_and_the_other_does_not_and_the_corresponding_property_is_not_excluded_then_equivalency_test_should_fail()
     {
         // Arrange
         var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -237,7 +242,8 @@ public class DataRowSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_one_data_row_has_errors_and_the_other_does_not_but_the_corresponding_property_is_excluded_then_equivalency_test_should_succeed()
+    public void
+        When_one_data_row_has_errors_and_the_other_does_not_but_the_corresponding_property_is_excluded_then_equivalency_test_should_succeed()
     {
         // Arrange
         var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -254,7 +260,8 @@ public class DataRowSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_the_data_row_state_does_not_match_and_the_corresponding_property_is_not_excluded_equivalency_test_should_fail()
+    public void
+        When_the_data_row_state_does_not_match_and_the_corresponding_property_is_not_excluded_equivalency_test_should_fail()
     {
         // Arrange
         var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -277,7 +284,8 @@ public class DataRowSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_the_data_row_state_does_not_match_but_the_corresponding_property_is_excluded_equivalency_test_should_succeed()
+    public void
+        When_the_data_row_state_does_not_match_but_the_corresponding_property_is_excluded_equivalency_test_should_succeed()
     {
         // Arrange
         var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -341,6 +349,7 @@ public class DataRowSpecs : DataSpecs
         // Arrange
         var table = new DataTable();
         var dataRow = table.NewRow();
+
         var subject = new
         {
             DataRow = "foobar"
@@ -414,7 +423,8 @@ public class DataRowSpecs : DataSpecs
             () => dataRow.Should().HaveColumn("Does not matter");
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataRow to contain a column named *Does not matter*, but found <null>*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataRow to contain a column named *Does not matter*, but found <null>*");
     }
 
     [Fact]
@@ -491,7 +501,8 @@ public class DataRowSpecs : DataSpecs
             () => dataRow.Should().HaveColumns(subsetOfColumnNamesWithUnicorn);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected table containing dataRow to contain a column named *Unicorn*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected table containing dataRow to contain a column named *Unicorn*");
     }
 
     [Fact]
@@ -512,6 +523,7 @@ public class DataRowSpecs : DataSpecs
             () => dataRow.Should().HaveColumns(columnNames);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected table containing dataRow to contain a column named *Unicorn*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected table containing dataRow to contain a column named *Unicorn*");
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
@@ -3,7 +3,6 @@ using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-
 using Xunit;
 using Xunit.Sdk;
 
@@ -78,7 +77,8 @@ public class DataSetSpecs : DataSpecs
         Action action = () => dataSet.Should().BeEquivalentTo(dataSetOfMismatchedType);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataSet to be of type *TypedDataSetSubclass, but found System.Data.DataSet*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataSet to be of type *TypedDataSetSubclass, but found System.Data.DataSet*");
     }
 
     [Fact]
@@ -137,7 +137,8 @@ public class DataSetSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_one_data_set_is_configured_to_be_case_sensitive_and_the_other_is_not_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_one_data_set_is_configured_to_be_case_sensitive_and_the_other_is_not_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -153,11 +154,13 @@ public class DataSetSpecs : DataSpecs
         Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataSet1 to have CaseSensitive value of True, but found False instead*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataSet1 to have CaseSensitive value of True, but found False instead*");
     }
 
     [Fact]
-    public void When_one_data_set_is_configured_to_be_case_sensitive_and_the_other_is_not_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
+    public void
+        When_one_data_set_is_configured_to_be_case_sensitive_and_the_other_is_not_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -174,7 +177,8 @@ public class DataSetSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_one_data_set_is_configured_to_enforce_constraints_and_the_other_is_not_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_one_data_set_is_configured_to_enforce_constraints_and_the_other_is_not_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -190,11 +194,13 @@ public class DataSetSpecs : DataSpecs
         Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataSet1 to have EnforceConstraints value of False, but found True instead*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataSet1 to have EnforceConstraints value of False, but found True instead*");
     }
 
     [Fact]
-    public void When_one_data_set_is_configured_to_enforce_constraints_and_the_other_is_not_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
+    public void
+        When_one_data_set_is_configured_to_enforce_constraints_and_the_other_is_not_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -211,7 +217,8 @@ public class DataSetSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_one_data_set_has_errors_and_the_other_does_not_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_one_data_set_has_errors_and_the_other_does_not_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -231,7 +238,8 @@ public class DataSetSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_one_data_set_has_errors_and_the_other_does_not_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
+    public void
+        When_one_data_set_has_errors_and_the_other_does_not_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -249,7 +257,8 @@ public class DataSetSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_sets_have_mismatched_locale_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_data_sets_have_mismatched_locale_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -266,7 +275,8 @@ public class DataSetSpecs : DataSpecs
         Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataSet1 to have Locale value of fr-CA, but found en-US instead*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataSet1 to have Locale value of fr-CA, but found en-US instead*");
     }
 
     [Fact]
@@ -288,7 +298,8 @@ public class DataSetSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_set_namespace_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_data_set_namespace_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -308,7 +319,8 @@ public class DataSetSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_set_namespace_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
+    public void
+        When_data_set_namespace_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -365,7 +377,8 @@ public class DataSetSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_set_remoting_format_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_data_set_remoting_format_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -373,7 +386,7 @@ public class DataSetSpecs : DataSpecs
         var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
         typedDataSet2.RemotingFormat =
-            (typedDataSet2.RemotingFormat == SerializationFormat.Binary)
+            typedDataSet2.RemotingFormat == SerializationFormat.Binary
                 ? SerializationFormat.Xml
                 : SerializationFormat.Binary;
 
@@ -384,11 +397,14 @@ public class DataSetSpecs : DataSpecs
         Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataSet1 to have RemotingFormat value of SerializationFormat.Binary*, but found *Xml* instead*");
+        action.Should().Throw<XunitException>()
+            .WithMessage(
+                "Expected dataSet1 to have RemotingFormat value of SerializationFormat.Binary*, but found *Xml* instead*");
     }
 
     [Fact]
-    public void When_data_set_remoting_format_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
+    public void
+        When_data_set_remoting_format_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -396,7 +412,7 @@ public class DataSetSpecs : DataSpecs
         var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
         typedDataSet2.RemotingFormat =
-            (typedDataSet2.RemotingFormat == SerializationFormat.Binary)
+            typedDataSet2.RemotingFormat == SerializationFormat.Binary
                 ? SerializationFormat.Xml
                 : SerializationFormat.Binary;
 
@@ -406,12 +422,14 @@ public class DataSetSpecs : DataSpecs
         // Act & Assert
         dataSet1.Should().BeEquivalentTo(dataSet2, options => options
             .Excluding(dataSet => dataSet.RemotingFormat)
-            .ExcludingRelated((DataTable dataTable) => dataTable.RemotingFormat));
+            .ExcludingRelated(dataTable => dataTable.RemotingFormat));
     }
 
     [Theory]
     [MemberData(nameof(AllChangeTypes))]
-    public void When_data_set_extended_properties_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(ChangeType changeType)
+    public void
+        When_data_set_extended_properties_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(
+            ChangeType changeType)
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -432,7 +450,9 @@ public class DataSetSpecs : DataSpecs
 
     [Theory]
     [MemberData(nameof(AllChangeTypes))]
-    public void When_data_set_extended_properties_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(ChangeType changeType)
+    public void
+        When_data_set_extended_properties_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(
+            ChangeType changeType)
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -451,7 +471,8 @@ public class DataSetSpecs : DataSpecs
     [Theory]
     [MemberData(nameof(AllChangeTypes))]
     [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "All enum values are accounted for.")]
-    public void When_data_set_relations_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(ChangeType changeType)
+    public void When_data_set_relations_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(
+        ChangeType changeType)
     {
         // Arrange
         TypedDataSetSubclass typedDataSet1;
@@ -496,7 +517,8 @@ public class DataSetSpecs : DataSpecs
     [Theory]
     [MemberData(nameof(AllChangeTypes))]
     [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "All enum values are accounted for.")]
-    public void When_data_set_relations_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(ChangeType changeType)
+    public void When_data_set_relations_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(
+        ChangeType changeType)
     {
         // Arrange
         TypedDataSetSubclass typedDataSet1;
@@ -534,10 +556,10 @@ public class DataSetSpecs : DataSpecs
         // Act & Assert
         dataSet1.Should().BeEquivalentTo(dataSet2, options => options
             .Excluding(dataSet => dataSet.Relations)
-            .ExcludingRelated((DataTable dataTable) => dataTable.Constraints)
-            .ExcludingRelated((DataTable dataTable) => dataTable.ParentRelations)
-            .ExcludingRelated((DataTable dataTable) => dataTable.ChildRelations)
-            .ExcludingRelated((DataColumn dataColumn) => dataColumn.Unique));
+            .ExcludingRelated(dataTable => dataTable.Constraints)
+            .ExcludingRelated(dataTable => dataTable.ParentRelations)
+            .ExcludingRelated(dataTable => dataTable.ChildRelations)
+            .ExcludingRelated(dataColumn => dataColumn.Unique));
     }
 
     [Fact]
@@ -592,7 +614,9 @@ public class DataSetSpecs : DataSpecs
         Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataSet1.Relations[0].ExtendedProperties* to reference column *ForeignRowID* in table *Different*, but found a reference to *ForeignRowID* in table *TypedDataTable2* instead*");
+        action.Should().Throw<XunitException>()
+            .WithMessage(
+                "Expected dataSet1.Relations[0].ExtendedProperties* to reference column *ForeignRowID* in table *Different*, but found a reference to *ForeignRowID* in table *TypedDataTable2* instead*");
     }
 
     [Fact]
@@ -612,7 +636,9 @@ public class DataSetSpecs : DataSpecs
         Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataSet1[TypedDataTable2].Rows[0] to have RowState value of *Modified*, but found *Unchanged* instead*");
+        action.Should().Throw<XunitException>()
+            .WithMessage(
+                "Expected dataSet1[TypedDataTable2].Rows[0] to have RowState value of *Modified*, but found *Unchanged* instead*");
     }
 
     [Fact]
@@ -773,7 +799,8 @@ public class DataSetSpecs : DataSpecs
             () => dataSet.Should().HaveTables(tableNames);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataSet to contain a table named *Unicorn*, but it does not.");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataSet to contain a table named *Unicorn*, but it does not.");
     }
 
     [Fact]
@@ -789,6 +816,7 @@ public class DataSetSpecs : DataSpecs
             () => dataSet.Should().HaveTables(nonExistentTableNames);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataSet to contain a table named *Unicorn*, but it does not.");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataSet to contain a table named *Unicorn*, but it does not.");
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/DataSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSpecs.cs
@@ -17,6 +17,7 @@ public class DataSpecs
     public int Dummy { get; set; }
 
     #region Subject Types
+
     /*
 
     NB: TypedDataTable1 and TypedDataTable2 intentionally have the same schema. This allows testing of
@@ -71,8 +72,10 @@ public class DataSpecs
         }
     }
 
-    [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1306", Justification = "DataColumn accessors are named after the columns.")]
-    [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1516", Justification = "DataColumn accessors are grouped in a block of lines.")]
+    [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1306",
+        Justification = "DataColumn accessors are named after the columns.")]
+    [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1516",
+        Justification = "DataColumn accessors are grouped in a block of lines.")]
     public class TypedDataTable1 : TypedTableBase<TypedDataRow1>
     {
         public TypedDataTable1()
@@ -161,8 +164,10 @@ public class DataSpecs
         }
     }
 
-    [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1306", Justification = "DataColumn accessors are named after the columns.")]
-    [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1516", Justification = "DataColumn accessors are grouped in a block of lines.")]
+    [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1306",
+        Justification = "DataColumn accessors are named after the columns.")]
+    [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1516",
+        Justification = "DataColumn accessors are grouped in a block of lines.")]
     public class TypedDataTable2 : TypedTableBase<TypedDataRow2>
     {
         public TypedDataTable2()
@@ -204,7 +209,8 @@ public class DataSpecs
         public DataColumn ForeignRowIDColumn => Columns["ForeignRowID"];
     }
 
-    [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1516", Justification = "DataTable accessors are grouped in a block of lines.")]
+    [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1516",
+        Justification = "DataTable accessors are grouped in a block of lines.")]
     public class TypedDataSet : DataSet
     {
         public override SchemaSerializationMode SchemaSerializationMode { get; set; }
@@ -299,8 +305,8 @@ public class DataSpecs
                 foreach (var constraint in typedTable.Constraints.Cast<Constraint>())
                 {
                     if (!Relations.Cast<DataRelation>().Any(rel =>
-                        (rel.ChildKeyConstraint == constraint) ||
-                        (rel.ParentKeyConstraint == constraint)))
+                            rel.ChildKeyConstraint == constraint ||
+                            rel.ParentKeyConstraint == constraint))
                     {
                         if (constraint is UniqueConstraint uniqueConstraint)
                         {
@@ -331,8 +337,10 @@ public class DataSpecs
                 // NB: In the context of the unit test, this is assuming that there is only one column in a relation.
                 var dataRelation = new DataRelation(
                     relation.RelationName,
-                    parentColumn: dataSet.Tables[relation.ParentTable.TableName].Columns[relation.ParentColumns.Single().ColumnName],
-                    childColumn: dataSet.Tables[relation.ChildTable.TableName].Columns[relation.ChildColumns.Single().ColumnName]);
+                    parentColumn: dataSet.Tables[relation.ParentTable.TableName]
+                        .Columns[relation.ParentColumns.Single().ColumnName],
+                    childColumn: dataSet.Tables[relation.ChildTable.TableName]
+                        .Columns[relation.ChildColumns.Single().ColumnName]);
 
                 foreach (var property in relation.ExtendedProperties.Cast<DictionaryEntry>())
                 {
@@ -365,12 +373,12 @@ public class DataSpecs
             SchemaSerializationMode = copyFrom.SchemaSerializationMode;
 
             CopyTable<TypedDataTable1, TypedDataRow1>(
-                @from: copyFrom.TypedDataTable1,
+                from: copyFrom.TypedDataTable1,
                 to: TypedDataTable1,
                 randomizeRowOrder);
 
             CopyTable<TypedDataTable2, TypedDataRow2>(
-                @from: copyFrom.TypedDataTable2,
+                from: copyFrom.TypedDataTable2,
                 to: TypedDataTable2,
                 randomizeRowOrder);
 
@@ -384,8 +392,10 @@ public class DataSpecs
                 // NB: In the context of the unit test, this is assuming that there is only one column in a relation.
                 var relation = new DataRelation(
                     copyFromRelation.RelationName,
-                    parentColumn: Tables[copyFromRelation.ParentTable.TableName].Columns[copyFromRelation.ParentColumns.Single().ColumnName],
-                    childColumn: Tables[copyFromRelation.ChildTable.TableName].Columns[copyFromRelation.ChildColumns.Single().ColumnName]);
+                    parentColumn: Tables[copyFromRelation.ParentTable.TableName]
+                        .Columns[copyFromRelation.ParentColumns.Single().ColumnName],
+                    childColumn: Tables[copyFromRelation.ChildTable.TableName]
+                        .Columns[copyFromRelation.ChildColumns.Single().ColumnName]);
 
                 foreach (var property in copyFromRelation.ExtendedProperties.Cast<DictionaryEntry>())
                 {
@@ -429,11 +439,13 @@ public class DataSpecs
             }
         }
     }
+
     #endregion
 
-    private static readonly Random Random = new Random();
+    private static readonly Random Random = new();
 
-    internal static TDataSet CreateDummyDataSet<TDataSet>(bool identicalTables = false, bool includeDummyData = true, bool includeRelation = true)
+    internal static TDataSet CreateDummyDataSet<TDataSet>(bool identicalTables = false, bool includeDummyData = true,
+        bool includeRelation = true)
         where TDataSet : TypedDataSet, new()
     {
         var ret = new TDataSet();
@@ -497,7 +509,8 @@ public class DataSpecs
 
     protected static void AddRelation(TypedDataSet dataSet)
     {
-        var relation = new DataRelation("TestRelation", dataSet.TypedDataTable1.RowIDColumn, dataSet.TypedDataTable2.ForeignRowIDColumn);
+        var relation = new DataRelation("TestRelation", dataSet.TypedDataTable1.RowIDColumn,
+            dataSet.TypedDataTable2.ForeignRowIDColumn);
 
         AddExtendedProperties(relation.ExtendedProperties);
 
@@ -540,7 +553,8 @@ public class DataSpecs
         table.Rows.Add(row);
     }
 
-    [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "TypedDataTable test types have a limited set of columns.")]
+    [SuppressMessage("Style", "IDE0010:Add missing cases",
+        Justification = "TypedDataTable test types have a limited set of columns.")]
     private static object GetDummyValueOfType(Type dataType)
     {
         switch (Type.GetTypeCode(dataType))
@@ -548,7 +562,8 @@ public class DataSpecs
             case TypeCode.Int32:
                 return Random.Next();
             case TypeCode.DateTime:
-                return DateTime.MinValue.AddTicks((Random.Next() & 0x7FFFFFFF) * 1469337835L).AddTicks((Random.Next() & 0x7FFFFFFF) * 1469337835L / 2147483648);
+                return DateTime.MinValue.AddTicks((Random.Next() & 0x7FFFFFFF) * 1469337835L)
+                    .AddTicks(((Random.Next() & 0x7FFFFFFF) * 1469337835L) / 2147483648);
             case TypeCode.Decimal:
                 return new decimal(Random.NextDouble());
             case TypeCode.String:
@@ -571,11 +586,11 @@ public class DataSpecs
         Removed,
     }
 
-    public static IEnumerable<object[]> AllChangeTypes
-        => Enum.GetValues(typeof(ChangeType)).Cast<ChangeType>().Select(t => new object[] { t });
+    public static IEnumerable<object[]> AllChangeTypes =>
+        Enum.GetValues(typeof(ChangeType)).Cast<ChangeType>().Select(t => new object[] { t });
 
-    public static IEnumerable<object[]> AllChangeTypesWithAcceptChangesValues
-        => Enum.GetValues(typeof(ChangeType)).Cast<ChangeType>().Join(
+    public static IEnumerable<object[]> AllChangeTypesWithAcceptChangesValues =>
+        Enum.GetValues(typeof(ChangeType)).Cast<ChangeType>().Join(
             new[] { true, false },
             changeType => true,
             acceptChanges => true,
@@ -625,6 +640,7 @@ public class DataSpecs
                     new UniqueConstraint(
                         "Test",
                         columnForNewConstraint));
+
                 break;
             case ChangeType.Changed:
                 constraints[1].ConstraintName += "different";

--- a/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
@@ -63,7 +63,8 @@ public class DataTableSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_table_type_does_not_match_and_assertion_is_not_configured_to_allow_mismatched_types_equivalence_test_should_fail()
+    public void
+        When_data_table_type_does_not_match_and_assertion_is_not_configured_to_allow_mismatched_types_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
@@ -76,11 +77,13 @@ public class DataTableSpecs : DataSpecs
         Action action = () => dataTable.Should().BeEquivalentTo(dataTableOfMismatchedType);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataTable to be of type *TypedDataTable1*, but found *System.Data.DataTable*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataTable to be of type *TypedDataTable1*, but found *System.Data.DataTable*");
     }
 
     [Fact]
-    public void When_data_table_type_does_not_match_but_assertion_is_configured_to_allow_mismatched_types_equivalence_test_should_succeed()
+    public void
+        When_data_table_type_does_not_match_but_assertion_is_configured_to_allow_mismatched_types_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
@@ -109,7 +112,8 @@ public class DataTableSpecs : DataSpecs
         Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataTable1 to have TableName *different*, but found *TypedDataTable1* instead*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataTable1 to have TableName *different*, but found *TypedDataTable1* instead*");
     }
 
     [Fact]
@@ -128,13 +132,14 @@ public class DataTableSpecs : DataSpecs
         dataTable1.Should().BeEquivalentTo(
             dataTable2,
             options => options
-            .Excluding(dataTable => dataTable.TableName)
-            .ExcludingRelated((DataColumn dataColumn) => dataColumn.Table)
-            .ExcludingRelated((Constraint constraint) => constraint.Table));
+                .Excluding(dataTable => dataTable.TableName)
+                .ExcludingRelated((DataColumn dataColumn) => dataColumn.Table)
+                .ExcludingRelated((Constraint constraint) => constraint.Table));
     }
 
     [Fact]
-    public void When_data_table_case_sensitivity_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_data_table_case_sensitivity_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -150,11 +155,13 @@ public class DataTableSpecs : DataSpecs
         Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataTable1 to have CaseSensitive value of True, but found False instead*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataTable1 to have CaseSensitive value of True, but found False instead*");
     }
 
     [Fact]
-    public void When_data_table_case_sensitivity_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
+    public void
+        When_data_table_case_sensitivity_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -171,7 +178,8 @@ public class DataTableSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_table_display_expression_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_data_table_display_expression_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -191,7 +199,8 @@ public class DataTableSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_table_display_expression_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
+    public void
+        When_data_table_display_expression_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -208,7 +217,8 @@ public class DataTableSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_one_data_table_has_errors_and_the_other_does_not_and_the_property_that_indicates_the_presence_of_errors_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_one_data_table_has_errors_and_the_other_does_not_and_the_property_that_indicates_the_presence_of_errors_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -228,7 +238,8 @@ public class DataTableSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_one_data_table_has_errors_and_the_other_does_not_but_the_property_that_indicates_the_presence_of_errors_is_excluded_equivalence_test_should_succeed()
+    public void
+        When_one_data_table_has_errors_and_the_other_does_not_but_the_property_that_indicates_the_presence_of_errors_is_excluded_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -247,7 +258,8 @@ public class DataTableSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_table_locale_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_data_table_locale_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -264,7 +276,8 @@ public class DataTableSpecs : DataSpecs
         Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataTable1 to have Locale value of *fr-CA*, but found *en-US* instead*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataTable1 to have Locale value of *fr-CA*, but found *en-US* instead*");
     }
 
     [Fact]
@@ -286,7 +299,8 @@ public class DataTableSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_table_namespace_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_data_table_namespace_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -302,11 +316,13 @@ public class DataTableSpecs : DataSpecs
         Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataTable1 to have Namespace value of *different*, but found *");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataTable1 to have Namespace value of *different*, but found *");
     }
 
     [Fact]
-    public void When_data_table_namespace_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
+    public void
+        When_data_table_namespace_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -325,7 +341,8 @@ public class DataTableSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_table_prefix_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_data_table_prefix_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -341,7 +358,8 @@ public class DataTableSpecs : DataSpecs
         Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataTable1 to have Prefix value of *different*, but found * instead*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataTable1 to have Prefix value of *different*, but found * instead*");
     }
 
     [Fact]
@@ -362,7 +380,8 @@ public class DataTableSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_table_remoting_format_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_data_table_remoting_format_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -370,9 +389,9 @@ public class DataTableSpecs : DataSpecs
         var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
         typedDataSet2.RemotingFormat =
-            (typedDataSet2.RemotingFormat == SerializationFormat.Binary)
-            ? SerializationFormat.Xml
-            : SerializationFormat.Binary;
+            typedDataSet2.RemotingFormat == SerializationFormat.Binary
+                ? SerializationFormat.Xml
+                : SerializationFormat.Binary;
 
         var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
         var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
@@ -381,11 +400,13 @@ public class DataTableSpecs : DataSpecs
         Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataTable1 to have RemotingFormat value of *Binary*, but found *Xml* instead*");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataTable1 to have RemotingFormat value of *Binary*, but found *Xml* instead*");
     }
 
     [Fact]
-    public void When_data_table_remoting_format_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
+    public void
+        When_data_table_remoting_format_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -393,9 +414,9 @@ public class DataTableSpecs : DataSpecs
         var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
 
         typedDataSet2.RemotingFormat =
-            (typedDataSet2.RemotingFormat == SerializationFormat.Binary)
-            ? SerializationFormat.Xml
-            : SerializationFormat.Binary;
+            typedDataSet2.RemotingFormat == SerializationFormat.Binary
+                ? SerializationFormat.Xml
+                : SerializationFormat.Binary;
 
         var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
         var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
@@ -408,7 +429,8 @@ public class DataTableSpecs : DataSpecs
 
     [Theory]
     [MemberData(nameof(AllChangeTypes))]
-    public void When_data_table_columns_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(ChangeType changeType)
+    public void When_data_table_columns_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(
+        ChangeType changeType)
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -429,7 +451,8 @@ public class DataTableSpecs : DataSpecs
 
     [Theory]
     [MemberData(nameof(AllChangeTypes))]
-    public void When_data_table_columns_do_not_match_but_columns_and_rows_are_excluded_equivalence_test_should_succeed(ChangeType changeType)
+    public void When_data_table_columns_do_not_match_but_columns_and_rows_are_excluded_equivalence_test_should_succeed(
+        ChangeType changeType)
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -449,7 +472,9 @@ public class DataTableSpecs : DataSpecs
 
     [Theory]
     [MemberData(nameof(AllChangeTypes))]
-    public void When_data_table_extended_properties_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(ChangeType changeType)
+    public void
+        When_data_table_extended_properties_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(
+            ChangeType changeType)
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -470,7 +495,9 @@ public class DataTableSpecs : DataSpecs
 
     [Theory]
     [MemberData(nameof(AllChangeTypes))]
-    public void When_data_table_extended_properties_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(ChangeType changeType)
+    public void
+        When_data_table_extended_properties_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(
+            ChangeType changeType)
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -487,7 +514,8 @@ public class DataTableSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_table_primary_key_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
+    public void
+        When_data_table_primary_key_does_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -509,11 +537,14 @@ public class DataTableSpecs : DataSpecs
                 .Excluding(dataTable => dataTable.Constraints));
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected property dataTable1.PrimaryKey to be a collection with * item(s), but *contains * item(s) less than*");
+        action.Should().Throw<XunitException>()
+            .WithMessage(
+                "Expected property dataTable1.PrimaryKey to be a collection with * item(s), but *contains * item(s) less than*");
     }
 
     [Fact]
-    public void When_data_table_primary_key_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
+    public void
+        When_data_table_primary_key_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -546,7 +577,8 @@ public class DataTableSpecs : DataSpecs
     [Theory]
     [InlineData(NumberOfColumnsInConstraintDifference.SingleColumn)]
     [InlineData(NumberOfColumnsInConstraintDifference.MultipleColumns)]
-    public void When_columns_for_constraint_in_data_table_do_not_match_message_should_list_all_columns_involved(NumberOfColumnsInConstraintDifference difference)
+    public void When_columns_for_constraint_in_data_table_do_not_match_message_should_list_all_columns_involved(
+        NumberOfColumnsInConstraintDifference difference)
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -580,6 +612,7 @@ public class DataTableSpecs : DataSpecs
 
         var missingColumnNames = dataTable2ColumnsForConstraint.Select(col => col.ColumnName)
             .Except(dataTable1ColumnsForConstraint.Select(col => col.ColumnName));
+
         var extraColumnNames = dataTable1ColumnsForConstraint.Select(col => col.ColumnName)
             .Except(dataTable2ColumnsForConstraint.Select(col => col.ColumnName));
 
@@ -598,7 +631,9 @@ public class DataTableSpecs : DataSpecs
 
     [Theory]
     [MemberData(nameof(AllChangeTypes))]
-    public void When_data_table_constraints_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(ChangeType changeType)
+    public void
+        When_data_table_constraints_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(
+            ChangeType changeType)
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -612,8 +647,8 @@ public class DataTableSpecs : DataSpecs
 
         string expectedExceptionPattern =
             changeType == ChangeType.Changed
-            ? "Found unexpected constraint named *Constraint2* in property dataTable1.Constraints*"
-            : "Expected property dataTable1.Columns[*].Unique to be *, but found *";
+                ? "Found unexpected constraint named *Constraint2* in property dataTable1.Constraints*"
+                : "Expected property dataTable1.Columns[*].Unique to be *, but found *";
 
         // Act
         Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
@@ -624,7 +659,9 @@ public class DataTableSpecs : DataSpecs
 
     [Theory]
     [MemberData(nameof(AllChangeTypes))]
-    public void When_data_table_constraints_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(ChangeType changeType)
+    public void
+        When_data_table_constraints_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(
+            ChangeType changeType)
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -639,12 +676,13 @@ public class DataTableSpecs : DataSpecs
         // Act & Assert
         dataTable1.Should().BeEquivalentTo(dataTable2, options => options
             .Excluding(dataTable => dataTable.Constraints)
-            .ExcludingRelated((DataColumn dataColumn) => dataColumn.Unique));
+            .ExcludingRelated(dataColumn => dataColumn.Unique));
     }
 
     [Theory]
     [MemberData(nameof(AllChangeTypesWithAcceptChangesValues))]
-    public void When_data_table_rows_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(ChangeType changeType, bool acceptChanges)
+    public void When_data_table_rows_do_not_match_and_the_corresponding_property_is_not_excluded_equivalence_test_should_fail(
+        ChangeType changeType, bool acceptChanges)
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -667,8 +705,8 @@ public class DataTableSpecs : DataSpecs
         {
             exceptionPattern =
                 acceptChanges
-                ? "Expected dataTable1.Rows[1][String] to be *different* with a length of *, but * has a length of *, differs near *"
-                : "Expected dataTable1.Rows[1] to have RowState value of *Modified*, but found *Unchanged* instead*";
+                    ? "Expected dataTable1.Rows[1][String] to be *different* with a length of *, but * has a length of *, differs near *"
+                    : "Expected dataTable1.Rows[1] to have RowState value of *Modified*, but found *Unchanged* instead*";
         }
         else
         {
@@ -685,7 +723,8 @@ public class DataTableSpecs : DataSpecs
 
     [Theory]
     [MemberData(nameof(AllChangeTypesWithAcceptChangesValues))]
-    public void When_data_table_rows_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(ChangeType changeType, bool acceptChanges)
+    public void When_data_table_rows_do_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed(
+        ChangeType changeType, bool acceptChanges)
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -707,7 +746,8 @@ public class DataTableSpecs : DataSpecs
     }
 
     [Fact]
-    public void When_data_table_data_matches_in_different_order_and_the_row_match_mode_is_by_primary_key_equivalence_test_should_succeed()
+    public void
+        When_data_table_data_matches_in_different_order_and_the_row_match_mode_is_by_primary_key_equivalence_test_should_succeed()
     {
         // Arrange
         var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
@@ -851,7 +891,8 @@ public class DataTableSpecs : DataSpecs
             () => dataTable.Should().HaveColumn("Unicorn");
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataTable to contain a column named *Unicorn*, but it does not.");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataTable to contain a column named *Unicorn*, but it does not.");
     }
 
     [Fact]
@@ -902,7 +943,8 @@ public class DataTableSpecs : DataSpecs
             () => dataTable.Should().HaveColumns(columnNames);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataTable to contain a column named *Unicorn*, but it does not.");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataTable to contain a column named *Unicorn*, but it does not.");
     }
 
     [Fact]
@@ -920,6 +962,7 @@ public class DataTableSpecs : DataSpecs
             () => dataTable.Should().HaveColumns(nonExistingColumnNames);
 
         // Assert
-        action.Should().Throw<XunitException>().WithMessage("Expected dataTable to contain a column named *Unicorn*, but it does not.");
+        action.Should().Throw<XunitException>()
+            .WithMessage("Expected dataTable to contain a column named *Unicorn*, but it does not.");
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
@@ -75,7 +75,7 @@ public class DictionarySpecs
 
     private class GenericDictionaryNotImplementingIDictionary<TKey, TValue> : IDictionary<TKey, TValue>
     {
-        private readonly Dictionary<TKey, TValue> dictionary = new Dictionary<TKey, TValue>();
+        private readonly Dictionary<TKey, TValue> dictionary = new();
 
         IEnumerator IEnumerable.GetEnumerator()
         {
@@ -234,7 +234,7 @@ public class DictionarySpecs
 
     public class UserRolesLookupElement
     {
-        private readonly Dictionary<Guid, List<string>> innerRoles = new Dictionary<Guid, List<string>>();
+        private readonly Dictionary<Guid, List<string>> innerRoles = new();
 
         public virtual Dictionary<Guid, IEnumerable<string>> Roles
         {
@@ -305,7 +305,7 @@ public class DictionarySpecs
         };
 
         ICollection<KeyValuePair<string, int>> collection =
-            new List<KeyValuePair<string, int>> { new KeyValuePair<string, int>("hi", 1) };
+            new List<KeyValuePair<string, int>> { new("hi", 1) };
 
         // Act
         Action act = () => dictionary.Should().BeEquivalentTo(collection);
@@ -320,14 +320,14 @@ public class DictionarySpecs
         // Arrange
         IReadOnlyDictionary<string, IEnumerable<string>> dictionary =
             new ReadOnlyDictionary<string, IEnumerable<string>>(
-            new Dictionary<string, IEnumerable<string>>()
-            {
-                ["Key2"] = new[] { "Value2" },
-                ["Key1"] = new[] { "Value1" }
-            });
+                new Dictionary<string, IEnumerable<string>>
+                {
+                    ["Key2"] = new[] { "Value2" },
+                    ["Key1"] = new[] { "Value1" }
+                });
 
         // Act
-        Action act = () => dictionary.Should().BeEquivalentTo(new Dictionary<string, IEnumerable<string>>()
+        Action act = () => dictionary.Should().BeEquivalentTo(new Dictionary<string, IEnumerable<string>>
         {
             ["Key1"] = new[] { "Value1" },
             ["Key2"] = new[] { "Value2" }
@@ -343,14 +343,14 @@ public class DictionarySpecs
         // Arrange
         IReadOnlyDictionary<string, IEnumerable<string>> dictionary =
             new ReadOnlyDictionary<string, IEnumerable<string>>(
-            new Dictionary<string, IEnumerable<string>>()
-            {
-                ["Key2"] = new[] { "Value2" },
-                ["Key1"] = new[] { "Value1" }
-            });
+                new Dictionary<string, IEnumerable<string>>
+                {
+                    ["Key2"] = new[] { "Value2" },
+                    ["Key1"] = new[] { "Value1" }
+                });
 
         // Act
-        Action act = () => dictionary.Should().BeEquivalentTo(new Dictionary<string, IEnumerable<string>>()
+        Action act = () => dictionary.Should().BeEquivalentTo(new Dictionary<string, IEnumerable<string>>
         {
             ["Key2"] = new[] { "Value3" },
             ["Key1"] = new[] { "Value1" }
@@ -365,7 +365,7 @@ public class DictionarySpecs
     {
         // Arrange
         Dictionary<int, int> subject = null;
-        Dictionary<int, int> expectation = new Dictionary<int, int>();
+        Dictionary<int, int> expectation = new();
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, "because we do expect a valid dictionary");
@@ -393,8 +393,9 @@ public class DictionarySpecs
     public void When_a_dictionary_is_compared_to_a_dictionary_it_should_allow_chaining()
     {
         // Arrange
-        Dictionary<int, int> subject = new Dictionary<int, int> { [42] = 1337 };
-        Dictionary<int, int> expectation = new Dictionary<int, int> { [42] = 1337 };
+        Dictionary<int, int> subject = new() { [42] = 1337 };
+
+        Dictionary<int, int> expectation = new() { [42] = 1337 };
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation)
@@ -408,8 +409,9 @@ public class DictionarySpecs
     public void When_a_dictionary_is_compared_to_a_dictionary_with_a_config_it_should_allow_chaining()
     {
         // Arrange
-        Dictionary<int, int> subject = new Dictionary<int, int> { [42] = 1337 };
-        Dictionary<int, int> expectation = new Dictionary<int, int> { [42] = 1337 };
+        Dictionary<int, int> subject = new() { [42] = 1337 };
+
+        Dictionary<int, int> expectation = new() { [42] = 1337 };
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt)
@@ -455,7 +457,7 @@ public class DictionarySpecs
         var collection = new List<KeyValuePair<string, int>> { new("hi", 1) };
 
         // Act / Assert
-        Action act = () => collection.Should().BeEquivalentTo(new Dictionary<string, int>()
+        Action act = () => collection.Should().BeEquivalentTo(new Dictionary<string, int>
         {
             { "hi", 2 }
         });
@@ -575,7 +577,7 @@ public class DictionarySpecs
     public void When_asserting_equivalence_of_dictionaries_it_should_respect_the_declared_type()
     {
         // Arrange
-        var actual = new Dictionary<int, CustomerType> { [0] = new CustomerType("123") };
+        var actual = new Dictionary<int, CustomerType> { [0] = new("123") };
         var expectation = new Dictionary<int, CustomerType> { [0] = new DerivedCustomerType("123") };
 
         // Act
@@ -605,7 +607,7 @@ public class DictionarySpecs
         When_asserting_equivalence_of_generic_dictionaries_and_configured_to_use_runtime_properties_it_should_respect_the_runtime_type()
     {
         // Arrange
-        var actual = new Dictionary<int, CustomerType> { [0] = new CustomerType("123") };
+        var actual = new Dictionary<int, CustomerType> { [0] = new("123") };
         var expectation = new Dictionary<int, CustomerType> { [0] = new DerivedCustomerType("123") };
 
         // Act
@@ -662,7 +664,8 @@ public class DictionarySpecs
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Expected actual to be a dictionary or collection of key-value pairs that is keyed to type System.String*");
+            .WithMessage(
+                "Expected actual to be a dictionary or collection of key-value pairs that is keyed to type System.String*");
     }
 
     [Fact]
@@ -709,7 +712,7 @@ public class DictionarySpecs
             [0] = new DerivedCustomerType("123")
         };
 
-        var expectation = new Dictionary<int, CustomerType> { [0] = new CustomerType("123") };
+        var expectation = new Dictionary<int, CustomerType> { [0] = new("123") };
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation);
@@ -812,7 +815,8 @@ public class DictionarySpecs
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Expected property subject.Customers to be a dictionary or collection of key-value pairs that is keyed to type System.String*");
+            .WithMessage(
+                "Expected property subject.Customers to be a dictionary or collection of key-value pairs that is keyed to type System.String*");
     }
 
     [Fact]
@@ -849,6 +853,7 @@ public class DictionarySpecs
         {
             ["greeting"] = "hello"
         };
+
         var dictionary2 = new Dictionary<string, string>
         {
             ["greeting"] = "hello",
@@ -864,7 +869,8 @@ public class DictionarySpecs
     }
 
     [Fact]
-    public void When_subject_dictionary_with_class_keys_asserted_to_be_equivalent_have_less_elements_other_dictionary_derived_class_keys_fails_describing_missing_keys()
+    public void
+        When_subject_dictionary_with_class_keys_asserted_to_be_equivalent_have_less_elements_other_dictionary_derived_class_keys_fails_describing_missing_keys()
     {
         // Arrange
         var dictionary1 = new Dictionary<SomeBaseKeyClass, string>
@@ -894,6 +900,7 @@ public class DictionarySpecs
         {
             ["greeting"] = "hello"
         };
+
         var subject = new Dictionary<string, string>
         {
             ["greeting"] = "hello",
@@ -905,11 +912,13 @@ public class DictionarySpecs
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Expected subject*to be a dictionary with 1 item(s) because we expect one pair, but*additional key(s) {\"farewell\"}*");
+            .WithMessage(
+                "Expected subject*to be a dictionary with 1 item(s) because we expect one pair, but*additional key(s) {\"farewell\"}*");
     }
 
     [Fact]
-    public void When_subject_dictionary_with_class_keys_asserted_to_be_equivalent_and_other_dictionary_derived_class_keys_fails_because_of_types_incompatibility()
+    public void
+        When_subject_dictionary_with_class_keys_asserted_to_be_equivalent_and_other_dictionary_derived_class_keys_fails_because_of_types_incompatibility()
     {
         // Arrange
         var dictionary1 = new Dictionary<SomeBaseKeyClass, string>
@@ -928,17 +937,20 @@ public class DictionarySpecs
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Expected dictionary2 to be a dictionary or collection of key-value pairs that is keyed to type FluentAssertions.Equivalency.Specs.DictionarySpecs+SomeBaseKeyClass.*");
+            .WithMessage(
+                "Expected dictionary2 to be a dictionary or collection of key-value pairs that is keyed to type FluentAssertions.Equivalency.Specs.DictionarySpecs+SomeBaseKeyClass.*");
     }
 
     [Fact]
-    public void When_subject_dictionary_asserted_to_be_equivalent_have_less_elements_but_some_missing_and_some_additional_elements_fails_describing_missing_and_additional_keys()
+    public void
+        When_subject_dictionary_asserted_to_be_equivalent_have_less_elements_but_some_missing_and_some_additional_elements_fails_describing_missing_and_additional_keys()
     {
         // Arrange
         var dictionary1 = new Dictionary<string, string>
         {
             ["GREETING"] = "hello"
         };
+
         var dictionary2 = new Dictionary<string, string>
         {
             ["greeting"] = "hello",
@@ -950,17 +962,20 @@ public class DictionarySpecs
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Expected*to be a dictionary with 2 item(s), but*misses key(s)*{\"greeting\", \"farewell\"}*additional key(s) {\"GREETING\"}*");
+            .WithMessage(
+                "Expected*to be a dictionary with 2 item(s), but*misses key(s)*{\"greeting\", \"farewell\"}*additional key(s) {\"GREETING\"}*");
     }
 
     [Fact]
-    public void When_subject_dictionary_asserted_to_be_equivalent_have_more_elements_but_some_missing_and_some_additional_elements_fails_describing_missing_and_additional_keys()
+    public void
+        When_subject_dictionary_asserted_to_be_equivalent_have_more_elements_but_some_missing_and_some_additional_elements_fails_describing_missing_and_additional_keys()
     {
         // Arrange
         var dictionary1 = new Dictionary<string, string>
         {
             ["GREETING"] = "hello"
         };
+
         var dictionary2 = new Dictionary<string, string>
         {
             ["greeting"] = "hello",
@@ -972,7 +987,8 @@ public class DictionarySpecs
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Expected*to be a dictionary with 1 item(s), but*misses key(s) {\"GREETING\"}*additional key(s) {\"greeting\", \"farewell\"}*");
+            .WithMessage(
+                "Expected*to be a dictionary with 1 item(s), but*misses key(s) {\"GREETING\"}*additional key(s) {\"greeting\", \"farewell\"}*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/EnumSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/EnumSpecs.cs
@@ -100,7 +100,9 @@ public class EnumSpecs
     {
         // Arrange
         var subject = new ClassWithEnumOne { Enum = EnumOne.Two };
-        var expectation = new ClassWithEnumThree() { Enum = EnumThree.Two };
+
+        var expectation = new ClassWithEnumThree
+            { Enum = EnumThree.Two };
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, config => config.ComparingEnumsByName());

--- a/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
@@ -143,13 +143,14 @@ public class ExtensibilitySpecs
         public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions options)
         {
             string name = expectedMember.Name;
+
             if (name.EndsWith("Id", StringComparison.Ordinal))
             {
                 name = name.Replace("Id", "");
             }
 
             PropertyInfo runtimeProperty = subject.GetType().GetRuntimeProperty(name);
-            return (runtimeProperty is not null) ? new Property(runtimeProperty, parent) : null;
+            return runtimeProperty is not null ? new Property(runtimeProperty, parent) : null;
         }
     }
 
@@ -321,7 +322,7 @@ public class ExtensibilitySpecs
         act.Should().Throw<XunitException>()
             .Which.Message.Should()
             .Contain("Expected property subject.Id to be <null>, but found \"foo\"")
-                .And.NotContain("from expectation");
+            .And.NotContain("from expectation");
     }
 
     [Fact]
@@ -348,7 +349,7 @@ public class ExtensibilitySpecs
         act.Should().Throw<XunitException>()
             .Which.Message.Should()
             .Contain("Expected property subject.Id to be \"bar\", but found <null>")
-                .And.NotContain("from subject");
+            .And.NotContain("from subject");
     }
 
     [Fact]
@@ -407,7 +408,7 @@ public class ExtensibilitySpecs
 
         var expectation = new
         {
-            Date = 14.July(2012).At(13, 0, 0)
+            Date = 14.July(2012).At(13, 0)
         };
 
         // Act
@@ -434,10 +435,10 @@ public class ExtensibilitySpecs
 
         var expectation = new
         {
-            Date = 21.July(2012).At(11, 9, 0),
+            Date = 21.July(2012).At(11, 9),
             Nested = new
             {
-                NestedDate = 14.July(2012).At(13, 0, 0)
+                NestedDate = 14.July(2012).At(13, 0)
             }
         };
 
@@ -624,7 +625,8 @@ public class ExtensibilitySpecs
 
     private class AlwaysFailOnDateTimesEquivalencyStep : IEquivalencyStep
     {
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+            IEquivalencyValidator nestedValidator)
         {
             if (comparands.Expectation is DateTime)
             {
@@ -637,7 +639,8 @@ public class ExtensibilitySpecs
 
     private class RelaxingDateTimeEquivalencyStep : IEquivalencyStep
     {
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+            IEquivalencyValidator nestedValidator)
         {
             if (comparands.Expectation is DateTime time)
             {
@@ -690,7 +693,8 @@ public class ExtensibilitySpecs
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, options => options
-            .Using<ClassWithSomeFieldsAndProperties>(ctx => ctx.Subject.Should().BeEquivalentTo(ctx.Expectation, nestedOptions => nestedOptions.Excluding(x => x.Property2)))
+            .Using<ClassWithSomeFieldsAndProperties>(ctx =>
+                ctx.Subject.Should().BeEquivalentTo(ctx.Expectation, nestedOptions => nestedOptions.Excluding(x => x.Property2)))
             .WhenTypeIs<ClassWithSomeFieldsAndProperties>());
 
         // Assert
@@ -806,7 +810,8 @@ public class ExtensibilitySpecs
     private class ThrowExceptionEquivalencyStep<TException> : IEquivalencyStep
         where TException : Exception, new()
     {
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+            IEquivalencyValidator nestedValidator)
         {
             throw new TException();
         }
@@ -814,7 +819,8 @@ public class ExtensibilitySpecs
 
     private class AlwaysHandleEquivalencyStep : IEquivalencyStep
     {
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+            IEquivalencyValidator nestedValidator)
         {
             return EquivalencyResult.AssertionCompleted;
         }
@@ -822,7 +828,8 @@ public class ExtensibilitySpecs
 
     private class NeverHandleEquivalencyStep : IEquivalencyStep
     {
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+            IEquivalencyValidator nestedValidator)
         {
             return EquivalencyResult.ContinueWithNext;
         }
@@ -830,7 +837,8 @@ public class ExtensibilitySpecs
 
     private class EqualityEquivalencyStep : IEquivalencyStep
     {
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+            IEquivalencyValidator nestedValidator)
         {
             comparands.Subject.Should().Be(comparands.Expectation, context.Reason.FormattedMessage, context.Reason.Arguments);
             return EquivalencyResult.AssertionCompleted;
@@ -846,7 +854,8 @@ public class ExtensibilitySpecs
             this.doAction = doAction;
         }
 
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+            IEquivalencyValidator nestedValidator)
         {
             doAction();
             return EquivalencyResult.AssertionCompleted;

--- a/Tests/FluentAssertions.Equivalency.Specs/MemberConversionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/MemberConversionSpecs.cs
@@ -144,7 +144,7 @@ public class MemberConversionSpecs
     {
         // Arrange
         string str = "This is a test";
-        CustomConvertible obj = new CustomConvertible(str);
+        CustomConvertible obj = new(str);
 
         // Act
         Action act = () => obj.Should().BeEquivalentTo(str, options => options.WithAutoConversion());

--- a/Tests/FluentAssertions.Equivalency.Specs/MemberLessObjectsSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/MemberLessObjectsSpecs.cs
@@ -40,7 +40,7 @@ public class MemberLessObjectsSpecs
     public void When_asserting_instance_of_object_is_equivalent_to_null_it_should_fail_with_a_descriptive_message()
     {
         // Arrange
-        object actual = new object();
+        object actual = new();
         object expected = null;
 
         // Act
@@ -56,7 +56,7 @@ public class MemberLessObjectsSpecs
     {
         // Arrange
         object actual = null;
-        object expected = new object();
+        object expected = new();
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -213,7 +213,7 @@ public class SelectionRulesSpecs
             // Arrange
             var sut = new List<BaseClassPointingToClassWithoutProperties>
             {
-                new BaseClassPointingToClassWithoutProperties
+                new()
                 {
                     Name = "theName"
                 }
@@ -233,7 +233,7 @@ public class SelectionRulesSpecs
         {
             public string Name { get; set; }
 
-            public ClassWithoutProperty ClassWithoutProperty { get; } = new ClassWithoutProperty();
+            public ClassWithoutProperty ClassWithoutProperty { get; } = new();
         }
 
         internal class ClassWithoutProperty
@@ -404,11 +404,11 @@ public class SelectionRulesSpecs
             // Arrange
             var list1 = new List<CustomType>
             {
-                new CustomType
+                new()
                 {
                     Name = "A"
                 },
-                new CustomType
+                new()
                 {
                     Name = "B"
                 }
@@ -416,11 +416,11 @@ public class SelectionRulesSpecs
 
             var list2 = new List<CustomType>
             {
-                new CustomType
+                new()
                 {
                     Name = "C"
                 },
-                new CustomType
+                new()
                 {
                     Name = "D"
                 }
@@ -793,8 +793,8 @@ public class SelectionRulesSpecs
             // Act
             Action act = () => subject.Should().BeEquivalentTo(expected, config =>
                 config.Excluding(ctx => ctx.WhichGetterHas(CSharpAccessModifier.Internal) ||
-                                        ctx.WhichGetterHas(CSharpAccessModifier.ProtectedInternal) ||
-                                        ctx.WhichGetterHas(CSharpAccessModifier.PrivateProtected)));
+                    ctx.WhichGetterHas(CSharpAccessModifier.ProtectedInternal) ||
+                    ctx.WhichGetterHas(CSharpAccessModifier.PrivateProtected)));
 
             // Assert
             act.Should().NotThrow();
@@ -813,9 +813,9 @@ public class SelectionRulesSpecs
             // Act
             Action act = () => subject.Should().BeEquivalentTo(expected, config =>
                 config.Excluding(ctx => ctx.WhichSetterHas(CSharpAccessModifier.Internal) ||
-                                        ctx.WhichSetterHas(CSharpAccessModifier.ProtectedInternal) ||
-                                        ctx.WhichSetterHas(CSharpAccessModifier.Private) ||
-                                        ctx.WhichSetterHas(CSharpAccessModifier.PrivateProtected)));
+                    ctx.WhichSetterHas(CSharpAccessModifier.ProtectedInternal) ||
+                    ctx.WhichSetterHas(CSharpAccessModifier.Private) ||
+                    ctx.WhichSetterHas(CSharpAccessModifier.PrivateProtected)));
 
             // Assert
             act.Should().NotThrow();
@@ -872,11 +872,11 @@ public class SelectionRulesSpecs
                 }.ToList(),
                 Dictionary = new Dictionary<string, ClassWithOnlyAProperty>
                 {
-                    ["Foo"] = new ClassWithOnlyAProperty
+                    ["Foo"] = new()
                     {
                         Value = 1
                     },
-                    ["Bar"] = new ClassWithOnlyAProperty
+                    ["Bar"] = new()
                     {
                         Value = 2
                     }
@@ -900,11 +900,11 @@ public class SelectionRulesSpecs
                 }.ToList(),
                 Dictionary = new Dictionary<string, ClassWithOnlyAProperty>
                 {
-                    ["Foo"] = new ClassWithOnlyAProperty
+                    ["Foo"] = new()
                     {
                         Value = 1
                     },
-                    ["Bar"] = new ClassWithOnlyAProperty
+                    ["Bar"] = new()
                     {
                         Value = 3
                     }
@@ -943,11 +943,11 @@ public class SelectionRulesSpecs
                 }.ToList(),
                 Dictionary = new Dictionary<string, ClassWithOnlyAProperty>
                 {
-                    ["Foo"] = new ClassWithOnlyAProperty
+                    ["Foo"] = new()
                     {
                         Value = 1
                     },
-                    ["Bar"] = new ClassWithOnlyAProperty
+                    ["Bar"] = new()
                     {
                         Value = 2
                     }
@@ -971,11 +971,11 @@ public class SelectionRulesSpecs
                 }.ToList(),
                 Dictionary = new Dictionary<string, ClassWithOnlyAProperty>
                 {
-                    ["Foo"] = new ClassWithOnlyAProperty
+                    ["Foo"] = new()
                     {
                         Value = 6
                     },
-                    ["Bar"] = new ClassWithOnlyAProperty
+                    ["Bar"] = new()
                     {
                         Value = 3
                     }

--- a/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
@@ -1,6 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+// ReSharper disable NotAccessedField.Global
+// ReSharper disable NotAccessedField.Local
+// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
+// ReSharper disable UnusedMember.Global
+// ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 #pragma warning disable SA1649
 
 namespace FluentAssertions.Equivalency.Specs;
@@ -22,7 +27,7 @@ public enum EnumLong : long
 
 public class ClassOne
 {
-    public ClassTwo RefOne { get; set; } = new ClassTwo();
+    public ClassTwo RefOne { get; set; } = new();
 
     public int ValOne { get; set; } = 1;
 }
@@ -182,11 +187,15 @@ internal class ClassWithSomeFieldsAndProperties
 
 internal class ClassWithCctor
 {
-    static ClassWithCctor() { }
+    // ReSharper disable once EmptyConstructor
+    static ClassWithCctor()
+    {
+    }
 }
 
 internal class ClassWithCctorAndNonDefaultConstructor
 {
+    // ReSharper disable once EmptyConstructor
     static ClassWithCctorAndNonDefaultConstructor() { }
 
     public ClassWithCctorAndNonDefaultConstructor(int _) { }
@@ -267,11 +276,11 @@ public class CustomerType
         Code = code;
     }
 
-    public string Code { get; private set; }
+    public string Code { get; }
 
     public override bool Equals(object obj)
     {
-        return (obj is CustomerType other) && Code == other.Code;
+        return obj is CustomerType other && Code == other.Code;
     }
 
     public override int GetHashCode()
@@ -286,7 +295,7 @@ public class CustomerType
             return true;
         }
 
-        if ((a is null) || (b is null))
+        if (a is null || b is null)
         {
             return false;
         }

--- a/Tests/FluentAssertions.Equivalency.Specs/TupleSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TupleSpecs.cs
@@ -24,8 +24,8 @@ public class TupleSpecs
     public void When_a_tuple_is_compared_it_should_compare_its_components()
     {
         // Arrange
-        var actual = new Tuple<string, bool, int[]>("Hello", true, new int[] { 3, 2, 1 });
-        var expected = new Tuple<string, bool, int[]>("Hello", true, new int[] { 1, 2, 3 });
+        var actual = new Tuple<string, bool, int[]>("Hello", true, new[] { 3, 2, 1 });
+        var expected = new Tuple<string, bool, int[]>("Hello", true, new[] { 1, 2, 3 });
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);

--- a/Tests/FluentAssertions.Equivalency.Specs/TypedDataSetSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TypedDataSetSpecs.cs
@@ -237,6 +237,7 @@ public class TypedDataSetSpecs : DataSpecs
 
         // Act & Assert
         IEnumerable<string> excludedTables = new[] { "TypedDataTable1" };
+
         dataSet1.Should().BeEquivalentTo(dataSet2,
             config => config.Excluding(dataSet => dataSet.HasErrors).ExcludingTables(excludedTables));
     }
@@ -346,7 +347,7 @@ public class TypedDataSetSpecs : DataSpecs
         var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
         dataSet2.RemotingFormat =
-            (dataSet2.RemotingFormat == SerializationFormat.Binary)
+            dataSet2.RemotingFormat == SerializationFormat.Binary
                 ? SerializationFormat.Xml
                 : SerializationFormat.Binary;
 
@@ -366,14 +367,14 @@ public class TypedDataSetSpecs : DataSpecs
         var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
         dataSet2.RemotingFormat =
-            (dataSet2.RemotingFormat == SerializationFormat.Binary)
+            dataSet2.RemotingFormat == SerializationFormat.Binary
                 ? SerializationFormat.Xml
                 : SerializationFormat.Binary;
 
         // Act & Assert
         dataSet1.Should().BeEquivalentTo(dataSet2, options => options
             .Excluding(dataSet => dataSet.RemotingFormat)
-            .ExcludingRelated((DataTable dataTable) => dataTable.RemotingFormat));
+            .ExcludingRelated(dataTable => dataTable.RemotingFormat));
     }
 
     [Fact]
@@ -385,7 +386,7 @@ public class TypedDataSetSpecs : DataSpecs
         var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
         dataSet2.SchemaSerializationMode =
-            (dataSet2.SchemaSerializationMode == SchemaSerializationMode.ExcludeSchema)
+            dataSet2.SchemaSerializationMode == SchemaSerializationMode.ExcludeSchema
                 ? SchemaSerializationMode.IncludeSchema
                 : SchemaSerializationMode.ExcludeSchema;
 
@@ -405,7 +406,7 @@ public class TypedDataSetSpecs : DataSpecs
         var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
         dataSet2.SchemaSerializationMode =
-            (dataSet2.SchemaSerializationMode == SchemaSerializationMode.ExcludeSchema)
+            dataSet2.SchemaSerializationMode == SchemaSerializationMode.ExcludeSchema
                 ? SchemaSerializationMode.IncludeSchema
                 : SchemaSerializationMode.ExcludeSchema;
 
@@ -506,8 +507,8 @@ public class TypedDataSetSpecs : DataSpecs
         // Act & Assert
         dataSet1.Should().BeEquivalentTo(dataSet2, options => options
             .Excluding(dataSet => dataSet.Relations)
-            .ExcludingRelated((DataTable dataTable) => dataTable.ParentRelations)
-            .ExcludingRelated((DataTable dataTable) => dataTable.ChildRelations));
+            .ExcludingRelated(dataTable => dataTable.ParentRelations)
+            .ExcludingRelated(dataTable => dataTable.ChildRelations));
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/TypedDataTableSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TypedDataTableSpecs.cs
@@ -157,9 +157,9 @@ public class TypedDataTableSpecs : DataSpecs
         dataTable1.Should().BeEquivalentTo(
             dataTable2,
             options => options
-            .Excluding(dataTable => dataTable.TableName)
-            .ExcludingRelated((DataColumn dataColumn) => dataColumn.Table)
-            .ExcludingRelated((Constraint constraint) => constraint.Table));
+                .Excluding(dataTable => dataTable.TableName)
+                .ExcludingRelated((DataColumn dataColumn) => dataColumn.Table)
+                .ExcludingRelated((Constraint constraint) => constraint.Table));
     }
 
     [Fact]
@@ -397,9 +397,9 @@ public class TypedDataTableSpecs : DataSpecs
         var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
         dataSet2.RemotingFormat =
-            (dataSet2.RemotingFormat == SerializationFormat.Binary)
-            ? SerializationFormat.Xml
-            : SerializationFormat.Binary;
+            dataSet2.RemotingFormat == SerializationFormat.Binary
+                ? SerializationFormat.Xml
+                : SerializationFormat.Binary;
 
         var dataTable1 = dataSet1.TypedDataTable1;
         var dataTable2 = dataSet2.TypedDataTable1;
@@ -420,9 +420,9 @@ public class TypedDataTableSpecs : DataSpecs
         var dataSet2 = new TypedDataSetSubclass(dataSet1);
 
         dataSet2.RemotingFormat =
-            (dataSet2.RemotingFormat == SerializationFormat.Binary)
-            ? SerializationFormat.Xml
-            : SerializationFormat.Binary;
+            dataSet2.RemotingFormat == SerializationFormat.Binary
+                ? SerializationFormat.Xml
+                : SerializationFormat.Binary;
 
         var dataTable1 = dataSet1.TypedDataTable1;
         var dataTable2 = dataSet2.TypedDataTable1;
@@ -597,7 +597,7 @@ public class TypedDataTableSpecs : DataSpecs
         // Act & Assert
         dataTable1.Should().BeEquivalentTo(dataTable2, options => options
             .Excluding(dataTable => dataTable.Constraints)
-            .ExcludingRelated((DataColumn dataColumn) => dataColumn.Unique));
+            .ExcludingRelated(dataColumn => dataColumn.Unique));
     }
 
     [Theory]

--- a/Tests/FluentAssertions.Equivalency.Specs/XmlSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/XmlSpecs.cs
@@ -8,7 +8,8 @@ namespace FluentAssertions.Equivalency.Specs;
 public class XmlSpecs
 {
     [Fact]
-    public void When_asserting_a_xml_selfclosing_document_is_equivalent_to_a_different_xml_document_with_same_structure_it_should_succeed()
+    public void
+        When_asserting_a_xml_selfclosing_document_is_equivalent_to_a_different_xml_document_with_same_structure_it_should_succeed()
     {
         // Arrange
         var subject = new
@@ -125,6 +126,6 @@ public class XmlSpecs
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
-            $"Expected property subject.Attribute to be name2=\"value\" because we want to test the failure message, but found name=\"value\"*");
+            "Expected property subject.Attribute to be name2=\"value\" because we want to test the failure message, but found name=\"value\"*");
     }
 }

--- a/Tests/FluentAssertions.Specs/AssertionExtensions.cs
+++ b/Tests/FluentAssertions.Specs/AssertionExtensions.cs
@@ -35,7 +35,6 @@ internal static class AssertionExtensions
     }
 
 #if NET6_0_OR_GREATER
-
     public static TaskCompletionSourceAssertions Should(this TaskCompletionSource tcs, IClock clock)
     {
         return new TaskCompletionSourceAssertions(tcs, clock);

--- a/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
@@ -33,6 +33,7 @@ public class AssertionExtensionsSpecs
     {
         MethodInfo equals = t.GetMethod("Equals", BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public,
             null, new[] { typeof(object) }, null);
+
         return equals is not null;
     }
 
@@ -151,8 +152,8 @@ public class AssertionExtensionsSpecs
 
         // Assert
         fakeOverloads.Should().BeEquivalentTo(realOverloads, opt => opt
-            .Using<Type>(ctx => ctx.Subject.Name.Should().Be(ctx.Expectation.Name))
-            .WhenTypeIs<Type>(),
+                .Using<Type>(ctx => ctx.Subject.Name.Should().Be(ctx.Expectation.Name))
+                .WhenTypeIs<Type>(),
             "AssertionExtensions.cs should have a guard overload of Should calling InvalidShouldCall()");
     }
 

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -16,8 +16,10 @@ public class AssertionOptionsSpecs
 {
     // Due to tests that call AssertionOptions
     [CollectionDefinition("AssertionOptionsSpecs", DisableParallelization = true)]
-    public class AssertionOptionsSpecsDefinition { }
-    
+    public class AssertionOptionsSpecsDefinition
+    {
+    }
+
     public abstract class Given_temporary_global_assertion_options : GivenWhenThen
     {
         protected override void Dispose(bool disposing)
@@ -52,6 +54,7 @@ public class AssertionOptionsSpecs
             When(() =>
             {
                 IEquivalencyAssertionOptions equivalencyAssertionOptions = new EquivalencyAssertionOptions();
+
                 return () => Parallel.For(0, 10_000, new ParallelOptions { MaxDegreeOfParallelism = 8 },
                     _ => equivalencyAssertionOptions.GetEqualityStrategy(typeof(IEnumerable))
                 );
@@ -116,7 +119,9 @@ public class AssertionOptionsSpecs
         [Fact]
         public void It_should_try_to_compare_the_classes_by_value_semantics_and_thus_throw()
         {
-            Action act = () => new MyClass { Value = 1 }.Should().BeEquivalentTo(new MyClass { Value = 1 });
+            MyClass myClass = new() { Value = 1 };
+
+            Action act = () => myClass.Should().BeEquivalentTo(new MyClass { Value = 1 });
 
             act.Should().Throw<XunitException>();
         }
@@ -141,7 +146,7 @@ public class AssertionOptionsSpecs
         [Fact]
         public void It_should_use_the_global_settings_for_comparing_records()
         {
-            new Position(123).Should().BeEquivalentTo(new Position(123));    
+            new Position(123).Should().BeEquivalentTo(new Position(123));
         }
 
         private record Position
@@ -156,8 +161,7 @@ public class AssertionOptionsSpecs
     }
 
     [Collection("AssertionOptionsSpecs")]
-    public class When_assertion_doubles_should_always_allow_small_deviations :
-        Given_temporary_global_assertion_options
+    public class When_assertion_doubles_should_always_allow_small_deviations : Given_temporary_global_assertion_options
     {
         public When_assertion_doubles_should_always_allow_small_deviations()
         {

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
@@ -56,9 +56,8 @@ public partial class CollectionAssertionSpecs
             var collection = Enumerable.Empty<int>();
 
             // Act
-            Action act = ()
-                => collection.Should()
-                    .AllSatisfy(x => x.Should().Be(1), "because we want to test the failure {0}", "message");
+            Action act = () =>
+                collection.Should().AllSatisfy(x => x.Should().Be(1), "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should()
@@ -93,6 +92,7 @@ public partial class CollectionAssertionSpecs
                     customer =>
                     {
                         customer.Age.Should().BeLessThan(21);
+
                         customer.Items.Should()
                             .AllSatisfy(item => item.Should().Be(3));
                     },
@@ -113,7 +113,7 @@ public partial class CollectionAssertionSpecs
 *Expected item to be 3, but found 2
 *At index 1:
 *Expected customer.Age to be less than 21, but found 22 (difference of 1)"
-                    );
+                );
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -194,7 +194,7 @@ public partial class CollectionAssertionSpecs
 
         public void Reset() { }
 
-        public object Current => new object();
+        public object Current => new();
 
         object IEnumerator.Current => Current;
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
@@ -129,7 +129,8 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act =
-                () => collection.Should().BeEquivalentTo(collection1, "because we want to test the behaviour with a null subject");
+                () => collection.Should()
+                    .BeEquivalentTo(collection1, "because we want to test the behaviour with a null subject");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -286,8 +287,8 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () => collection.Should().NotBeEquivalentTo(collection1, opt => opt
-                .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.5))
-                .WhenTypeIs<double>(),
+                    .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.5))
+                    .WhenTypeIs<double>(),
                 "because we want to test the failure {0}", "message");
 
             // Assert
@@ -300,7 +301,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             int[] actual = null;
-            int[] expectation = new[] { 1, 2, 3 };
+            int[] expectation = { 1, 2, 3 };
 
             // Act
             Action act = () =>

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
@@ -44,7 +44,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_succeed()
+        public void
+            When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_succeed()
         {
             // Arrange
             var collection = new[] { 1, 2, 2, 3 };
@@ -69,7 +70,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_throw()
+        public void
+            When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_throw()
         {
             // Arrange
             var collection = new[] { 1, 6, 12, 15, 12, 17, 26 };
@@ -126,7 +128,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_single_element_collection_with_no_parameters_ordered_in_ascending_it_should_succeed()
         {
             // Arrange
-            var collection = new int[] { 42 };
+            var collection = new[] { 42 };
 
             // Act
             Action act = () => collection.Should().BeInAscendingOrder();
@@ -141,7 +143,7 @@ public partial class CollectionAssertionSpecs
             // Arrange
             var collection = new SomeClass[]
             {
-            new SomeClass { Text = "a", Number = 1 }
+                new() { Text = "a", Number = 1 }
             };
 
             // Act
@@ -152,7 +154,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_specified_property_it_should_throw()
+        public void
+            When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_specified_property_it_should_throw()
         {
             // Arrange
             var collection = new[]
@@ -171,7 +174,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_throw()
+        public void
+            When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_throw()
         {
             // Arrange
             var collection = new[]
@@ -182,7 +186,8 @@ public partial class CollectionAssertionSpecs
             };
 
             // Act
-            Action act = () => collection.Should().BeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should be sorted");
+            Action act = () =>
+                collection.Should().BeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should be sorted");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -190,7 +195,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_specified_property_it_should_succeed()
+        public void
+            When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_specified_property_it_should_succeed()
         {
             // Arrange
             var collection = new[]
@@ -208,7 +214,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
+        public void
+            When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
         {
             // Arrange
             var collection = new[]
@@ -301,7 +308,8 @@ public partial class CollectionAssertionSpecs
             string[] strings = { "dennis", "roy", "thomas" };
 
             // Act
-            Action act = () => strings.Should().BeInAscendingOrder((sut, exp) => sut.Last().CompareTo(exp.Last()), "of {0}", "reasons");
+            Action act = () =>
+                strings.Should().BeInAscendingOrder((sut, exp) => sut.Last().CompareTo(exp.Last()), "of {0}", "reasons");
 
             // Assert
             act.Should()
@@ -338,7 +346,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_a_null_collection_are_ordered_using_the_specified_property_and_the_given_comparer_it_should_throw()
+        public void
+            When_asserting_the_items_in_a_null_collection_are_ordered_using_the_specified_property_and_the_given_comparer_it_should_throw()
         {
             // Arrange
             const IEnumerable<SomeClass> collection = null;
@@ -423,7 +432,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_succeed()
+        public void
+            When_asserting_the_items_in_an_unordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_succeed()
         {
             // Arrange
             var collection = new[] { 1, 5, 3 };
@@ -448,13 +458,15 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_throw()
+        public void
+            When_asserting_the_items_in_an_ascendingly_ordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_throw()
         {
             // Arrange
             var collection = new[] { 1, 2, 2, 3 };
 
             // Act
-            Action action = () => collection.Should().NotBeInAscendingOrder(Comparer<int>.Default, "because numbers are not ordered");
+            Action action = () =>
+                collection.Should().NotBeInAscendingOrder(Comparer<int>.Default, "because numbers are not ordered");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -494,7 +506,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_single_element_collection_with_no_parameters_not_be_ordered_in_ascending_it_should_throw()
         {
             // Arrange
-            var collection = new int[] { 42 };
+            var collection = new[] { 42 };
 
             // Act
             Action act = () => collection.Should().NotBeInAscendingOrder();
@@ -505,12 +517,13 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_single_element_collection_by_property_expression_to_not_be_ordered_in_ascending_it_should_throw()
+        public void
+            When_asserting_single_element_collection_by_property_expression_to_not_be_ordered_in_ascending_it_should_throw()
         {
             // Arrange
             var collection = new SomeClass[]
             {
-            new SomeClass { Text = "a", Number = 1 }
+                new() { Text = "a", Number = 1 }
             };
 
             // Act
@@ -521,7 +534,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_a_ascending_ordered_collection_are_not_ordered_ascending_using_the_given_comparer_it_should_throw()
+        public void
+            When_asserting_the_items_in_a_ascending_ordered_collection_are_not_ordered_ascending_using_the_given_comparer_it_should_throw()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
@@ -535,7 +549,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_not_in_an_ascendingly_ordered_collection_are_not_ordered_ascending_using_the_given_comparer_it_should_succeed()
+        public void
+            When_asserting_the_items_not_in_an_ascendingly_ordered_collection_are_not_ordered_ascending_using_the_given_comparer_it_should_succeed()
         {
             // Arrange
             var collection = new[] { 3, 2, 1 };
@@ -548,7 +563,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_a_ascending_ordered_collection_are_not_ordered_ascending_using_the_specified_property_it_should_throw()
+        public void
+            When_asserting_the_items_in_a_ascending_ordered_collection_are_not_ordered_ascending_using_the_specified_property_it_should_throw()
         {
             // Arrange
             var collection = new[]
@@ -567,7 +583,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_ordered_collection_are_not_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_throw()
+        public void
+            When_asserting_the_items_in_an_ordered_collection_are_not_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_throw()
         {
             // Arrange
             var collection = new[]
@@ -578,7 +595,9 @@ public partial class CollectionAssertionSpecs
             };
 
             // Act
-            Action act = () => collection.Should().NotBeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should not be sorted");
+            Action act = () =>
+                collection.Should()
+                    .NotBeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should not be sorted");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -586,7 +605,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_not_in_an_ascendingly_ordered_collection_are_not_ordered_ascending_using_the_specified_property_it_should_succeed()
+        public void
+            When_asserting_the_items_not_in_an_ascendingly_ordered_collection_are_not_ordered_ascending_using_the_specified_property_it_should_succeed()
         {
             // Arrange
             var collection = new[]
@@ -604,7 +624,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_not_in_an_ascendingly_ordered_collection_are_not_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
+        public void
+            When_asserting_the_items_not_in_an_ascendingly_ordered_collection_are_not_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
         {
             // Arrange
             var collection = new[]
@@ -697,7 +718,8 @@ public partial class CollectionAssertionSpecs
             string[] strings = { "barbara", "dennis", "roy" };
 
             // Act
-            Action act = () => strings.Should().NotBeInAscendingOrder((sut, exp) => sut.Last().CompareTo(exp.Last()), "of {0}", "reasons");
+            Action act = () =>
+                strings.Should().NotBeInAscendingOrder((sut, exp) => sut.Last().CompareTo(exp.Last()), "of {0}", "reasons");
 
             // Assert
             act.Should()
@@ -742,7 +764,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_a_null_collection_are_not_ordered_using_the_specified_property_and_the_given_comparer_it_should_throw()
+        public void
+            When_asserting_the_items_in_a_null_collection_are_not_ordered_using_the_specified_property_and_the_given_comparer_it_should_throw()
         {
             // Arrange
             const IEnumerable<SomeClass> collection = null;
@@ -784,7 +807,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_ay_collection_are_not_ordered_using_an_invalid_property_expression_it_should_throw()
+        public void
+            When_asserting_the_items_in_ay_collection_are_not_ordered_using_an_invalid_property_expression_it_should_throw()
         {
             // Arrange
             var collection = Enumerable.Empty<SomeClass>();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInDescendingOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInDescendingOrder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -69,7 +68,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_single_element_collection_with_no_parameters_ordered_in_descending_it_should_succeed()
         {
             // Arrange
-            var collection = new int[] { 42 };
+            var collection = new[] { 42 };
 
             // Act
             Action act = () => collection.Should().BeInDescendingOrder();
@@ -84,7 +83,7 @@ public partial class CollectionAssertionSpecs
             // Arrange
             var collection = new SomeClass[]
             {
-            new SomeClass { Text = "a", Number = 1 }
+                new() { Text = "a", Number = 1 }
             };
 
             // Act
@@ -95,13 +94,15 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_using_the_given_comparer_it_should_throw()
+        public void
+            When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_using_the_given_comparer_it_should_throw()
         {
             // Arrange
             var collection = new[] { "z", "x", "y" };
 
             // Act
-            Action action = () => collection.Should().BeInDescendingOrder(Comparer<object>.Default, "because letters are ordered");
+            Action action = () =>
+                collection.Should().BeInDescendingOrder(Comparer<object>.Default, "because letters are ordered");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -110,7 +111,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_using_the_given_comparer_it_should_succeed()
+        public void
+            When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_using_the_given_comparer_it_should_succeed()
         {
             // Arrange
             var collection = new[] { "z", "y", "x" };
@@ -120,7 +122,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_using_the_specified_property_it_should_throw()
+        public void
+            When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_using_the_specified_property_it_should_throw()
         {
             // Arrange
             var collection = new[]
@@ -139,7 +142,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_using_the_specified_property_and_the_given_comparer_it_should_throw()
+        public void
+            When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_using_the_specified_property_and_the_given_comparer_it_should_throw()
         {
             // Arrange
             var collection = new[]
@@ -150,7 +154,8 @@ public partial class CollectionAssertionSpecs
             };
 
             // Act
-            Action act = () => collection.Should().BeInDescendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should be sorted");
+            Action act = () =>
+                collection.Should().BeInDescendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should be sorted");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -158,7 +163,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_using_the_specified_property_it_should_succeed()
+        public void
+            When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_using_the_specified_property_it_should_succeed()
         {
             // Arrange
             var collection = new[]
@@ -176,7 +182,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
+        public void
+            When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
         {
             // Arrange
             var collection = new[]
@@ -269,7 +276,8 @@ public partial class CollectionAssertionSpecs
             string[] strings = { "dennis", "roy", "barbara" };
 
             // Act
-            Action act = () => strings.Should().BeInDescendingOrder((sut, exp) => sut.Last().CompareTo(exp.Last()), "of {0}", "reasons");
+            Action act = () =>
+                strings.Should().BeInDescendingOrder((sut, exp) => sut.Last().CompareTo(exp.Last()), "of {0}", "reasons");
 
             // Assert
             act.Should()
@@ -291,7 +299,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_unordered_collection_are_not_in_descending_order_using_the_given_comparer_it_should_succeed()
+        public void
+            When_asserting_the_items_in_an_unordered_collection_are_not_in_descending_order_using_the_given_comparer_it_should_succeed()
         {
             // Arrange
             var collection = new[] { "x", "y", "x" };
@@ -316,13 +325,15 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_a_descending_ordered_collection_are_not_in_descending_order_using_the_given_comparer_it_should_throw()
+        public void
+            When_asserting_the_items_in_a_descending_ordered_collection_are_not_in_descending_order_using_the_given_comparer_it_should_throw()
         {
             // Arrange
             var collection = new[] { "c", "b", "a" };
 
             // Act
-            Action action = () => collection.Should().NotBeInDescendingOrder(Comparer<object>.Default, "because numbers are not ordered");
+            Action action = () =>
+                collection.Should().NotBeInDescendingOrder(Comparer<object>.Default, "because numbers are not ordered");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -362,7 +373,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_single_element_collection_with_no_parameters_not_be_ordered_in_descending_it_should_throw()
         {
             // Arrange
-            var collection = new int[] { 42 };
+            var collection = new[] { 42 };
 
             // Act
             Action act = () => collection.Should().NotBeInDescendingOrder();
@@ -373,12 +384,13 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_single_element_collection_by_property_expression_to_not_be_ordered_in_descending_it_should_throw()
+        public void
+            When_asserting_single_element_collection_by_property_expression_to_not_be_ordered_in_descending_it_should_throw()
         {
             // Arrange
             var collection = new SomeClass[]
             {
-            new SomeClass { Text = "a", Number = 1 }
+                new() { Text = "a", Number = 1 }
             };
 
             // Act
@@ -389,7 +401,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_a_descending_ordered_collection_are_not_ordered_descending_using_the_given_comparer_it_should_throw()
+        public void
+            When_asserting_the_items_in_a_descending_ordered_collection_are_not_ordered_descending_using_the_given_comparer_it_should_throw()
         {
             // Arrange
             var collection = new[] { 3, 2, 1 };
@@ -403,7 +416,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_not_in_an_descendingly_ordered_collection_are_not_ordered_descending_using_the_given_comparer_it_should_succeed()
+        public void
+            When_asserting_the_items_not_in_an_descendingly_ordered_collection_are_not_ordered_descending_using_the_given_comparer_it_should_succeed()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
@@ -416,7 +430,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_a_descending_ordered_collection_are_not_ordered_descending_using_the_specified_property_it_should_throw()
+        public void
+            When_asserting_the_items_in_a_descending_ordered_collection_are_not_ordered_descending_using_the_specified_property_it_should_throw()
         {
             // Arrange
             var collection = new[]
@@ -435,7 +450,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_in_an_ordered_collection_are_not_ordered_descending_using_the_specified_property_and_the_given_comparer_it_should_throw()
+        public void
+            When_asserting_the_items_in_an_ordered_collection_are_not_ordered_descending_using_the_specified_property_and_the_given_comparer_it_should_throw()
         {
             // Arrange
             var collection = new[]
@@ -446,7 +462,9 @@ public partial class CollectionAssertionSpecs
             };
 
             // Act
-            Action act = () => collection.Should().NotBeInDescendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should not be sorted");
+            Action act = () =>
+                collection.Should()
+                    .NotBeInDescendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should not be sorted");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -454,7 +472,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_not_in_an_descendingly_ordered_collection_are_not_ordered_descending_using_the_specified_property_it_should_succeed()
+        public void
+            When_asserting_the_items_not_in_an_descendingly_ordered_collection_are_not_ordered_descending_using_the_specified_property_it_should_succeed()
         {
             // Arrange
             var collection = new[]
@@ -472,7 +491,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_the_items_not_in_an_descendingly_ordered_collection_are_not_ordered_descending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
+        public void
+            When_asserting_the_items_not_in_an_descendingly_ordered_collection_are_not_ordered_descending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
         {
             // Arrange
             var collection = new[]
@@ -565,7 +585,8 @@ public partial class CollectionAssertionSpecs
             string[] strings = { "roy", "dennis", "barbara" };
 
             // Act
-            Action act = () => strings.Should().NotBeInDescendingOrder((sut, exp) => sut.Last().CompareTo(exp.Last()), "of {0}", "reasons");
+            Action act = () =>
+                strings.Should().NotBeInDescendingOrder((sut, exp) => sut.Last().CompareTo(exp.Last()), "of {0}", "reasons");
 
             // Assert
             act.Should()

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeSubsetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeSubsetOf.cs
@@ -36,7 +36,7 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected subset to be a subset of {1, 2, 4, 5} because we want to test the failure message, " +
-                    "but items {3, 6} are not part of the superset.");
+                "but items {3, 6} are not part of the superset.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
@@ -94,7 +94,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_a_collection_does_not_contain_other_collection_with_assertion_scope_it_should_throw_with_clear_explanation()
+        public void
+            When_a_collection_does_not_contain_other_collection_with_assertion_scope_it_should_throw_with_clear_explanation()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
@@ -461,7 +462,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_collection_doesnt_contain_values_according_to_predicate_but_collection_is_null_it_should_throw()
+        public void
+            When_asserting_collection_doesnt_contain_values_according_to_predicate_but_collection_is_null_it_should_throw()
         {
             // Arrange
             const IEnumerable<string> strings = null;

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainEquivalentOf.cs
@@ -49,25 +49,27 @@ public partial class CollectionAssertionSpecs
         public void When_string_collection_does_contain_same_string_with_other_case_it_should_throw()
         {
             // Arrange
-            string[] collection = new[] { "a", "b", "c" };
+            string[] collection = { "a", "b", "c" };
             string item = "C";
 
             // Act
             Action act = () => collection.Should().ContainEquivalentOf(item);
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection {\"a\", \"b\", \"c\"} to contain equivalent of \"C\".*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection {\"a\", \"b\", \"c\"} to contain equivalent of \"C\".*");
         }
 
         [Fact]
         public void When_string_collection_does_contain_same_string_it_should_throw_with_a_useful_message()
         {
             // Arrange
-            string[] collection = new[] { "a" };
+            string[] collection = { "a" };
             string item = "b";
 
             // Act
-            Action act = () => collection.Should().ContainEquivalentOf(item, "because we want to test the failure {0}", "message");
+            Action act = () =>
+                collection.Should().ContainEquivalentOf(item, "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -166,6 +168,7 @@ public partial class CollectionAssertionSpecs
                     Age = 18
                 }
             };
+
             var item = new Customer { Name = "John", Age = 20 };
 
             // Act
@@ -192,6 +195,7 @@ public partial class CollectionAssertionSpecs
                     Age = 18
                 }
             };
+
             var item = new Customer { Name = "John", Age = 20 };
 
             // Act / Assert
@@ -262,11 +266,13 @@ public partial class CollectionAssertionSpecs
             var collection = new[] { 0, 1 };
 
             // Act
-            Action act = () => collection.Should().NotContainEquivalentOf(item, "because we want to test the failure {0}", "message");
+            Action act = () =>
+                collection.Should().NotContainEquivalentOf(item, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection {0, 1} not to contain*because we want to test the failure message, " +
-                                                             "but found one at index 1.*With configuration*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {0, 1} not to contain*because we want to test the failure message, " +
+                "but found one at index 1.*With configuration*");
         }
 
         [Fact]
@@ -277,11 +283,13 @@ public partial class CollectionAssertionSpecs
             var collection = new[] { 0, 1, 1 };
 
             // Act
-            Action act = () => collection.Should().NotContainEquivalentOf(item, "because we want to test the failure {0}", "message");
+            Action act = () =>
+                collection.Should().NotContainEquivalentOf(item, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection {0, 1, 1} not to contain*because we want to test the failure message, " +
-                                                             "but found several at indices {1, 2}.*With configuration*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {0, 1, 1} not to contain*because we want to test the failure message, " +
+                "but found several at indices {1, 2}.*With configuration*");
         }
 
         [Fact]
@@ -370,6 +378,7 @@ public partial class CollectionAssertionSpecs
                     Age = 18
                 }
             };
+
             var item = new Customer { Name = "John", Age = 20 };
 
             // Act
@@ -399,7 +408,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected collection*not to contain*first message*but*.\n" +
-                                                             "Expected*4 item(s)*because*second message*but*.");
+                "Expected*4 item(s)*because*second message*but*.");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInConsecutiveOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInConsecutiveOrder.cs
@@ -33,7 +33,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_the_first_collection_contains_a_partial_duplicate_sequence_at_the_start_without_affecting_the_explicit_order_it_should_not_throw()
+        public void
+            When_the_first_collection_contains_a_partial_duplicate_sequence_at_the_start_without_affecting_the_explicit_order_it_should_not_throw()
         {
             // Arrange
             var collection = new[] { 1, 2, 1, 2, 3, 2 };
@@ -69,7 +70,7 @@ public partial class CollectionAssertionSpecs
             var collection = new object[] { 1, null, 2, "string" };
 
             // Act / Assert
-            collection.Should().ContainInConsecutiveOrder(new object[] { 1, null, 2, "string" });
+            collection.Should().ContainInConsecutiveOrder(1, null, 2, "string");
         }
 
         [Fact]
@@ -148,7 +149,7 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected collection {1, 2, 3} to contain items {4, 1} in order because we failed, " +
-                    "but 4 (index 0) did not appear (in the right consecutive order).");
+                "but 4 (index 0) did not appear (in the right consecutive order).");
         }
 
         [Fact]
@@ -172,7 +173,9 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().ContainInConsecutiveOrder(new[] { 4 }, "because we're checking how it reacts to a null subject");
+
+                collection.Should()
+                    .ContainInConsecutiveOrder(new[] { 4 }, "because we're checking how it reacts to a null subject");
             };
 
             // Assert
@@ -263,7 +266,8 @@ public partial class CollectionAssertionSpecs
             Action act = () => collection.Should().NotContainInConsecutiveOrder(4);
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Cannot verify absence of ordered containment in a <null> collection.");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Cannot verify absence of ordered containment in a <null> collection.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInOrder.cs
@@ -29,7 +29,7 @@ public partial class CollectionAssertionSpecs
             var collection = new object[] { 1, null, 2, "string" };
 
             // Act / Assert
-            collection.Should().ContainInOrder(new object[] { 1, null, "string" });
+            collection.Should().ContainInOrder(1, null, "string");
         }
 
         [Fact]
@@ -86,7 +86,7 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected collection {1, 2, 3} to contain items {4, 1} in order because we failed, " +
-                    "but 4 (index 0) did not appear (in the right order).");
+                "but 4 (index 0) did not appear (in the right order).");
         }
 
         [Fact]
@@ -119,14 +119,14 @@ public partial class CollectionAssertionSpecs
         public void Collections_contain_the_empty_sequence()
         {
             // Assert
-            new[] { 1 }.Should().ContainInOrder(new int[0]);
+            new[] { 1 }.Should().ContainInOrder();
         }
 
         [Fact]
         public void Collections_do_not_not_contain_the_empty_sequence()
         {
             // Assert
-            new[] { 1 }.Should().NotContainInOrder(new int[0]);
+            new[] { 1 }.Should().NotContainInOrder();
         }
 
         [Fact]
@@ -200,7 +200,8 @@ public partial class CollectionAssertionSpecs
             Action act = () => collection.Should().NotContainInOrder(4);
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Cannot verify absence of ordered containment in a <null> collection.");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Cannot verify absence of ordered containment in a <null> collection.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
@@ -28,10 +28,10 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             var collection = new List<object>
-        {
-            1,
-            "2"
-        };
+            {
+                1,
+                "2"
+            };
 
             // Act / Assert
             collection.Should().ContainItemsAssignableTo<string>();
@@ -65,7 +65,9 @@ public partial class CollectionAssertionSpecs
             Action act = () => collection.Should().ContainItemsAssignableTo<int>();
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected collection to contain at least one element assignable to type \"System.Int32\", but found {empty}.");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected collection to contain at least one element assignable to type \"System.Int32\", but found {empty}.");
         }
 
         [Fact]
@@ -76,7 +78,8 @@ public partial class CollectionAssertionSpecs
             Action act = () => collection.Should().ContainItemsAssignableTo<int>();
 
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain at least one element assignable to type \"System.Int32\", but found {System.String, System.Decimal}.");
+                .WithMessage(
+                    "Expected collection to contain at least one element assignable to type \"System.Int32\", but found {System.String, System.Decimal}.");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
@@ -53,7 +53,7 @@ public partial class CollectionAssertionSpecs
 
         // Assert
         string expectedMessage =
-            $"Expected collection to contain a single item matching (item == 2), but the collection is empty.";
+            "Expected collection to contain a single item matching (item == 2), but the collection is empty.";
 
         act.Should().Throw<XunitException>().WithMessage(expectedMessage);
     }
@@ -74,7 +74,7 @@ public partial class CollectionAssertionSpecs
 
         // Assert
         string expectedMessage =
-            $"Expected collection to contain a single item matching (item == 2), but found <null>.";
+            "Expected collection to contain a single item matching (item == 2), but found <null>.";
 
         act.Should().Throw<XunitException>().WithMessage(expectedMessage);
     }
@@ -91,7 +91,7 @@ public partial class CollectionAssertionSpecs
 
         // Assert
         string expectedMessage =
-            $"Expected collection to contain a single item matching (item == 2), but no such item was found.";
+            "Expected collection to contain a single item matching (item == 2), but no such item was found.";
 
         act.Should().Throw<XunitException>().WithMessage(expectedMessage);
     }
@@ -108,7 +108,7 @@ public partial class CollectionAssertionSpecs
 
         // Assert
         string expectedMessage =
-            $"Expected collection to contain a single item matching (item == 2), but 3 such items were found.";
+            "Expected collection to contain a single item matching (item == 2), but 3 such items were found.";
 
         act.Should().Throw<XunitException>().WithMessage(expectedMessage);
     }
@@ -178,7 +178,8 @@ public partial class CollectionAssertionSpecs
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Expected collection to contain a single item because more is not allowed, but the collection is empty.");
+            .WithMessage(
+                "Expected collection to contain a single item because more is not allowed, but the collection is empty.");
     }
 
     [Fact]
@@ -285,6 +286,6 @@ public partial class CollectionAssertionSpecs
         // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("Expected*to contain a single item, but the collection is empty*" +
-            "Expected*to contain a single item, but the collection is empty*");
+                "Expected*to contain a single item, but the collection is empty*");
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.EndWith.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.EndWith.cs
@@ -83,13 +83,15 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_collection_does_not_end_with_a_specific_element_in_a_sequence_using_custom_equality_comparison_it_should_throw()
+        public void
+            When_collection_does_not_end_with_a_specific_element_in_a_sequence_using_custom_equality_comparison_it_should_throw()
         {
             // Arrange
             var collection = new[] { "john", "bill", "jane", "mike" };
 
             // Act
-            Action act = () => collection.Should().EndWith(new[] { "bill", "ryan", "mike" }, (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "of some reason");
+            Action act = () => collection.Should().EndWith(new[] { "bill", "ryan", "mike" },
+                (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "of some reason");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -123,13 +125,15 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_collection_ends_with_the_specific_sequence_of_elements_using_custom_equality_comparison_it_should_not_throw()
+        public void
+            When_collection_ends_with_the_specific_sequence_of_elements_using_custom_equality_comparison_it_should_not_throw()
         {
             // Arrange
             var collection = new[] { "john", "bill", "jane", "mike" };
 
             // Act
-            Action act = () => collection.Should().EndWith(new[] { "JaNe", "mIkE" }, (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
+            Action act = () => collection.Should().EndWith(new[] { "JaNe", "mIkE" },
+                (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
 
             // Assert
             act.Should().NotThrow();
@@ -162,13 +166,15 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_collection_ends_with_the_specific_sequence_with_null_elements_using_custom_equality_comparison_it_should_not_throw()
+        public void
+            When_collection_ends_with_the_specific_sequence_with_null_elements_using_custom_equality_comparison_it_should_not_throw()
         {
             // Arrange
             var collection = new[] { "john", "bill", "jane", null, "mike", null };
 
             // Act
-            Action act = () => collection.Should().EndWith(new[] { "JaNe", null, "mIkE", null }, (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
+            Action act = () => collection.Should().EndWith(new[] { "JaNe", null, "mIkE", null },
+                (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Equal.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Equal.cs
@@ -77,7 +77,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_two_collections_are_not_equal_because_the_actual_collection_contains_more_items_it_should_throw_using_the_reason()
+        public void
+            When_two_collections_are_not_equal_because_the_actual_collection_contains_more_items_it_should_throw_using_the_reason()
         {
             // Arrange
             var collection1 = new[] { 1, 2, 3 };
@@ -92,7 +93,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_two_collections_are_not_equal_because_the_actual_collection_contains_less_items_it_should_throw_using_the_reason()
+        public void
+            When_two_collections_are_not_equal_because_the_actual_collection_contains_less_items_it_should_throw_using_the_reason()
         {
             // Arrange
             var collection1 = new[] { 1, 2, 3 };
@@ -129,7 +131,8 @@ public partial class CollectionAssertionSpecs
             var collection1 = new[] { 1, 2, 3 };
 
             // Act
-            Action act = () => collection.Should().Equal(collection1, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+                collection.Should().Equal(collection1, "because we want to test the behaviour with a null subject");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -144,7 +147,8 @@ public partial class CollectionAssertionSpecs
             int[] collection1 = null;
 
             // Act
-            Action act = () => collection.Should().Equal(collection1, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+                collection.Should().Equal(collection1, "because we want to test the behaviour with a null subject");
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
@@ -187,6 +191,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             var actual = new List<string> { "ONE", "TWO", "THREE", "FOUR" };
+
             var expected = new[]
             {
                 new { Value = "One" },
@@ -208,6 +213,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             var actual = new List<string> { "ONE", "TWO", "THREE", "FOUR" };
+
             var expected = new[]
             {
                 new { Value = "One" },
@@ -311,7 +317,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_equality_with_a_collection_built_from_params_arguments_that_are_assignable_to_the_subjects_type_parameter_it_should_succeed_by_treating_the_arguments_as_of_that_type()
+        public void
+            When_asserting_equality_with_a_collection_built_from_params_arguments_that_are_assignable_to_the_subjects_type_parameter_it_should_succeed_by_treating_the_arguments_as_of_that_type()
         {
             // Arrange
             byte[] byteArray = { 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10 };
@@ -411,7 +418,8 @@ public partial class CollectionAssertionSpecs
             var collection2 = collection1;
 
             // Act
-            Action act = () => collection1.Should().NotEqual(collection2, "because we want to test the behaviour with same objects");
+            Action act = () =>
+                collection1.Should().NotEqual(collection2, "because we want to test the behaviour with same objects");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCount.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCount.cs
@@ -36,7 +36,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_collection_has_a_count_that_is_different_from_the_number_of_items_it_should_fail_with_descriptive_message_()
+        public void
+            When_collection_has_a_count_that_is_different_from_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
@@ -46,7 +47,8 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain 4 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+                .WithMessage(
+                    "Expected collection to contain 4 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]
@@ -148,7 +150,7 @@ public partial class CollectionAssertionSpecs
             var collection = new[] { 1, 2, 3 };
 
             // Act
-            Action act = () => collection.Should().HaveCount(c => c % 2 == 1);
+            Action act = () => collection.Should().HaveCount(c => (c % 2) == 1);
 
             // Assert
             act.Should().NotThrow();
@@ -161,7 +163,7 @@ public partial class CollectionAssertionSpecs
             var collection = new[] { 1, 2, 3 };
 
             // Act
-            Action act = () => collection.Should().HaveCount(c => c % 2 == 0);
+            Action act = () => collection.Should().HaveCount(c => (c % 2) == 0);
 
             // Assert
             act.Should().Throw<XunitException>();
@@ -248,7 +250,8 @@ public partial class CollectionAssertionSpecs
             };
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThan.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThan.cs
@@ -43,11 +43,13 @@ public partial class CollectionAssertionSpecs
             var collection = new[] { 1, 2, 3 };
 
             // Act
-            Action action = () => collection.Should().HaveCountGreaterThan(3, "because we want to test the failure {0}", "message");
+            Action action = () =>
+                collection.Should().HaveCountGreaterThan(3, "because we want to test the failure {0}", "message");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain more than 3 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+                .WithMessage(
+                    "Expected collection to contain more than 3 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]
@@ -64,7 +66,8 @@ public partial class CollectionAssertionSpecs
             };
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*more than*1*we want to test the behaviour with a null subject*found <null>*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("*more than*1*we want to test the behaviour with a null subject*found <null>*");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
@@ -36,17 +36,20 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_collection_has_a_count_greater_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+        public void
+            When_collection_has_a_count_greater_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
 
             // Act
-            Action action = () => collection.Should().HaveCountGreaterThanOrEqualTo(4, "because we want to test the failure {0}", "message");
+            Action action = () =>
+                collection.Should().HaveCountGreaterThanOrEqualTo(4, "because we want to test the failure {0}", "message");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain at least 4 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+                .WithMessage(
+                    "Expected collection to contain at least 4 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]
@@ -63,7 +66,8 @@ public partial class CollectionAssertionSpecs
             };
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThan.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThan.cs
@@ -46,7 +46,8 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain fewer than 3 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+                .WithMessage(
+                    "Expected collection to contain fewer than 3 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]
@@ -63,7 +64,8 @@ public partial class CollectionAssertionSpecs
             };
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*fewer than*1*we want to test the behaviour with a null subject*found <null>*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("*fewer than*1*we want to test the behaviour with a null subject*found <null>*");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
@@ -36,17 +36,20 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_collection_has_a_count_less_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+        public void
+            When_collection_has_a_count_less_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
 
             // Act
-            Action action = () => collection.Should().HaveCountLessThanOrEqualTo(2, "because we want to test the failure {0}", "message");
+            Action action = () =>
+                collection.Should().HaveCountLessThanOrEqualTo(2, "because we want to test the failure {0}", "message");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain at most 2 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+                .WithMessage(
+                    "Expected collection to contain at most 2 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]
@@ -63,7 +66,8 @@ public partial class CollectionAssertionSpecs
             };
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveSameCount.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveSameCount.cs
@@ -166,7 +166,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_collections_to_not_have_same_count_but_both_collections_references_the_same_object_it_should_throw()
+        public void
+            When_asserting_collections_to_not_have_same_count_but_both_collections_references_the_same_object_it_should_throw()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyHaveUniqueItems.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyHaveUniqueItems.cs
@@ -202,7 +202,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_with_a_predicate_a_collection_to_only_have_unique_items_but_collection_is_null_it_should_throw()
+        public void
+            When_asserting_with_a_predicate_a_collection_to_only_have_unique_items_but_collection_is_null_it_should_throw()
         {
             // Arrange
             IEnumerable<SomeClass> collection = null;

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Satisfy.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Satisfy.cs
@@ -19,7 +19,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_element_at_each_position_matches_predicate_at_same_position_should_not_throw()
         {
             // Arrange
-            var collection = new int[] { 1, 2, 3 };
+            var collection = new[] { 1, 2, 3 };
 
             // Act
             Action act = () => collection.Should().Satisfy(
@@ -35,7 +35,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_element_at_each_position_matches_predicate_at_reverse_position_should_not_throw()
         {
             // Arrange
-            var collection = new int[] { 1, 2, 3 };
+            var collection = new[] { 1, 2, 3 };
 
             // Act
             Action act = () => collection.Should().Satisfy(
@@ -51,7 +51,7 @@ public partial class CollectionAssertionSpecs
         public void When_one_element_does_not_have_matching_predicate_Satisfy_should_throw()
         {
             // Arrange
-            var collection = new int[] { 1, 2 };
+            var collection = new[] { 1, 2 };
 
             // Act
             Action act = () => collection.Should().Satisfy(
@@ -61,16 +61,17 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-@"Expected collection to satisfy all predicates, but:
+                @"Expected collection to satisfy all predicates, but:
 *The following predicates did not have matching elements:
 *(element == 3)");
         }
 
         [Fact]
-        public void When_some_predicates_have_multiple_matching_elements_and_most_restricitve_predicates_are_last_should_not_throw()
+        public void
+            When_some_predicates_have_multiple_matching_elements_and_most_restricitve_predicates_are_last_should_not_throw()
         {
             // Arrange
-            var collection = new int[] { 1, 2, 3, 4 };
+            var collection = new[] { 1, 2, 3, 4 };
 
             // Act
             Action act = () => collection.Should().Satisfy(
@@ -84,10 +85,11 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_some_predicates_have_multiple_matching_elements_and_most_restricitve_predicates_are_first_should_not_throw()
+        public void
+            When_some_predicates_have_multiple_matching_elements_and_most_restricitve_predicates_are_first_should_not_throw()
         {
             // Arrange
-            var collection = new int[] { 1, 2, 3, 4 };
+            var collection = new[] { 1, 2, 3, 4 };
 
             // Act
             Action act = () => collection.Should().Satisfy(
@@ -104,7 +106,7 @@ public partial class CollectionAssertionSpecs
         public void When_second_predicate_matches_first_and_last_element_and_solution_exists_should_not_throw()
         {
             // Arrange
-            var collection = new int[] { 1, 2, 3 };
+            var collection = new[] { 1, 2, 3 };
 
             // Act
             Action act = () => collection.Should().Satisfy(
@@ -117,7 +119,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_assertion_fails_then_failure_message_must_contain_predicates_without_matching_elements_and_elements_without_matching_predicates()
+        public void
+            When_assertion_fails_then_failure_message_must_contain_predicates_without_matching_elements_and_elements_without_matching_predicates()
         {
             // Arrange
             IEnumerable<SomeClass> collection = new[]
@@ -132,15 +135,15 @@ public partial class CollectionAssertionSpecs
             Action act = () => collection.Should().Satisfy(
                 new Expression<Func<SomeClass, bool>>[]
                 {
-                element => element.Text == "four" && element.Number == 4,
-                element => element.Text == "two" && element.Number == 2,
+                    element => element.Text == "four" && element.Number == 4,
+                    element => element.Text == "two" && element.Number == 2,
                 },
                 because: "we want to test formatting ({0})",
                 becauseArgs: "args");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-@"Expected collection to satisfy all predicates because we want to test formatting (args), but:
+                @"Expected collection to satisfy all predicates because we want to test formatting (args), but:
 *The following predicates did not have matching elements:
 *(element.Text == ""two"") AndAlso (element.Number == 2)
 *The following elements did not match any predicate:
@@ -187,6 +190,7 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
+
                 collection.Should().Satisfy(
                     new Expression<Func<int, bool>>[]
                     {
@@ -235,7 +239,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-@"Expected collection to satisfy all predicates, but:
+                @"Expected collection to satisfy all predicates, but:
 *The following elements did not match any predicate:
 *Index: 0, Element: 1
 *Index: 2, Element: 3");

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.SatisfyRespectively.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.SatisfyRespectively.cs
@@ -52,6 +52,7 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
+
                 collection.Should().SatisfyRespectively(
                     new Action<int>[] { x => x.Should().Be(1) }, "because we want to test the failure {0}", "message");
             };
@@ -110,18 +111,19 @@ public partial class CollectionAssertionSpecs
             Action act = () => customers.Should().SatisfyRespectively(
                 new Action<CustomerWithItems>[]
                 {
-                customer =>
-                {
-                    customer.Age.Should().BeLessThan(21);
-                    customer.Items.Should().SatisfyRespectively(
-                        item => item.Should().Be(2),
-                        item => item.Should().Be(1));
-                },
-                customer =>
-                {
-                    customer.Age.Should().BeLessThan(22);
-                    customer.Items.Should().SatisfyRespectively(item => item.Should().Be(2));
-                }
+                    customer =>
+                    {
+                        customer.Age.Should().BeLessThan(21);
+
+                        customer.Items.Should().SatisfyRespectively(
+                            item => item.Should().Be(2),
+                            item => item.Should().Be(1));
+                    },
+                    customer =>
+                    {
+                        customer.Age.Should().BeLessThan(22);
+                        customer.Items.Should().SatisfyRespectively(item => item.Should().Be(2));
+                    }
                 }, "because we want to test {0}", "nested assertions");
 
             // Assert
@@ -188,7 +190,7 @@ public partial class CollectionAssertionSpecs
 
     private class Customer
     {
-        private string PrivateProperty { get; set; }
+        private string PrivateProperty { get; }
 
         protected string ProtectedProperty { get; set; }
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.StartWith.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.StartWith.cs
@@ -70,13 +70,15 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_collection_does_not_start_with_a_specific_element_in_a_sequence_using_custom_equality_comparison_it_should_throw()
+        public void
+            When_collection_does_not_start_with_a_specific_element_in_a_sequence_using_custom_equality_comparison_it_should_throw()
         {
             // Arrange
             var collection = new[] { "john", "bill", "jane", "mike" };
 
             // Act
-            Action act = () => collection.Should().StartWith(new[] { "john", "ryan", "jane" }, (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "of some reason");
+            Action act = () => collection.Should().StartWith(new[] { "john", "ryan", "jane" },
+                (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "of some reason");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -110,13 +112,15 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_collection_starts_with_the_specific_sequence_of_elements_using_custom_equality_comparison_it_should_not_throw()
+        public void
+            When_collection_starts_with_the_specific_sequence_of_elements_using_custom_equality_comparison_it_should_not_throw()
         {
             // Arrange
             var collection = new[] { "john", "bill", "jane", "mike" };
 
             // Act
-            Action act = () => collection.Should().StartWith(new[] { "JoHn", "bIlL" }, (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
+            Action act = () => collection.Should().StartWith(new[] { "JoHn", "bIlL" },
+                (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
 
             // Assert
             act.Should().NotThrow();
@@ -175,13 +179,15 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_collection_starts_with_the_specific_sequence_with_null_elements_using_custom_equality_comparison_it_should_not_throw()
+        public void
+            When_collection_starts_with_the_specific_sequence_with_null_elements_using_custom_equality_comparison_it_should_not_throw()
         {
             // Arrange
             var collection = new[] { null, "john", null, "bill", "jane", "mike" };
 
             // Act
-            Action act = () => collection.Should().StartWith(new[] { null, "JoHn", null, "bIlL" }, (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
+            Action act = () => collection.Should().StartWith(new[] { null, "JoHn", null, "bIlL" },
+                (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -75,7 +75,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_the_collection_is_ordered_according_to_the_subsequent_ascending_assertion_with_comparer_it_should_succeed()
+        public void
+            When_the_collection_is_ordered_according_to_the_subsequent_ascending_assertion_with_comparer_it_should_succeed()
         {
             // Arrange
             var collection = new[]
@@ -166,7 +167,8 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_the_collection_is_ordered_according_to_the_subsequent_descending_assertion_with_comparer_it_should_succeed()
+        public void
+            When_the_collection_is_ordered_according_to_the_subsequent_descending_assertion_with_comparer_it_should_succeed()
         {
             // Arrange
             var collection = new[]
@@ -316,7 +318,6 @@ internal class TrackingTestEnumerable : IEnumerable<int>
 internal class TrackingEnumerator : IEnumerator<int>
 {
     private readonly int[] values;
-    private int loopCount;
     private int index;
 
     public TrackingEnumerator(int[] values)
@@ -326,14 +327,11 @@ internal class TrackingEnumerator : IEnumerator<int>
         this.values = values;
     }
 
-    public int LoopCount
-    {
-        get { return loopCount; }
-    }
+    public int LoopCount { get; private set; }
 
     public void IncreaseEnumerationCount()
     {
-        loopCount++;
+        LoopCount++;
     }
 
     public bool MoveNext()

--- a/Tests/FluentAssertions.Specs/Collections/Data/DataColumnCollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/Data/DataColumnCollectionAssertionSpecs.cs
@@ -2,11 +2,6 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using FluentAssertions.Execution;
-
 using Xunit;
 using Xunit.Sdk;
 
@@ -17,7 +12,7 @@ public static class DataColumnCollectionAssertionSpecs
     public class BeSameAs
     {
         [Fact]
-        public void When_references_are_the_same_it_should_succeed()
+        public void Succeeds_for_references_to_the_same_object()
         {
             // Arrange
             var dataTable = new DataTable("Test");
@@ -30,7 +25,7 @@ public static class DataColumnCollectionAssertionSpecs
         }
 
         [Fact]
-        public void When_references_are_different_it_should_fail()
+        public void Throws_for_different_references()
         {
             // Arrange
             var dataTable1 = new DataTable("Test1");

--- a/Tests/FluentAssertions.Specs/Collections/Data/DataRowCollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/Data/DataRowCollectionAssertionSpecs.cs
@@ -1,13 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using FluentAssertions.Execution;
-
 using Xunit;
 using Xunit.Sdk;
 
@@ -456,9 +450,14 @@ public static class DataRowCollectionAssertionSpecs
             dataTable.Columns.Add("Flag", typeof(bool));
             dataTable.Columns.Add("Timestamp", typeof(DateTime));
 
-            dataTable.Rows.Add(new Guid("6f460c1a-755d-d8e4-ad67-65d5f519dbc8"), "1851925803", 2137491580, true, new DateTime(638898932425580731));
-            dataTable.Rows.Add(new Guid("8286d046-9740-a3e4-95cf-ff46699c73c4"), "607156385", 1321446349, true, new DateTime(641752306337096884));
-            dataTable.Rows.Add(new Guid("95c69371-b924-6fe3-7c38-98b7dd200bc1"), "1509870614", 505401118, true, new DateTime(623130841631129390));
+            dataTable.Rows.Add(new Guid("6f460c1a-755d-d8e4-ad67-65d5f519dbc8"), "1851925803", 2137491580, true,
+                new DateTime(638898932425580731));
+
+            dataTable.Rows.Add(new Guid("8286d046-9740-a3e4-95cf-ff46699c73c4"), "607156385", 1321446349, true,
+                new DateTime(641752306337096884));
+
+            dataTable.Rows.Add(new Guid("95c69371-b924-6fe3-7c38-98b7dd200bc1"), "1509870614", 505401118, true,
+                new DateTime(623130841631129390));
 
             var subjectTable = new DataTable();
 
@@ -468,7 +467,8 @@ public static class DataRowCollectionAssertionSpecs
             subjectTable.Columns.Add("Flag", typeof(bool));
             subjectTable.Columns.Add("Timestamp", typeof(DateTime));
 
-            subjectTable.Rows.Add(new Guid("95c69371-b924-6fe3-7c38-98b7dd200bc1"), "1509870614", 505401118, true, new DateTime(623130841631129390));
+            subjectTable.Rows.Add(new Guid("95c69371-b924-6fe3-7c38-98b7dd200bc1"), "1509870614", 505401118, true,
+                new DateTime(623130841631129390));
 
             var subjectRow = subjectTable.Rows[0];
 
@@ -488,9 +488,14 @@ public static class DataRowCollectionAssertionSpecs
             dataTable.Columns.Add("Flag", typeof(bool));
             dataTable.Columns.Add("Timestamp", typeof(DateTime));
 
-            dataTable.Rows.Add(new Guid("8286d046-9740-a3e4-95cf-ff46699c73c4"), "607156385", 1321446349, true, new DateTime(641752306337096884));
-            dataTable.Rows.Add(new Guid("95c69371-b924-6fe3-7c38-98b7dd200bc1"), "1509870614", 505401118, true, new DateTime(623130841631129390));
-            dataTable.Rows.Add(new Guid("a905569d-db07-3ae3-63a0-322750a4a3bd"), "265101196", 1836839534, true, new DateTime(625984215542645543));
+            dataTable.Rows.Add(new Guid("8286d046-9740-a3e4-95cf-ff46699c73c4"), "607156385", 1321446349, true,
+                new DateTime(641752306337096884));
+
+            dataTable.Rows.Add(new Guid("95c69371-b924-6fe3-7c38-98b7dd200bc1"), "1509870614", 505401118, true,
+                new DateTime(623130841631129390));
+
+            dataTable.Rows.Add(new Guid("a905569d-db07-3ae3-63a0-322750a4a3bd"), "265101196", 1836839534, true,
+                new DateTime(625984215542645543));
 
             var subjectTable = new DataTable();
 
@@ -500,7 +505,8 @@ public static class DataRowCollectionAssertionSpecs
             subjectTable.Columns.Add("Flag", typeof(bool));
             subjectTable.Columns.Add("Timestamp", typeof(DateTime));
 
-            subjectTable.Rows.Add(new Guid("bc4519c8-fdeb-06e2-4a08-cc98c4273aba"), "1167815425", 1020794303, true, new DateTime(628837589454161696));
+            subjectTable.Rows.Add(new Guid("bc4519c8-fdeb-06e2-4a08-cc98c4273aba"), "1167815425", 1020794303, true,
+                new DateTime(628837589454161696));
 
             var subjectRow = subjectTable.Rows[0];
 
@@ -546,9 +552,14 @@ public static class DataRowCollectionAssertionSpecs
             dataTable.Columns.Add("Flag", typeof(bool));
             dataTable.Columns.Add("Timestamp", typeof(DateTime));
 
-            dataTable.Rows.Add(new Guid("8286d046-9740-a3e4-95cf-ff46699c73c4"), "607156385", 1321446349, true, new DateTime(641752306337096884));
-            dataTable.Rows.Add(new Guid("95c69371-b924-6fe3-7c38-98b7dd200bc1"), "1509870614", 505401118, true, new DateTime(623130841631129390));
-            dataTable.Rows.Add(new Guid("a905569d-db07-3ae3-63a0-322750a4a3bd"), "265101196", 1836839534, true, new DateTime(625984215542645543));
+            dataTable.Rows.Add(new Guid("8286d046-9740-a3e4-95cf-ff46699c73c4"), "607156385", 1321446349, true,
+                new DateTime(641752306337096884));
+
+            dataTable.Rows.Add(new Guid("95c69371-b924-6fe3-7c38-98b7dd200bc1"), "1509870614", 505401118, true,
+                new DateTime(623130841631129390));
+
+            dataTable.Rows.Add(new Guid("a905569d-db07-3ae3-63a0-322750a4a3bd"), "265101196", 1836839534, true,
+                new DateTime(625984215542645543));
 
             var subjectTable = new DataTable();
 
@@ -558,7 +569,8 @@ public static class DataRowCollectionAssertionSpecs
             subjectTable.Columns.Add("Flag", typeof(bool));
             subjectTable.Columns.Add("Timestamp", typeof(DateTime));
 
-            subjectTable.Rows.Add(new Guid("95c69371-b924-6fe3-7c38-98b7dd200bc1"), "1509870614", 505401118, true, new DateTime(623130841631129390));
+            subjectTable.Rows.Add(new Guid("95c69371-b924-6fe3-7c38-98b7dd200bc1"), "1509870614", 505401118, true,
+                new DateTime(623130841631129390));
 
             var subjectRow = subjectTable.Rows[0];
 
@@ -584,9 +596,14 @@ public static class DataRowCollectionAssertionSpecs
             dataTable.Columns.Add("Flag", typeof(bool));
             dataTable.Columns.Add("Timestamp", typeof(DateTime));
 
-            dataTable.Rows.Add(new Guid("8286d046-9740-a3e4-95cf-ff46699c73c4"), "607156385", 1321446349, true, new DateTime(641752306337096884));
-            dataTable.Rows.Add(new Guid("95c69371-b924-6fe3-7c38-98b7dd200bc1"), "1509870614", 505401118, true, new DateTime(623130841631129390));
-            dataTable.Rows.Add(new Guid("a905569d-db07-3ae3-63a0-322750a4a3bd"), "265101196", 1836839534, true, new DateTime(625984215542645543));
+            dataTable.Rows.Add(new Guid("8286d046-9740-a3e4-95cf-ff46699c73c4"), "607156385", 1321446349, true,
+                new DateTime(641752306337096884));
+
+            dataTable.Rows.Add(new Guid("95c69371-b924-6fe3-7c38-98b7dd200bc1"), "1509870614", 505401118, true,
+                new DateTime(623130841631129390));
+
+            dataTable.Rows.Add(new Guid("a905569d-db07-3ae3-63a0-322750a4a3bd"), "265101196", 1836839534, true,
+                new DateTime(625984215542645543));
 
             var subjectTable = new DataTable();
 
@@ -596,7 +613,8 @@ public static class DataRowCollectionAssertionSpecs
             subjectTable.Columns.Add("Flag", typeof(bool));
             subjectTable.Columns.Add("Timestamp", typeof(DateTime));
 
-            subjectTable.Rows.Add(new Guid("bc4519c8-fdeb-06e2-4a08-cc98c4273aba"), "1167815425", 1020794303, true, new DateTime(628837589454161696));
+            subjectTable.Rows.Add(new Guid("bc4519c8-fdeb-06e2-4a08-cc98c4273aba"), "1167815425", 1020794303, true,
+                new DateTime(628837589454161696));
 
             var subjectRow = subjectTable.Rows[0];
 

--- a/Tests/FluentAssertions.Specs/Collections/Data/DataTableCollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/Data/DataTableCollectionAssertionSpecs.cs
@@ -2,11 +2,6 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using FluentAssertions.Execution;
-
 using Xunit;
 using Xunit.Sdk;
 
@@ -513,7 +508,7 @@ public static class DataTableCollectionAssertionSpecs
                 // Act
                 Action action =
                     () => genericDataTableCollection.Should().NotHaveSameCount(secondDataSet.Tables,
-                    because: "we {0}", "care");
+                        because: "we {0}", "care");
 
                 // Assert
                 action.Should().Throw<XunitException>().WithMessage(

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.AllSatisfy.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.AllSatisfy.cs
@@ -15,7 +15,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void All_items_satisfying_inspector_should_succeed()
         {
             // Arrange
-            string[] collection = new[] { "John", "John" };
+            string[] collection = { "John", "John" };
 
             // Act / Assert
             collection.Should().AllSatisfy(value => value.Should().Be("John"));
@@ -25,7 +25,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void Any_items_not_satisfying_inspector_should_throw()
         {
             // Arrange
-            string[] collection = new[] { "Jack", "Jessica" };
+            string[] collection = { "Jack", "Jessica" };
 
             // Act
             Action act = () => collection.Should()

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -843,7 +843,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         // Assert
         action.Should().Throw<XunitException>()
             .WithMessage("Expected collection to intersect with {\"four\", \"five\"} because they should share items," +
-                         " but {\"one\", \"two\", \"three\"} does not contain any shared items.");
+                " but {\"one\", \"two\", \"three\"} does not contain any shared items.");
     }
 
     [Fact]
@@ -1465,8 +1465,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_two_arrays_contain_the_same_elements_it_should_treat_them_as_equivalent()
     {
         // Arrange
-        string[] array1 = new[] { "one", "two", "three" };
-        string[] array2 = new[] { "three", "two", "one" };
+        string[] array1 = { "one", "two", "three" };
+        string[] array2 = { "three", "two", "one" };
 
         // Act / Assert
         array1.Should().BeEquivalentTo(array2);
@@ -1697,7 +1697,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_collection_contains_a_match_it_should_not_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+        IEnumerable<string> collection = new[] { "build succeded", "test failed" };
 
         // Act
         Action action = () => collection.Should().ContainMatch("* failed");
@@ -1710,7 +1710,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_collection_contains_multiple_matches_it_should_not_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test failed", "pack failed" };
+        IEnumerable<string> collection = new[] { "build succeded", "test failed", "pack failed" };
 
         // Act
         Action action = () => collection.Should().ContainMatch("* failed");
@@ -1723,7 +1723,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_collection_contains_multiple_matches_which_should_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test failed", "pack failed" };
+        IEnumerable<string> collection = new[] { "build succeded", "test failed", "pack failed" };
 
         // Act
         Action action = () =>
@@ -1741,21 +1741,22 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_collection_does_not_contain_a_match_it_should_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+        IEnumerable<string> collection = new[] { "build succeded", "test failed" };
 
         // Act
         Action action = () => collection.Should().ContainMatch("* stopped", "because {0}", "we do");
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Expected collection {\"build succeded\", \"test failed\"} to contain a match of \"* stopped\" because we do.");
+            .WithMessage(
+                "Expected collection {\"build succeded\", \"test failed\"} to contain a match of \"* stopped\" because we do.");
     }
 
     [Fact]
     public void When_collection_contains_a_match_that_differs_in_casing_it_should_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+        IEnumerable<string> collection = new[] { "build succeded", "test failed" };
 
         // Act
         Action action = () => collection.Should().ContainMatch("* Failed");
@@ -1801,14 +1802,15 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_asserting_collection_to_have_null_match_it_should_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+        IEnumerable<string> collection = new[] { "build succeded", "test failed" };
 
         // Act
         Action action = () => collection.Should().ContainMatch(null);
 
         // Assert
         action.Should().Throw<ArgumentNullException>()
-            .WithMessage("Cannot match strings in collection against <null>. Provide a wildcard pattern or use the Contain method.*")
+            .WithMessage(
+                "Cannot match strings in collection against <null>. Provide a wildcard pattern or use the Contain method.*")
             .WithParameterName("wildcardPattern");
     }
 
@@ -1816,14 +1818,15 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_asserting_collection_to_have_empty_string_match_it_should_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+        IEnumerable<string> collection = new[] { "build succeded", "test failed" };
 
         // Act
         Action action = () => collection.Should().ContainMatch(string.Empty);
 
         // Assert
         action.Should().Throw<ArgumentException>()
-            .WithMessage("Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the Contain method.*")
+            .WithMessage(
+                "Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the Contain method.*")
             .WithParameterName("wildcardPattern");
     }
 
@@ -1835,7 +1838,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_collection_doesnt_contain_a_match_it_should_not_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test" };
+        IEnumerable<string> collection = new[] { "build succeded", "test" };
 
         // Act
         Action action = () => collection.Should().NotContainMatch("* failed");
@@ -1848,7 +1851,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_collection_doesnt_contain_multiple_matches_it_should_not_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test", "pack" };
+        IEnumerable<string> collection = new[] { "build succeded", "test", "pack" };
 
         // Act
         Action action = () => collection.Should().NotContainMatch("* failed");
@@ -1861,35 +1864,37 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_collection_contains_a_match_it_should_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+        IEnumerable<string> collection = new[] { "build succeded", "test failed" };
 
         // Act
         Action action = () => collection.Should().NotContainMatch("* failed", "because {0}", "it shouldn't");
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Did not expect collection {\"build succeded\", \"test failed\"} to contain a match of \"* failed\" because it shouldn't.");
+            .WithMessage(
+                "Did not expect collection {\"build succeded\", \"test failed\"} to contain a match of \"* failed\" because it shouldn't.");
     }
 
     [Fact]
     public void When_collection_contains_multiple_matches_it_should_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build failed", "test failed" };
+        IEnumerable<string> collection = new[] { "build failed", "test failed" };
 
         // Act
         Action action = () => collection.Should().NotContainMatch("* failed", "because {0}", "it shouldn't");
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Did not expect collection {\"build failed\", \"test failed\"} to contain a match of \"* failed\" because it shouldn't.");
+            .WithMessage(
+                "Did not expect collection {\"build failed\", \"test failed\"} to contain a match of \"* failed\" because it shouldn't.");
     }
 
     [Fact]
     public void When_collection_contains_a_match_with_different_casing_it_should_not_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+        IEnumerable<string> collection = new[] { "build succeded", "test failed" };
 
         // Act
         Action action = () => collection.Should().NotContainMatch("* Failed");
@@ -1902,14 +1907,15 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_asserting_collection_to_not_have_null_match_it_should_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+        IEnumerable<string> collection = new[] { "build succeded", "test failed" };
 
         // Act
         Action action = () => collection.Should().NotContainMatch(null);
 
         // Assert
         action.Should().Throw<ArgumentNullException>()
-            .WithMessage("Cannot match strings in collection against <null>. Provide a wildcard pattern or use the NotContain method.*")
+            .WithMessage(
+                "Cannot match strings in collection against <null>. Provide a wildcard pattern or use the NotContain method.*")
             .WithParameterName("wildcardPattern");
     }
 
@@ -1917,14 +1923,15 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_asserting_collection_to_not_have_empty_string_match_it_should_throw()
     {
         // Arrange
-        IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+        IEnumerable<string> collection = new[] { "build succeded", "test failed" };
 
         // Act
         Action action = () => collection.Should().NotContainMatch(string.Empty);
 
         // Assert
         action.Should().Throw<ArgumentException>()
-            .WithMessage("Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the NotContain method.*")
+            .WithMessage(
+                "Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the NotContain method.*")
             .WithParameterName("wildcardPattern");
     }
 
@@ -1954,7 +1961,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_string_collection_satisfies_all_inspectors_it_should_succeed()
     {
         // Arrange
-        string[] collection = new[] { "John", "Jane" };
+        string[] collection = { "John", "Jane" };
 
         // Act / Assert
         collection.Should().SatisfyRespectively(
@@ -1967,7 +1974,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
     public void When_string_collection_does_not_satisfy_all_inspectors_it_should_throw()
     {
         // Arrange
-        string[] collection = new[] { "Jack", "Jessica" };
+        string[] collection = { "Jack", "Jessica" };
 
         // Act
         Action act = () => collection.Should().SatisfyRespectively(new Action<string>[]
@@ -1995,6 +2002,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         Action action = () => someCollection.Should().Equals(someCollection);
 
         // Assert
-        action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean BeSameAs(), Equal(), or BeEquivalentTo() instead?");
+        action.Should().Throw<NotSupportedException>()
+            .WithMessage(
+                "Equals is not part of Fluent Assertions. Did you mean BeSameAs(), Equal(), or BeEquivalentTo() instead?");
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -171,7 +171,8 @@ public class GenericDictionaryAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to contain 4 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+                .WithMessage(
+                    "Expected dictionary to contain 4 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -320,7 +321,8 @@ public class GenericDictionaryAssertionSpecs
             Action act = () => dictionary.Should().NotHaveCount(1, "we want to test the behaviour with a null subject");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
         }
     }
 
@@ -371,11 +373,13 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action action = () => dictionary.Should().HaveCountGreaterThan(3, "because we want to test the failure {0}", "message");
+            Action action = () =>
+                dictionary.Should().HaveCountGreaterThan(3, "because we want to test the failure {0}", "message");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to contain more than 3 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+                .WithMessage(
+                    "Expected dictionary to contain more than 3 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -388,7 +392,8 @@ public class GenericDictionaryAssertionSpecs
             Action act = () => dictionary.Should().HaveCountGreaterThan(1, "we want to test the behaviour with a null subject");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*more than*1*we want to test the behaviour with a null subject*found <null>*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("*more than*1*we want to test the behaviour with a null subject*found <null>*");
         }
     }
 
@@ -428,7 +433,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void When_dictionary_has_a_count_greater_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+        public void
+            When_dictionary_has_a_count_greater_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -439,11 +445,13 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action action = () => dictionary.Should().HaveCountGreaterThanOrEqualTo(4, "because we want to test the failure {0}", "message");
+            Action action = () =>
+                dictionary.Should().HaveCountGreaterThanOrEqualTo(4, "because we want to test the failure {0}", "message");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to contain at least 4 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+                .WithMessage(
+                    "Expected dictionary to contain at least 4 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -453,10 +461,12 @@ public class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().HaveCountGreaterThanOrEqualTo(1, "we want to test the behaviour with a null subject");
+            Action act = () =>
+                dictionary.Should().HaveCountGreaterThanOrEqualTo(1, "we want to test the behaviour with a null subject");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
         }
     }
 
@@ -511,7 +521,8 @@ public class GenericDictionaryAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to contain fewer than 3 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+                .WithMessage(
+                    "Expected dictionary to contain fewer than 3 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -524,7 +535,8 @@ public class GenericDictionaryAssertionSpecs
             Action act = () => dictionary.Should().HaveCountLessThan(1, "we want to test the behaviour with a null subject");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*fewer than*1*we want to test the behaviour with a null subject*found <null>*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("*fewer than*1*we want to test the behaviour with a null subject*found <null>*");
         }
     }
 
@@ -564,7 +576,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void When_dictionary_has_a_count_less_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+        public void
+            When_dictionary_has_a_count_less_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -575,11 +588,13 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action action = () => dictionary.Should().HaveCountLessThanOrEqualTo(2, "because we want to test the failure {0}", "message");
+            Action action = () =>
+                dictionary.Should().HaveCountLessThanOrEqualTo(2, "because we want to test the failure {0}", "message");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to contain at most 2 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+                .WithMessage(
+                    "Expected dictionary to contain at most 2 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -589,10 +604,12 @@ public class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().HaveCountLessThanOrEqualTo(1, "we want to test the behaviour with a null subject");
+            Action act = () =>
+                dictionary.Should().HaveCountLessThanOrEqualTo(1, "we want to test the behaviour with a null subject");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
         }
     }
 
@@ -608,6 +625,7 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two",
                 [3] = "Three"
             };
+
             var collection = new[] { 4, 5, 6 };
 
             // Act / Assert
@@ -624,6 +642,7 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two",
                 [3] = "Three"
             };
+
             var collection = new[] { 4, 6 };
 
             // Act
@@ -644,6 +663,7 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two",
                 [3] = "Three"
             };
+
             var collection = new[] { 4, 6 };
 
             // Act
@@ -680,6 +700,7 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two",
                 [3] = "Three"
             };
+
             int[] collection = null;
 
             // Act
@@ -703,6 +724,7 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two",
                 [3] = "Three"
             };
+
             var collection = new[] { 4, 6 };
 
             // Act / Assert
@@ -719,6 +741,7 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two",
                 [3] = "Three"
             };
+
             var collection = new[] { 4, 5, 6 };
 
             // Act
@@ -739,6 +762,7 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two",
                 [3] = "Three"
             };
+
             var collection = new[] { 4, 5, 6 };
 
             // Act
@@ -775,6 +799,7 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two",
                 [3] = "Three"
             };
+
             int[] collection = null;
 
             // Act
@@ -786,7 +811,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_dictionary_and_collection_to_not_have_same_count_but_both_reference_the_same_object_it_should_throw()
+        public void
+            When_asserting_dictionary_and_collection_to_not_have_same_count_but_both_reference_the_same_object_it_should_throw()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -795,6 +821,7 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two",
                 [3] = "Three"
             };
+
             var collection = dictionary;
 
             // Act
@@ -849,7 +876,8 @@ public class GenericDictionaryAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to be empty because we want to test the failure message, but found {[1] = \"One\"}.");
+                .WithMessage(
+                    "Expected dictionary to be empty because we want to test the failure message, but found {[1] = \"One\"}.");
         }
 
         [Fact]
@@ -866,7 +894,6 @@ public class GenericDictionaryAssertionSpecs
         }
 
 #if !NET5_0_OR_GREATER
-
         [Fact]
         public void When_asserting_dictionary_with_items_is_not_empty_it_should_enumerate_the_dictionary_only_once()
         {
@@ -949,6 +976,7 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
+
             var dictionary2 = new Dictionary<int, string>
             {
                 [1] = "One",
@@ -968,6 +996,7 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = null
             };
+
             var dictionary2 = new Dictionary<int, string>
             {
                 [1] = "One",
@@ -987,6 +1016,7 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
+
             var dictionary2 = new Dictionary<int, string>
             {
                 [1] = "One",
@@ -1011,6 +1041,7 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two",
                 [3] = "Three"
             };
+
             var dictionary2 = new Dictionary<int, string>
             {
                 [1] = "One",
@@ -1034,6 +1065,7 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
+
             var dictionary2 = new Dictionary<int, string>
             {
                 [1] = "One",
@@ -1053,6 +1085,7 @@ public class GenericDictionaryAssertionSpecs
         {
             // Arrange
             Dictionary<int, string> dictionary1 = null;
+
             var dictionary2 = new Dictionary<int, string>
             {
                 [1] = "One",
@@ -1060,7 +1093,8 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+                dictionary1.Should().Equal(dictionary2, "because we want to test the behaviour with a null subject");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1076,10 +1110,12 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
+
             Dictionary<int, string> dictionary2 = null;
 
             // Act
-            Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+                dictionary1.Should().Equal(dictionary2, "because we want to test the behaviour with a null subject");
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
@@ -1092,6 +1128,7 @@ public class GenericDictionaryAssertionSpecs
         {
             // Arrange
             var dictionary1 = new Dictionary<int, string>();
+
             var dictionary2 = new Dictionary<int, string>
             {
                 [1] = "One",
@@ -1118,6 +1155,7 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
+
             var dictionary2 = new Dictionary<int, string>
             {
                 [1] = "One",
@@ -1137,6 +1175,7 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = null
             };
+
             var dictionary2 = new Dictionary<int, string>
             {
                 [1] = "One",
@@ -1156,6 +1195,7 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
+
             var dictionary2 = new Dictionary<int, string>
             {
                 [1] = "One",
@@ -1179,6 +1219,7 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
+
             var dictionary2 = new Dictionary<int, string>
             {
                 [1] = "One",
@@ -1198,6 +1239,7 @@ public class GenericDictionaryAssertionSpecs
         {
             // Arrange
             Dictionary<int, string> dictionary1 = null;
+
             var dictionary2 = new Dictionary<int, string>
             {
                 [1] = "One",
@@ -1222,6 +1264,7 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
+
             Dictionary<int, string> dictionary2 = null;
 
             // Act
@@ -1235,7 +1278,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_dictionaries_not_to_be_equal_subject_but_both_dictionaries_reference_the_same_object_it_should_throw()
+        public void
+            When_asserting_dictionaries_not_to_be_equal_subject_but_both_dictionaries_reference_the_same_object_it_should_throw()
         {
             // Arrange
             var dictionary1 = new Dictionary<int, string>
@@ -1243,6 +1287,7 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
+
             var dictionary2 = dictionary1;
 
             // Act
@@ -1327,7 +1372,7 @@ public class GenericDictionaryAssertionSpecs
             // Arrange
             var dictionary = new Dictionary<string, MyClass>
             {
-                ["Key"] = new MyClass { SomeProperty = 3 }
+                ["Key"] = new() { SomeProperty = 3 }
             };
 
             // Act
@@ -1356,7 +1401,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void When_the_contents_of_a_dictionary_are_checked_against_an_empty_list_of_keys_it_should_throw_clear_explanation()
+        public void
+            When_the_contents_of_a_dictionary_are_checked_against_an_empty_list_of_keys_it_should_throw_clear_explanation()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -1366,7 +1412,7 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().ContainKeys(new int[0]);
+            Action act = () => dictionary.Should().ContainKeys();
 
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
@@ -1480,7 +1526,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void When_the_noncontents_of_a_dictionary_are_checked_against_an_empty_list_of_keys_it_should_throw_clear_explanation()
+        public void
+            When_the_noncontents_of_a_dictionary_are_checked_against_an_empty_list_of_keys_it_should_throw_clear_explanation()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -1490,7 +1537,7 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainKeys(new int[0]);
+            Action act = () => dictionary.Should().NotContainKeys();
 
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
@@ -1498,7 +1545,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void When_a_dictionary_checks_a_list_of_keys_not_to_be_present_it_will_honor_the_case_sensitive_equality_comparer_of_the_dictionary()
+        public void
+            When_a_dictionary_checks_a_list_of_keys_not_to_be_present_it_will_honor_the_case_sensitive_equality_comparer_of_the_dictionary()
         {
             // Arrange
             var dictionary = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -1508,14 +1556,15 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainKeys(new[] { "One", "Two" });
+            Action act = () => dictionary.Should().NotContainKeys("One", "Two");
 
             // Assert
             act.Should().NotThrow<XunitException>();
         }
 
         [Fact]
-        public void When_a_dictionary_checks_a_list_of_keys_not_to_be_present_it_will_honor_the_case_insensitive_equality_comparer_of_the_dictionary()
+        public void
+            When_a_dictionary_checks_a_list_of_keys_not_to_be_present_it_will_honor_the_case_insensitive_equality_comparer_of_the_dictionary()
         {
             // Arrange
             var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -1525,7 +1574,7 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainKeys(new[] { "One", "Two" });
+            Action act = () => dictionary.Should().NotContainKeys("One", "Two");
 
             // Assert
             act.Should().Throw<XunitException>();
@@ -1623,7 +1672,7 @@ public class GenericDictionaryAssertionSpecs
         public void When_the_specified_value_exists_it_should_allow_continuation_using_that_value()
         {
             // Arrange
-            var myClass = new MyClass()
+            var myClass = new MyClass
             {
                 SomeProperty = 0
             };
@@ -1649,7 +1698,7 @@ public class GenericDictionaryAssertionSpecs
             var dictionary = new Dictionary<int, MyClass>
             {
                 [1] = myClass,
-                [2] = new MyClass { SomeProperty = 0 }
+                [2] = new() { SomeProperty = 0 }
             };
 
             // Act
@@ -1718,7 +1767,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void When_the_contents_of_a_dictionary_are_checked_against_an_empty_list_of_values_it_should_throw_clear_explanation()
+        public void
+            When_the_contents_of_a_dictionary_are_checked_against_an_empty_list_of_values_it_should_throw_clear_explanation()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -1728,7 +1778,7 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().ContainValues(new string[0]);
+            Action act = () => dictionary.Should().ContainValues();
 
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
@@ -1842,7 +1892,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void When_the_noncontents_of_a_dictionary_are_checked_against_an_empty_list_of_values_it_should_throw_clear_explanation()
+        public void
+            When_the_noncontents_of_a_dictionary_are_checked_against_an_empty_list_of_values_it_should_throw_clear_explanation()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -1852,7 +1903,7 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainValues(new string[0]);
+            Action act = () => dictionary.Should().NotContainValues();
 
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
@@ -1872,10 +1923,10 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(1, "One")
-        };
+            var keyValuePairs = new List<KeyValuePair<int, string>>
+            {
+                new(1, "One")
+            };
 
             // Act / Assert
             dictionary.Should().Contain(keyValuePairs);
@@ -1910,11 +1961,11 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(1, "One"),
-            new KeyValuePair<int, string>(2, "Two")
-        };
+            var keyValuePairs = new List<KeyValuePair<int, string>>
+            {
+                new(1, "One"),
+                new(2, "Two")
+            };
 
             // Act / Assert
             dictionary.Should().Contain(keyValuePairs);
@@ -1930,11 +1981,11 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(1, "One"),
-            new KeyValuePair<int, string>(2, "Three")
-        };
+            var keyValuePairs = new List<KeyValuePair<int, string>>
+            {
+                new(1, "One"),
+                new(2, "Three")
+            };
 
             // Act
             Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
@@ -1945,7 +1996,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void When_a_dictionary_does_not_contain_multiple_values_for_key_value_pairs_it_should_throw_with_clear_explanation()
+        public void
+            When_a_dictionary_does_not_contain_multiple_values_for_key_value_pairs_it_should_throw_with_clear_explanation()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -1954,11 +2006,11 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(1, "Two"),
-            new KeyValuePair<int, string>(2, "Three")
-        };
+            var keyValuePairs = new List<KeyValuePair<int, string>>
+            {
+                new(1, "Two"),
+                new(2, "Three")
+            };
 
             // Act
             Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
@@ -1978,10 +2030,10 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(3, "Three")
-        };
+            var keyValuePairs = new List<KeyValuePair<int, string>>
+            {
+                new(3, "Three")
+            };
 
             // Act
             Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
@@ -2001,12 +2053,12 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(1, "One"),
-            new KeyValuePair<int, string>(3, "Three"),
-            new KeyValuePair<int, string>(4, "Four")
-        };
+            var keyValuePairs = new List<KeyValuePair<int, string>>
+            {
+                new(1, "One"),
+                new(3, "Three"),
+                new(4, "Four")
+            };
 
             // Act
             Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
@@ -2021,11 +2073,12 @@ public class GenericDictionaryAssertionSpecs
         {
             // Arrange
             Dictionary<int, string> dictionary = null;
-            List<KeyValuePair<int, string>> keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(1, "One"),
-            new KeyValuePair<int, string>(1, "Two")
-        };
+
+            List<KeyValuePair<int, string>> keyValuePairs = new()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(1, "Two")
+            };
 
             // Act
             Action act = () => dictionary.Should().Contain(keyValuePairs,
@@ -2045,10 +2098,12 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
-            List<KeyValuePair<int, string>> keyValuePairs = new List<KeyValuePair<int, string>>();
+
+            List<KeyValuePair<int, string>> keyValuePairs = new();
 
             // Act
-            Action act = () => dictionary1.Should().Contain(keyValuePairs, "because we want to test the behaviour with an empty set of key/value pairs");
+            Action act = () => dictionary1.Should().Contain(keyValuePairs,
+                "because we want to test the behaviour with an empty set of key/value pairs");
 
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
@@ -2064,10 +2119,12 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
+
             List<KeyValuePair<int, string>> keyValuePairs = null;
 
             // Act
-            Action act = () => dictionary1.Should().Contain(keyValuePairs, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+                dictionary1.Should().Contain(keyValuePairs, "because we want to test the behaviour with a null subject");
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
@@ -2113,11 +2170,12 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act / Assert
-            var items = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(1, "One"),
-            new KeyValuePair<int, string>(2, "Two")
-        };
+            var items = new List<KeyValuePair<int, string>>
+            {
+                new(1, "One"),
+                new(2, "Two")
+            };
+
             dictionary.Should().Contain(items);
         }
 
@@ -2165,11 +2223,11 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var items = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(1, "Two"),
-            new KeyValuePair<int, string>(2, "Three")
-        };
+            var items = new List<KeyValuePair<int, string>>
+            {
+                new(1, "Two"),
+                new(2, "Three")
+            };
 
             // Act
             Action act = () => dictionary.Should().Contain(items, "we put them {0}", "there");
@@ -2234,7 +2292,8 @@ public class GenericDictionaryAssertionSpecs
         public void When_a_dictionary_like_collection_contains_the_default_key_it_should_succeed()
         {
             // Arrange
-            var subject = new List<KeyValuePair<int, int>>() { new(0, 0) };
+            var subject = new List<KeyValuePair<int, int>>
+                { new(0, 0) };
 
             // Act
             Action act = () => subject.Should().Contain(0, 0);
@@ -2256,10 +2315,10 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(3, "Three")
-        };
+            var keyValuePairs = new List<KeyValuePair<int, string>>
+            {
+                new(3, "Three")
+            };
 
             // Act / Assert
             dictionary.Should().NotContain(keyValuePairs);
@@ -2283,7 +2342,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void Should_succeed_when_asserting_dictionary_does_not_contain_single_key_value_pair_with_existing_key_but_different_value()
+        public void
+            Should_succeed_when_asserting_dictionary_does_not_contain_single_key_value_pair_with_existing_key_but_different_value()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -2292,10 +2352,10 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(1, "Two")
-        };
+            var keyValuePairs = new List<KeyValuePair<int, string>>
+            {
+                new(1, "Two")
+            };
 
             // Act / Assert
             dictionary.Should().NotContain(keyValuePairs);
@@ -2311,18 +2371,19 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(3, "Three"),
-            new KeyValuePair<int, string>(4, "Four")
-        };
+            var keyValuePairs = new List<KeyValuePair<int, string>>
+            {
+                new(3, "Three"),
+                new(4, "Four")
+            };
 
             // Act / Assert
             dictionary.Should().NotContain(keyValuePairs);
         }
 
         [Fact]
-        public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_key_value_pairs_with_existing_keys_but_different_values()
+        public void
+            Should_succeed_when_asserting_dictionary_does_not_contain_multiple_key_value_pairs_with_existing_keys_but_different_values()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -2331,11 +2392,11 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(1, "Three"),
-            new KeyValuePair<int, string>(2, "Four")
-        };
+            var keyValuePairs = new List<KeyValuePair<int, string>>
+            {
+                new(1, "Three"),
+                new(2, "Four")
+            };
 
             // Act / Assert
             dictionary.Should().NotContain(keyValuePairs);
@@ -2351,10 +2412,10 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(1, "One")
-        };
+            var keyValuePairs = new List<KeyValuePair<int, string>>
+            {
+                new(1, "One")
+            };
 
             // Act
             Action act = () => dictionary.Should().NotContain(keyValuePairs, "because {0}", "we do");
@@ -2374,11 +2435,11 @@ public class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            var keyValuePairs = new List<KeyValuePair<int, string>>()
-        {
-            new KeyValuePair<int, string>(1, "One"),
-            new KeyValuePair<int, string>(2, "Two")
-        };
+            var keyValuePairs = new List<KeyValuePair<int, string>>
+            {
+                new(1, "One"),
+                new(2, "Two")
+            };
 
             // Act
             Action act = () => dictionary.Should().NotContain(keyValuePairs, "because {0}", "we do");
@@ -2393,7 +2454,8 @@ public class GenericDictionaryAssertionSpecs
         {
             // Arrange
             Dictionary<int, string> dictionary = null;
-            List<KeyValuePair<int, string>> keyValuePairs = new List<KeyValuePair<int, string>>()
+
+            List<KeyValuePair<int, string>> keyValuePairs = new()
             {
                 new KeyValuePair<int, string>(1, "One"),
                 new KeyValuePair<int, string>(1, "Two")
@@ -2409,7 +2471,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_dictionary_does_not_contain_key_value_pairs_but_expected_key_value_pairs_are_empty_it_should_throw()
+        public void
+            When_asserting_dictionary_does_not_contain_key_value_pairs_but_expected_key_value_pairs_are_empty_it_should_throw()
         {
             // Arrange
             var dictionary1 = new Dictionary<int, string>
@@ -2417,10 +2480,12 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
-            List<KeyValuePair<int, string>> keyValuePair = new List<KeyValuePair<int, string>>();
+
+            List<KeyValuePair<int, string>> keyValuePair = new();
 
             // Act
-            Action act = () => dictionary1.Should().NotContain(keyValuePair, "because we want to test the behaviour with an empty set of key/value pairs");
+            Action act = () => dictionary1.Should().NotContain(keyValuePair,
+                "because we want to test the behaviour with an empty set of key/value pairs");
 
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
@@ -2428,7 +2493,8 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_dictionary_does_not_contain_key_value_pairs_but_expected_key_value_pairs_are_null_it_should_throw()
+        public void
+            When_asserting_dictionary_does_not_contain_key_value_pairs_but_expected_key_value_pairs_are_null_it_should_throw()
         {
             // Arrange
             var dictionary1 = new Dictionary<int, string>
@@ -2436,10 +2502,12 @@ public class GenericDictionaryAssertionSpecs
                 [1] = "One",
                 [2] = "Two"
             };
+
             List<KeyValuePair<int, string>> keyValuePairs = null;
 
             // Act
-            Action act = () => dictionary1.Should().NotContain(keyValuePairs, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+                dictionary1.Should().NotContain(keyValuePairs, "because we want to test the behaviour with a null subject");
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
@@ -2502,11 +2570,12 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act / Assert
-            var items = new List<KeyValuePair<int, string>>()
+            var items = new List<KeyValuePair<int, string>>
             {
-                new KeyValuePair<int, string>(3, "Three"),
-                new KeyValuePair<int, string>(4, "Four")
+                new(3, "Three"),
+                new(4, "Four")
             };
+
             dictionary.Should().NotContain(items);
         }
 
@@ -2555,11 +2624,12 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            var items = new List<KeyValuePair<int, string>>()
+            var items = new List<KeyValuePair<int, string>>
             {
-                new KeyValuePair<int, string>(1, "One"),
-                new KeyValuePair<int, string>(2, "Two")
+                new(1, "One"),
+                new(2, "Two")
             };
+
             Action act = () => dictionary.Should().NotContain(items, "we did not put them {0}", "there");
 
             // Assert
@@ -2675,23 +2745,23 @@ public class GenericDictionaryAssertionSpecs
         }
 
         public static IEnumerable<object[]> SingleDictionaryData() =>
-                Dictionaries().Select(x => new[] { x });
+            Dictionaries().Select(x => new[] { x });
 
         public static object[] Dictionaries()
         {
             return new object[]
             {
-                new Dictionary<int, int>() { [1] = 42 },
-                new TrueReadOnlyDictionary<int, int>(new Dictionary<int, int>() { [1] = 42 }),
-                new List<KeyValuePair<int, int>> { new KeyValuePair<int, int>(1, 42) }
+                new Dictionary<int, int> { [1] = 42 },
+                new TrueReadOnlyDictionary<int, int>(new Dictionary<int, int> { [1] = 42 }),
+                new List<KeyValuePair<int, int>> { new(1, 42) }
             };
         }
 
         public static IEnumerable<object[]> DictionariesData()
         {
             return from x in Dictionaries()
-                   from y in Dictionaries()
-                   select new[] { x, y };
+                from y in Dictionaries()
+                select new[] { x, y };
         }
     }
 
@@ -2717,7 +2787,7 @@ public class GenericDictionaryAssertionSpecs
 
     /// <summary>
     /// This class only implements <see cref="IReadOnlyDictionary{TKey, TValue}"/>,
-    /// as <see cref="ReadOnlyDictionary{TKey, TValue}"/> also implements <see cref="IDictionary{TKey, TValue}"/>.
+    /// as <see cref="ReadOnlyDictionary{TKey,TValue}"/> also implements <see cref="IDictionary{TKey, TValue}"/>.
     /// </summary>
     /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
     /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
@@ -2847,7 +2917,6 @@ internal class TrackingTestDictionary : IDictionary<int, string>
 internal class TrackingDictionaryEnumerator : IEnumerator<KeyValuePair<int, string>>
 {
     private readonly KeyValuePair<int, string>[] values;
-    private int loopCount;
     private int index;
 
     public TrackingDictionaryEnumerator(KeyValuePair<int, string>[] values)
@@ -2856,14 +2925,11 @@ internal class TrackingDictionaryEnumerator : IEnumerator<KeyValuePair<int, stri
         this.values = values;
     }
 
-    public int LoopCount
-    {
-        get { return loopCount; }
-    }
+    public int LoopCount { get; private set; }
 
     public void IncreaseEnumerationCount()
     {
-        loopCount++;
+        LoopCount++;
     }
 
     public void Dispose()
@@ -2894,7 +2960,7 @@ internal class TrackingDictionaryEnumerator : IEnumerator<KeyValuePair<int, stri
 
 internal class DictionaryNotImplementingIReadOnlyDictionary<TKey, TValue> : IDictionary<TKey, TValue>
 {
-    private readonly Dictionary<TKey, TValue> dictionary = new Dictionary<TKey, TValue>();
+    private readonly Dictionary<TKey, TValue> dictionary = new();
 
     public TValue this[TKey key] { get => dictionary[key]; set => throw new NotImplementedException(); }
 

--- a/Tests/FluentAssertions.Specs/Common/TimeSpanExtensions.cs
+++ b/Tests/FluentAssertions.Specs/Common/TimeSpanExtensions.cs
@@ -17,6 +17,7 @@ public static class TimeSpanExtensions
         // Rounding to the nearest tick is as close to the result we would have with unlimited
         // precision as possible, and so likely to have the least potential to surprise.
         double ticks = Math.Round(timeSpan.Ticks * factor);
+
         if (ticks is > long.MaxValue or < long.MinValue)
         {
             throw new OverflowException("TimeSpan overflowed because the duration is too long.");
@@ -33,6 +34,7 @@ public static class TimeSpanExtensions
         }
 
         double ticks = Math.Round(timeSpan.Ticks / divisor);
+
         if (ticks > long.MaxValue || ticks < long.MinValue || double.IsNaN(ticks))
         {
             throw new OverflowException("TimeSpan overflowed because the duration is too long.");

--- a/Tests/FluentAssertions.Specs/ConfigurationSpecs.cs
+++ b/Tests/FluentAssertions.Specs/ConfigurationSpecs.cs
@@ -33,4 +33,6 @@ public class ConfigurationSpecs
 
 // Due to tests that call Configuration.Current
 [CollectionDefinition("ConfigurationSpecs", DisableParallelization = true)]
-public class ConfigurationSpecsDefinition { }
+public class ConfigurationSpecsDefinition
+{
+}

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedFactAttributeDiscoverer.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedFactAttributeDiscoverer.cs
@@ -14,7 +14,8 @@ public class CulturedFactAttributeDiscoverer : IXunitTestCaseDiscoverer
         this.diagnosticMessageSink = diagnosticMessageSink;
     }
 
-    public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+    public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod,
+        IAttributeInfo factAttribute)
     {
         var ctorArgs = factAttribute.GetConstructorArguments().ToArray();
         var cultures = Reflector.ConvertArguments(ctorArgs, new[] { typeof(string[]) }).Cast<string[]>().Single();
@@ -27,6 +28,7 @@ public class CulturedFactAttributeDiscoverer : IXunitTestCaseDiscoverer
         TestMethodDisplay methodDisplay = discoveryOptions.MethodDisplayOrDefault();
         TestMethodDisplayOptions methodDisplayOptions = discoveryOptions.MethodDisplayOptionsOrDefault();
 
-        return cultures.Select(culture => new CulturedXunitTestCase(diagnosticMessageSink, methodDisplay, methodDisplayOptions, testMethod, culture)).ToList();
+        return cultures.Select(culture =>
+            new CulturedXunitTestCase(diagnosticMessageSink, methodDisplay, methodDisplayOptions, testMethod, culture)).ToList();
     }
 }

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedTheoryAttribute.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedTheoryAttribute.cs
@@ -3,7 +3,8 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.CultureAwareTesting;
 
-[XunitTestCaseDiscoverer("FluentAssertions.Specs.CultureAwareTesting.CulturedTheoryAttributeDiscoverer", "FluentAssertions.Specs")]
+[XunitTestCaseDiscoverer("FluentAssertions.Specs.CultureAwareTesting.CulturedTheoryAttributeDiscoverer",
+    "FluentAssertions.Specs")]
 public sealed class CulturedTheoryAttribute : TheoryAttribute
 {
 #pragma warning disable CA1019 // Define accessors for attribute arguments

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedTheoryAttributeDiscoverer.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedTheoryAttributeDiscoverer.cs
@@ -8,18 +8,28 @@ namespace FluentAssertions.Specs.CultureAwareTesting;
 public class CulturedTheoryAttributeDiscoverer : TheoryDiscoverer
 {
     public CulturedTheoryAttributeDiscoverer(IMessageSink diagnosticMessageSink)
-        : base(diagnosticMessageSink) { }
-
-    protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
+        : base(diagnosticMessageSink)
     {
-        var cultures = GetCultures(theoryAttribute);
-        return cultures.Select(culture => new CulturedXunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, culture, dataRow)).ToList();
     }
 
-    protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions,
+        ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
     {
         var cultures = GetCultures(theoryAttribute);
-        return cultures.Select(culture => new CulturedXunitTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, culture)).ToList();
+
+        return cultures.Select(culture => new CulturedXunitTestCase(DiagnosticMessageSink,
+            discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, culture,
+            dataRow)).ToList();
+    }
+
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions,
+        ITestMethod testMethod, IAttributeInfo theoryAttribute)
+    {
+        var cultures = GetCultures(theoryAttribute);
+
+        return cultures.Select(culture => new CulturedXunitTheoryTestCase(DiagnosticMessageSink,
+                discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, culture))
+            .ToList();
     }
 
     private static string[] GetCultures(IAttributeInfo culturedTheoryAttribute)

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTestCase.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTestCase.cs
@@ -17,11 +17,11 @@ public class CulturedXunitTestCase : XunitTestCase
     public CulturedXunitTestCase() { }
 
     public CulturedXunitTestCase(IMessageSink diagnosticMessageSink,
-                                 TestMethodDisplay defaultMethodDisplay,
-                                 TestMethodDisplayOptions defaultMethodDisplayOptions,
-                                 ITestMethod testMethod,
-                                 string culture,
-                                 object[] testMethodArguments = null)
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod,
+        string culture,
+        object[] testMethodArguments = null)
         : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
     {
         Initialize(culture);
@@ -36,8 +36,7 @@ public class CulturedXunitTestCase : XunitTestCase
         DisplayName += $"[{culture}]";
     }
 
-    protected override string GetUniqueID()
-        => $"{base.GetUniqueID()}[{culture}]";
+    protected override string GetUniqueID() => $"{base.GetUniqueID()}[{culture}]";
 
     public override void Deserialize(IXunitSerializationInfo data)
     {
@@ -54,10 +53,10 @@ public class CulturedXunitTestCase : XunitTestCase
     }
 
     public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
-                                                    IMessageBus messageBus,
-                                                    object[] constructorArguments,
-                                                    ExceptionAggregator aggregator,
-                                                    CancellationTokenSource cancellationTokenSource)
+        IMessageBus messageBus,
+        object[] constructorArguments,
+        ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
     {
         CultureInfo originalCulture = CurrentCulture;
         CultureInfo originalUICulture = CurrentUICulture;
@@ -68,7 +67,8 @@ public class CulturedXunitTestCase : XunitTestCase
             CurrentCulture = cultureInfo;
             CurrentUICulture = cultureInfo;
 
-            return await base.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource);
+            return await base.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator,
+                cancellationTokenSource);
         }
         finally
         {

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTheoryTestCase.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTheoryTestCase.cs
@@ -21,10 +21,10 @@ public class CulturedXunitTheoryTestCase : XunitTheoryTestCase
     /// <param name="defaultMethodDisplayOptions">Default method display options to use (when not customized).</param>
     /// <param name="testMethod">The method under test.</param>
     public CulturedXunitTheoryTestCase(IMessageSink diagnosticMessageSink,
-                                       TestMethodDisplay defaultMethodDisplay,
-                                       TestMethodDisplayOptions defaultMethodDisplayOptions,
-                                       ITestMethod testMethod,
-                                       string culture)
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod,
+        string culture)
         : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod)
     {
         Initialize(culture);
@@ -39,8 +39,7 @@ public class CulturedXunitTheoryTestCase : XunitTheoryTestCase
         Initialize(data.GetValue<string>("Culture"));
     }
 
-    protected override string GetUniqueID()
-        => $"{base.GetUniqueID()}[{Culture}]";
+    protected override string GetUniqueID() => $"{base.GetUniqueID()}[{Culture}]";
 
     private void Initialize(string culture)
     {
@@ -52,11 +51,12 @@ public class CulturedXunitTheoryTestCase : XunitTheoryTestCase
     }
 
     public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
-                                              IMessageBus messageBus,
-                                              object[] constructorArguments,
-                                              ExceptionAggregator aggregator,
-                                              CancellationTokenSource cancellationTokenSource)
-        => new CulturedXunitTheoryTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource).RunAsync();
+        IMessageBus messageBus,
+        object[] constructorArguments,
+        ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource) =>
+        new CulturedXunitTheoryTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, diagnosticMessageSink,
+            messageBus, aggregator, cancellationTokenSource).RunAsync();
 
     public override void Serialize(IXunitSerializationInfo data)
     {

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTheoryTestCaseRunner.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTheoryTestCaseRunner.cs
@@ -14,14 +14,15 @@ public class CulturedXunitTheoryTestCaseRunner : XunitTheoryTestCaseRunner
     private CultureInfo originalUICulture;
 
     public CulturedXunitTheoryTestCaseRunner(CulturedXunitTheoryTestCase culturedXunitTheoryTestCase,
-                                             string displayName,
-                                             string skipReason,
-                                             object[] constructorArguments,
-                                             IMessageSink diagnosticMessageSink,
-                                             IMessageBus messageBus,
-                                             ExceptionAggregator aggregator,
-                                             CancellationTokenSource cancellationTokenSource)
-        : base(culturedXunitTheoryTestCase, displayName, skipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource)
+        string displayName,
+        string skipReason,
+        object[] constructorArguments,
+        IMessageSink diagnosticMessageSink,
+        IMessageBus messageBus,
+        ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+        : base(culturedXunitTheoryTestCase, displayName, skipReason, constructorArguments, diagnosticMessageSink, messageBus,
+            aggregator, cancellationTokenSource)
     {
         culture = culturedXunitTheoryTestCase.Culture;
     }

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -1,9 +1,4 @@
-﻿#if NETFRAMEWORK
-using System.Reflection;
-using System.Reflection.Emit;
-#endif
-
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Linq;
 using FluentAssertions.Events;
@@ -11,6 +6,10 @@ using FluentAssertions.Extensions;
 using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;
+#if NETFRAMEWORK
+using System.Reflection;
+using System.Reflection.Emit;
+#endif
 
 namespace FluentAssertions.Specs.Events;
 
@@ -96,7 +95,7 @@ public class EventAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected object " + Formatter.ToString(subject) +
-                             " to not raise event \"PropertyChanged\" because Foo() should cause the event to get raised, but it did.");
+                    " to not raise event \"PropertyChanged\" because Foo() should cause the event to get raised, but it did.");
         }
 
         [Fact]
@@ -224,7 +223,7 @@ public class EventAssertionSpecs
             // Arrange
             void Action(int _)
             {
-                EventRaisingClass subject = new EventRaisingClass();
+                EventRaisingClass subject = new();
                 using var monitor = subject.Monitor();
                 subject.RaiseEventWithSender();
                 monitor.Should().Raise("PropertyChanged");
@@ -321,7 +320,8 @@ public class EventAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected at least one event with some argument*type*Int32*matches*(args == " + wrongArgument + "), but found none.");
+                "Expected at least one event with some argument*type*Int32*matches*(args == " + wrongArgument +
+                "), but found none.");
         }
 
         [Fact]
@@ -516,7 +516,8 @@ public class EventAssertionSpecs
         }
 
         [Fact]
-        public void When_the_property_changed_event_was_raised_for_the_wrong_property_it_should_throw_and_include_the_actual_properties_raised()
+        public void
+            When_the_property_changed_event_was_raised_for_the_wrong_property_it_should_throw_and_include_the_actual_properties_raised()
         {
             // Arrange
             var bar = new EventRaisingClass();
@@ -727,12 +728,17 @@ public class EventAssertionSpecs
         {
             Type baseType = typeof(EventRaisingClass);
             Type interfaceType = typeof(IEventRaisingInterface);
-            AssemblyName assemblyName = new AssemblyName { Name = baseType.Assembly.FullName + ".GeneratedForTest" };
+
+            AssemblyName assemblyName = new() { Name = baseType.Assembly.FullName + ".GeneratedForTest" };
+
             AssemblyBuilder assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName,
                 AssemblyBuilderAccess.Run);
+
             ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name, false);
             string typeName = baseType.Name + "_GeneratedForTest";
-            TypeBuilder typeBuilder = moduleBuilder.DefineType(typeName, TypeAttributes.Public, baseType, new[] { interfaceType });
+
+            TypeBuilder typeBuilder =
+                moduleBuilder.DefineType(typeName, TypeAttributes.Public, baseType, new[] { interfaceType });
 
             MethodBuilder addHandler = EmitAddRemoveEventHandler("add");
             typeBuilder.DefineMethodOverride(addHandler, interfaceType.GetMethod("add_InterfaceEvent"));
@@ -749,6 +755,7 @@ public class EventAssertionSpecs
                         MethodAttributes.Private | MethodAttributes.Virtual | MethodAttributes.Final |
                         MethodAttributes.HideBySig |
                         MethodAttributes.NewSlot);
+
                 method.SetReturnType(typeof(void));
                 method.SetParameters(typeof(EventHandler));
                 ILGenerator gen = method.GetILGenerator();
@@ -828,7 +835,7 @@ public class EventAssertionSpecs
         public void One_matching_argument_type_before_mismatching_types_passes()
         {
             // Arrange
-            A a = new A();
+            A a = new();
             using var aMonitor = a.Monitor();
 
             a.OnEvent(new B());
@@ -843,7 +850,7 @@ public class EventAssertionSpecs
         public void One_matching_argument_type_after_mismatching_types_passes()
         {
             // Arrange
-            A a = new A();
+            A a = new();
             using var aMonitor = a.Monitor();
 
             a.OnEvent(new C());
@@ -858,7 +865,7 @@ public class EventAssertionSpecs
         public void Throws_when_none_of_the_arguments_are_of_the_expected_type()
         {
             // Arrange
-            A a = new A();
+            A a = new();
             using var aMonitor = a.Monitor();
 
             a.OnEvent(new C());
@@ -876,7 +883,7 @@ public class EventAssertionSpecs
         public void One_matching_argument_type_anywhere_between_mismatching_types_passes()
         {
             // Arrange
-            A a = new A();
+            A a = new();
             using var aMonitor = a.Monitor();
 
             a.OnEvent(new C());
@@ -892,7 +899,7 @@ public class EventAssertionSpecs
         public void One_matching_argument_type_anywhere_between_mismatching_types_with_parameters_passes()
         {
             // Arrange
-            A a = new A();
+            A a = new();
             using var aMonitor = a.Monitor();
 
             a.OnEvent(new C());
@@ -908,7 +915,7 @@ public class EventAssertionSpecs
         public void Mismatching_argument_types_with_one_parameter_matching_a_different_type_fails()
         {
             // Arrange
-            A a = new A();
+            A a = new();
             using var aMonitor = a.Monitor();
 
             a.OnEvent(new C());
@@ -926,7 +933,7 @@ public class EventAssertionSpecs
         public void Mismatching_argument_types_with_two_or_more_parameters_matching_a_different_type_fails()
         {
             // Arrange
-            A a = new A();
+            A a = new();
             using var aMonitor = a.Monitor();
 
             a.OnEvent(new C());
@@ -944,7 +951,7 @@ public class EventAssertionSpecs
         public void One_matching_argument_type_with_two_or_more_parameters_matching_a_mismatching_type_fails()
         {
             // Arrange
-            A a = new A();
+            A a = new();
             using var aMonitor = a.Monitor();
 
             a.OnEvent(new C());
@@ -969,9 +976,13 @@ public class EventAssertionSpecs
         }
     }
 
-    public class B { }
+    public class B
+    {
+    }
 
-    public class C { }
+    public class C
+    {
+    }
 
     public class ClassThatRaisesEventsItself : IInheritsEventRaisingInterface
     {

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -1,14 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Sdk;
 #if NETFRAMEWORK
 using FluentAssertions.Specs.Common;
 #endif
-using Xunit;
-using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.Exceptions;
 
@@ -215,7 +213,7 @@ public class AsyncFunctionExceptionAssertionSpecs
 
     public static TheoryData<Func<Task>, Exception> AggregateExceptionTestData()
     {
-        var tasks = new Func<Task>[]
+        var tasks = new[]
         {
             AggregateExceptionWithLeftNestedException,
             AggregateExceptionWithRightNestedException
@@ -284,7 +282,8 @@ public class AsyncFunctionExceptionAssertionSpecs
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
+            .WithMessage(
+                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
     }
 
     [Fact]
@@ -300,7 +299,8 @@ public class AsyncFunctionExceptionAssertionSpecs
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
+            .WithMessage(
+                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
     }
 
     [Fact]
@@ -316,7 +316,8 @@ public class AsyncFunctionExceptionAssertionSpecs
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
+            .WithMessage(
+                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
     }
 
     [Fact]
@@ -332,7 +333,8 @@ public class AsyncFunctionExceptionAssertionSpecs
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
+            .WithMessage(
+                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
     }
 
     [Fact]
@@ -429,7 +431,8 @@ public class AsyncFunctionExceptionAssertionSpecs
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
+            .WithMessage(
+                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
     }
 
     [Fact]
@@ -445,7 +448,8 @@ public class AsyncFunctionExceptionAssertionSpecs
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
+            .WithMessage(
+                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
     }
 
     [Fact]
@@ -461,7 +465,8 @@ public class AsyncFunctionExceptionAssertionSpecs
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
+            .WithMessage(
+                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
     }
 
     [Fact]
@@ -477,7 +482,8 @@ public class AsyncFunctionExceptionAssertionSpecs
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
+            .WithMessage(
+                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
     }
 
     [Fact]
@@ -700,7 +706,8 @@ public class AsyncFunctionExceptionAssertionSpecs
     }
 
     [Fact]
-    public async Task When_async_method_throws_exception_through_ValueTask_and_expected_not_to_throw_another_one_it_should_succeed()
+    public async Task
+        When_async_method_throws_exception_through_ValueTask_and_expected_not_to_throw_another_one_it_should_succeed()
     {
         // Arrange
         var asyncObject = new AsyncClass();
@@ -743,7 +750,8 @@ public class AsyncFunctionExceptionAssertionSpecs
     }
 
     [Fact]
-    public async Task When_async_method_succeeds_and_expected_not_to_throw_particular_exception_through_ValueTask_it_should_succeed()
+    public async Task
+        When_async_method_succeeds_and_expected_not_to_throw_particular_exception_through_ValueTask_it_should_succeed()
     {
         // Arrange
         var asyncObject = new AsyncClass();
@@ -1102,6 +1110,7 @@ public class AsyncFunctionExceptionAssertionSpecs
     }
 
     #region NotThrowAfterAsync
+
     [Fact]
     public async Task When_wait_time_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
     {
@@ -1150,6 +1159,7 @@ public class AsyncFunctionExceptionAssertionSpecs
         Func<Task> testAction = async () =>
         {
             using var _ = new AssertionScope();
+
             await action.Should().NotThrowAfterAsync(waitTime, pollInterval,
                 "because we want to test the failure {0}", "message");
         };
@@ -1249,7 +1259,8 @@ public class AsyncFunctionExceptionAssertionSpecs
     public partial class UIFacts
     {
         [UIFact]
-        public async Task When_no_exception_should_be_thrown_on_UI_thread_for_async_func_after_wait_time_but_it_was_it_should_throw()
+        public async Task
+            When_no_exception_should_be_thrown_on_UI_thread_for_async_func_after_wait_time_but_it_was_it_should_throw()
         {
             // Arrange
             var waitTime = 2.Seconds();
@@ -1310,7 +1321,8 @@ public class AsyncFunctionExceptionAssertionSpecs
     public partial class UIFacts
     {
         [UIFact]
-        public async Task When_no_exception_should_be_thrown_on_UI_thread_for_async_func_after_wait_time_and_none_was_it_should_not_throw()
+        public async Task
+            When_no_exception_should_be_thrown_on_UI_thread_for_async_func_after_wait_time_and_none_was_it_should_not_throw()
         {
             // Arrange
             var waitTime = 6.Seconds();
@@ -1337,6 +1349,7 @@ public class AsyncFunctionExceptionAssertionSpecs
             await act.Should().NotThrowAsync();
         }
     }
+
     #endregion
 }
 

--- a/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
@@ -1,14 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
-#if NETFRAMEWORK
-using FluentAssertions.Specs.Common;
-#endif
 using Xunit;
 using Xunit.Sdk;
-
-using static FluentAssertions.Extensions.FluentTimeSpanExtensions;
 
 namespace FluentAssertions.Specs.Exceptions;
 
@@ -52,7 +45,7 @@ public class ExceptionAssertionSpecs
 
     public static TheoryData<Action, Exception> AggregateExceptionTestData()
     {
-        var tasks = new Action[]
+        var tasks = new[]
         {
             AggregateExceptionWithLeftNestedException,
             AggregateExceptionWithRightNestedException
@@ -119,7 +112,9 @@ public class ExceptionAssertionSpecs
         catch (XunitException ex)
         {
             // Assert
-            ex.Message.Should().Match("Expected type to be System.ArgumentException because Does.Do should do that, but found System.ArgumentNullException.");
+            ex.Message.Should()
+                .Match(
+                    "Expected type to be System.ArgumentException because Does.Do should do that, but found System.ArgumentNullException.");
         }
     }
 
@@ -139,7 +134,9 @@ public class ExceptionAssertionSpecs
         catch (XunitException ex)
         {
             // Assert
-            ex.Message.Should().Match("Expected type to be System.ArgumentException because Does.Do should do that, but found System.AggregateException.");
+            ex.Message.Should()
+                .Match(
+                    "Expected type to be System.ArgumentException because Does.Do should do that, but found System.AggregateException.");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
@@ -1,13 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Sdk;
 #if NETFRAMEWORK
 using FluentAssertions.Specs.Common;
 #endif
-using Xunit;
-using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.Exceptions;
 
@@ -70,7 +69,7 @@ public class FunctionExceptionAssertionSpecs
 
     public static TheoryData<Func<int>, Exception> AggregateExceptionTestData()
     {
-        var tasks = new Func<int>[]
+        var tasks = new[]
         {
             AggregateExceptionWithLeftNestedException,
             AggregateExceptionWithRightNestedException
@@ -217,7 +216,8 @@ public class FunctionExceptionAssertionSpecs
     }
 
     [Fact]
-    public void When_function_does_not_throw_expected_exception_but_throws_aggregate_in_aggregate_it_should_fail_with_inner_exception_one_level_deep()
+    public void
+        When_function_does_not_throw_expected_exception_but_throws_aggregate_in_aggregate_it_should_fail_with_inner_exception_one_level_deep()
     {
         // Arrange
         Func<int> f = () => throw new AggregateException(new AggregateException(new ArgumentNullException()));
@@ -260,6 +260,7 @@ public class FunctionExceptionAssertionSpecs
     #endregion
 
     #region ThrowExactly
+
     [Fact]
     public void When_subject_is_null_when_an_exact_exception_should_be_thrown_it_should_throw()
     {
@@ -348,6 +349,7 @@ public class FunctionExceptionAssertionSpecs
     #endregion
 
     #region NotThrow
+
     [Fact]
     public void When_subject_is_null_when_an_exception_should_not_be_thrown_it_should_throw()
     {
@@ -420,7 +422,8 @@ public class FunctionExceptionAssertionSpecs
     }
 
     [Fact]
-    public void When_function_throw_aggregate_in_aggregate_exception_and_that_was_not_expected_it_should_fail_with_most_inner_exception_in_message()
+    public void
+        When_function_throw_aggregate_in_aggregate_exception_and_that_was_not_expected_it_should_fail_with_most_inner_exception_in_message()
     {
         // Arrange
         Func<int> f = () => throw new AggregateException(new AggregateException(new ArgumentNullException()));
@@ -443,6 +446,7 @@ public class FunctionExceptionAssertionSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             throwingFunction.Should().NotThrow()
                 .And.BeNull();
         };
@@ -458,6 +462,7 @@ public class FunctionExceptionAssertionSpecs
     #endregion
 
     #region NotThrowAfter
+
     [Fact]
     public void When_subject_is_null_it_should_throw()
     {
@@ -540,7 +545,7 @@ public class FunctionExceptionAssertionSpecs
 
         // Assert
         action.Should().Throw<XunitException>()
-                     .WithMessage("Did not expect any exceptions after 100ms because we passed valid arguments*");
+            .WithMessage("Did not expect any exceptions after 100ms because we passed valid arguments*");
     }
 
     [Fact]
@@ -590,7 +595,7 @@ public class FunctionExceptionAssertionSpecs
 
         // Act
         Action act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval)
-                .Which.Should().Be(42);
+            .Which.Should().Be(42);
 
         // Assert
         act.Should().NotThrow();
@@ -608,6 +613,7 @@ public class FunctionExceptionAssertionSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             throwingFunction.Should().NotThrowAfter(waitTime, pollInterval)
                 .And.BeNull();
         };
@@ -621,9 +627,12 @@ public class FunctionExceptionAssertionSpecs
     }
 
     #endregion
+
     #region NotThrow<T>
+
     [Fact]
-    public void When_function_does_not_throw_at_all_when_some_particular_exception_was_not_expected_it_should_succeed_but_then_cannot_continue_assertion()
+    public void
+        When_function_does_not_throw_at_all_when_some_particular_exception_was_not_expected_it_should_succeed_but_then_cannot_continue_assertion()
     {
         // Arrange
         Func<int> f = () => 12;
@@ -643,7 +652,8 @@ public class FunctionExceptionAssertionSpecs
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("*Did not expect System.InvalidOperationException because it was so fast, but found System.InvalidOperationException with message*custom message*");
+            .WithMessage(
+                "*Did not expect System.InvalidOperationException because it was so fast, but found System.InvalidOperationException with message*custom message*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Exceptions/InnerExceptionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/InnerExceptionSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using Xunit;
 using Xunit.Sdk;
 
@@ -47,7 +46,8 @@ public class InnerExceptionSpecs
     }
 
     [Fact]
-    public void WithInnerExceptionExactly_no_parameters_when_subject_throws_subclass_of_expected_inner_exception_it_should_throw_with_clear_description()
+    public void
+        WithInnerExceptionExactly_no_parameters_when_subject_throws_subclass_of_expected_inner_exception_it_should_throw_with_clear_description()
     {
         // Arrange
         var innerException = new ArgumentNullException("InnerExceptionMessage", (Exception)null);
@@ -77,11 +77,12 @@ public class InnerExceptionSpecs
 
         // Act / Assert
         act.Should().Throw<BadImageFormatException>()
-                .WithInnerExceptionExactly<ArgumentNullException>();
+            .WithInnerExceptionExactly<ArgumentNullException>();
     }
 
     [Fact]
-    public void WithInnerExceptionExactly_when_subject_throws_subclass_of_expected_inner_exception_it_should_throw_with_clear_description()
+    public void
+        WithInnerExceptionExactly_when_subject_throws_subclass_of_expected_inner_exception_it_should_throw_with_clear_description()
     {
         // Arrange
         var innerException = new ArgumentNullException("InnerExceptionMessage", (Exception)null);
@@ -99,12 +100,14 @@ public class InnerExceptionSpecs
         catch (XunitException ex)
         {
             // Assert
-            ex.Message.Should().Match("Expected*ArgumentException*the action should do just that*ArgumentNullException*InnerExceptionMessage*");
+            ex.Message.Should()
+                .Match("Expected*ArgumentException*the action should do just that*ArgumentNullException*InnerExceptionMessage*");
         }
     }
 
     [Fact]
-    public void WithInnerExceptionExactly_with_type_exception_when_subject_throws_expected_inner_exception_it_should_not_do_anything()
+    public void
+        WithInnerExceptionExactly_with_type_exception_when_subject_throws_expected_inner_exception_it_should_not_do_anything()
     {
         // Arrange
         Action act = () => throw new BadImageFormatException("", new ArgumentNullException());
@@ -115,7 +118,8 @@ public class InnerExceptionSpecs
     }
 
     [Fact]
-    public void WithInnerExceptionExactly_with_type_exception_no_parameters_when_subject_throws_expected_inner_exception_it_should_not_do_anything()
+    public void
+        WithInnerExceptionExactly_with_type_exception_no_parameters_when_subject_throws_expected_inner_exception_it_should_not_do_anything()
     {
         // Arrange
         Action act = () => throw new BadImageFormatException("", new ArgumentNullException());
@@ -126,7 +130,8 @@ public class InnerExceptionSpecs
     }
 
     [Fact]
-    public void WithInnerExceptionExactly_with_type_exception_when_subject_throws_subclass_of_expected_inner_exception_it_should_throw_with_clear_description()
+    public void
+        WithInnerExceptionExactly_with_type_exception_when_subject_throws_subclass_of_expected_inner_exception_it_should_throw_with_clear_description()
     {
         // Arrange
         var innerException = new ArgumentNullException("InnerExceptionMessage", (Exception)null);
@@ -144,7 +149,8 @@ public class InnerExceptionSpecs
         catch (XunitException ex)
         {
             // Assert
-            ex.Message.Should().Match("Expected*ArgumentException*the action should do just that*ArgumentNullException*InnerExceptionMessage*");
+            ex.Message.Should()
+                .Match("Expected*ArgumentException*the action should do just that*ArgumentNullException*InnerExceptionMessage*");
         }
     }
 
@@ -156,7 +162,7 @@ public class InnerExceptionSpecs
 
         // Act / Assert
         act.Should().Throw<BadImageFormatException>()
-                .WithInnerExceptionExactly<ArgumentNullException>("because {0} should do just that", "the action");
+            .WithInnerExceptionExactly<ArgumentNullException>("because {0} should do just that", "the action");
     }
 
     [Fact]
@@ -205,7 +211,8 @@ public class InnerExceptionSpecs
     }
 
     [Fact]
-    public void When_subject_throws_an_exception_without_expected_inner_exception_and_has_reason_it_should_throw_with_clear_description()
+    public void
+        When_subject_throws_an_exception_without_expected_inner_exception_and_has_reason_it_should_throw_with_clear_description()
     {
         try
         {
@@ -238,7 +245,8 @@ public class InnerExceptionSpecs
     }
 
     [Fact]
-    public void When_an_inner_exception_matches_exactly_it_should_allow_chaining_more_asserts_on_that_exception_type_from_argument()
+    public void
+        When_an_inner_exception_matches_exactly_it_should_allow_chaining_more_asserts_on_that_exception_type_from_argument()
     {
         // Act
         Action act = () =>

--- a/Tests/FluentAssertions.Specs/Exceptions/MiscellaneousExceptionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/MiscellaneousExceptionSpecs.cs
@@ -68,7 +68,7 @@ public class MiscellaneousExceptionSpecs
         {
             // Act
             act
-                .Should().Throw<ArgumentException>("")
+                .Should().Throw<ArgumentException>()
                 .Where(e => e.Message.Length > 0, "an exception must have a message");
 
             throw new XunitException("This point should not be reached");
@@ -91,7 +91,7 @@ public class MiscellaneousExceptionSpecs
         {
             // Act
             act
-                .Should().Throw<ArgumentException>("")
+                .Should().Throw<ArgumentException>()
                 .Where(e => e.Message.Length > 0)
                 .Where(e => e.Message == "Error");
 

--- a/Tests/FluentAssertions.Specs/Exceptions/NotThrowSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/NotThrowSpecs.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
-using FluentAssertions.Execution;
-#if NETFRAMEWORK
+﻿#if NETFRAMEWORK
 using FluentAssertions.Specs.Common;
 #endif
+using System;
+using System.Threading.Tasks;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
-
 using static FluentAssertions.Extensions.FluentTimeSpanExtensions;
 
 namespace FluentAssertions.Specs.Exceptions;
@@ -47,7 +45,7 @@ public class NotThrowSpecs
         action
             .Should().Throw<XunitException>().WithMessage(
                 "Did not expect System.ArgumentException because we passed valid arguments, " +
-                    "but found*with message \"An exception was forced\"*");
+                "but found*with message \"An exception was forced\"*");
     }
 
     [Fact]
@@ -83,7 +81,7 @@ public class NotThrowSpecs
         action
             .Should().Throw<XunitException>().WithMessage(
                 "Did not expect any exception because we passed valid arguments, " +
-                    "but found System.ArgumentException with message \"An exception was forced\"*");
+                "but found System.ArgumentException with message \"An exception was forced\"*");
     }
 
     [Fact]
@@ -106,6 +104,7 @@ public class NotThrowSpecs
         Action action = () =>
         {
             using var _ = new AssertionScope();
+
             act.Should().NotThrowAfter(0.Milliseconds(), 0.Milliseconds(),
                 "because we want to test the failure {0}", "message");
         };
@@ -193,7 +192,7 @@ public class NotThrowSpecs
 
         // Assert
         action.Should().Throw<XunitException>()
-                     .WithMessage("Did not expect any exceptions after 100ms because we passed valid arguments*");
+            .WithMessage("Did not expect any exceptions after 100ms because we passed valid arguments*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Exceptions/OuterExceptionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/OuterExceptionSpecs.cs
@@ -70,11 +70,13 @@ public class OuterExceptionSpecs
 
         // Assert
         action.Should().Throw<Exception>()
-            .WithMessage("Expected exception message to match the equivalent of*\"Expected mes*\", but*\"OxpectOd message\" does not*");
+            .WithMessage(
+                "Expected exception message to match the equivalent of*\"Expected mes*\", but*\"OxpectOd message\" does not*");
     }
 
     [Fact]
-    public void When_subject_throws_expected_exception_with_message_starting_with_expected_equivalent_message_it_should_not_throw()
+    public void
+        When_subject_throws_expected_exception_with_message_starting_with_expected_equivalent_message_it_should_not_throw()
     {
         // Arrange
         Does testSubject = Does.Throw(new InvalidOperationException("Expected Message"));
@@ -96,13 +98,14 @@ public class OuterExceptionSpecs
 
         // Act
         Action action = () => testSubject
-                .Invoking(s => s.Do())
-                .Should().Throw<InvalidOperationException>()
-                .WithMessage("expected mes");
+            .Invoking(s => s.Do())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("expected mes");
 
         // Assert
         action.Should().Throw<Exception>()
-            .WithMessage("Expected exception message to match the equivalent of*\"expected mes*\", but*\"OxpectOd message\" does not*");
+            .WithMessage(
+                "Expected exception message to match the equivalent of*\"expected mes*\", but*\"OxpectOd message\" does not*");
     }
 
     [Fact]
@@ -154,7 +157,8 @@ public class OuterExceptionSpecs
     }
 
     [Fact]
-    public void When_subject_throws_some_exception_with_message_which_contains_complete_expected_exception_and_more_it_should_throw()
+    public void
+        When_subject_throws_some_exception_with_message_which_contains_complete_expected_exception_and_more_it_should_throw()
     {
         // Arrange
         Does subjectThatThrows = Does.Throw(new ArgumentNullException("someParam", "message2"));
@@ -266,7 +270,8 @@ public class OuterExceptionSpecs
     }
 
     [Fact]
-    public void When_asserting_with_an_aggregate_exception_and_inner_exception_type_from_argument_the_asserts_should_occur_against_the_aggregate_exception()
+    public void
+        When_asserting_with_an_aggregate_exception_and_inner_exception_type_from_argument_the_asserts_should_occur_against_the_aggregate_exception()
     {
         // Arrange
         Does testSubject = Does.Throw(new AggregateException("Outer Message", new Exception("Inner Message")));

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScope.ChainingApiSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScope.ChainingApiSpecs.cs
@@ -27,7 +27,7 @@ public partial class AssertionScopeSpecs
         catch (Exception e)
         {
             // Assert
-            succeeded = (e is XunitException xUnitException) && xUnitException.Message.Contains("Second");
+            succeeded = e is XunitException xUnitException && xUnitException.Message.Contains("Second");
         }
 
         if (!succeeded)
@@ -145,6 +145,7 @@ public partial class AssertionScopeSpecs
     {
         // Arrange
         bool secondConditionEvaluated = false;
+
         try
         {
             using var _ = new AssertionScope();
@@ -195,6 +196,7 @@ public partial class AssertionScopeSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             Execute.Assertion
                 .ForCondition(false)
                 .FailWith("First assertion")
@@ -214,6 +216,7 @@ public partial class AssertionScopeSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             Execute.Assertion
                 .ForCondition(false)
                 .FailWith("First assertion")
@@ -233,6 +236,7 @@ public partial class AssertionScopeSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             Execute.Assertion
                 .ForCondition(false)
                 .FailWith("First assertion")
@@ -252,6 +256,7 @@ public partial class AssertionScopeSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             Execute.Assertion
                 .WithExpectation("Expectations are the root ")
                 .ForCondition(false)
@@ -273,6 +278,7 @@ public partial class AssertionScopeSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             Execute.Assertion
                 .WithExpectation("Expectations are the {0} ", "root")
                 .ForCondition(false)
@@ -294,6 +300,7 @@ public partial class AssertionScopeSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             Execute.Assertion
                 .WithDefaultIdentifier("identifier")
                 .ForCondition(false)
@@ -315,6 +322,7 @@ public partial class AssertionScopeSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             Execute.Assertion
                 .BecauseOf("because {0}", "whatever")
                 .ForCondition(false)
@@ -336,6 +344,7 @@ public partial class AssertionScopeSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             Execute.Assertion
                 .BecauseOf("because {0}", "whatever")
                 .ForCondition(false)

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScope.ContextDataSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScope.ContextDataSpecs.cs
@@ -41,9 +41,9 @@ public partial class AssertionScopeSpecs
     {
         // Arrange
         var scope = new AssertionScope();
-#pragma warning disable IDE0004 // Remove Unnecessary Cast
-        scope.AddNonReportable("SomeKey", (int?)null);
-#pragma warning restore IDE0004 // Remove Unnecessary Cast
+
+        int? someValue = null;
+        scope.AddNonReportable("SomeKey", someValue);
 
         // Act
         var value = scope.Get<int>("SomeKey");

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScope.MessageFormatingSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScope.MessageFormatingSpecs.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
@@ -143,11 +142,13 @@ public partial class AssertionScopeSpecs
     public void Because_reason_should_inform_about_invalid_parentheses_with_a_default_message()
     {
         // Act
-        Action act = () => 1.Should().Be(2, "use of {} is considered invalid in because parameter with becauseArgs", "additional becauseArgs argument");
+        Action act = () => 1.Should().Be(2, "use of {} is considered invalid in because parameter with becauseArgs",
+            "additional becauseArgs argument");
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("*because message 'use of {} is considered invalid in because parameter with becauseArgs' could not be formatted with string.Format*");
+            .WithMessage(
+                "*because message 'use of {} is considered invalid in because parameter with becauseArgs' could not be formatted with string.Format*");
     }
 
     [Fact]
@@ -381,6 +382,7 @@ public partial class AssertionScopeSpecs
         // Assert
         act.Should().ThrowExactly<XunitException>()
             .WithMessage("MyValue*\n\nWith MyKey:\nMyValue\n");
+
         deferredValueInvoked.Should().BeTrue();
     }
 

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -68,6 +68,7 @@ namespace FluentAssertions.Specs.Execution
             // Arrange
             var scope = new AssertionScope();
             bool failReasonCalled = false;
+
             AssertionScope.Current
                 .ForCondition(true)
                 .FailWith(() =>
@@ -241,8 +242,8 @@ namespace FluentAssertions.Specs.Execution
             // Arrange/Act
             using (var outerScope = new AssertionScope())
             {
-                outerScope.AddReportable("outerReportable", "foo"); 
-                                                                   
+                outerScope.AddReportable("outerReportable", "foo");
+
                 using (var innerScope = new AssertionScope())
                 {
                     innerScope.AddReportable("innerReportable", "bar");

--- a/Tests/FluentAssertions.Specs/Execution/GivenSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/GivenSelectorSpecs.cs
@@ -122,6 +122,7 @@ public class GivenSelectorSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             Execute.Assertion
                 .Given(() => "First")
                 .FailWith("First selector")
@@ -141,6 +142,7 @@ public class GivenSelectorSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             Execute.Assertion
                 .Given(() => "First")
                 .FailWith("{0} selector", "First")
@@ -160,6 +162,7 @@ public class GivenSelectorSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
+
             Execute.Assertion
                 .Given(() => "First")
                 .FailWith("{0} selector", _ => "First")
@@ -187,7 +190,8 @@ public class GivenSelectorSpecs
     }
 
     [Fact]
-    public void The_failure_message_should_not_be_preceded_by_the_expectation_after_selecting_a_subject_and_clearing_the_expectation()
+    public void
+        The_failure_message_should_not_be_preceded_by_the_expectation_after_selecting_a_subject_and_clearing_the_expectation()
     {
         // Act
         Action act = () => Execute.Assertion

--- a/Tests/FluentAssertions.Specs/Execution/TestFrameworkProviderTests.cs
+++ b/Tests/FluentAssertions.Specs/Execution/TestFrameworkProviderTests.cs
@@ -30,6 +30,7 @@ public class TestFrameworkProviderTests
         {
             TestFrameworkName = "xunit2"
         };
+
         var testFrameworkProvider = new TestFrameworkProvider(configuration);
 
         // Act
@@ -47,6 +48,7 @@ public class TestFrameworkProviderTests
         {
             TestFrameworkName = "foo"
         };
+
         var testFrameworkProvider = new TestFrameworkProvider(configuration);
 
         // Act
@@ -65,6 +67,7 @@ public class TestFrameworkProviderTests
         {
             TestFrameworkName = "nspec3"
         };
+
         var testFrameworkProvider = new TestFrameworkProvider(configuration);
 
         // Act
@@ -83,6 +86,7 @@ public class TestFrameworkProviderTests
         {
             TestFrameworkName = "nunit"
         };
+
         var testFrameworkProvider = new TestFrameworkProvider(configuration);
 
         // Act

--- a/Tests/FluentAssertions.Specs/Extensions/FluentDateTimeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/FluentDateTimeSpecs.cs
@@ -147,7 +147,9 @@ public class FluentDateTimeSpecs
         DateTimeOffset dateTime = 10.December(2011).ToDateTimeOffset().At(09, 30, 45, 123, 456, 700);
 
         // Assert
-        dateTime.Should().Be(new DateTimeOffset(2011, 12, 10, 9, 30, 45, 123, TimeSpan.Zero).AddMicroseconds(456).AddNanoseconds(700));
+        dateTime.Should().Be(new DateTimeOffset(2011, 12, 10, 9, 30, 45, 123, TimeSpan.Zero).AddMicroseconds(456)
+            .AddNanoseconds(700));
+
         dateTime.Microsecond().Should().Be(456);
         dateTime.Nanosecond().Should().Be(700);
     }
@@ -159,7 +161,7 @@ public class FluentDateTimeSpecs
     {
         // Act
         string expectedParameterName = "microseconds";
-        Action act = () => 10.December(2011).At(0, 0, 0, 0, microseconds, 0);
+        Action act = () => 10.December(2011).At(0, 0, 0, 0, microseconds);
 
         // Assert
         act.Should().Throw<ArgumentOutOfRangeException>()
@@ -172,7 +174,7 @@ public class FluentDateTimeSpecs
     public void When_fluently_specifying_a_datetime_with_inrange_microseconds_it_should_not_throw(int microseconds)
     {
         // Act
-        Action act = () => 10.December(2011).At(0, 0, 0, 0, microseconds, 0);
+        Action act = () => 10.December(2011).At(0, 0, 0, 0, microseconds);
 
         // Assert
         act.Should().NotThrow();
@@ -211,7 +213,7 @@ public class FluentDateTimeSpecs
     {
         // Act
         var expectedParameterName = "microseconds";
-        Action act = () => 10.December(2011).ToDateTimeOffset().At(0, 0, 0, 0, microseconds, 0);
+        Action act = () => 10.December(2011).ToDateTimeOffset().At(0, 0, 0, 0, microseconds);
 
         // Assert
         act.Should().Throw<ArgumentOutOfRangeException>()
@@ -224,7 +226,7 @@ public class FluentDateTimeSpecs
     public void When_fluently_specifying_a_datetimeoffset_with_inrange_microseconds_it_should_not_throw(int microseconds)
     {
         // Act
-        Action act = () => 10.December(2011).ToDateTimeOffset().At(0, 0, 0, 0, microseconds, 0);
+        Action act = () => 10.December(2011).ToDateTimeOffset().At(0, 0, 0, 0, microseconds);
 
         // Assert
         act.Should().NotThrow();

--- a/Tests/FluentAssertions.Specs/Extensions/ObjectExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/ObjectExtensionsSpecs.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions.Common;
-using FluentAssertions.Specs.Common;
 using Xunit;
 
 namespace FluentAssertions.Specs.Extensions;
@@ -59,9 +58,10 @@ public class ObjectExtensionsSpecs
 
     public static IEnumerable<object[]> GetNumericAndNumericData()
     {
-        return from x in GetNumericIConvertibles()
-               from y in GetNumericIConvertibles()
-               select new[] { x, y };
+        return
+            from x in GetNumericIConvertibles()
+            from y in GetNumericIConvertibles()
+            select new[] { x, y };
     }
 
     [Theory]
@@ -81,8 +81,8 @@ public class ObjectExtensionsSpecs
     public static IEnumerable<object[]> GetNonNumericAndNumericData()
     {
         return from x in GetNonNumericIConvertibles()
-               from y in GetNumericIConvertibles()
-               select new[] { x, y };
+            from y in GetNumericIConvertibles()
+            select new[] { x, y };
     }
 
     [Theory]
@@ -102,8 +102,8 @@ public class ObjectExtensionsSpecs
     public static IEnumerable<object[]> GetNumericAndNonNumericData()
     {
         return from x in GetNumericIConvertibles()
-               from y in GetNonNumericIConvertibles()
-               select new[] { x, y };
+            from y in GetNonNumericIConvertibles()
+            select new[] { x, y };
     }
 
     [Theory]
@@ -123,10 +123,12 @@ public class ObjectExtensionsSpecs
     public static IEnumerable<object[]> GetNonNumericAndNonNumericData()
     {
         object[] nonNumerics = GetNonNumericIConvertibles();
-        return from x in nonNumerics
-               from y in nonNumerics
-               where x != y
-               select new[] { x, y };
+
+        return
+            from x in nonNumerics
+            from y in nonNumerics
+            where x != y
+            select new[] { x, y };
     }
 
     private static object[] GetNumericIConvertibles()

--- a/Tests/FluentAssertions.Specs/Formatting/DateTimeOffsetValueFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/DateTimeOffsetValueFormatterSpecs.cs
@@ -32,7 +32,7 @@ public class DateTimeOffsetValueFormatterSpecs
     public void When_the_offset_is_negative_it_should_include_it_in_the_output()
     {
         // Arrange
-        DateTimeOffset date = new DateTimeOffset(1973, 9, 20, 12, 59, 59, -3.Hours());
+        DateTimeOffset date = new(1973, 9, 20, 12, 59, 59, -3.Hours());
 
         // Act
         string result = Formatter.ToString(date);
@@ -110,7 +110,8 @@ public class DateTimeOffsetValueFormatterSpecs
     [InlineData("0001-02-03 00:00:00.0000100", "<0001-02-03 00:00:00.000010>")]
     [InlineData("0001-02-03 00:00:00.0000010", "<0001-02-03 00:00:00.000001>")]
     [InlineData("0001-02-03 00:00:00.0000001", "<0001-02-03 00:00:00.0000001>")]
-    public void When_datetime_components_are_not_relevant_they_should_not_be_included_in_the_output(string actual, string expected)
+    public void When_datetime_components_are_not_relevant_they_should_not_be_included_in_the_output(string actual,
+        string expected)
     {
         // Arrange
         var value = DateTime.Parse(actual, CultureInfo.InvariantCulture);
@@ -138,7 +139,8 @@ public class DateTimeOffsetValueFormatterSpecs
     [InlineData("0001-02-03 00:00:00.0000100 +1", "<0001-02-03 00:00:00.000010 +1h>")]
     [InlineData("0001-02-03 00:00:00.0000010 +1", "<0001-02-03 00:00:00.000001 +1h>")]
     [InlineData("0001-02-03 00:00:00.0000001 +1", "<0001-02-03 00:00:00.0000001 +1h>")]
-    public void When_datetimeoffset_components_are_not_relevant_they_should_not_be_included_in_the_output(string actual, string expected)
+    public void When_datetimeoffset_components_are_not_relevant_they_should_not_be_included_in_the_output(string actual,
+        string expected)
     {
         // Arrange
         var value = DateTimeOffset.Parse(actual, CultureInfo.InvariantCulture);

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -36,6 +36,7 @@ public class FormatterSpecs
     {
         // Arrange
         var a = new A();
+
         var b = new B
         {
             X = a,
@@ -160,13 +161,13 @@ public class FormatterSpecs
         // Arrange
         var stuff = new List<Stuff<int>>
         {
-            new Stuff<int>
+            new()
             {
                 StuffId = 1,
                 Description = "Stuff_1",
                 Children = new List<int> { 1, 2, 3, 4 }
             },
-            new Stuff<int>
+            new()
             {
                 StuffId = 2,
                 Description = "Stuff_2",
@@ -176,13 +177,13 @@ public class FormatterSpecs
 
         var expectedStuff = new List<Stuff<int>>
         {
-            new Stuff<int>
+            new()
             {
                 StuffId = 1,
                 Description = "Stuff_1",
                 Children = new List<int> { 1, 2, 3, 4 }
             },
-            new Stuff<int>
+            new()
             {
                 StuffId = 2,
                 Description = "WRONG_DESCRIPTION",
@@ -224,6 +225,7 @@ public class FormatterSpecs
 
         int maxDepth = 10;
         int iterations = (maxDepth / 2) + 1; // Each iteration adds two levels of depth to the graph
+
         foreach (int i in Enumerable.Range(0, iterations))
         {
             var newHead = new Node();
@@ -249,6 +251,7 @@ public class FormatterSpecs
         var node = head;
 
         int iterations = 10;
+
         foreach (int i in Enumerable.Range(0, iterations))
         {
             var newHead = new Node();
@@ -609,7 +612,7 @@ public class FormatterSpecs
         // Arrange
         var subject = new Dictionary<MyKey, MyValue>
         {
-            [new() { KeyProp = 13 }] = new() { ValueProp = 37 }
+            [new MyKey { KeyProp = 13 }] = new() { ValueProp = 37 }
         };
 
         // Act
@@ -646,13 +649,14 @@ public class FormatterSpecs
     }
 
     [Fact]
-    public void When_formatting_multiple_items_with_a_custom_string_representation_using_line_breaks_it_should_end_lines_with_a_comma()
+    public void
+        When_formatting_multiple_items_with_a_custom_string_representation_using_line_breaks_it_should_end_lines_with_a_comma()
     {
         // Arrange
         var subject = new[] { typeof(A), typeof(B) };
 
         // Act
-        string result = Formatter.ToString(subject, new FormattingOptions { UseLineBreaks = true } );
+        string result = Formatter.ToString(subject, new FormattingOptions { UseLineBreaks = true });
 
         // Assert
         result.Should().Contain($"FluentAssertions.Specs.Formatting.FormatterSpecs+A, {Environment.NewLine}");
@@ -707,7 +711,7 @@ public class FormatterSpecs
         // Arrange
         Configuration.Current.ValueFormatterDetectionMode = ValueFormatterDetectionMode.Scan;
 
-        var subject = new SomeClassInheritedFromClassWithCustomFormatterLvl1()
+        var subject = new SomeClassInheritedFromClassWithCustomFormatterLvl1
         {
             Property = "SomeValue"
         };
@@ -725,7 +729,7 @@ public class FormatterSpecs
         // Arrange
         Configuration.Current.ValueFormatterDetectionMode = ValueFormatterDetectionMode.Scan;
 
-        var subject = new SomeClassInheritedFromClassWithCustomFormatterLvl2()
+        var subject = new SomeClassInheritedFromClassWithCustomFormatterLvl2
         {
             Property = "SomeValue"
         };
@@ -743,7 +747,7 @@ public class FormatterSpecs
         // Arrange
         Configuration.Current.ValueFormatterDetectionMode = ValueFormatterDetectionMode.Scan;
 
-        var subject = new SomeClassInheritedFromClassWithCustomFormatterLvl3()
+        var subject = new SomeClassInheritedFromClassWithCustomFormatterLvl3
         {
             Property = "SomeValue"
         };
@@ -889,10 +893,10 @@ public class FormatterSpecs
 
         // Assert
         str.Should().Match(
-"*CustomClass" + Environment.NewLine +
-"{" + Environment.NewLine +
-"    IntProperty = 0" + Environment.NewLine +
-"}*");
+            "*CustomClass" + Environment.NewLine +
+            "{" + Environment.NewLine +
+            "    IntProperty = 0" + Environment.NewLine +
+            "}*");
     }
 
     private class CustomClass
@@ -925,8 +929,8 @@ public class FormatterSpecs
         // Arrange
         var values = new CustomClass[]
         {
-            new CustomClass { IntProperty = 1 },
-            new CustomClass { IntProperty = 2 }
+            new() { IntProperty = 1 },
+            new() { IntProperty = 2 }
         };
 
         var formatter = new SingleItemValueFormatter();
@@ -936,11 +940,11 @@ public class FormatterSpecs
         string str = Formatter.ToString(values);
 
         str.Should().Match(
-"{*FluentAssertions*FormatterSpecs+CustomClass" + Environment.NewLine +
-"    {" + Environment.NewLine +
-"        IntProperty = 1, " + Environment.NewLine +
-"        StringProperty = <null>" + Environment.NewLine +
-"    },*…1 more…*}*");
+            "{*FluentAssertions*FormatterSpecs+CustomClass" + Environment.NewLine +
+            "    {" + Environment.NewLine +
+            "        IntProperty = 1, " + Environment.NewLine +
+            "        StringProperty = <null>" + Environment.NewLine +
+            "    },*…1 more…*}*");
     }
 
     private class SingleItemValueFormatter : EnumerableValueFormatter
@@ -966,7 +970,9 @@ public class FormatterSpecs
 
 // Due to the tests that call Configuration.Current
 [CollectionDefinition("FormatterSpecs", DisableParallelization = true)]
-public class FormatterSpecsDefinition { }
+public class FormatterSpecsDefinition
+{
+}
 
 internal class ExceptionThrowingClass
 {
@@ -995,7 +1001,7 @@ internal class Node
         Children = new List<Node>();
     }
 
-    public static Node Default { get; } = new Node();
+    public static Node Default { get; } = new();
 
     public List<Node> Children { get; set; }
 }

--- a/Tests/FluentAssertions.Specs/Formatting/MultidimensionalArrayFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/MultidimensionalArrayFormatterSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using FluentAssertions.Formatting;
 using Xunit;
 
@@ -28,7 +27,7 @@ public class MultidimensionalArrayFormatterSpecs
             "{empty}"
         },
         {
-            new int[,]
+            new[,]
             {
                 { 1, 2 },
                 { 3, 4 }
@@ -36,7 +35,7 @@ public class MultidimensionalArrayFormatterSpecs
             "{{1, 2}, {3, 4}}"
         },
         {
-            new int[,,]
+            new[,,]
             {
                 {
                     { 1, 2, 3 },
@@ -55,16 +54,17 @@ public class MultidimensionalArrayFormatterSpecs
     public void When_formatting_a_multi_dimensional_array_with_bounds_it_should_show_structure()
     {
         // Arrange
-        var lengthsArray = new int[] { 2, 3, 4 };
-        var boundsArray = new int[] { 1, 5, 7 };
+        var lengthsArray = new[] { 2, 3, 4 };
+        var boundsArray = new[] { 1, 5, 7 };
         var value = Array.CreateInstance(typeof(string), lengthsArray, boundsArray);
+
         for (int i = value.GetLowerBound(0); i <= value.GetUpperBound(0); i++)
         {
             for (int j = value.GetLowerBound(1); j <= value.GetUpperBound(1); j++)
             {
                 for (int k = value.GetLowerBound(2); k <= value.GetUpperBound(2); k++)
                 {
-                    var indices = new int[] { i, j, k };
+                    var indices = new[] { i, j, k };
                     value.SetValue($"{i}-{j}-{k}", indices);
                 }
             }
@@ -74,6 +74,8 @@ public class MultidimensionalArrayFormatterSpecs
         string result = Formatter.ToString(value);
 
         // Assert
-        result.Should().Match("{{{'1-5-7', '1-5-8', '1-5-9', '1-5-10'}, {'1-6-7', '1-6-8', '1-6-9', '1-6-10'}, {'1-7-7', '1-7-8', '1-7-9', '1-7-10'}}, {{'2-5-7', '2-5-8', '2-5-9', '2-5-10'}, {'2-6-7', '2-6-8', '2-6-9', '2-6-10'}, {'2-7-7', '2-7-8', '2-7-9', '2-7-10'}}}".Replace("'", "\""));
+        result.Should().Match(
+                "{{{'1-5-7', '1-5-8', '1-5-9', '1-5-10'}, {'1-6-7', '1-6-8', '1-6-9', '1-6-10'}, {'1-7-7', '1-7-8', '1-7-9', '1-7-10'}}, {{'2-5-7', '2-5-8', '2-5-9', '2-5-10'}, {'2-6-7', '2-6-8', '2-6-9', '2-6-10'}, {'2-7-7', '2-7-8', '2-7-9', '2-7-10'}}}"
+                    .Replace("'", "\""));
     }
 }

--- a/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
@@ -22,7 +22,8 @@ public class PredicateLambdaExpressionValueFormatterSpecs
     }
 
     [Fact]
-    public void When_first_level_properties_are_tested_for_equality_against_constant_expressions_then_output_should_contain_values_of_constant_expressions()
+    public void
+        When_first_level_properties_are_tested_for_equality_against_constant_expressions_then_output_should_contain_values_of_constant_expressions()
     {
         // Arrange
         var expectedText = "foo";

--- a/Tests/FluentAssertions.Specs/Formatting/TimeSpanFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/TimeSpanFormatterSpecs.cs
@@ -64,7 +64,8 @@ public class TimeSpanFormatterSpecs
     [InlineData("-01:02:03.123456", "-1h, 2m, 3s, 123ms and 456.0µs")]
     [InlineData("01:02:03.1234567", "1h, 2m, 3s, 123ms and 456.7µs")]
     [InlineData("-01:02:03.1234567", "-1h, 2m, 3s, 123ms and 456.7µs")]
-    public void When_timespan_components_are_not_relevant_they_should_not_be_included_in_the_output(string actual, string expected)
+    public void When_timespan_components_are_not_relevant_they_should_not_be_included_in_the_output(string actual,
+        string expected)
     {
         // Arrange
         var value = TimeSpan.Parse(actual, CultureInfo.InvariantCulture);

--- a/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
@@ -111,7 +111,8 @@ public class ComparableSpecs
             var value = new EquatableOfInt(3);
 
             // Act
-            Action act = () => value.Should().BeOneOf(new[] { new EquatableOfInt(4), new EquatableOfInt(5) }, "because those are the valid {0}", "values");
+            Action act = () => value.Should().BeOneOf(new[] { new EquatableOfInt(4), new EquatableOfInt(5) },
+                "because those are the valid {0}", "values");
 
             // Assert
             act
@@ -190,6 +191,7 @@ public class ComparableSpecs
         {
             // Arrange
             var subject = new ComparableCustomer(42);
+
             var expected = new AnotherCustomerDto(42)
             {
                 SomeOtherProperty = 1337
@@ -221,6 +223,7 @@ public class ComparableSpecs
         {
             // Arrange
             var subject = new ComparableCustomer(42);
+
             var expected = new AnotherCustomerDto(42)
             {
                 SomeOtherProperty = 1337

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -3980,6 +3980,7 @@ public class NumericAssertionSpecs
         Action action = () => value.Should().Equals(1);
 
         // Assert
-        action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+        action.Should().Throw<NotSupportedException>()
+            .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
     }
 }

--- a/Tests/FluentAssertions.Specs/Numeric/NumericDifferenceAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericDifferenceAssertionsSpecs.cs
@@ -37,7 +37,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"Expected value to be {expected} because we want to test the failure message, but found {value} (difference of {expectedDifference}).");
+                .WithMessage(
+                    $"Expected value to be {expected} because we want to test the failure message, but found {value} (difference of {expectedDifference}).");
         }
 
         [Theory]
@@ -94,7 +95,8 @@ public class NumericDifferenceAssertionsSpecs
         [InlineData(20, 50, -30)]
         [InlineData(123, -123, 246)]
         [InlineData(-123, 123, -246)]
-        public void The_difference_between_nullable_ints_is_included_in_the_message(int? value, int expected, int expectedDifference)
+        public void The_difference_between_nullable_ints_is_included_in_the_message(int? value, int expected,
+            int expectedDifference)
         {
             // Act
             Action act = () =>
@@ -103,7 +105,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"Expected value to be {expected} because we want to test the failure message, but found {value} (difference of {expectedDifference}).");
+                .WithMessage(
+                    $"Expected value to be {expected} because we want to test the failure message, but found {value} (difference of {expectedDifference}).");
         }
 
         [Fact]
@@ -120,7 +123,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 19u because we want to test the failure message, but found 29u (difference of 10).");
+                .WithMessage(
+                    "Expected value to be 19u because we want to test the failure message, but found 29u (difference of 10).");
         }
 
         [Theory]
@@ -135,7 +139,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"Expected value to be {expected}L because we want to test the failure message, but found {value}L.");
+                .WithMessage(
+                    $"Expected value to be {expected}L because we want to test the failure message, but found {value}L.");
         }
 
         [Theory]
@@ -150,7 +155,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"Expected value to be {expected}L because we want to test the failure message, but found {value}L (difference of {expectedDifference}).");
+                .WithMessage(
+                    $"Expected value to be {expected}L because we want to test the failure message, but found {value}L (difference of {expectedDifference}).");
         }
 
         [Theory]
@@ -165,13 +171,15 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"Expected value to be {expected}L because we want to test the failure message, but found {value}L.");
+                .WithMessage(
+                    $"Expected value to be {expected}L because we want to test the failure message, but found {value}L.");
         }
 
         [Theory]
         [InlineData(50L, 20, 30)]
         [InlineData(20L, 50, -30)]
-        public void The_difference_between_nullable_longs_is_included_in_the_message(long? value, long expected, long expectedDifference)
+        public void The_difference_between_nullable_longs_is_included_in_the_message(long? value, long expected,
+            long expectedDifference)
         {
             // Act
             Action act = () =>
@@ -180,7 +188,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"Expected value to be {expected}L because we want to test the failure message, but found {value}L (difference of {expectedDifference}).");
+                .WithMessage(
+                    $"Expected value to be {expected}L because we want to test the failure message, but found {value}L (difference of {expectedDifference}).");
         }
 
         [Theory]
@@ -195,13 +204,15 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"Expected value to be {expected}s because we want to test the failure message, but found {value}s.");
+                .WithMessage(
+                    $"Expected value to be {expected}s because we want to test the failure message, but found {value}s.");
         }
 
         [Theory]
         [InlineData(50, 20, 30)]
         [InlineData(20, 50, -30)]
-        public void The_difference_between_shorts_is_included_in_the_message(short value, short expected, short expectedDifference)
+        public void The_difference_between_shorts_is_included_in_the_message(short value, short expected,
+            short expectedDifference)
         {
             // Act
             Action act = () =>
@@ -210,7 +221,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"Expected value to be {expected}s because we want to test the failure message, but found {value}s (difference of {expectedDifference}).");
+                .WithMessage(
+                    $"Expected value to be {expected}s because we want to test the failure message, but found {value}s (difference of {expectedDifference}).");
         }
 
         [Fact]
@@ -244,7 +256,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 2s because we want to test the failure message, but found 15s (difference of 13).");
+                .WithMessage(
+                    "Expected value to be 2s because we want to test the failure message, but found 15s (difference of 13).");
         }
 
         [Fact]
@@ -278,7 +291,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 20UL because we want to test the failure message, but found 50UL (difference of 30).");
+                .WithMessage(
+                    "Expected value to be 20UL because we want to test the failure message, but found 50UL (difference of 30).");
         }
 
         [Fact]
@@ -312,7 +326,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 20UL because we want to test the failure message, but found 50UL (difference of 30).");
+                .WithMessage(
+                    "Expected value to be 20UL because we want to test the failure message, but found 50UL (difference of 30).");
         }
 
         [Fact]
@@ -329,7 +344,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 2us because we want to test the failure message, but found 11us (difference of 9).");
+                .WithMessage(
+                    "Expected value to be 2us because we want to test the failure message, but found 11us (difference of 9).");
         }
 
         [Fact]
@@ -346,7 +362,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 1.0 because we want to test the failure message, but found 1.5 (difference of 0.5).");
+                .WithMessage(
+                    "Expected value to be 1.0 because we want to test the failure message, but found 1.5 (difference of 0.5).");
         }
 
         [Fact]
@@ -363,7 +380,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 1.0 because we want to test the failure message, but found 1.5 (difference of 0.5).");
+                .WithMessage(
+                    "Expected value to be 1.0 because we want to test the failure message, but found 1.5 (difference of 0.5).");
         }
 
         [Fact]
@@ -380,7 +398,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 1F because we want to test the failure message, but found 1.5F (difference of 0.5).");
+                .WithMessage(
+                    "Expected value to be 1F because we want to test the failure message, but found 1.5F (difference of 0.5).");
         }
 
         [Fact]
@@ -397,7 +416,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 1F because we want to test the failure message, but found 1.5F (difference of 0.5).");
+                .WithMessage(
+                    "Expected value to be 1F because we want to test the failure message, but found 1.5F (difference of 0.5).");
         }
 
         [Fact]
@@ -414,7 +434,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 1m because we want to test the failure message, but found 1.5m (difference of 0.5).");
+                .WithMessage(
+                    "Expected value to be 1m because we want to test the failure message, but found 1.5m (difference of 0.5).");
         }
 
         [Fact]
@@ -431,7 +452,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 1m because we want to test the failure message, but found 1.5m (difference of 0.5).");
+                .WithMessage(
+                    "Expected value to be 1m because we want to test the failure message, but found 1.5m (difference of 0.5).");
         }
 
         [Fact]
@@ -448,7 +470,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 3y because we want to test the failure message, but found 1y (difference of -2).");
+                .WithMessage(
+                    "Expected value to be 3y because we want to test the failure message, but found 1y (difference of -2).");
         }
 
         [Fact]
@@ -465,7 +488,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 3y because we want to test the failure message, but found 1y (difference of -2).");
+                .WithMessage(
+                    "Expected value to be 3y because we want to test the failure message, but found 1y (difference of -2).");
         }
     }
 
@@ -519,7 +543,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be less than 22 because we want to test the failure message, but found 52 (difference of 30).");
+                .WithMessage(
+                    "Expected value to be less than 22 because we want to test the failure message, but found 52 (difference of 30).");
         }
     }
 
@@ -539,7 +564,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be less than or equal to 2 because we want to test the failure message, but found 4.");
+                .WithMessage(
+                    "Expected value to be less than or equal to 2 because we want to test the failure message, but found 4.");
         }
 
         [Fact]
@@ -556,7 +582,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be less than or equal to 22 because we want to test the failure message, but found 52 (difference of 30).");
+                .WithMessage(
+                    "Expected value to be less than or equal to 22 because we want to test the failure message, but found 52 (difference of 30).");
         }
     }
 
@@ -610,7 +637,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be greater than 52 because we want to test the failure message, but found 22 (difference of -30).");
+                .WithMessage(
+                    "Expected value to be greater than 52 because we want to test the failure message, but found 22 (difference of -30).");
         }
 
         [Fact]
@@ -661,7 +689,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be greater than 2.3F because we want to test the failure message, but found 2.3F.");
+                .WithMessage(
+                    "Expected value to be greater than 2.3F because we want to test the failure message, but found 2.3F.");
         }
 
         [Fact]
@@ -678,7 +707,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be greater than 11us because we want to test the failure message, but found 11us.");
+                .WithMessage(
+                    "Expected value to be greater than 11us because we want to test the failure message, but found 11us.");
         }
 
         [Fact]
@@ -712,7 +742,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be greater than 15UL because we want to test the failure message, but found 15UL.");
+                .WithMessage(
+                    "Expected value to be greater than 15UL because we want to test the failure message, but found 15UL.");
         }
     }
 
@@ -732,7 +763,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be greater than or equal to 4 because we want to test the failure message, but found 2.");
+                .WithMessage(
+                    "Expected value to be greater than or equal to 4 because we want to test the failure message, but found 2.");
         }
 
         [Fact]
@@ -749,7 +781,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be greater than or equal to 52 because we want to test the failure message, but found 22 (difference of -30).");
+                .WithMessage(
+                    "Expected value to be greater than or equal to 52 because we want to test the failure message, but found 22 (difference of -30).");
         }
     }
 
@@ -823,7 +856,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected long.MinValue to be 9223372036854775807L*found -9223372036854775808L (difference of -18446744073709551615).");
+                .WithMessage(
+                    "Expected long.MinValue to be 9223372036854775807L*found -9223372036854775808L (difference of -18446744073709551615).");
         }
 
         [Fact]
@@ -839,7 +873,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected minValue to be 9223372036854775807L*found -9223372036854775808L (difference of -18446744073709551615).");
+                .WithMessage(
+                    "Expected minValue to be 9223372036854775807L*found -9223372036854775808L (difference of -18446744073709551615).");
         }
 
         [Fact]
@@ -852,7 +887,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected ulong.MinValue to be 18446744073709551615UL*found 0UL (difference of -18446744073709551615).");
+                .WithMessage(
+                    "Expected ulong.MinValue to be 18446744073709551615UL*found 0UL (difference of -18446744073709551615).");
         }
 
         [Fact]
@@ -881,7 +917,8 @@ public class NumericDifferenceAssertionsSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected decimal.MinValue to be 79228162514264337593543950335M*found -79228162514264337593543950335M.");
+                .WithMessage(
+                    "Expected decimal.MinValue to be 79228162514264337593543950335M*found -79228162514264337593543950335M.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -162,7 +162,8 @@ public class BooleanAssertionSpecs
             Action action = () => true.Should().Equals(true);
 
             // Assert
-            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Primitives/DateOnlyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateOnlyAssertionSpecs.cs
@@ -3,7 +3,6 @@ using Xunit;
 using Xunit.Sdk;
 
 #if NET6_0_OR_GREATER
-
 namespace FluentAssertions.Specs.Primitives;
 
 public class DateOnlyAssertionSpecs
@@ -784,7 +783,8 @@ public class DateOnlyAssertionSpecs
             Action action = () => someDateOnly.Should().Equals(someDateOnly);
 
             // Assert
-            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
@@ -133,8 +133,8 @@ public class DateTimeAssertionSpecs
         public void Should_succeed_when_asserting_datetime_value_is_equal_to_the_same_value()
         {
             // Arrange
-            DateTime dateTime = new DateTime(2016, 06, 04);
-            DateTime sameDateTime = new DateTime(2016, 06, 04);
+            DateTime dateTime = new(2016, 06, 04);
+            DateTime sameDateTime = new(2016, 06, 04);
 
             // Act
             Action act = () => dateTime.Should().Be(sameDateTime);
@@ -235,7 +235,7 @@ public class DateTimeAssertionSpecs
         {
             // Arrange
             DateTime? nullableDateTime = new DateTime(2014, 4, 20, 9, 11, 0, DateTimeKind.Unspecified);
-            DateTime normalDateTime = new DateTime(2014, 4, 20, 9, 11, 0, DateTimeKind.Utc);
+            DateTime normalDateTime = new(2014, 4, 20, 9, 11, 0, DateTimeKind.Utc);
 
             // Act
             Action action = () =>
@@ -249,8 +249,8 @@ public class DateTimeAssertionSpecs
         public void When_two_date_times_are_equal_but_the_kinds_differ_it_should_still_succeed()
         {
             // Arrange
-            DateTime dateTimeA = new DateTime(2014, 4, 20, 9, 11, 0, DateTimeKind.Unspecified);
-            DateTime dateTimeB = new DateTime(2014, 4, 20, 9, 11, 0, DateTimeKind.Utc);
+            DateTime dateTimeA = new(2014, 4, 20, 9, 11, 0, DateTimeKind.Unspecified);
+            DateTime dateTimeB = new(2014, 4, 20, 9, 11, 0, DateTimeKind.Utc);
 
             // Act
             Action action = () =>
@@ -302,7 +302,8 @@ public class DateTimeAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected nullableDateTime to be <2016-06-04> because we want to test the failure message, but found <null>.");
+                .WithMessage(
+                    "Expected nullableDateTime to be <2016-06-04> because we want to test the failure message, but found <null>.");
         }
     }
 
@@ -312,8 +313,8 @@ public class DateTimeAssertionSpecs
         public void Should_succeed_when_asserting_datetime_value_is_not_equal_to_a_different_value()
         {
             // Arrange
-            DateTime dateTime = new DateTime(2016, 06, 04);
-            DateTime otherDateTime = new DateTime(2016, 06, 05);
+            DateTime dateTime = new(2016, 06, 04);
+            DateTime otherDateTime = new(2016, 06, 05);
 
             // Act
             Action act = () => dateTime.Should().NotBe(otherDateTime);
@@ -349,7 +350,8 @@ public class DateTimeAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected dateTime not to be <2012-03-10 10:00:00> because we want to test the failure message, but it is.");
+                .WithMessage(
+                    "Expected dateTime not to be <2012-03-10 10:00:00> because we want to test the failure message, but it is.");
         }
 
         [Fact]
@@ -365,7 +367,8 @@ public class DateTimeAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected dateTime not to be <2012-03-10 10:00:00> because we want to test the failure message, but it is.");
+                .WithMessage(
+                    "Expected dateTime not to be <2012-03-10 10:00:00> because we want to test the failure message, but it is.");
         }
     }
 
@@ -488,7 +491,8 @@ public class DateTimeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_subject_datetime_is_close_to_another_value_that_is_later_by_more_than_a_20ms_timespan_it_should_throw()
+        public void
+            When_asserting_subject_datetime_is_close_to_another_value_that_is_later_by_more_than_a_20ms_timespan_it_should_throw()
         {
             // Arrange
             DateTime time = 13.March(2012).At(12, 15, 30, 979);
@@ -663,7 +667,8 @@ public class DateTimeAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 20ms from <2016-06-04 12:15:31>, but it was <2016-06-04 12:15:30.980>.");
+                .WithMessage(
+                    "Did not expect time to be within 20ms from <2016-06-04 12:15:31>, but it was <2016-06-04 12:15:30.980>.");
         }
 
         [Fact]
@@ -678,7 +683,8 @@ public class DateTimeAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 20ms from <2016-06-04 12:15:31>, but it was <2016-06-04 12:15:31.020>.");
+                .WithMessage(
+                    "Did not expect time to be within 20ms from <2016-06-04 12:15:31>, but it was <2016-06-04 12:15:31.020>.");
         }
 
         [Fact]
@@ -693,11 +699,13 @@ public class DateTimeAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 20ms from <2016-06-04 12:15:31>, but it was <2016-06-04 12:15:31.020>.");
+                .WithMessage(
+                    "Did not expect time to be within 20ms from <2016-06-04 12:15:31>, but it was <2016-06-04 12:15:31.020>.");
         }
 
         [Fact]
-        public void When_asserting_subject_datetime_is_not_close_to_another_value_that_is_later_by_more_than_20ms_it_should_succeed()
+        public void
+            When_asserting_subject_datetime_is_not_close_to_another_value_that_is_later_by_more_than_20ms_it_should_succeed()
         {
             // Arrange
             DateTime time = 13.March(2012).At(12, 15, 30, 979);
@@ -711,7 +719,8 @@ public class DateTimeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_subject_datetime_is_not_close_to_another_value_that_is_earlier_by_more_than_20ms_it_should_succeed()
+        public void
+            When_asserting_subject_datetime_is_not_close_to_another_value_that_is_earlier_by_more_than_20ms_it_should_succeed()
         {
             // Arrange
             DateTime time = 13.March(2012).At(12, 15, 31, 021);
@@ -736,7 +745,8 @@ public class DateTimeAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 35ms from <2016-06-04 12:15:31>, but it was <2016-06-04 12:15:31.035>.");
+                .WithMessage(
+                    "Did not expect time to be within 35ms from <2016-06-04 12:15:31>, but it was <2016-06-04 12:15:31.035>.");
         }
 
         [Fact]
@@ -781,7 +791,8 @@ public class DateTimeAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 100ms from <9999-12-31 23:59:59.9999999>, but it was <9999-12-31 23:59:59.9499999>.");
+                .WithMessage(
+                    "Did not expect time to be within 100ms from <9999-12-31 23:59:59.9999999>, but it was <9999-12-31 23:59:59.9499999>.");
         }
     }
 
@@ -805,8 +816,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_is_before_earlier_expected_datetime_it_should_throw()
         {
             // Arrange
-            DateTime expected = new DateTime(2016, 06, 03);
-            DateTime subject = new DateTime(2016, 06, 04);
+            DateTime expected = new(2016, 06, 03);
+            DateTime subject = new(2016, 06, 04);
 
             // Act
             Action act = () => subject.Should().BeBefore(expected);
@@ -820,8 +831,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_before_the_same_datetime_it_should_throw()
         {
             // Arrange
-            DateTime expected = new DateTime(2016, 06, 04);
-            DateTime subject = new DateTime(2016, 06, 04);
+            DateTime expected = new(2016, 06, 04);
+            DateTime subject = new(2016, 06, 04);
 
             // Act
             Action act = () => subject.Should().BeBefore(expected);
@@ -853,8 +864,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_is_not_before_earlier_expected_datetime_it_should_succeed()
         {
             // Arrange
-            DateTime expected = new DateTime(2016, 06, 03);
-            DateTime subject = new DateTime(2016, 06, 04);
+            DateTime expected = new(2016, 06, 03);
+            DateTime subject = new(2016, 06, 04);
 
             // Act
             Action act = () => subject.Should().NotBeBefore(expected);
@@ -867,8 +878,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_not_before_the_same_datetime_it_should_succeed()
         {
             // Arrange
-            DateTime expected = new DateTime(2016, 06, 04);
-            DateTime subject = new DateTime(2016, 06, 04);
+            DateTime expected = new(2016, 06, 04);
+            DateTime subject = new(2016, 06, 04);
 
             // Act
             Action act = () => subject.Should().NotBeBefore(expected);
@@ -884,8 +895,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_on_or_before_expected_datetime_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 05);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 05);
 
             // Act
             Action act = () => subject.Should().BeOnOrBefore(expectation);
@@ -898,8 +909,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_on_or_before_the_same_date_as_the_expected_datetime_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 04);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 04);
 
             // Act
             Action act = () => subject.Should().BeOnOrBefore(expectation);
@@ -912,8 +923,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_not_on_or_before_earlier_expected_datetime_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 03);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 03);
 
             // Act
             Action act = () => subject.Should().BeOnOrBefore(expectation);
@@ -930,8 +941,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_on_or_before_expected_datetime_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 05);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 05);
 
             // Act
             Action act = () => subject.Should().NotBeOnOrBefore(expectation);
@@ -945,8 +956,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_on_or_before_the_same_date_as_the_expected_datetime_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 04);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 04);
 
             // Act
             Action act = () => subject.Should().NotBeOnOrBefore(expectation);
@@ -960,8 +971,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_not_on_or_before_earlier_expected_datetime_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 03);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 03);
 
             // Act
             Action act = () => subject.Should().NotBeOnOrBefore(expectation);
@@ -977,8 +988,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_after_earlier_expected_datetime_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 03);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 03);
 
             // Act
             Action act = () => subject.Should().BeAfter(expectation);
@@ -991,8 +1002,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_after_later_expected_datetime_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 05);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 05);
 
             // Act
             Action act = () => subject.Should().BeAfter(expectation);
@@ -1006,8 +1017,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_after_the_same_expected_datetime_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 04);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 04);
 
             // Act
             Action act = () => subject.Should().BeAfter(expectation);
@@ -1024,8 +1035,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_not_after_earlier_expected_datetime_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 03);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 03);
 
             // Act
             Action act = () => subject.Should().NotBeAfter(expectation);
@@ -1039,8 +1050,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_not_after_later_expected_datetime_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 05);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 05);
 
             // Act
             Action act = () => subject.Should().NotBeAfter(expectation);
@@ -1053,8 +1064,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_not_after_the_same_expected_datetime_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 04);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 04);
 
             // Act
             Action act = () => subject.Should().NotBeAfter(expectation);
@@ -1070,8 +1081,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_on_or_after_earlier_expected_datetime_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 03);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 03);
 
             // Act
             Action act = () => subject.Should().BeOnOrAfter(expectation);
@@ -1084,8 +1095,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_on_or_after_the_same_expected_datetime_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 04);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 04);
 
             // Act
             Action act = () => subject.Should().BeOnOrAfter(expectation);
@@ -1098,8 +1109,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_on_or_after_later_expected_datetime_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 05);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 05);
 
             // Act
             Action act = () => subject.Should().BeOnOrAfter(expectation);
@@ -1116,8 +1127,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_not_on_or_after_earlier_expected_datetime_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 03);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 03);
 
             // Act
             Action act = () => subject.Should().NotBeOnOrAfter(expectation);
@@ -1131,8 +1142,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_not_on_or_after_the_same_expected_datetime_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 04);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 04);
 
             // Act
             Action act = () => subject.Should().NotBeOnOrAfter(expectation);
@@ -1146,8 +1157,8 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_is_not_on_or_after_later_expected_datetime_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2016, 06, 04);
-            DateTime expectation = new DateTime(2016, 06, 05);
+            DateTime subject = new(2016, 06, 04);
+            DateTime expectation = new(2016, 06, 05);
 
             // Act
             Action act = () => subject.Should().NotBeOnOrAfter(expectation);
@@ -1163,7 +1174,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_have_year_with_the_same_value_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31);
+            DateTime subject = new(2009, 12, 31);
             int expectation = 2009;
 
             // Act
@@ -1177,7 +1188,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_have_year_with_a_different_value_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31);
+            DateTime subject = new(2009, 12, 31);
             int expectation = 2008;
 
             // Act
@@ -1210,7 +1221,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_not_have_year_with_the_same_value_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31);
+            DateTime subject = new(2009, 12, 31);
             int expectation = 2009;
 
             // Act
@@ -1225,7 +1236,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_not_have_year_with_a_different_value_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31);
+            DateTime subject = new(2009, 12, 31);
             int expectation = 2008;
 
             // Act
@@ -1257,7 +1268,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_have_month_with_the_same_value_it_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31);
+            DateTime subject = new(2009, 12, 31);
             int expectation = 12;
 
             // Act
@@ -1271,7 +1282,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_have_a_month_with_a_different_value_it_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31);
+            DateTime subject = new(2009, 12, 31);
             int expectation = 11;
 
             // Act
@@ -1304,7 +1315,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_not_have_month_with_the_same_value_it_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31);
+            DateTime subject = new(2009, 12, 31);
             int expectation = 12;
 
             // Act
@@ -1319,7 +1330,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_not_have_a_month_with_a_different_value_it_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31);
+            DateTime subject = new(2009, 12, 31);
             int expectation = 11;
 
             // Act
@@ -1351,7 +1362,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_have_day_with_the_same_value_it_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31);
+            DateTime subject = new(2009, 12, 31);
             int expectation = 31;
 
             // Act
@@ -1365,7 +1376,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_have_day_with_a_different_value_it_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31);
+            DateTime subject = new(2009, 12, 31);
             int expectation = 30;
 
             // Act
@@ -1398,7 +1409,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_not_have_day_with_the_same_value_it_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31);
+            DateTime subject = new(2009, 12, 31);
             int expectation = 31;
 
             // Act
@@ -1413,7 +1424,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_not_have_day_with_a_different_value_it_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31);
+            DateTime subject = new(2009, 12, 31);
             int expectation = 30;
 
             // Act
@@ -1445,7 +1456,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_have_hour_with_the_same_value_it_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00);
             int expectation = 23;
 
             // Act
@@ -1459,7 +1470,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_have_hour_with_different_value_it_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00);
             int expectation = 22;
 
             // Act
@@ -1492,7 +1503,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_not_have_hour_with_the_same_value_it_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00);
             int expectation = 23;
 
             // Act
@@ -1507,7 +1518,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_not_have_hour_with_different_value_it_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00);
             int expectation = 22;
 
             // Act
@@ -1539,7 +1550,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_have_minutes_with_the_same_value_it_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00);
             int expectation = 59;
 
             // Act
@@ -1553,7 +1564,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_have_minutes_with_different_value_it_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00);
             int expectation = 58;
 
             // Act
@@ -1586,7 +1597,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_not_have_minutes_with_the_same_value_it_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00);
             int expectation = 59;
 
             // Act
@@ -1601,7 +1612,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_not_have_minutes_with_different_value_it_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00);
             int expectation = 58;
 
             // Act
@@ -1633,7 +1644,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_have_seconds_with_the_same_value_it_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00);
             int expectation = 0;
 
             // Act
@@ -1647,7 +1658,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_have_seconds_with_different_value_it_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00);
             int expectation = 1;
 
             // Act
@@ -1680,7 +1691,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_not_have_seconds_with_the_same_value_it_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00);
             int expectation = 0;
 
             // Act
@@ -1695,7 +1706,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_should_not_have_seconds_with_different_value_it_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00);
             int expectation = 1;
 
             // Act
@@ -1727,7 +1738,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_represents_its_own_kind_it_should_succeed()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00, DateTimeKind.Local);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00, DateTimeKind.Local);
 
             // Act
             Action act = () => subject.Should().BeIn(DateTimeKind.Local);
@@ -1740,7 +1751,7 @@ public class DateTimeAssertionSpecs
         public void When_asserting_subject_datetime_represents_a_different_kind_it_should_throw()
         {
             // Arrange
-            DateTime subject = new DateTime(2009, 12, 31, 23, 59, 00, DateTimeKind.Local);
+            DateTime subject = new(2009, 12, 31, 23, 59, 00, DateTimeKind.Local);
 
             // Act
             Action act = () => subject.Should().BeIn(DateTimeKind.Utc);
@@ -1781,7 +1792,8 @@ public class DateTimeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_subject_datetime_should_be_same_as_another_with_same_date_but_different_time_it_should_succeed()
+        public void
+            When_asserting_subject_datetime_should_be_same_as_another_with_same_date_but_different_time_it_should_succeed()
         {
             // Arrange
             var subject = new DateTime(2009, 12, 31, 4, 5, 6);
@@ -1839,7 +1851,8 @@ public class DateTimeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_subject_datetime_should_not_be_same_as_another_with_same_date_but_different_time_it_should_throw()
+        public void
+            When_asserting_subject_datetime_should_not_be_same_as_another_with_same_date_but_different_time_it_should_throw()
         {
             // Arrange
             var subject = new DateTime(2009, 12, 31, 4, 5, 6);
@@ -2064,7 +2077,8 @@ public class DateTimeAssertionSpecs
         [Theory]
         [InlineData(30, 20)] // edge case
         [InlineData(30, 15)]
-        public void When_asserting_subject_be_at_least_10_seconds_after_target_but_subject_is_before_target_it_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_at_least_10_seconds_after_target_but_subject_is_before_target_it_should_throw(
+            int targetSeconds, int subjectSeconds)
         {
             // Arrange
             var expectation = 1.January(0001).At(0, 0, targetSeconds);
@@ -2075,7 +2089,8 @@ public class DateTimeAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage(
+                    $"Expected subject <00:00:{subjectSeconds}> to be at least 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2096,7 +2111,8 @@ public class DateTimeAssertionSpecs
         [Theory]
         [InlineData(30, 20)] // edge case
         [InlineData(30, 25)]
-        public void When_asserting_subject_be_within_10_seconds_after_target_but_subject_is_before_target_it_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_within_10_seconds_after_target_but_subject_is_before_target_it_should_throw(
+            int targetSeconds, int subjectSeconds)
         {
             // Arrange
             var expectation = 1.January(0001).At(0, 0, targetSeconds);
@@ -2107,7 +2123,8 @@ public class DateTimeAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage(
+                    $"Expected subject <00:00:{subjectSeconds}> to be within 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2143,7 +2160,8 @@ public class DateTimeAssertionSpecs
         [Theory]
         [InlineData(30, 40)] // edge case
         [InlineData(30, 45)]
-        public void When_asserting_subject_be_at_least_10_seconds_before_target_but_subject_is_after_target_it_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_at_least_10_seconds_before_target_but_subject_is_after_target_it_should_throw(
+            int targetSeconds, int subjectSeconds)
         {
             // Arrange
             var expectation = 1.January(0001).At(0, 0, targetSeconds);
@@ -2154,7 +2172,8 @@ public class DateTimeAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage(
+                    $"Expected subject <00:00:{subjectSeconds}> to be at least 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2175,7 +2194,8 @@ public class DateTimeAssertionSpecs
         [Theory]
         [InlineData(30, 40)] // edge case
         [InlineData(30, 35)]
-        public void When_asserting_subject_be_within_10_seconds_before_target_but_subject_is_after_target_it_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_within_10_seconds_before_target_but_subject_is_after_target_it_should_throw(
+            int targetSeconds, int subjectSeconds)
         {
             // Arrange
             var expectation = 1.January(0001).At(0, 0, targetSeconds);
@@ -2186,7 +2206,8 @@ public class DateTimeAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage(
+                    $"Expected subject <00:00:{subjectSeconds}> to be within 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2211,7 +2232,7 @@ public class DateTimeAssertionSpecs
         public void Should_support_chaining_constraints_with_and()
         {
             // Arrange
-            DateTime earlierDateTime = new DateTime(2016, 06, 03);
+            DateTime earlierDateTime = new(2016, 06, 03);
             DateTime? nullableDateTime = new DateTime(2016, 06, 04);
 
             // Act
@@ -2232,38 +2253,42 @@ public class DateTimeAssertionSpecs
         public void When_a_value_is_not_one_of_the_specified_values_it_should_throw()
         {
             // Arrange
-            DateTime value = new DateTime(2016, 12, 30, 23, 58, 57);
+            DateTime value = new(2016, 12, 30, 23, 58, 57);
 
             // Act
             Action action = () => value.Should().BeOneOf(value + 1.Days(), value + 1.Milliseconds());
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {<2016-12-31 23:58:57>, <2016-12-30 23:58:57.001>}, but found <2016-12-30 23:58:57>.");
+                .WithMessage(
+                    "Expected value to be one of {<2016-12-31 23:58:57>, <2016-12-30 23:58:57.001>}, but found <2016-12-30 23:58:57>.");
         }
 
         [Fact]
         public void When_a_value_is_not_one_of_the_specified_values_it_should_throw_with_descriptive_message()
         {
             // Arrange
-            DateTime value = new DateTime(2016, 12, 30, 23, 58, 57);
+            DateTime value = new(2016, 12, 30, 23, 58, 57);
 
             // Act
-            Action action = () => value.Should().BeOneOf(new[] { value + 1.Days(), value + 1.Milliseconds() }, "because it's true");
+            Action action = () =>
+                value.Should().BeOneOf(new[] { value + 1.Days(), value + 1.Milliseconds() }, "because it's true");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {<2016-12-31 23:58:57>, <2016-12-30 23:58:57.001>} because it's true, but found <2016-12-30 23:58:57>.");
+                .WithMessage(
+                    "Expected value to be one of {<2016-12-31 23:58:57>, <2016-12-30 23:58:57.001>} because it's true, but found <2016-12-30 23:58:57>.");
         }
 
         [Fact]
         public void When_a_value_is_one_of_the_specified_values_it_should_succeed()
         {
             // Arrange
-            DateTime value = new DateTime(2016, 12, 30, 23, 58, 57);
+            DateTime value = new(2016, 12, 30, 23, 58, 57);
 
             // Act
-            Action action = () => value.Should().BeOneOf(new DateTime(2216, 1, 30, 0, 5, 7), new DateTime(2016, 12, 30, 23, 58, 57), new DateTime(2012, 3, 3));
+            Action action = () => value.Should().BeOneOf(new DateTime(2216, 1, 30, 0, 5, 7),
+                new DateTime(2016, 12, 30, 23, 58, 57), new DateTime(2012, 3, 3));
 
             // Assert
             action.Should().NotThrow();
@@ -2309,7 +2334,8 @@ public class DateTimeAssertionSpecs
             Action action = () => someDateTime.Should().Equals(someDateTime);
 
             // Assert
-            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
         }
 
         [Fact]
@@ -2322,7 +2348,8 @@ public class DateTimeAssertionSpecs
             Action action = () => someDateTime.Should().BeLessThan(0.Seconds()).Equals(someDateTime);
 
             // Assert
-            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Before() or After() instead?");
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean Before() or After() instead?");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -270,7 +270,8 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected nullableDateTime to represent the same point in time as <2016-03-27 +1h> because we want to test the failure message, but found a <null> DateTimeOffset.");
+                .WithMessage(
+                    "Expected nullableDateTime to represent the same point in time as <2016-03-27 +1h> because we want to test the failure message, but found a <null> DateTimeOffset.");
         }
 
         [Fact]
@@ -286,7 +287,8 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected nullableDateTime to be <null> because we want to test the failure message, but it was <2016-03-27 +1h>.");
+                .WithMessage(
+                    "Expected nullableDateTime to be <null> because we want to test the failure message, but it was <2016-03-27 +1h>.");
         }
 
         [Fact]
@@ -355,7 +357,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_datetimeoffset_value_is_not_equal_to_the_same_nullable_value_notbe_should_failed()
         {
             // Arrange
-            DateTimeOffset dateTime = new DateTimeOffset(10.March(2012), 1.Hours());
+            DateTimeOffset dateTime = new(10.March(2012), 1.Hours());
             DateTimeOffset? sameDateTime = new DateTimeOffset(10.March(2012), 1.Hours());
 
             // Act
@@ -369,7 +371,7 @@ public class DateTimeOffsetAssertionSpecs
 
         [Fact]
         public void
-        When_asserting_different_date_time_offsets_representing_different_world_times_it_should_not_succeed()
+            When_asserting_different_date_time_offsets_representing_different_world_times_it_should_not_succeed()
         {
             // Arrange
             var specificDate = 1.May(2008).At(6, 32);
@@ -486,7 +488,8 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected nullableDateTime to be exactly <2016-03-27 +1h> because we want to test the failure message, but found a <null> DateTimeOffset.");
+                .WithMessage(
+                    "Expected nullableDateTime to be exactly <2016-03-27 +1h> because we want to test the failure message, but found a <null> DateTimeOffset.");
         }
     }
 
@@ -534,7 +537,7 @@ public class DateTimeOffsetAssertionSpecs
         public void Should_fail_when_asserting_value_is_not_exactly_equal_to_the_same_nullable_value()
         {
             // Arrange
-            DateTimeOffset dateTime = new DateTimeOffset(10.March(2012), 1.Hours());
+            DateTimeOffset dateTime = new(10.March(2012), 1.Hours());
             DateTimeOffset? sameDateTime = new DateTimeOffset(10.March(2012), 1.Hours());
 
             // Act
@@ -625,8 +628,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_close_to_a_later_datetimeoffset_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset time = new DateTimeOffset(2016, 06, 04, 12, 15, 30, 980, TimeSpan.Zero);
-            DateTimeOffset nearbyTime = new DateTimeOffset(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
+            DateTimeOffset time = new(2016, 06, 04, 12, 15, 30, 980, TimeSpan.Zero);
+            DateTimeOffset nearbyTime = new(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
 
             // Act
             Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
@@ -639,8 +642,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_close_to_an_earlier_datetimeoffset_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset time = new DateTimeOffset(2016, 06, 04, 12, 15, 31, 020, TimeSpan.Zero);
-            DateTimeOffset nearbyTime = new DateTimeOffset(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
+            DateTimeOffset time = new(2016, 06, 04, 12, 15, 31, 020, TimeSpan.Zero);
+            DateTimeOffset nearbyTime = new(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
 
             // Act
             Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
@@ -650,7 +653,8 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_subject_datetimeoffset_is_close_to_another_value_that_is_later_by_more_than_20ms_it_should_throw()
+        public void
+            When_asserting_subject_datetimeoffset_is_close_to_another_value_that_is_later_by_more_than_20ms_it_should_throw()
         {
             // Arrange
             DateTimeOffset time = 13.March(2012).At(12, 15, 30, 979).ToDateTimeOffset(1.Hours());
@@ -666,7 +670,8 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_subject_datetimeoffset_is_close_to_another_value_that_is_earlier_by_more_than_20ms_it_should_throw()
+        public void
+            When_asserting_subject_datetimeoffset_is_close_to_another_value_that_is_earlier_by_more_than_20ms_it_should_throw()
         {
             // Arrange
             DateTimeOffset time = 13.March(2012).At(12, 15, 31, 021).ToDateTimeOffset(1.Hours());
@@ -682,7 +687,8 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_subject_datetimeoffset_is_close_to_another_value_that_is_earlier_by_more_than_a_35ms_timespan_it_should_throw()
+        public void
+            When_asserting_subject_datetimeoffset_is_close_to_another_value_that_is_earlier_by_more_than_a_35ms_timespan_it_should_throw()
         {
             // Arrange
             DateTimeOffset time = 13.March(2012).At(12, 15, 31, 036).WithOffset(1.Hours());
@@ -833,23 +839,25 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_not_close_to_a_later_datetimeoffset_it_should_throw()
         {
             // Arrange
-            DateTimeOffset time = new DateTimeOffset(2016, 06, 04, 12, 15, 30, 980, TimeSpan.Zero);
-            DateTimeOffset nearbyTime = new DateTimeOffset(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
+            DateTimeOffset time = new(2016, 06, 04, 12, 15, 30, 980, TimeSpan.Zero);
+            DateTimeOffset nearbyTime = new(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
 
             // Act
             Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 20ms from <2016-06-04 12:15:31 +0h>, but it was <2016-06-04 12:15:30.980 +0h>.");
+                .WithMessage(
+                    "Did not expect time to be within 20ms from <2016-06-04 12:15:31 +0h>, but it was <2016-06-04 12:15:30.980 +0h>.");
         }
 
         [Fact]
-        public void When_asserting_subject_datetimeoffset_is_not_close_to_a_later_datetimeoffset_by_a_20ms_timespan_it_should_throw()
+        public void
+            When_asserting_subject_datetimeoffset_is_not_close_to_a_later_datetimeoffset_by_a_20ms_timespan_it_should_throw()
         {
             // Arrange
-            DateTimeOffset time = new DateTimeOffset(2016, 06, 04, 12, 15, 30, 980, TimeSpan.Zero);
-            DateTimeOffset nearbyTime = new DateTimeOffset(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
+            DateTimeOffset time = new(2016, 06, 04, 12, 15, 30, 980, TimeSpan.Zero);
+            DateTimeOffset nearbyTime = new(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
 
             // Act
             Action act = () => time.Should().NotBeCloseTo(nearbyTime, TimeSpan.FromMilliseconds(20));
@@ -863,19 +871,21 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_not_close_to_an_earlier_datetimeoffset_it_should_throw()
         {
             // Arrange
-            DateTimeOffset time = new DateTimeOffset(2016, 06, 04, 12, 15, 31, 020, TimeSpan.Zero);
-            DateTimeOffset nearbyTime = new DateTimeOffset(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
+            DateTimeOffset time = new(2016, 06, 04, 12, 15, 31, 020, TimeSpan.Zero);
+            DateTimeOffset nearbyTime = new(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
 
             // Act
             Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 20ms from <2016-06-04 12:15:31 +0h>, but it was <2016-06-04 12:15:31.020 +0h>.");
+                .WithMessage(
+                    "Did not expect time to be within 20ms from <2016-06-04 12:15:31 +0h>, but it was <2016-06-04 12:15:31.020 +0h>.");
         }
 
         [Fact]
-        public void When_asserting_subject_datetimeoffset_is_not_close_to_another_value_that_is_later_by_more_than_20ms_it_should_succeed()
+        public void
+            When_asserting_subject_datetimeoffset_is_not_close_to_another_value_that_is_later_by_more_than_20ms_it_should_succeed()
         {
             // Arrange
             DateTimeOffset time = 13.March(2012).At(12, 15, 30, 979).ToDateTimeOffset(1.Hours());
@@ -889,7 +899,8 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_subject_datetimeoffset_is_not_close_to_another_value_that_is_earlier_by_more_than_20ms_it_should_succeed()
+        public void
+            When_asserting_subject_datetimeoffset_is_not_close_to_another_value_that_is_earlier_by_more_than_20ms_it_should_succeed()
         {
             // Arrange
             DateTimeOffset time = 13.March(2012).At(12, 15, 31, 021).ToDateTimeOffset(1.Hours());
@@ -914,7 +925,8 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 35ms from <2012-03-13 12:15:31 +1h>, but it was <2012-03-13 12:15:31.035 +1h>.");
+                .WithMessage(
+                    "Did not expect time to be within 35ms from <2012-03-13 12:15:31 +1h>, but it was <2012-03-13 12:15:31.035 +1h>.");
         }
 
         [Fact]
@@ -944,7 +956,8 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 100ms from <0001-01-01 00:00:00.000>, but it was <00:00:00.050 +0h>.");
+                .WithMessage(
+                    "Did not expect time to be within 100ms from <0001-01-01 00:00:00.000>, but it was <00:00:00.050 +0h>.");
         }
 
         [Fact]
@@ -959,7 +972,8 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 100ms from <9999-12-31 23:59:59.9999999 +0h>, but it was <9999-12-31 23:59:59.9499999 +0h>.");
+                .WithMessage(
+                    "Did not expect time to be within 100ms from <9999-12-31 23:59:59.9999999 +0h>, but it was <9999-12-31 23:59:59.9499999 +0h>.");
         }
     }
 
@@ -969,8 +983,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_a_point_of_time_is_before_a_later_point_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset earlierDate = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset laterDate = new DateTimeOffset(new DateTime(2016, 06, 04, 0, 5, 0), TimeSpan.Zero);
+            DateTimeOffset earlierDate = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset laterDate = new(new DateTime(2016, 06, 04, 0, 5, 0), TimeSpan.Zero);
 
             // Act
             Action act = () => earlierDate.Should().BeBefore(laterDate);
@@ -983,8 +997,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_is_before_earlier_expected_datetimeoffset_it_should_throw()
         {
             // Arrange
-            DateTimeOffset expected = new DateTimeOffset(new DateTime(2016, 06, 03), TimeSpan.Zero);
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expected = new(new DateTime(2016, 06, 03), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeBefore(expected);
@@ -998,8 +1012,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_before_the_same_datetimeoffset_it_should_throw()
         {
             // Arrange
-            DateTimeOffset expected = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expected = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeBefore(expected);
@@ -1016,8 +1030,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_a_point_of_time_is_not_before_another_it_should_throw()
         {
             // Arrange
-            DateTimeOffset earlierDate = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset laterDate = new DateTimeOffset(new DateTime(2016, 06, 04, 0, 5, 0), TimeSpan.Zero);
+            DateTimeOffset earlierDate = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset laterDate = new(new DateTime(2016, 06, 04, 0, 5, 0), TimeSpan.Zero);
 
             // Act
             Action act = () => earlierDate.Should().NotBeBefore(laterDate);
@@ -1031,8 +1045,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_is_not_before_earlier_expected_datetimeoffset_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset expected = new DateTimeOffset(new DateTime(2016, 06, 03), TimeSpan.Zero);
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expected = new(new DateTime(2016, 06, 03), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeBefore(expected);
@@ -1045,8 +1059,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_not_before_the_same_datetimeoffset_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset expected = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expected = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeBefore(expected);
@@ -1062,8 +1076,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_on_or_before_expected_datetimeoffset_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 05), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 05), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeOnOrBefore(expectation);
@@ -1073,11 +1087,12 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_subject_datetimeoffset_is_on_or_before_the_same_date_as_the_expected_datetimeoffset_should_succeed()
+        public void
+            When_asserting_subject_datetimeoffset_is_on_or_before_the_same_date_as_the_expected_datetimeoffset_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeOnOrBefore(expectation);
@@ -1090,8 +1105,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_not_on_or_before_earlier_expected_datetimeoffset_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 03), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 03), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeOnOrBefore(expectation);
@@ -1108,8 +1123,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_on_or_before_expected_datetimeoffset_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 05), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 05), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeOnOrBefore(expectation);
@@ -1120,11 +1135,12 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_subject_datetimeoffset_is_on_or_before_the_same_date_as_the_expected_datetimeoffset_should_throw()
+        public void
+            When_asserting_subject_datetimeoffset_is_on_or_before_the_same_date_as_the_expected_datetimeoffset_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeOnOrBefore(expectation);
@@ -1138,8 +1154,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_not_on_or_before_earlier_expected_datetimeoffset_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 03), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 03), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeOnOrBefore(expectation);
@@ -1155,8 +1171,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_after_earlier_expected_datetimeoffset_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 03), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 03), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeAfter(expectation);
@@ -1169,8 +1185,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_after_later_expected_datetimeoffset_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 05), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 05), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeAfter(expectation);
@@ -1184,8 +1200,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_after_the_same_expected_datetimeoffset_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeAfter(expectation);
@@ -1202,8 +1218,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_not_after_earlier_expected_datetimeoffset_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 03), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 03), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeAfter(expectation);
@@ -1217,8 +1233,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_not_after_later_expected_datetimeoffset_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 05), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 05), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeAfter(expectation);
@@ -1231,8 +1247,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_not_after_the_same_expected_datetimeoffset_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeAfter(expectation);
@@ -1248,8 +1264,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_on_or_after_earlier_expected_datetimeoffset_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 03), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 03), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeOnOrAfter(expectation);
@@ -1262,8 +1278,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_on_or_after_the_same_expected_datetimeoffset_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeOnOrAfter(expectation);
@@ -1276,8 +1292,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_on_or_after_later_expected_datetimeoffset_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 05), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 05), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeOnOrAfter(expectation);
@@ -1294,8 +1310,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_not_on_or_after_earlier_expected_datetimeoffset_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 03), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 03), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeOnOrAfter(expectation);
@@ -1309,8 +1325,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_not_on_or_after_the_same_expected_datetimeoffset_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeOnOrAfter(expectation);
@@ -1324,8 +1340,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_is_not_on_or_after_later_expected_datetimeoffset_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2016, 06, 04), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2016, 06, 05), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2016, 06, 04), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2016, 06, 05), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeOnOrAfter(expectation);
@@ -1341,7 +1357,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_year_with_the_same_value_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 06, 04), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 06, 04), TimeSpan.Zero);
             int expectation = 2009;
 
             // Act
@@ -1355,7 +1371,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_year_with_a_different_value_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 06, 04), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 06, 04), TimeSpan.Zero);
             int expectation = 2008;
 
             // Act
@@ -1388,7 +1404,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_year_with_the_same_value_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 06, 04), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 06, 04), TimeSpan.Zero);
             int expectation = 2009;
 
             // Act
@@ -1403,7 +1419,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_year_with_a_different_value_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 06, 04), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 06, 04), TimeSpan.Zero);
             int expectation = 2008;
 
             // Act
@@ -1435,7 +1451,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_month_with_the_same_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
             int expectation = 12;
 
             // Act
@@ -1449,7 +1465,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_a_month_with_a_different_value_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
             int expectation = 11;
 
             // Act
@@ -1482,7 +1498,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_month_with_the_same_value_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
             int expectation = 12;
 
             // Act
@@ -1497,7 +1513,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_a_month_with_a_different_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
             int expectation = 11;
 
             // Act
@@ -1529,7 +1545,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_day_with_the_same_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
             int expectation = 31;
 
             // Act
@@ -1543,7 +1559,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_day_with_a_different_value_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
             int expectation = 30;
 
             // Act
@@ -1576,7 +1592,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_day_with_the_same_value_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
             int expectation = 31;
 
             // Act
@@ -1591,7 +1607,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_day_with_a_different_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
             int expectation = 30;
 
             // Act
@@ -1623,7 +1639,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_hour_with_the_same_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             int expectation = 23;
 
             // Act
@@ -1637,7 +1653,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_hour_with_different_value_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             int expectation = 22;
 
             // Act
@@ -1670,7 +1686,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_hour_with_the_same_value_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             int expectation = 23;
 
             // Act
@@ -1685,7 +1701,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_hour_with_different_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             int expectation = 22;
 
             // Act
@@ -1717,7 +1733,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_minutes_with_the_same_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             int expectation = 59;
 
             // Act
@@ -1731,7 +1747,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_minutes_with_different_value_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             int expectation = 58;
 
             // Act
@@ -1764,7 +1780,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_minutes_with_the_same_value_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             int expectation = 59;
 
             // Act
@@ -1779,7 +1795,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_minutes_with_different_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             int expectation = 58;
 
             // Act
@@ -1811,7 +1827,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_seconds_with_the_same_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             int expectation = 0;
 
             // Act
@@ -1825,7 +1841,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_seconds_with_different_value_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             int expectation = 1;
 
             // Act
@@ -1858,7 +1874,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_seconds_with_the_same_value_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             int expectation = 0;
 
             // Act
@@ -1873,7 +1889,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_seconds_with_different_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             int expectation = 1;
 
             // Act
@@ -1905,7 +1921,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_offset_with_the_same_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.FromHours(7));
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.FromHours(7));
             TimeSpan expectation = TimeSpan.FromHours(7);
 
             // Act
@@ -1919,7 +1935,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_offset_with_different_value_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 10), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 10), TimeSpan.Zero);
             TimeSpan expectation = TimeSpan.FromHours(3);
 
             // Act
@@ -1952,7 +1968,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_offset_with_the_same_value_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.FromHours(7));
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.FromHours(7));
             TimeSpan expectation = TimeSpan.FromHours(7);
 
             // Act
@@ -1967,7 +1983,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_offset_with_different_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
             TimeSpan expectation = TimeSpan.FromHours(3);
 
             // Act
@@ -1999,8 +2015,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_be_same_date_as_another_with_the_same_date_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeSameDateAs(expectation);
@@ -2010,11 +2026,12 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_subject_datetimeoffset_should_be_same_as_another_with_same_date_but_different_time_it_should_succeed()
+        public void
+            When_asserting_subject_datetimeoffset_should_be_same_as_another_with_same_date_but_different_time_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2009, 12, 31, 11, 15, 11), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2009, 12, 31, 11, 15, 11), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeSameDateAs(expectation);
@@ -2028,7 +2045,7 @@ public class DateTimeOffsetAssertionSpecs
         {
             // Arrange
             DateTimeOffset? subject = null;
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeSameDateAs(expectation);
@@ -2042,8 +2059,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_have_same_date_as_another_but_it_doesnt_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2009, 12, 30), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2009, 12, 30), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().BeSameDateAs(expectation);
@@ -2060,8 +2077,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_be_same_date_as_another_with_the_same_date_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeSameDateAs(expectation);
@@ -2072,11 +2089,12 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_subject_datetimeoffset_should_not_be_same_as_another_with_same_date_but_different_time_it_should_throw()
+        public void
+            When_asserting_subject_datetimeoffset_should_not_be_same_as_another_with_same_date_but_different_time_it_should_throw()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2009, 12, 31, 11, 15, 11), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2009, 12, 31, 11, 15, 11), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeSameDateAs(expectation);
@@ -2091,7 +2109,7 @@ public class DateTimeOffsetAssertionSpecs
         {
             // Arrange
             DateTimeOffset? subject = null;
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeSameDateAs(expectation);
@@ -2105,8 +2123,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_asserting_subject_datetimeoffset_should_not_have_same_date_as_another_but_it_doesnt_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31), TimeSpan.Zero);
-            DateTimeOffset expectation = new DateTimeOffset(new DateTime(2009, 12, 30), TimeSpan.Zero);
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2009, 12, 30), TimeSpan.Zero);
 
             // Act
             Action act = () => subject.Should().NotBeSameDateAs(expectation);
@@ -2294,13 +2312,15 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:15 +0h> to be more than 10s after <00:00:30 +0h>, but it is behind by 15s.");
+                .WithMessage(
+                    "Expected subject <00:00:15 +0h> to be more than 10s after <00:00:30 +0h>, but it is behind by 15s.");
         }
 
         [Theory]
         [InlineData(30, 20)] // edge case
         [InlineData(30, 15)]
-        public void When_asserting_subject_be_at_least_10_seconds_after_target_but_subject_is_before_target_it_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_at_least_10_seconds_after_target_but_subject_is_before_target_it_should_throw(
+            int targetSeconds, int subjectSeconds)
         {
             // Arrange
             var expectation = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
@@ -2311,7 +2331,8 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds} +0h> to be at least 10s after <00:00:30 +0h>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage(
+                    $"Expected subject <00:00:{subjectSeconds} +0h> to be at least 10s after <00:00:30 +0h>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2332,7 +2353,8 @@ public class DateTimeOffsetAssertionSpecs
         [Theory]
         [InlineData(30, 20)] // edge case
         [InlineData(30, 25)]
-        public void When_asserting_subject_be_within_10_seconds_after_target_but_subject_is_before_target_it_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_within_10_seconds_after_target_but_subject_is_before_target_it_should_throw(
+            int targetSeconds, int subjectSeconds)
         {
             // Arrange
             var expectation = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
@@ -2343,7 +2365,8 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds} +0h> to be within 10s after <00:00:30 +0h>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage(
+                    $"Expected subject <00:00:{subjectSeconds} +0h> to be within 10s after <00:00:30 +0h>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2373,13 +2396,15 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:45 +0h> to be more than 10s before <00:00:30 +0h>, but it is ahead by 15s.");
+                .WithMessage(
+                    "Expected subject <00:00:45 +0h> to be more than 10s before <00:00:30 +0h>, but it is ahead by 15s.");
         }
 
         [Theory]
         [InlineData(30, 40)] // edge case
         [InlineData(30, 45)]
-        public void When_asserting_subject_be_at_least_10_seconds_before_target_but_subject_is_after_target_it_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_at_least_10_seconds_before_target_but_subject_is_after_target_it_should_throw(
+            int targetSeconds, int subjectSeconds)
         {
             // Arrange
             var expectation = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
@@ -2390,7 +2415,8 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds} +0h> to be at least 10s before <00:00:30 +0h>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage(
+                    $"Expected subject <00:00:{subjectSeconds} +0h> to be at least 10s before <00:00:30 +0h>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2411,7 +2437,8 @@ public class DateTimeOffsetAssertionSpecs
         [Theory]
         [InlineData(30, 40)] // edge case
         [InlineData(30, 35)]
-        public void When_asserting_subject_be_within_10_seconds_before_target_but_subject_is_after_target_it_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_within_10_seconds_before_target_but_subject_is_after_target_it_should_throw(
+            int targetSeconds, int subjectSeconds)
         {
             // Arrange
             var expectation = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
@@ -2422,7 +2449,8 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds} +0h> to be within 10s before <00:00:30 +0h>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage(
+                    $"Expected subject <00:00:{subjectSeconds} +0h> to be within 10s before <00:00:30 +0h>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2437,7 +2465,8 @@ public class DateTimeOffsetAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:45 +0h> to be less than 10s before <00:00:30 +0h>, but it is ahead by 15s.");
+                .WithMessage(
+                    "Expected subject <00:00:45 +0h> to be less than 10s before <00:00:30 +0h>, but it is ahead by 15s.");
         }
 
         [Fact]
@@ -2450,7 +2479,8 @@ public class DateTimeOffsetAssertionSpecs
             Action action = () => someDateTimeOffset.Should().BeLessThan(0.Seconds()).Equals(someDateTimeOffset);
 
             // Assert
-            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Before() or After() instead?");
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean Before() or After() instead?");
         }
     }
 
@@ -2509,10 +2539,11 @@ public class DateTimeOffsetAssertionSpecs
         public void When_a_value_is_one_of_the_specified_values_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset value = new DateTimeOffset(2016, 12, 30, 23, 58, 57, TimeSpan.FromHours(4));
+            DateTimeOffset value = new(2016, 12, 30, 23, 58, 57, TimeSpan.FromHours(4));
 
             // Act
-            Action action = () => value.Should().BeOneOf(new DateTimeOffset(2216, 1, 30, 0, 5, 7, TimeSpan.FromHours(2)), new DateTimeOffset(2016, 12, 30, 23, 58, 57, TimeSpan.FromHours(4)));
+            Action action = () => value.Should().BeOneOf(new DateTimeOffset(2216, 1, 30, 0, 5, 7, TimeSpan.FromHours(2)),
+                new DateTimeOffset(2016, 12, 30, 23, 58, 57, TimeSpan.FromHours(4)));
 
             // Assert
             action.Should().NotThrow();
@@ -2525,7 +2556,8 @@ public class DateTimeOffsetAssertionSpecs
             DateTimeOffset? value = null;
 
             // Act
-            Action action = () => value.Should().BeOneOf(new DateTimeOffset(2216, 1, 30, 0, 5, 7, TimeSpan.FromHours(1)), new DateTimeOffset(2016, 2, 10, 2, 45, 7, TimeSpan.FromHours(2)));
+            Action action = () => value.Should().BeOneOf(new DateTimeOffset(2216, 1, 30, 0, 5, 7, TimeSpan.FromHours(1)),
+                new DateTimeOffset(2016, 2, 10, 2, 45, 7, TimeSpan.FromHours(2)));
 
             // Assert
             action.Should().Throw<XunitException>().WithMessage(
@@ -2558,7 +2590,8 @@ public class DateTimeOffsetAssertionSpecs
             Action action = () => someDateTimeOffset.Should().Equals(someDateTimeOffset);
 
             // Assert
-            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/EnumAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/EnumAssertionSpecs.cs
@@ -56,7 +56,8 @@ public class EnumAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*have flag TestEnum.Three {value: 4}*because we want to test the failure message*but found TestEnum.One|Two {value: 3}.");
+                .WithMessage(
+                    "Expected*have flag TestEnum.Three {value: 4}*because we want to test the failure message*but found TestEnum.One|Two {value: 3}.");
         }
     }
 
@@ -83,7 +84,8 @@ public class EnumAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*someObject*to not have flag TestEnum.Two {value: 2}*because we want to test the failure message*");
+                .WithMessage(
+                    "Expected*someObject*to not have flag TestEnum.Two {value: 2}*because we want to test the failure message*");
         }
 
         [Fact]
@@ -766,7 +768,8 @@ public class EnumAssertionSpecs
             BindingFlags flags = BindingFlags.DeclaredOnly;
 
             // Act / Assert
-            Action act = () => flags.Should().BeOneOf(new[] { BindingFlags.Public, BindingFlags.ExactBinding }, "that's what we need");
+            Action act = () =>
+                flags.Should().BeOneOf(new[] { BindingFlags.Public, BindingFlags.ExactBinding }, "that's what we need");
 
             act.Should()
                 .Throw<XunitException>()
@@ -896,7 +899,8 @@ public class EnumAssertionSpecs
             Action action = () => subject.Should().Equals(subject);
 
             // Assert
-            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/GuidAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/GuidAssertionSpecs.cs
@@ -222,7 +222,8 @@ public class GuidAssertionSpecs
             Action action = () => subject.Should().Equals(subject);
 
             // Assert
-            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() or BeOneOf() instead?");
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() or BeOneOf() instead?");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/NullableBooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/NullableBooleanAssertionSpecs.cs
@@ -127,7 +127,8 @@ public class NullableBooleanAssertionSpecs
     }
 
     [Fact]
-    public void When_asserting_nullable_boolean_value_with_a_value_to_be_not_have_a_value_it_should_fail_with_descriptive_message()
+    public void
+        When_asserting_nullable_boolean_value_with_a_value_to_be_not_have_a_value_it_should_fail_with_descriptive_message()
     {
         // Arrange
         bool? nullableBoolean = true;
@@ -213,7 +214,8 @@ public class NullableBooleanAssertionSpecs
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Expected nullableBoolean not to be <null> because we want to test the failure message, but found <null>.");
+            .WithMessage(
+                "Expected nullableBoolean not to be <null> because we want to test the failure message, but found <null>.");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/NullableGuidAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/NullableGuidAssertionSpecs.cs
@@ -168,7 +168,8 @@ public class NullableGuidAssertionSpecs
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Did not expect a value because we want to test the failure message, but found {11111111-aaaa-bbbb-cccc-999999999999}.");
+            .WithMessage(
+                "Did not expect a value because we want to test the failure message, but found {11111111-aaaa-bbbb-cccc-999999999999}.");
     }
 
     [Fact]
@@ -182,7 +183,8 @@ public class NullableGuidAssertionSpecs
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Did not expect a value because we want to test the failure message, but found {11111111-aaaa-bbbb-cccc-999999999999}.");
+            .WithMessage(
+                "Did not expect a value because we want to test the failure message, but found {11111111-aaaa-bbbb-cccc-999999999999}.");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/NullableSimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/NullableSimpleTimeSpanAssertionSpecs.cs
@@ -143,7 +143,8 @@ public class NullableSimpleTimeSpanAssertionSpecs
     }
 
     [Fact]
-    public void When_asserting_a_nullable_TimeSpan_is_equal_to_a_different_nullable_TimeSpan_it_should_should_throw_appropriately()
+    public void
+        When_asserting_a_nullable_TimeSpan_is_equal_to_a_different_nullable_TimeSpan_it_should_should_throw_appropriately()
     {
         // Arrange
         TimeSpan? nullableTimeSpanA = 1.Seconds();
@@ -157,7 +158,8 @@ public class NullableSimpleTimeSpanAssertionSpecs
     }
 
     [Fact]
-    public void When_asserting_a_nullable_TimeSpan_is_equal_to_another_a_nullable_TimeSpan_but_it_is_null_it_should_fail_with_a_descriptive_message()
+    public void
+        When_asserting_a_nullable_TimeSpan_is_equal_to_another_a_nullable_TimeSpan_but_it_is_null_it_should_fail_with_a_descriptive_message()
     {
         // Arrange
         TimeSpan? nullableTimeSpanA = null;

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.Serialization;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
+using AssemblyA;
+using AssemblyB;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using Xunit;
@@ -159,7 +162,8 @@ public class ObjectAssertionSpecs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {ClassWithCustomEqualMethod(4), ClassWithCustomEqualMethod(5)}, but found ClassWithCustomEqualMethod(3).");
+                .WithMessage(
+                    "Expected value to be one of {ClassWithCustomEqualMethod(4), ClassWithCustomEqualMethod(5)}, but found ClassWithCustomEqualMethod(3).");
         }
 
         [Fact]
@@ -169,12 +173,15 @@ public class ObjectAssertionSpecs
             var value = new ClassWithCustomEqualMethod(3);
 
             // Act
-            Action act = () => value.Should().BeOneOf(new[] { new ClassWithCustomEqualMethod(4), new ClassWithCustomEqualMethod(5) }, "because those are the valid values");
+            Action act = () =>
+                value.Should().BeOneOf(new[] { new ClassWithCustomEqualMethod(4), new ClassWithCustomEqualMethod(5) },
+                    "because those are the valid values");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {ClassWithCustomEqualMethod(4), ClassWithCustomEqualMethod(5)} because those are the valid values, but found ClassWithCustomEqualMethod(3).");
+                .WithMessage(
+                    "Expected value to be one of {ClassWithCustomEqualMethod(4), ClassWithCustomEqualMethod(5)} because those are the valid values, but found ClassWithCustomEqualMethod(3).");
         }
 
         [Fact]
@@ -343,7 +350,8 @@ public class ObjectAssertionSpecs
             int? valueTypeObject = null;
 
             // Act
-            Action act = () => valueTypeObject.Should().BeOfType(typeof(int), "because we want to test the failure {0}", "message");
+            Action act = () =>
+                valueTypeObject.Should().BeOfType(typeof(int), "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -361,7 +369,8 @@ public class ObjectAssertionSpecs
             Action act = () => valueTypeObject.Should().BeOfType(doubleType);
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage($"Expected type to be {doubleType}, but found {valueTypeObject.GetType()}.");
+            act.Should().Throw<XunitException>()
+                .WithMessage($"Expected type to be {doubleType}, but found {valueTypeObject.GetType()}.");
         }
 
         [Fact]
@@ -406,23 +415,25 @@ public class ObjectAssertionSpecs
         }
 
         [Fact]
-        public void When_object_type_is_same_as_expected_type_but_in_different_assembly_it_should_fail_with_assembly_qualified_name()
+        public void
+            When_object_type_is_same_as_expected_type_but_in_different_assembly_it_should_fail_with_assembly_qualified_name()
         {
             // Arrange
             var typeFromOtherAssembly =
-                new AssemblyA.ClassA().ReturnClassC();
+                new ClassA().ReturnClassC();
 
             // Act
 #pragma warning disable 436 // disable the warning on conflicting types, as this is the intention for the spec
 
             Action act = () =>
-                typeFromOtherAssembly.Should().BeOfType<AssemblyB.ClassC>();
+                typeFromOtherAssembly.Should().BeOfType<ClassC>();
 
 #pragma warning restore 436
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be [AssemblyB.ClassC, FluentAssertions.Specs*], but found [AssemblyB.ClassC, AssemblyB*].");
+                .WithMessage(
+                    "Expected type to be [AssemblyB.ClassC, FluentAssertions.Specs*], but found [AssemblyB.ClassC, AssemblyB*].");
         }
 
         [Fact]
@@ -471,7 +482,8 @@ public class ObjectAssertionSpecs
         }
 
         [Fact]
-        public void When_object_type_is_value_type_and_doesnt_match_received_type_as_expected_should_not_fail_and_assert_correctly()
+        public void
+            When_object_type_is_value_type_and_doesnt_match_received_type_as_expected_should_not_fail_and_assert_correctly()
         {
             // Arrange
             int valueTypeObject = 42;
@@ -490,7 +502,8 @@ public class ObjectAssertionSpecs
             int? valueTypeObject = null;
 
             // Act
-            Action act = () => valueTypeObject.Should().NotBeOfType(typeof(int), "because we want to test the failure {0}", "message");
+            Action act = () =>
+                valueTypeObject.Should().NotBeOfType(typeof(int), "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -508,7 +521,8 @@ public class ObjectAssertionSpecs
             Action act = () => valueTypeObject.Should().NotBeOfType(expectedType);
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage($"Expected type not to be [{expectedType.AssemblyQualifiedName}], but it is.");
+            act.Should().Throw<XunitException>()
+                .WithMessage($"Expected type not to be [{expectedType.AssemblyQualifiedName}], but it is.");
         }
     }
 
@@ -635,10 +649,10 @@ public class ObjectAssertionSpecs
         public void When_an_implemented_open_generic_interface_type_instance_it_should_succeed()
         {
             // Arrange
-            var someObject = new System.Collections.Generic.List<string>();
+            var someObject = new List<string>();
 
             // Act / Assert
-            someObject.Should().BeAssignableTo(typeof(System.Collections.Generic.IList<>));
+            someObject.Should().BeAssignableTo(typeof(IList<>));
         }
 
         [Fact]
@@ -664,7 +678,9 @@ public class ObjectAssertionSpecs
         {
             // Arrange
             var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+
+            Action act = () =>
+                someObject.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -676,11 +692,13 @@ public class ObjectAssertionSpecs
         {
             // Arrange
             var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().BeAssignableTo(typeof(System.Collections.Generic.IList<>), "because we want to test the failure {0}", "message");
+
+            Action act = () =>
+                someObject.Should().BeAssignableTo(typeof(IList<>), "because we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*assignable to {typeof(System.Collections.Generic.IList<>)}*failure message*{typeof(DummyImplementingClass)} is not*");
+                .WithMessage($"*assignable to {typeof(IList<>)}*failure message*{typeof(DummyImplementingClass)} is not*");
         }
 
         [Fact]
@@ -698,8 +716,8 @@ public class ObjectAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                "Expected * to be assignable to System.Int32, but System.String is not.*" +
-                "Expected * to be assignable to System.Int64, but System.String is not.");
+                    "Expected * to be assignable to System.Int32, but System.String is not.*" +
+                    "Expected * to be assignable to System.Int64, but System.String is not.");
         }
     }
 
@@ -724,11 +742,15 @@ public class ObjectAssertionSpecs
         {
             // Arrange
             var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().NotBeAssignableTo<DummyImplementingClass>("because we want to test the failure {0}", "message");
+
+            Action act = () =>
+                someObject.Should()
+                    .NotBeAssignableTo<DummyImplementingClass>("because we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(DummyImplementingClass)}*failure message*{typeof(DummyImplementingClass)} is*");
+                .WithMessage(
+                    $"*not be assignable to {typeof(DummyImplementingClass)}*failure message*{typeof(DummyImplementingClass)} is*");
         }
 
         [Fact]
@@ -736,11 +758,14 @@ public class ObjectAssertionSpecs
         {
             // Arrange
             var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().NotBeAssignableTo<DummyBaseClass>("because we want to test the failure {0}", "message");
+
+            Action act = () =>
+                someObject.Should().NotBeAssignableTo<DummyBaseClass>("because we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(DummyBaseClass)}*failure message*{typeof(DummyImplementingClass)} is*");
+                .WithMessage(
+                    $"*not be assignable to {typeof(DummyBaseClass)}*failure message*{typeof(DummyImplementingClass)} is*");
         }
 
         [Fact]
@@ -748,7 +773,9 @@ public class ObjectAssertionSpecs
         {
             // Arrange
             var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().NotBeAssignableTo<IDisposable>("because we want to test the failure {0}", "message");
+
+            Action act = () =>
+                someObject.Should().NotBeAssignableTo<IDisposable>("because we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -766,7 +793,8 @@ public class ObjectAssertionSpecs
         }
 
         [Fact]
-        public void When_not_to_the_unexpected_type_and_asserting_not_assignable_it_should_not_cast_the_returned_object_for_chaining()
+        public void
+            When_not_to_the_unexpected_type_and_asserting_not_assignable_it_should_not_cast_the_returned_object_for_chaining()
         {
             // Arrange
             var someObject = new Exception("Actual Message");
@@ -785,11 +813,15 @@ public class ObjectAssertionSpecs
         {
             // Arrange
             var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().NotBeAssignableTo(typeof(DummyImplementingClass), "because we want to test the failure {0}", "message");
+
+            Action act = () =>
+                someObject.Should().NotBeAssignableTo(typeof(DummyImplementingClass), "because we want to test the failure {0}",
+                    "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(DummyImplementingClass)}*failure message*{typeof(DummyImplementingClass)} is*");
+                .WithMessage(
+                    $"*not be assignable to {typeof(DummyImplementingClass)}*failure message*{typeof(DummyImplementingClass)} is*");
         }
 
         [Fact]
@@ -797,19 +829,26 @@ public class ObjectAssertionSpecs
         {
             // Arrange
             var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().NotBeAssignableTo(typeof(DummyBaseClass), "because we want to test the failure {0}", "message");
+
+            Action act = () =>
+                someObject.Should()
+                    .NotBeAssignableTo(typeof(DummyBaseClass), "because we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(DummyBaseClass)}*failure message*{typeof(DummyImplementingClass)} is*");
+                .WithMessage(
+                    $"*not be assignable to {typeof(DummyBaseClass)}*failure message*{typeof(DummyImplementingClass)} is*");
         }
 
         [Fact]
-        public void When_an_implemented_interface_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+        public void
+            When_an_implemented_interface_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
         {
             // Arrange
             var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().NotBeAssignableTo(typeof(IDisposable), "because we want to test the failure {0}", "message");
+
+            Action act = () =>
+                someObject.Should().NotBeAssignableTo(typeof(IDisposable), "because we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -817,15 +856,18 @@ public class ObjectAssertionSpecs
         }
 
         [Fact]
-        public void When_an_implemented_open_generic_interface_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+        public void
+            When_an_implemented_open_generic_interface_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
         {
             // Arrange
-            var someObject = new System.Collections.Generic.List<string>();
-            Action act = () => someObject.Should().NotBeAssignableTo(typeof(System.Collections.Generic.IList<>), "because we want to test the failure {0}", "message");
+            var someObject = new List<string>();
+
+            Action act = () =>
+                someObject.Should().NotBeAssignableTo(typeof(IList<>), "because we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*not be assignable to {typeof(System.Collections.Generic.IList<>)}*failure message*{typeof(System.Collections.Generic.List<string>)} is*");
+                .WithMessage($"*not be assignable to {typeof(IList<>)}*failure message*{typeof(List<string>)} is*");
         }
 
         [Fact]
@@ -863,7 +905,7 @@ public class ObjectAssertionSpecs
             var someObject = new DummyImplementingClass();
 
             // Act / Assert
-            someObject.Should().NotBeAssignableTo(typeof(System.Collections.Generic.IList<>), "because we want to test the failure {0}", "message");
+            someObject.Should().NotBeAssignableTo(typeof(IList<>), "because we want to test the failure {0}", "message");
         }
     }
 
@@ -892,7 +934,8 @@ public class ObjectAssertionSpecs
             Action action = () => someObject.Should().Equals(someObject);
 
             // Assert
-            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() or BeSameAs() instead?");
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() or BeSameAs() instead?");
         }
     }
 
@@ -919,7 +962,7 @@ public class ObjectAssertionSpecs
         public void When_an_object_is_binary_serializable_with_non_serializable_members_it_should_succeed()
         {
             // Arrange
-            var subject = new SerializableClassWithNonSerializableMember()
+            var subject = new SerializableClassWithNonSerializableMember
             {
                 Name = "John",
                 NonSerializable = "Nonserializable value"
@@ -961,7 +1004,8 @@ public class ObjectAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be serializable because we need to store it on disk, but serialization failed with:*UnserializableClass*");
+                .WithMessage(
+                    "*to be serializable because we need to store it on disk, but serialization failed with:*UnserializableClass*");
         }
 
         [Fact]
@@ -979,7 +1023,8 @@ public class ObjectAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be serializable, but serialization failed with:*BinarySerializableClassMissingDeserializationConstructor*");
+                .WithMessage(
+                    "*to be serializable, but serialization failed with:*BinarySerializableClassMissingDeserializationConstructor*");
         }
 
         [Fact]
@@ -1109,7 +1154,8 @@ public class ObjectAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be serializable because we need to store it on disk, but serialization failed with:*NonPublicClass*");
+                .WithMessage(
+                    "*to be serializable because we need to store it on disk, but serialization failed with:*NonPublicClass*");
         }
 
         [Fact]
@@ -1228,8 +1274,9 @@ public class ObjectAssertionSpecs
             };
 
             // Act
-            Action act = () => subject.Should().BeDataContractSerializable<DataContractSerializableClassNotRestoringAllProperties>(
-                options => options.Excluding(x => x.Name));
+            Action act = () => subject.Should()
+                .BeDataContractSerializable<DataContractSerializableClassNotRestoringAllProperties>(
+                    options => options.Excluding(x => x.Name));
 
             // Assert
             act.Should().NotThrow();
@@ -1242,8 +1289,9 @@ public class ObjectAssertionSpecs
             var subject = new DataContractSerializableClassNotRestoringAllProperties();
 
             // Act
-            Action act = () => subject.Should().BeDataContractSerializable<DataContractSerializableClassNotRestoringAllProperties>(
-                options: null);
+            Action act = () => subject.Should()
+                .BeDataContractSerializable<DataContractSerializableClassNotRestoringAllProperties>(
+                    options: null);
 
             // Assert
             act.Should().ThrowExactly<ArgumentNullException>()

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using FluentAssertions.Primitives;
@@ -88,10 +89,10 @@ public class ReferenceTypeAssertionsSpecs
     public void When_object_is_of_the_expected_open_generic_type_it_should_not_throw()
     {
         // Arrange
-        var aList = new System.Collections.Generic.List<string>();
+        var aList = new List<string>();
 
         // Act
-        Action action = () => aList.Should().BeOfType(typeof(System.Collections.Generic.List<>));
+        Action action = () => aList.Should().BeOfType(typeof(List<>));
 
         // Assert
         action.Should().NotThrow();
@@ -101,14 +102,14 @@ public class ReferenceTypeAssertionsSpecs
     public void When_object_is_not_of_the_expected_open_generic_type_it_should_throw()
     {
         // Arrange
-        var aList = new System.Collections.Generic.List<string>();
+        var aList = new List<string>();
 
         // Act
-        Action action = () => aList.Should().BeOfType(typeof(System.Collections.Generic.Dictionary<,>));
+        Action action = () => aList.Should().BeOfType(typeof(Dictionary<,>));
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage($"Expected type to be {typeof(System.Collections.Generic.Dictionary<,>).FullName}, but found {typeof(System.Collections.Generic.List<>).FullName}.");
+            .WithMessage($"Expected type to be {typeof(Dictionary<,>).FullName}, but found {typeof(List<>).FullName}.");
     }
 
     [Fact]
@@ -158,8 +159,8 @@ public class ReferenceTypeAssertionsSpecs
         // Assert
         act.Should().Throw<XunitException>()
             .WithMessage(
-            "Expected type to be System.Int32, but found System.String.*" +
-            "Expected type to be System.Int64, but found System.String.");
+                "Expected type to be System.Int32, but found System.String.*" +
+                "Expected type to be System.Int64, but found System.String.");
     }
 
     [Fact]
@@ -194,14 +195,14 @@ public class ReferenceTypeAssertionsSpecs
     public void When_object_is_of_the_unexpected_open_generic_type_it_should_throw()
     {
         // Arrange
-        var aList = new System.Collections.Generic.List<string>();
+        var aList = new List<string>();
 
         // Act
-        Action action = () => aList.Should().NotBeOfType(typeof(System.Collections.Generic.List<>));
+        Action action = () => aList.Should().NotBeOfType(typeof(List<>));
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Expected type not to be [" + typeof(System.Collections.Generic.List<>).AssemblyQualifiedName + "], but it is.");
+            .WithMessage("Expected type not to be [" + typeof(List<>).AssemblyQualifiedName + "], but it is.");
     }
 
     [Fact]
@@ -221,10 +222,10 @@ public class ReferenceTypeAssertionsSpecs
     public void When_object_is_not_of_the_unexpected_open_generic_type_it_should_not_throw()
     {
         // Arrange
-        var aList = new System.Collections.Generic.List<string>();
+        var aList = new List<string>();
 
         // Act
-        Action action = () => aList.Should().NotBeOfType(typeof(System.Collections.Generic.Dictionary<,>));
+        Action action = () => aList.Should().NotBeOfType(typeof(Dictionary<,>));
 
         // Assert
         action.Should().NotThrow();
@@ -234,7 +235,7 @@ public class ReferenceTypeAssertionsSpecs
     public void When_generic_object_is_not_of_the_unexpected_type_it_should_not_throw()
     {
         // Arrange
-        var aList = new System.Collections.Generic.List<string>();
+        var aList = new List<string>();
 
         // Act
         Action action = () => aList.Should().NotBeOfType<string>();
@@ -250,7 +251,7 @@ public class ReferenceTypeAssertionsSpecs
         var aString = "blah";
 
         // Act
-        Action action = () => aString.Should().NotBeOfType(typeof(System.Collections.Generic.Dictionary<,>));
+        Action action = () => aString.Should().NotBeOfType(typeof(Dictionary<,>));
 
         // Assert
         action.Should().NotThrow();
@@ -372,8 +373,8 @@ public class ReferenceTypeAssertionsSpecs
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
             "Expected subject to be*FluentAssertions*SomeDto*{*Age = 2*Birthdate = <2009-02-22>*" +
-                "  Name = \"Teddie\"*}, but found*FluentAssertions*SomeDto*{*Age = 37*" +
-                    "  Birthdate = <1973-09-20>*Name = \"Dennis\"*}.");
+            "  Name = \"Teddie\"*}, but found*FluentAssertions*SomeDto*{*Age = 37*" +
+            "  Birthdate = <1973-09-20>*Name = \"Dennis\"*}.");
     }
 
     [Fact]
@@ -404,7 +405,7 @@ public class ReferenceTypeAssertionsSpecs
         // Assert
         act.Should().Throw<XunitException>()
             .WithMessage($"Expected subject to be System.Object (HashCode={other.GetHashCode()}), " +
-                         $"but found System.Object (HashCode={subject.GetHashCode()}).");
+                $"but found System.Object (HashCode={subject.GetHashCode()}).");
     }
 
     #endregion
@@ -421,13 +422,16 @@ public class ReferenceTypeAssertionsSpecs
             Action action = () => subject.Equals(subject);
 
             // Assert
-            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean BeSameAs() instead?");
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean BeSameAs() instead?");
         }
 
         public class ReferenceTypeAssertionsDummy : ReferenceTypeAssertions<object, ReferenceTypeAssertionsDummy>
         {
             public ReferenceTypeAssertionsDummy(object subject)
-                : base(subject) { }
+                : base(subject)
+            {
+            }
 
             protected override string Identifier => string.Empty;
         }
@@ -450,7 +454,7 @@ internal class ClassWithCustomEqualMethod
         Key = key;
     }
 
-    private int Key { get; set; }
+    private int Key { get; }
 
     private bool Equals(ClassWithCustomEqualMethod other)
     {

--- a/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
@@ -339,7 +339,8 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan expected = 1.Seconds();
 
         // Act
-        Action act = () => nullTimeSpan.Should().BeGreaterThanOrEqualTo(expected, "because we want to test the failure {0}", "message");
+        Action act = () =>
+            nullTimeSpan.Should().BeGreaterThanOrEqualTo(expected, "because we want to test the failure {0}", "message");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -377,7 +378,8 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan actual = 1.Seconds();
 
         // Act
-        Action act = () => actual.Should().BeGreaterThanOrEqualTo(2.Seconds(), "because we want to test the failure {0}", "message");
+        Action act = () =>
+            actual.Should().BeGreaterThanOrEqualTo(2.Seconds(), "because we want to test the failure {0}", "message");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -470,7 +472,8 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan expected = 1.Seconds();
 
         // Act
-        Action act = () => nullTimeSpan.Should().BeLessThanOrEqualTo(expected, "because we want to test the failure {0}", "message");
+        Action act = () =>
+            nullTimeSpan.Should().BeLessThanOrEqualTo(expected, "because we want to test the failure {0}", "message");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -525,7 +528,8 @@ public class SimpleTimeSpanAssertionSpecs
         Action act = () => someTimeSpan.Should().Equals(someTimeSpan);
 
         // Assert
-        act.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+        act.Should().Throw<NotSupportedException>()
+            .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
     }
 
     #region Be Close To
@@ -643,7 +647,8 @@ public class SimpleTimeSpanAssertionSpecs
         var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
         // Act
-        Action act = () => time.Should().BeCloseTo(nearbyTime, TimeSpan.FromMilliseconds(20), "we want to test the error message");
+        Action act = () =>
+            time.Should().BeCloseTo(nearbyTime, TimeSpan.FromMilliseconds(20), "we want to test the error message");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -682,7 +687,8 @@ public class SimpleTimeSpanAssertionSpecs
         Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
         // Assert
-        act.Should().Throw<XunitException>().WithMessage("Expected time to not be within 20ms from 1d, 12h, 15m and 31s, but found 1d, 12h, 15m, 30s and 980ms.");
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected time to not be within 20ms from 1d, 12h, 15m and 31s, but found 1d, 12h, 15m, 30s and 980ms.");
     }
 
     [Fact]
@@ -696,7 +702,8 @@ public class SimpleTimeSpanAssertionSpecs
         Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
         // Assert
-        act.Should().Throw<XunitException>().WithMessage("Expected time to not be within 20ms from 1d, 12h, 15m and 31s, but found 1d, 12h, 15m, 31s and 20ms.");
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected time to not be within 20ms from 1d, 12h, 15m and 31s, but found 1d, 12h, 15m, 31s and 20ms.");
     }
 
     [Fact]
@@ -710,7 +717,8 @@ public class SimpleTimeSpanAssertionSpecs
         Action act = () => time.Should().NotBeCloseTo(nearbyTime, TimeSpan.FromMilliseconds(20));
 
         // Assert
-        act.Should().Throw<XunitException>().WithMessage("Expected time to not be within 20ms from 1d, 12h, 15m and 31s, but found 1d, 12h, 15m, 31s and 20ms.");
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected time to not be within 20ms from 1d, 12h, 15m and 31s, but found 1d, 12h, 15m, 31s and 20ms.");
     }
 
     [Fact]
@@ -752,7 +760,8 @@ public class SimpleTimeSpanAssertionSpecs
         Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35.Milliseconds());
 
         // Assert
-        act.Should().Throw<XunitException>().WithMessage("Expected time to not be within 35ms from 1d, 12h, 15m and 31s, but found 1d, 12h, 15m, 31s and 35ms.");
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected time to not be within 35ms from 1d, 12h, 15m and 31s, but found 1d, 12h, 15m, 31s and 35ms.");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -155,7 +155,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_the_actual_string_is_the_same_as_the_expected_but_with_trailing_spaces_it_should_throw_with_clear_error_message()
+        public void
+            When_the_actual_string_is_the_same_as_the_expected_but_with_trailing_spaces_it_should_throw_with_clear_error_message()
         {
             // Act
             Action act = () => "ABC ".Should().Be("ABC", "because I say {0}", "so");

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeEquivalentTo.cs
@@ -82,7 +82,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_the_expected_string_is_equivalent_to_the_actual_string_but_with_trailing_spaces_it_should_throw_with_clear_error_message()
+        public void
+            When_the_expected_string_is_equivalent_to_the_actual_string_but_with_trailing_spaces_it_should_throw_with_clear_error_message()
         {
             // Act
             Action act = () => "ABC".Should().BeEquivalentTo("abc ", "because I say {0}", "so");
@@ -93,7 +94,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_the_actual_string_equivalent_to_the_expected_but_with_trailing_spaces_it_should_throw_with_clear_error_message()
+        public void
+            When_the_actual_string_equivalent_to_the_expected_but_with_trailing_spaces_it_should_throw_with_clear_error_message()
         {
             // Act
             Action act = () => "ABC ".Should().BeEquivalentTo("abc", "because I say {0}", "so");

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeOneOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeOneOf.cs
@@ -36,7 +36,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {\"def\", \"xyz\"} because those are the valid values, but found \"abc\".");
+                .WithMessage(
+                    "Expected value to be one of {\"def\", \"xyz\"} because those are the valid values, but found \"abc\".");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Contain.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Contain.cs
@@ -77,7 +77,8 @@ public partial class StringAssertionSpecs
         public class ContainExactly
         {
             [Fact]
-            public void When_string_containment_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw()
+            public void
+                When_string_containment_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw()
             {
                 // Arrange
                 string actual = "ABCDEF";
@@ -88,7 +89,8 @@ public partial class StringAssertionSpecs
 
                 // Assert
                 act.Should().Throw<XunitException>()
-                    .WithMessage("Expected * \"ABCDEF\" to contain \"XYS\" exactly 1 time because that is required, but found it 0 times.");
+                    .WithMessage(
+                        "Expected * \"ABCDEF\" to contain \"XYS\" exactly 1 time because that is required, but found it 0 times.");
             }
 
             [Fact]
@@ -138,7 +140,8 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_exactly_is_asserted_and_actual_value_contains_the_expected_string_exactly_expected_times_it_should_not_throw()
+            public void
+                When_string_containment_exactly_is_asserted_and_actual_value_contains_the_expected_string_exactly_expected_times_it_should_not_throw()
             {
                 // Arrange
                 string actual = "ABCDEBCDF";
@@ -152,7 +155,8 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_exactly_is_asserted_and_actual_value_contains_the_expected_string_but_not_exactly_expected_times_it_should_throw()
+            public void
+                When_string_containment_exactly_is_asserted_and_actual_value_contains_the_expected_string_but_not_exactly_expected_times_it_should_throw()
             {
                 // Arrange
                 string actual = "ABCDEBCDF";
@@ -170,7 +174,8 @@ public partial class StringAssertionSpecs
         public class ContainAtLeast
         {
             [Fact]
-            public void When_string_containment_at_least_is_asserted_and_actual_value_contains_the_expected_string_at_least_expected_times_it_should_not_throw()
+            public void
+                When_string_containment_at_least_is_asserted_and_actual_value_contains_the_expected_string_at_least_expected_times_it_should_not_throw()
             {
                 // Arrange
                 string actual = "ABCDEBCDF";
@@ -184,7 +189,8 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_at_least_is_asserted_and_actual_value_contains_the_expected_string_but_not_at_least_expected_times_it_should_throw()
+            public void
+                When_string_containment_at_least_is_asserted_and_actual_value_contains_the_expected_string_but_not_at_least_expected_times_it_should_throw()
             {
                 // Arrange
                 string actual = "ABCDEBCDF";
@@ -199,7 +205,8 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_at_least_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw_earlier()
+            public void
+                When_string_containment_at_least_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw_earlier()
             {
                 // Arrange
                 string actual = "ABCDEF";
@@ -232,7 +239,8 @@ public partial class StringAssertionSpecs
         public class ContainMoreThan
         {
             [Fact]
-            public void When_string_containment_more_than_is_asserted_and_actual_value_contains_the_expected_string_more_than_expected_times_it_should_not_throw()
+            public void
+                When_string_containment_more_than_is_asserted_and_actual_value_contains_the_expected_string_more_than_expected_times_it_should_not_throw()
             {
                 // Arrange
                 string actual = "ABCDEBCDF";
@@ -246,7 +254,8 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_more_than_is_asserted_and_actual_value_contains_the_expected_string_but_not_more_than_expected_times_it_should_throw()
+            public void
+                When_string_containment_more_than_is_asserted_and_actual_value_contains_the_expected_string_but_not_more_than_expected_times_it_should_throw()
             {
                 // Arrange
                 string actual = "ABCDEBCDF";
@@ -261,7 +270,8 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_more_than_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw()
+            public void
+                When_string_containment_more_than_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw()
             {
                 // Arrange
                 string actual = "ABCDEF";
@@ -294,7 +304,8 @@ public partial class StringAssertionSpecs
         public class ContainAtMost
         {
             [Fact]
-            public void When_string_containment_at_most_is_asserted_and_actual_value_contains_the_expected_string_at_most_expected_times_it_should_not_throw()
+            public void
+                When_string_containment_at_most_is_asserted_and_actual_value_contains_the_expected_string_at_most_expected_times_it_should_not_throw()
             {
                 // Arrange
                 string actual = "ABCDEBCDF";
@@ -308,7 +319,8 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_at_most_is_asserted_and_actual_value_contains_the_expected_string_but_not_at_most_expected_times_it_should_throw()
+            public void
+                When_string_containment_at_most_is_asserted_and_actual_value_contains_the_expected_string_but_not_at_most_expected_times_it_should_throw()
             {
                 // Arrange
                 string actual = "ABCDEBCDF";
@@ -323,7 +335,8 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_at_most_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_not_throw()
+            public void
+                When_string_containment_at_most_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_not_throw()
             {
                 // Arrange
                 string actual = "ABCDEF";
@@ -354,7 +367,8 @@ public partial class StringAssertionSpecs
         public class ContainsLessThan
         {
             [Fact]
-            public void When_string_containment_less_than_is_asserted_and_actual_value_contains_the_expected_string_less_than_expected_times_it_should_not_throw()
+            public void
+                When_string_containment_less_than_is_asserted_and_actual_value_contains_the_expected_string_less_than_expected_times_it_should_not_throw()
             {
                 // Arrange
                 string actual = "ABCDEBCDF";
@@ -368,7 +382,8 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_less_than_is_asserted_and_actual_value_contains_the_expected_string_but_not_less_than_expected_times_it_should_throw()
+            public void
+                When_string_containment_less_than_is_asserted_and_actual_value_contains_the_expected_string_but_not_less_than_expected_times_it_should_throw()
             {
                 // Arrange
                 string actual = "ABCDEBCDF";
@@ -383,7 +398,8 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_less_than_twice_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_not_throw()
+            public void
+                When_string_containment_less_than_twice_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_not_throw()
             {
                 // Arrange
                 string actual = "ABCDEF";

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainAll.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainAll.cs
@@ -52,7 +52,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_containment_of_all_strings_in_a_collection_is_asserted_and_equivalent_but_not_exact_matches_exist_for_all_it_should_throw()
+        public void
+            When_containment_of_all_strings_in_a_collection_is_asserted_and_equivalent_but_not_exact_matches_exist_for_all_it_should_throw()
         {
             // Arrange
             const string redLowerCase = "red";
@@ -71,7 +72,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_containment_of_all_strings_in_a_collection_is_asserted_and_none_of_the_strings_are_present_it_should_throw()
+        public void
+            When_containment_of_all_strings_in_a_collection_is_asserted_and_none_of_the_strings_are_present_it_should_throw()
         {
             // Arrange
             const string red = "red";
@@ -90,7 +92,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_containment_of_all_strings_in_a_collection_is_asserted_with_reason_and_assertion_fails_then_failure_message_should_contain_reason()
+        public void
+            When_containment_of_all_strings_in_a_collection_is_asserted_with_reason_and_assertion_fails_then_failure_message_should_contain_reason()
         {
             // Arrange
             const string red = "red";
@@ -109,7 +112,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_containment_of_all_strings_in_a_collection_is_asserted_and_only_some_of_the_strings_are_present_it_should_throw()
+        public void
+            When_containment_of_all_strings_in_a_collection_is_asserted_and_only_some_of_the_strings_are_present_it_should_throw()
         {
             // Arrange
             const string red = "red";
@@ -155,7 +159,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_exclusion_of_all_strings_in_a_collection_is_asserted_and_all_strings_in_collection_are_present_it_should_throw()
+        public void
+            When_exclusion_of_all_strings_in_a_collection_is_asserted_and_all_strings_in_collection_are_present_it_should_throw()
         {
             // Arrange
             const string red = "red";
@@ -191,7 +196,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_exclusion_of_all_strings_in_a_collection_is_asserted_and_only_some_of_the_strings_in_collection_are_present_it_should_succeed()
+        public void
+            When_exclusion_of_all_strings_in_a_collection_is_asserted_and_only_some_of_the_strings_in_collection_are_present_it_should_succeed()
         {
             // Arrange
             const string red = "red";
@@ -208,7 +214,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_exclusion_of_all_strings_in_a_collection_is_asserted_and_none_of_the_strings_in_the_collection_are_present_it_should_succeed()
+        public void
+            When_exclusion_of_all_strings_in_a_collection_is_asserted_and_none_of_the_strings_in_the_collection_are_present_it_should_succeed()
         {
             // Arrange
             const string red = "red";
@@ -225,7 +232,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_exclusion_of_all_strings_in_a_collection_is_asserted_and_equivalent_but_not_exact_strings_are_present_in_collection_it_should_succeed()
+        public void
+            When_exclusion_of_all_strings_in_a_collection_is_asserted_and_equivalent_but_not_exact_strings_are_present_in_collection_it_should_succeed()
         {
             // Arrange
             const string redWithoutWhitespace = "red";

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainAny.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainAny.cs
@@ -36,7 +36,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_containment_of_any_string_in_a_collection_is_asserted_and_all_of_the_strings_are_present_it_should_succeed()
+        public void
+            When_containment_of_any_string_in_a_collection_is_asserted_and_all_of_the_strings_are_present_it_should_succeed()
         {
             // Arrange
             const string red = "red";
@@ -52,7 +53,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_containment_of_any_string_in_a_collection_is_asserted_and_only_some_of_the_strings_are_present_it_should_succeed()
+        public void
+            When_containment_of_any_string_in_a_collection_is_asserted_and_only_some_of_the_strings_are_present_it_should_succeed()
         {
             // Arrange
             const string red = "red";
@@ -68,7 +70,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_containment_of_any_string_in_a_collection_is_asserted_and_none_of_the_strings_are_present_it_should_throw()
+        public void
+            When_containment_of_any_string_in_a_collection_is_asserted_and_none_of_the_strings_are_present_it_should_throw()
         {
             // Arrange
             const string red = "red";
@@ -87,7 +90,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_containment_of_any_string_in_a_collection_is_asserted_and_there_are_equivalent_but_not_exact_matches_it_should_throw()
+        public void
+            When_containment_of_any_string_in_a_collection_is_asserted_and_there_are_equivalent_but_not_exact_matches_it_should_throw()
         {
             // Arrange
             const string redLowerCase = "red";
@@ -106,7 +110,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_containment_of_any_string_in_a_collection_is_asserted_with_reason_and_assertion_fails_then_failure_message_contains_reason()
+        public void
+            When_containment_of_any_string_in_a_collection_is_asserted_with_reason_and_assertion_fails_then_failure_message_contains_reason()
         {
             // Arrange
             const string red = "red";
@@ -170,7 +175,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_exclusion_of_any_string_in_a_collection_is_asserted_and_only_some_of_the_strings_are_present_it_should_throw()
+        public void
+            When_exclusion_of_any_string_in_a_collection_is_asserted_and_only_some_of_the_strings_are_present_it_should_throw()
         {
             // Arrange
             const string red = "red";
@@ -207,7 +213,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_exclusion_of_any_string_in_a_collection_is_asserted_and_there_are_equivalent_but_not_exact_matches_it_should_succeed()
+        public void
+            When_exclusion_of_any_string_in_a_collection_is_asserted_and_there_are_equivalent_but_not_exact_matches_it_should_succeed()
         {
             // Arrange
             const string redLowerCase = "red";
@@ -224,7 +231,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_exclusion_of_any_string_in_a_collection_is_asserted_and_none_of_the_strings_are_present_it_should_succeed()
+        public void
+            When_exclusion_of_any_string_in_a_collection_is_asserted_and_none_of_the_strings_are_present_it_should_succeed()
         {
             // Arrange
             const string red = "red";

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainEquivalentOf.cs
@@ -77,22 +77,26 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_equivalent_of_exactly_once_is_asserted_and_actual_value_is_null_then_it_should_throw_earlier()
+            public void
+                When_string_containment_equivalent_of_exactly_once_is_asserted_and_actual_value_is_null_then_it_should_throw_earlier()
             {
                 // Arrange
                 string actual = null;
                 string expectedSubstring = "XyZ";
 
                 // Act
-                Action act = () => actual.Should().ContainEquivalentOf(expectedSubstring, Exactly.Once(), "that is {0}", "required");
+                Action act = () =>
+                    actual.Should().ContainEquivalentOf(expectedSubstring, Exactly.Once(), "that is {0}", "required");
 
                 // Assert
                 act.Should().Throw<XunitException>()
-                    .WithMessage("Expected * <null> to contain equivalent of \"XyZ\" exactly 1 time because that is required, but found it 0 times.");
+                    .WithMessage(
+                        "Expected * <null> to contain equivalent of \"XyZ\" exactly 1 time because that is required, but found it 0 times.");
             }
 
             [Fact]
-            public void When_string_containment_equivalent_of_exactly_is_asserted_and_actual_value_contains_the_expected_string_exactly_expected_times_it_should_not_throw()
+            public void
+                When_string_containment_equivalent_of_exactly_is_asserted_and_actual_value_contains_the_expected_string_exactly_expected_times_it_should_not_throw()
             {
                 // Arrange
                 string actual = "abCDEBcDF";
@@ -106,7 +110,8 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_equivalent_of_exactly_is_asserted_and_actual_value_contains_the_expected_string_but_not_exactly_expected_times_it_should_throw()
+            public void
+                When_string_containment_equivalent_of_exactly_is_asserted_and_actual_value_contains_the_expected_string_but_not_exactly_expected_times_it_should_throw()
             {
                 // Arrange
                 string actual = "abCDEBcDF";
@@ -117,11 +122,13 @@ public partial class StringAssertionSpecs
 
                 // Assert
                 act.Should().Throw<XunitException>()
-                    .WithMessage("Expected * \"abCDEBcDF\" to contain equivalent of \"Bcd\" exactly 3 times, but found it 2 times.");
+                    .WithMessage(
+                        "Expected * \"abCDEBcDF\" to contain equivalent of \"Bcd\" exactly 3 times, but found it 2 times.");
             }
 
             [Fact]
-            public void When_string_containment_equivalent_of_exactly_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw()
+            public void
+                When_string_containment_equivalent_of_exactly_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw()
             {
                 // Arrange
                 string actual = "abCDEf";
@@ -156,7 +163,8 @@ public partial class StringAssertionSpecs
     public class ContainEquivalentOfAtLeast
     {
         [Fact]
-        public void When_string_containment_equivalent_of_at_least_is_asserted_and_actual_value_contains_the_expected_string_at_least_expected_times_it_should_not_throw()
+        public void
+            When_string_containment_equivalent_of_at_least_is_asserted_and_actual_value_contains_the_expected_string_at_least_expected_times_it_should_not_throw()
         {
             // Arrange
             string actual = "abCDEBcDF";
@@ -170,7 +178,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_string_containment_equivalent_of_at_least_is_asserted_and_actual_value_contains_the_expected_string_but_not_at_least_expected_times_it_should_throw()
+        public void
+            When_string_containment_equivalent_of_at_least_is_asserted_and_actual_value_contains_the_expected_string_but_not_at_least_expected_times_it_should_throw()
         {
             // Arrange
             string actual = "abCDEBcDF";
@@ -185,7 +194,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_string_containment_equivalent_of_at_least_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw_earlier()
+        public void
+            When_string_containment_equivalent_of_at_least_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw_earlier()
         {
             // Arrange
             string actual = "abCDEf";
@@ -200,7 +210,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_string_containment_equivalent_of_at_least_once_is_asserted_and_actual_value_is_null_then_it_should_throw_earlier()
+        public void
+            When_string_containment_equivalent_of_at_least_once_is_asserted_and_actual_value_is_null_then_it_should_throw_earlier()
         {
             // Arrange
             string actual = null;
@@ -218,7 +229,8 @@ public partial class StringAssertionSpecs
     public class ContainEquivalentOfMoreThan
     {
         [Fact]
-        public void When_string_containment_equivalent_of_more_than_is_asserted_and_actual_value_contains_the_expected_string_more_than_expected_times_it_should_not_throw()
+        public void
+            When_string_containment_equivalent_of_more_than_is_asserted_and_actual_value_contains_the_expected_string_more_than_expected_times_it_should_not_throw()
         {
             // Arrange
             string actual = "abCDEBcDF";
@@ -232,7 +244,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_string_containment_equivalent_of_more_than_is_asserted_and_actual_value_contains_the_expected_string_but_not_more_than_expected_times_it_should_throw()
+        public void
+            When_string_containment_equivalent_of_more_than_is_asserted_and_actual_value_contains_the_expected_string_but_not_more_than_expected_times_it_should_throw()
         {
             // Arrange
             string actual = "abCDEBcDF";
@@ -243,11 +256,13 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected * \"abCDEBcDF\" to contain equivalent of \"Bcd\" more than 2 times, but found it 2 times.");
+                .WithMessage(
+                    "Expected * \"abCDEBcDF\" to contain equivalent of \"Bcd\" more than 2 times, but found it 2 times.");
         }
 
         [Fact]
-        public void When_string_containment_equivalent_of_more_than_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw_earlier()
+        public void
+            When_string_containment_equivalent_of_more_than_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw_earlier()
         {
             // Arrange
             string actual = "abCDEf";
@@ -262,7 +277,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_string_containment_equivalent_of_more_than_once_is_asserted_and_actual_value_is_null_then_it_should_throw_earlier()
+        public void
+            When_string_containment_equivalent_of_more_than_once_is_asserted_and_actual_value_is_null_then_it_should_throw_earlier()
         {
             // Arrange
             string actual = null;
@@ -280,7 +296,8 @@ public partial class StringAssertionSpecs
     public class ContainEquivalentOfAtMost
     {
         [Fact]
-        public void When_string_containment_equivalent_of_at_most_is_asserted_and_actual_value_contains_the_expected_string_at_most_expected_times_it_should_not_throw()
+        public void
+            When_string_containment_equivalent_of_at_most_is_asserted_and_actual_value_contains_the_expected_string_at_most_expected_times_it_should_not_throw()
         {
             // Arrange
             string actual = "abCDEBcDF";
@@ -294,7 +311,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_string_containment_equivalent_of_at_most_is_asserted_and_actual_value_contains_the_expected_string_but_not_at_most_expected_times_it_should_throw()
+        public void
+            When_string_containment_equivalent_of_at_most_is_asserted_and_actual_value_contains_the_expected_string_but_not_at_most_expected_times_it_should_throw()
         {
             // Arrange
             string actual = "abCDEBcDF";
@@ -309,7 +327,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_string_containment_equivalent_of_at_most_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_not_throw()
+        public void
+            When_string_containment_equivalent_of_at_most_once_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_not_throw()
         {
             // Arrange
             string actual = "abCDEf";
@@ -323,7 +342,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_string_containment_equivalent_of_at_most_once_is_asserted_and_actual_value_is_null_then_it_should_not_throw()
+        public void
+            When_string_containment_equivalent_of_at_most_once_is_asserted_and_actual_value_is_null_then_it_should_not_throw()
         {
             // Arrange
             string actual = null;
@@ -340,7 +360,8 @@ public partial class StringAssertionSpecs
     public class ContainEquivalentOfLessThan
     {
         [Fact]
-        public void When_string_containment_equivalent_of_less_than_is_asserted_and_actual_value_contains_the_expected_string_less_than_expected_times_it_should_not_throw()
+        public void
+            When_string_containment_equivalent_of_less_than_is_asserted_and_actual_value_contains_the_expected_string_less_than_expected_times_it_should_not_throw()
         {
             // Arrange
             string actual = "abCDEBcDF";
@@ -354,7 +375,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_string_containment_equivalent_of_less_than_is_asserted_and_actual_value_contains_the_expected_string_but_not_less_than_expected_times_it_should_throw()
+        public void
+            When_string_containment_equivalent_of_less_than_is_asserted_and_actual_value_contains_the_expected_string_but_not_less_than_expected_times_it_should_throw()
         {
             // Arrange
             string actual = "abCDEBcDF";
@@ -365,11 +387,13 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected * \"abCDEBcDF\" to contain equivalent of \"Bcd\" less than 2 times, but found it 2 times.");
+                .WithMessage(
+                    "Expected * \"abCDEBcDF\" to contain equivalent of \"Bcd\" less than 2 times, but found it 2 times.");
         }
 
         [Fact]
-        public void When_string_containment_equivalent_of_less_than_twice_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw()
+        public void
+            When_string_containment_equivalent_of_less_than_twice_is_asserted_and_actual_value_does_not_contain_the_expected_string_it_should_throw()
         {
             // Arrange
             string actual = "abCDEf";
@@ -383,7 +407,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_string_containment_equivalent_of_less_than_twice_is_asserted_and_actual_value_is_null_then_it_should_not_throw()
+        public void
+            When_string_containment_equivalent_of_less_than_twice_is_asserted_and_actual_value_is_null_then_it_should_not_throw()
         {
             // Arrange
             string actual = null;

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.EndWith.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.EndWith.cs
@@ -79,8 +79,8 @@ public partial class StringAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected string to end with " +
-                    "\"00ABC\", but " +
-                        "\"ABC\" is too short.");
+                "\"00ABC\", but " +
+                "\"ABC\" is too short.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.EndWithEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.EndWithEquivalentOf.cs
@@ -75,8 +75,8 @@ public partial class StringAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected string to end with equivalent of " +
-                    "\"00abc\", but " +
-                        "\"ABC\" is too short.");
+                "\"00abc\", but " +
+                "\"ABC\" is too short.");
         }
 
         [Fact]
@@ -115,7 +115,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_string_does_not_end_with_equivalent_of_a_value_but_it_does_it_should_fail_with_a_descriptive_message()
+        public void
+            When_asserting_string_does_not_end_with_equivalent_of_a_value_but_it_does_it_should_fail_with_a_descriptive_message()
         {
             // Arrange
             string value = "ABC";

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Match.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Match.cs
@@ -22,7 +22,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to match*\"h*earth!\" because that's the universal greeting, but*\"hello world!\" does not.");
+                .WithMessage(
+                    "Expected subject to match*\"h*earth!\" because that's the universal greeting, but*\"hello world!\" does not.");
         }
 
         [Fact]
@@ -106,7 +107,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
-                .WithMessage("Cannot match string against an empty string. Provide a wildcard pattern or use the BeEmpty method.*")
+                .WithMessage(
+                    "Cannot match string against an empty string. Provide a wildcard pattern or use the BeEmpty method.*")
                 .WithParameterName("wildcardPattern");
         }
     }
@@ -167,7 +169,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
-                .WithMessage("Cannot match string against an empty string. Provide a wildcard pattern or use the NotBeEmpty method.*")
+                .WithMessage(
+                    "Cannot match string against an empty string. Provide a wildcard pattern or use the NotBeEmpty method.*")
                 .WithParameterName("wildcardPattern");
         }
     }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchEquivalentOf.cs
@@ -78,7 +78,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
-                .WithMessage("Cannot match string against an empty string. Provide a wildcard pattern or use the BeEmpty method.*")
+                .WithMessage(
+                    "Cannot match string against an empty string. Provide a wildcard pattern or use the BeEmpty method.*")
                 .WithParameterName("wildcardPattern");
         }
     }
@@ -111,7 +112,7 @@ public partial class StringAssertionSpecs
             act
                 .Should().Throw<XunitException>()
                 .WithMessage("Did not expect subject to match the equivalent of*\"*world*\" because that's illegal, " +
-                "but*\"hello WORLD\" matches.");
+                    "but*\"hello WORLD\" matches.");
         }
 
         [Fact]
@@ -128,7 +129,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_a_string_is_negatively_matched_against_the_equivalent_of_null_pattern_it_should_throw_with_a_clear_explanation()
+        public void
+            When_a_string_is_negatively_matched_against_the_equivalent_of_null_pattern_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
             string subject = "hello world";
@@ -143,7 +145,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_a_string_is_negatively_matched_against_the_equivalent_of_an_empty_string_it_should_throw_with_a_clear_explanation()
+        public void
+            When_a_string_is_negatively_matched_against_the_equivalent_of_an_empty_string_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
             string subject = "hello world";
@@ -153,7 +156,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
-                .WithMessage("Cannot match string against an empty string. Provide a wildcard pattern or use the NotBeEmpty method.*")
+                .WithMessage(
+                    "Cannot match string against an empty string. Provide a wildcard pattern or use the NotBeEmpty method.*")
                 .WithParameterName("wildcardPattern");
         }
     }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
@@ -40,7 +40,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-              .WithMessage("Expected subject to match regex*\"h.*\\sworld?$\" because that's the universal greeting, but*\"hello world!\" does not match.");
+                .WithMessage(
+                    "Expected subject to match regex*\"h.*\\sworld?$\" because that's the universal greeting, but*\"hello world!\" does not match.");
         }
 
         [Fact]
@@ -54,7 +55,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-             .WithMessage("Expected subject to match regex*\".*\" because it should be a string, but it was <null>.");
+                .WithMessage("Expected subject to match regex*\".*\" because it should be a string, but it was <null>.");
         }
 
         [Fact]
@@ -68,8 +69,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
-               .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the BeNull method.*")
-               .WithParameterName("regularExpression");
+                .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the BeNull method.*")
+                .WithParameterName("regularExpression");
         }
 
         [Fact]
@@ -84,7 +85,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-             .WithMessage("Cannot match subject against \".**\" because it is not a valid regular expression.*");
+                .WithMessage("Cannot match subject against \".**\" because it is not a valid regular expression.*");
         }
 
         [Fact]
@@ -104,7 +105,7 @@ public partial class StringAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .Which.Message.Should().Contain("is not a valid regular expression")
-                    .And.NotContain("does not match");
+                .And.NotContain("does not match");
         }
 
         [Fact]
@@ -148,7 +149,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-              .WithMessage("Expected subject to match regex*\"h.*\\sworld?$\" because that's the universal greeting, but*\"hello world!\" does not match.");
+                .WithMessage(
+                    "Expected subject to match regex*\"h.*\\sworld?$\" because that's the universal greeting, but*\"hello world!\" does not match.");
         }
 
         [Fact]
@@ -180,8 +182,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
-               .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the BeNull method.*")
-               .WithParameterName("regularExpression");
+                .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the BeNull method.*")
+                .WithParameterName("regularExpression");
         }
 
         [Fact]
@@ -225,7 +227,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject*Lorem*to match regex*\"Lorem.*\" exactly 2 times, but found it 1 time*");
+                .WithMessage("Expected subject*Lorem*to match regex*\"Lorem.*\" exactly 2 times, but found it 1 time*");
         }
 
         [Fact]
@@ -252,7 +254,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject*a*to match regex*\"a\" exactly 0 times, but found it 1 time*");
+                .WithMessage("Expected subject*a*to match regex*\"a\" exactly 0 times, but found it 1 time*");
         }
 
         [Fact]
@@ -305,7 +307,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject*to match regex* at least 1 time, but found it 0 times*");
+                .WithMessage("Expected subject*to match regex* at least 1 time, but found it 0 times*");
         }
 
         [Fact]
@@ -379,7 +381,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-              .WithMessage("Did not expect subject to match regex*\".*world.*\" because that's illegal, but*\"hello world!\" matches.");
+                .WithMessage(
+                    "Did not expect subject to match regex*\".*world.*\" because that's illegal, but*\"hello world!\" matches.");
         }
 
         [Fact]
@@ -393,7 +396,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-             .WithMessage("Expected subject to not match regex*\".*\" because it should not be a string, but it was <null>.");
+                .WithMessage("Expected subject to not match regex*\".*\" because it should not be a string, but it was <null>.");
         }
 
         [Fact]
@@ -407,8 +410,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
-               .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.*")
-               .WithParameterName("regularExpression");
+                .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.*")
+                .WithParameterName("regularExpression");
         }
 
         [Fact]
@@ -423,7 +426,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-             .WithMessage("Cannot match subject against \".**\" because it is not a valid regular expression.*");
+                .WithMessage("Cannot match subject against \".**\" because it is not a valid regular expression.*");
         }
 
         [Fact]
@@ -443,7 +446,7 @@ public partial class StringAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .Which.Message.Should().Contain("is not a valid regular expression")
-                    .And.NotContain("matches");
+                .And.NotContain("matches");
         }
 
         [Fact]
@@ -457,7 +460,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
-                .WithMessage("Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.*")
+                .WithMessage(
+                    "Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.*")
                 .WithParameterName("regularExpression");
         }
 
@@ -485,7 +489,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-              .WithMessage("Did not expect subject to match regex*\".*world.*\" because that's illegal, but*\"hello world!\" matches.");
+                .WithMessage(
+                    "Did not expect subject to match regex*\".*world.*\" because that's illegal, but*\"hello world!\" matches.");
         }
 
         [Fact]
@@ -517,8 +522,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
-               .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.*")
-               .WithParameterName("regularExpression");
+                .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.*")
+                .WithParameterName("regularExpression");
         }
 
         [Fact]
@@ -532,7 +537,8 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
-                .WithMessage("Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.*")
+                .WithMessage(
+                    "Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.*")
                 .WithParameterName("regularExpression");
         }
     }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.StartWith.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.StartWith.cs
@@ -35,12 +35,13 @@ public partial class StringAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected string to start with \"ABB\" because it should start," +
-                    " but \"ABC\" differs near \"C\" (index 2).");
+                " but \"ABC\" differs near \"C\" (index 2).");
         }
 
         [Fact]
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
-        public void When_string_does_not_start_with_expected_phrase_and_one_of_them_is_long_it_should_display_both_strings_on_separate_line()
+        public void
+            When_string_does_not_start_with_expected_phrase_and_one_of_them_is_long_it_should_display_both_strings_on_separate_line()
         {
             // Act
             Action act = () => "ABCDEFGHI".Should().StartWith("ABCDDFGHI", "it should {0}", "start");
@@ -48,7 +49,7 @@ public partial class StringAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected string to start with " +
-                    "*\"ABCDDFGHI\" because it should start, but " +
+                "*\"ABCDDFGHI\" because it should start, but " +
                 "*\"ABCDEFGHI\" differs near \"EFG\" (index 4).");
         }
 

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.StartWithEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.StartWithEquivalentOf.cs
@@ -36,7 +36,8 @@ public partial class StringAssertionSpecs
 
         [Fact]
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
-        public void When_start_of_string_does_not_meet_equivalent_and_one_of_them_is_long_it_should_display_both_strings_on_separate_line()
+        public void
+            When_start_of_string_does_not_meet_equivalent_and_one_of_them_is_long_it_should_display_both_strings_on_separate_line()
         {
             // Act
             Action act = () => "ABCDEFGHI".Should().StartWithEquivalentOf("abcddfghi", "it should {0}", "start");
@@ -44,8 +45,8 @@ public partial class StringAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected string to start with equivalent of " +
-                    "*\"abcddfghi\" because it should start, but " +
-                        "*\"ABCDEFGHI\" differs near \"EFG\" (index 4).");
+                "*\"abcddfghi\" because it should start, but " +
+                "*\"ABCDEFGHI\" differs near \"EFG\" (index 4).");
         }
 
         [Fact]
@@ -79,8 +80,8 @@ public partial class StringAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected string to start with equivalent of " +
-                    "\"abcdef\", but " +
-                        "\"ABC\" is too short.");
+                "\"abcdef\", but " +
+                "\"ABC\" is too short.");
         }
 
         [Fact]
@@ -113,7 +114,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_string_does_not_start_with_equivalent_of_a_value_but_it_does_it_should_fail_with_a_descriptive_message()
+        public void
+            When_asserting_string_does_not_start_with_equivalent_of_a_value_but_it_does_it_should_fail_with_a_descriptive_message()
         {
             // Arrange
             string value = "ABC";

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -3,9 +3,6 @@ using Xunit;
 
 namespace FluentAssertions.Specs.Primitives;
 
-/// <summary>
-/// <see cref="String"/> assertion specs.
-/// </summary>
 public partial class StringAssertionSpecs
 {
     [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
@@ -269,7 +269,7 @@ public class StringComparisonSpecs
 
         // Act
         scope.BecauseOf("{0}", 1.234)
-             .FailWith("{reason}");
+            .FailWith("{reason}");
 
         // Assert
         scope.Invoking(e => e.Dispose()).Should().Throw<XunitException>()
@@ -314,6 +314,7 @@ public class StringComparisonSpecs
         {
             ["FOO"] = 1.234
         };
+
         var strategy = new CollectingAssertionStrategy();
         strategy.HandleFailure(string.Empty);
 
@@ -337,6 +338,7 @@ public class StringComparisonSpecs
     public void Culture_is_ignored_when_sorting_strings()
     {
         using var _ = new AssertionScope();
+
         new[] { "A", "a" }.Should().BeInAscendingOrder()
             .And.BeInAscendingOrder(e => e)
             .And.ThenBeInAscendingOrder(e => e)
@@ -369,4 +371,6 @@ public class StringComparisonSpecs
 
 // Due to CulturedTheory changing CultureInfo
 [CollectionDefinition(nameof(StringComparisonSpecs), DisableParallelization = true)]
-public class StringComparisonDefinition { }
+public class StringComparisonDefinition
+{
+}

--- a/Tests/FluentAssertions.Specs/Primitives/TimeOnlyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/TimeOnlyAssertionSpecs.cs
@@ -5,7 +5,6 @@ using Xunit;
 using Xunit.Sdk;
 
 #if NET6_0_OR_GREATER
-
 namespace FluentAssertions.Specs.Primitives;
 
 public class TimeOnlyAssertionSpecs
@@ -238,8 +237,8 @@ public class TimeOnlyAssertionSpecs
         public void When_subject_time_is_close_to_another_value_that_is_later_by_more_than_20ms_it_should_throw()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(12, 15, 30, 979);
-            TimeOnly nearbyTime = new TimeOnly(12, 15, 31);
+            TimeOnly time = new(12, 15, 30, 979);
+            TimeOnly nearbyTime = new(12, 15, 31);
 
             // Act
             Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
@@ -254,8 +253,8 @@ public class TimeOnlyAssertionSpecs
         public void When_subject_time_is_close_to_another_value_that_is_earlier_by_more_than_20ms_it_should_throw()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(12, 15, 31, 021);
-            TimeOnly nearbyTime = new TimeOnly(12, 15, 31);
+            TimeOnly time = new(12, 15, 31, 021);
+            TimeOnly nearbyTime = new(12, 15, 31);
 
             // Act
             Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
@@ -270,8 +269,8 @@ public class TimeOnlyAssertionSpecs
         public void When_subject_time_is_close_to_an_earlier_time_by_35ms_it_should_succeed()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(12, 15, 31, 035);
-            TimeOnly nearbyTime = new TimeOnly(12, 15, 31);
+            TimeOnly time = new(12, 15, 31, 035);
+            TimeOnly nearbyTime = new(12, 15, 31);
 
             // Act / Assert
             time.Should().BeCloseTo(nearbyTime, 35.Milliseconds());
@@ -281,8 +280,8 @@ public class TimeOnlyAssertionSpecs
         public void A_time_is_close_to_a_later_time_when_passing_midnight()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(23, 59, 0);
-            TimeOnly nearbyTime = new TimeOnly(0, 1, 0);
+            TimeOnly time = new(23, 59, 0);
+            TimeOnly nearbyTime = new(0, 1, 0);
 
             // Act / Assert
             time.Should().BeCloseTo(nearbyTime, 2.Minutes());
@@ -292,8 +291,8 @@ public class TimeOnlyAssertionSpecs
         public void A_time_is_close_to_an_earlier_time_when_passing_midnight()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(0, 1, 0);
-            TimeOnly nearbyTime = new TimeOnly(23, 59, 0);
+            TimeOnly time = new(0, 1, 0);
+            TimeOnly nearbyTime = new(23, 59, 0);
 
             // Act / Assert
             time.Should().BeCloseTo(nearbyTime, 2.Minutes());
@@ -303,8 +302,8 @@ public class TimeOnlyAssertionSpecs
         public void A_time_outside_of_the_precision_to_a_later_time_when_passing_midnight_fails()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(23, 58, 59);
-            TimeOnly nearbyTime = new TimeOnly(0, 1, 0);
+            TimeOnly time = new(23, 58, 59);
+            TimeOnly nearbyTime = new(0, 1, 0);
 
             // Act
             Action act = () => time.Should().BeCloseTo(nearbyTime, 2.Minutes());
@@ -318,8 +317,8 @@ public class TimeOnlyAssertionSpecs
         public void A_time_outside_of_the_precision_to_an_earlier_time_when_passing_midnight_fails()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(0, 1, 0);
-            TimeOnly nearbyTime = new TimeOnly(23, 58, 59);
+            TimeOnly time = new(0, 1, 0);
+            TimeOnly nearbyTime = new(23, 58, 59);
 
             // Act
             Action act = () => time.Should().BeCloseTo(nearbyTime, 2.Minutes());
@@ -334,7 +333,7 @@ public class TimeOnlyAssertionSpecs
         {
             // Arrange
             TimeOnly? time = null;
-            TimeOnly nearbyTime = new TimeOnly(12, 15, 31);
+            TimeOnly nearbyTime = new(12, 15, 31);
 
             // Act
             Action act = () => time.Should().BeCloseTo(nearbyTime, 35.Milliseconds());
@@ -349,7 +348,7 @@ public class TimeOnlyAssertionSpecs
         {
             // Arrange
             TimeOnly? time = null;
-            TimeOnly nearbyTime = new TimeOnly(12, 15, 31);
+            TimeOnly nearbyTime = new(12, 15, 31);
 
             // Act
             Action act = () =>
@@ -371,7 +370,7 @@ public class TimeOnlyAssertionSpecs
         {
             // Arrange
             TimeOnly? time = null;
-            TimeOnly nearbyTime = new TimeOnly(12, 15, 31);
+            TimeOnly nearbyTime = new(12, 15, 31);
 
             // Act
             Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35.Milliseconds());
@@ -386,7 +385,7 @@ public class TimeOnlyAssertionSpecs
         {
             // Arrange
             TimeOnly? time = null;
-            TimeOnly nearbyTime = new TimeOnly(12, 15, 31);
+            TimeOnly nearbyTime = new(12, 15, 31);
 
             // Act
             Action act = () =>
@@ -476,8 +475,8 @@ public class TimeOnlyAssertionSpecs
         public void When_asserting_subject_time_is_not_close_to_an_earlier_time_it_should_throw()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(12, 15, 31, 020);
-            TimeOnly nearbyTime = new TimeOnly(12, 15, 31);
+            TimeOnly time = new(12, 15, 31, 020);
+            TimeOnly nearbyTime = new(12, 15, 31);
 
             // Act
             Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
@@ -491,8 +490,8 @@ public class TimeOnlyAssertionSpecs
         public void When_asserting_subject_time_is_not_close_to_an_earlier_time_by_a_20ms_timespan_it_should_throw()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(12, 15, 31, 020);
-            TimeOnly nearbyTime = new TimeOnly(12, 15, 31);
+            TimeOnly time = new(12, 15, 31, 020);
+            TimeOnly nearbyTime = new(12, 15, 31);
 
             // Act
             Action act = () => time.Should().NotBeCloseTo(nearbyTime, TimeSpan.FromMilliseconds(20));
@@ -506,19 +505,20 @@ public class TimeOnlyAssertionSpecs
         public void When_asserting_subject_time_is_not_close_to_another_value_that_is_later_by_more_than_20ms_it_should_succeed()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(12, 15, 30, 979);
-            TimeOnly nearbyTime = new TimeOnly(12, 15, 31);
+            TimeOnly time = new(12, 15, 30, 979);
+            TimeOnly nearbyTime = new(12, 15, 31);
 
             // Act / Assert
             time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
         }
 
         [Fact]
-        public void When_asserting_subject_time_is_not_close_to_another_value_that_is_earlier_by_more_than_20ms_it_should_succeed()
+        public void
+            When_asserting_subject_time_is_not_close_to_another_value_that_is_earlier_by_more_than_20ms_it_should_succeed()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(12, 15, 31, 021);
-            TimeOnly nearbyTime = new TimeOnly(12, 15, 31);
+            TimeOnly time = new(12, 15, 31, 021);
+            TimeOnly nearbyTime = new(12, 15, 31);
 
             // Act / Assert
             time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
@@ -528,8 +528,8 @@ public class TimeOnlyAssertionSpecs
         public void When_asserting_subject_datetime_is_not_close_to_an_earlier_datetime_by_35ms_it_should_throw()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(12, 15, 31, 035);
-            TimeOnly nearbyTime = new TimeOnly(12, 15, 31);
+            TimeOnly time = new(12, 15, 31, 035);
+            TimeOnly nearbyTime = new(12, 15, 31);
 
             // Act
             Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35.Milliseconds());
@@ -573,8 +573,8 @@ public class TimeOnlyAssertionSpecs
         public void A_time_is_not_close_to_a_later_time_when_passing_midnight()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(23, 58, 0);
-            TimeOnly nearbyTime = new TimeOnly(0, 1, 0);
+            TimeOnly time = new(23, 58, 0);
+            TimeOnly nearbyTime = new(0, 1, 0);
 
             // Act / Assert
             time.Should().NotBeCloseTo(nearbyTime, 2.Minutes());
@@ -584,8 +584,8 @@ public class TimeOnlyAssertionSpecs
         public void A_time_is_not_close_to_an_earlier_time_when_passing_midnight()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(0, 2, 0);
-            TimeOnly nearbyTime = new TimeOnly(23, 59, 0);
+            TimeOnly time = new(0, 2, 0);
+            TimeOnly nearbyTime = new(23, 59, 0);
 
             // Act / Assert
             time.Should().NotBeCloseTo(nearbyTime, 2.Minutes());
@@ -595,28 +595,30 @@ public class TimeOnlyAssertionSpecs
         public void A_time_inside_of_the_precision_to_a_later_time_when_passing_midnight_fails()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(23, 59, 0);
-            TimeOnly nearbyTime = new TimeOnly(0, 1, 0);
+            TimeOnly time = new(23, 59, 0);
+            TimeOnly nearbyTime = new(0, 1, 0);
 
             // Act
             Action act = () => time.Should().NotBeCloseTo(nearbyTime, 2.Minutes());
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Did not expect * to be within 2m from <00:01:00.000>*, but it was <23:59:00.000>*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect * to be within 2m from <00:01:00.000>*, but it was <23:59:00.000>*");
         }
 
         [Fact]
         public void A_time_inside_of_the_precision_to_an_earlier_time_when_passing_midnight_fails()
         {
             // Arrange
-            TimeOnly time = new TimeOnly(0, 1, 0);
-            TimeOnly nearbyTime = new TimeOnly(23, 59, 0);
+            TimeOnly time = new(0, 1, 0);
+            TimeOnly nearbyTime = new(23, 59, 0);
 
             // Act
             Action act = () => time.Should().NotBeCloseTo(nearbyTime, 2.Minutes());
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Did not expect * to be within 2m from <23:59:00.000>*, but it was <00:01:00.000>*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect * to be within 2m from <23:59:00.000>*, but it was <00:01:00.000>*");
         }
     }
 
@@ -1318,7 +1320,8 @@ public class TimeOnlyAssertionSpecs
             Action act = () => someTimeOnly.Should().Equals(someTimeOnly);
 
             // Assert
-            act.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+            act.Should().Throw<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
@@ -180,7 +180,8 @@ public class AssemblyAssertionSpecs
         }
 
         [Fact]
-        public void When_an_assembly_does_not_define_a_type_and_Should_DefineType_is_asserted_it_should_fail_with_a_useful_message()
+        public void
+            When_an_assembly_does_not_define_a_type_and_Should_DefineType_is_asserted_it_should_fail_with_a_useful_message()
         {
             // Arrange
             var thisAssembly = GetType().Assembly;
@@ -192,8 +193,8 @@ public class AssemblyAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage($"Expected assembly \"{thisAssembly.FullName}\" " +
-                             "to define type \"FakeNamespace\".\"FakeName\" " +
-                             "because we want to test the failure message, but it does not.");
+                    "to define type \"FakeNamespace\".\"FakeName\" " +
+                    "because we want to test the failure message, but it does not.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -94,7 +94,8 @@ public class ExecutionTimeAssertionsSpecs
             var subject = new List<object>();
 
             // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.AddRange(new object[] { })).Should().BeLessOrEqualTo(1.Nanoseconds());
+            Action act = () =>
+                subject.ExecutionTimeOf(s => s.AddRange(new object[] { })).Should().BeLessOrEqualTo(1.Nanoseconds());
 
             // Assert
             act.Should().ThrowExactly<XunitException>()
@@ -302,7 +303,8 @@ public class ExecutionTimeAssertionsSpecs
             var subject = new List<object>();
 
             // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.AddRange(new object[] { })).Should().BeGreaterThanOrEqualTo(1.Days());
+            Action act = () =>
+                subject.ExecutionTimeOf(s => s.AddRange(new object[] { })).Should().BeGreaterThanOrEqualTo(1.Days());
 
             // Assert
             act.Should().ThrowExactly<XunitException>()
@@ -627,7 +629,8 @@ public class ExecutionTimeAssertionsSpecs
             Action act = () => subject.ExecutionTimeOf(s => s.ToString()).Should().Equals(1.Seconds());
 
             // Assert
-            act.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean BeLessThanOrEqualTo() or BeGreaterThanOrEqualTo() instead?");
+            act.Should().Throw<NotSupportedException>().WithMessage(
+                "Equals is not part of Fluent Assertions. Did you mean BeLessThanOrEqualTo() or BeGreaterThanOrEqualTo() instead?");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -53,6 +53,7 @@ public static class TaskAssertionSpecs
             // Act
             Func<Task> action = () =>
                 taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+
             taskFactory.SetResult(true);
             timer.Complete();
 
@@ -93,7 +94,9 @@ public static class TaskAssertionSpecs
             var taskFactory = new TaskCompletionSource<bool>();
 
             // Act
-            Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+            Func<Task> action = () =>
+                taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+
             timer.Complete();
 
             // Assert
@@ -130,6 +133,7 @@ public static class TaskAssertionSpecs
             Func<Task> action = () => taskFactory
                 .Awaiting(t => (Task)t.Task).Should(timer)
                 .NotCompleteWithinAsync(100.Milliseconds());
+
             taskFactory.SetResult(true);
             timer.Complete();
 
@@ -173,6 +177,7 @@ public static class TaskAssertionSpecs
             Func<Task> action = () => taskFactory
                 .Awaiting(t => (Task)t.Task).Should(timer)
                 .NotCompleteWithinAsync(100.Milliseconds());
+
             timer.Complete();
 
             // Assert
@@ -193,6 +198,7 @@ public static class TaskAssertionSpecs
             // Act
             Func<Task> action = () =>
                 taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+
             taskFactory.SetResult(true);
             timer.Complete();
 
@@ -210,6 +216,7 @@ public static class TaskAssertionSpecs
             // Act
             Func<Task> action = () =>
                 taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+
             timer.Complete();
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
@@ -9,7 +9,6 @@ namespace FluentAssertions.Specs.Specialized;
 public class TaskCompletionSourceAssertionSpecs
 {
 #if NET6_0_OR_GREATER
-
     public class NonGeneric
     {
         [Fact]
@@ -113,7 +112,8 @@ public class TaskCompletionSourceAssertionSpecs
             Func<Task> action = () => Task.FromResult(subject.Should().Equals(subject));
 
             // Assert
-            await action.Should().ThrowAsync<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean CompleteWithinAsync() instead?");
+            await action.Should().ThrowAsync<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean CompleteWithinAsync() instead?");
         }
     }
 #endif
@@ -178,6 +178,7 @@ public class TaskCompletionSourceAssertionSpecs
             // Act
             Func<Task> action = async () =>
                 (await testSubject.Should(timer).CompleteWithinAsync(1.Seconds())).Which.Should().Be(42);
+
             testSubject.SetResult(99);
             timer.Complete();
 
@@ -246,7 +247,8 @@ public class TaskCompletionSourceAssertionSpecs
             timer.Complete();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>().WithMessage("Did not expect*to complete within*because test testArg*");
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Did not expect*to complete within*because test testArg*");
         }
 
         [Fact]
@@ -288,7 +290,8 @@ public class TaskCompletionSourceAssertionSpecs
             Func<Task<bool>> action = () => Task.FromResult(subject.Should().Equals(subject));
 
             // Assert
-            await action.Should().ThrowAsync<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean CompleteWithinAsync() instead?");
+            await action.Should().ThrowAsync<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean CompleteWithinAsync() instead?");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -1,14 +1,13 @@
-﻿using System;
+﻿#if NETFRAMEWORK
+using FluentAssertions.Specs.Common;
+#endif
+using System;
 using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
-#if NETFRAMEWORK
-using FluentAssertions.Specs.Common;
-#endif
 using FluentAssertions.Specs.Exceptions;
 using Xunit;
 using Xunit.Sdk;
-
 using static FluentAssertions.FluentActions;
 
 namespace FluentAssertions.Specs.Specialized;
@@ -44,6 +43,7 @@ public static class TaskOfTAssertionSpecs
             Func<Task> testAction = () =>
             {
                 using var _ = new AssertionScope();
+
                 return action.Should().CompleteWithinAsync(
                     timeSpan, "because we want to test the failure {0}", "message");
             };
@@ -180,11 +180,13 @@ public static class TaskOfTAssertionSpecs
                 using var _ = new AssertionScope();
                 return func.Should(timer).CompleteWithinAsync(100.Milliseconds()).WithResult(2);
             };
+
             timer.Complete();
 
             // Assert
             var assertionTask = action.Should().ThrowAsync<XunitException>()
                 .WithMessage("Expected*to complete within 100ms.*Expected return*to be 2, but found 0.");
+
             await Awaiting(() => assertionTask).Should().CompleteWithinAsync(200.Seconds());
         }
 
@@ -337,6 +339,7 @@ public static class TaskOfTAssertionSpecs
             Func<Task> testAction = async () =>
             {
                 using var _ = new AssertionScope();
+
                 await action.Should().NotThrowAfterAsync(waitTime, pollInterval,
                     "because we want to test the failure {0}", "message");
             };

--- a/Tests/FluentAssertions.Specs/Streams/StreamAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Streams/StreamAssertionSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using FluentAssertions.Execution;
 using Xunit;
@@ -588,7 +587,7 @@ public class StreamAssertionSpecs
     public static TheoryData<Exception> GetLengthExceptions => new()
     {
         // https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.length#exceptions
-        new IOException("GetLengthExceptionMessage") ,
+        new IOException("GetLengthExceptionMessage"),
         new NotSupportedException("GetLengthExceptionMessage"),
         new ObjectDisposedException("GetLengthExceptionMessage")
     };

--- a/Tests/FluentAssertions.Specs/TypeEnumerableExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/TypeEnumerableExtensionsSpecs.cs
@@ -13,7 +13,10 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_types_that_decorated_with_attribute_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(ClassWithSomeAttribute), typeof(ClassDerivedFromClassWithSomeAttribute) };
+            var types = new[]
+            {
+                typeof(JustAClass), typeof(ClassWithSomeAttribute), typeof(ClassDerivedFromClassWithSomeAttribute)
+            };
 
             types.ThatAreDecoratedWith<SomeAttribute>()
                 .Should()
@@ -24,7 +27,10 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_types_that_decorated_with_attribute_or_inherit_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(ClassWithSomeAttribute), typeof(ClassDerivedFromClassWithSomeAttribute) };
+            var types = new[]
+            {
+                typeof(JustAClass), typeof(ClassWithSomeAttribute), typeof(ClassDerivedFromClassWithSomeAttribute)
+            };
 
             types.ThatAreDecoratedWithOrInherit<SomeAttribute>()
                 .Should()
@@ -36,7 +42,10 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_types_that_not_decorated_with_attribute_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(ClassWithSomeAttribute), typeof(ClassDerivedFromClassWithSomeAttribute) };
+            var types = new[]
+            {
+                typeof(JustAClass), typeof(ClassWithSomeAttribute), typeof(ClassDerivedFromClassWithSomeAttribute)
+            };
 
             types.ThatAreNotDecoratedWith<SomeAttribute>()
                 .Should()
@@ -48,7 +57,10 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_types_that_not_decorated_with_attribute_or_inherit_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(ClassWithSomeAttribute), typeof(ClassDerivedFromClassWithSomeAttribute) };
+            var types = new[]
+            {
+                typeof(JustAClass), typeof(ClassWithSomeAttribute), typeof(ClassDerivedFromClassWithSomeAttribute)
+            };
 
             types.ThatAreNotDecoratedWithOrInherit<SomeAttribute>()
                 .Should()
@@ -233,9 +245,10 @@ namespace TypeEnumerableExtensionsSpecs.Internal
     {
     }
 
-    [AttributeUsage(AttributeTargets.Class, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Class)]
     internal class SomeAttribute : Attribute
     {
     }
 }
+
 #endregion

--- a/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
@@ -37,7 +37,7 @@ public class MethodBaseAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected the return type of method IntMethod to be System.String because we want to test the " +
-                             "error message, but it is \"System.Int32\".");
+                    "error message, but it is \"System.Int32\".");
         }
 
         [Fact]
@@ -53,7 +53,7 @@ public class MethodBaseAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected the return type of method VoidMethod to be System.String because we want to test the " +
-                             "error message, but it is \"System.Void\".");
+                    "error message, but it is \"System.Void\".");
         }
 
         [Fact]
@@ -117,7 +117,7 @@ public class MethodBaseAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected the return type of*IntMethod*not to be System.Int32*because we want to test the " +
-                             "error message, but it is.");
+                    "error message, but it is.");
         }
 
         [Fact]
@@ -132,7 +132,8 @@ public class MethodBaseAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method not to be *.String *failure message*, but methodInfo is <null>.");
+                .WithMessage(
+                    "Expected the return type of method not to be *.String *failure message*, but methodInfo is <null>.");
         }
 
         [Fact]
@@ -180,7 +181,7 @@ public class MethodBaseAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected the return type of method IntMethod to be System.String because we want to test the " +
-                             "error message, but it is \"System.Int32\".");
+                    "error message, but it is \"System.Int32\".");
         }
 
         [Fact]
@@ -228,7 +229,7 @@ public class MethodBaseAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected the return type of*IntMethod*not to be System.Int32*because we want to test the " +
-                             "error message, but it is.");
+                    "error message, but it is.");
         }
 
         [Fact]
@@ -243,7 +244,8 @@ public class MethodBaseAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method not to be *.String *failure message*, but methodInfo is <null>.");
+                .WithMessage(
+                    "Expected the return type of method not to be *.String *failure message*, but methodInfo is <null>.");
         }
     }
 
@@ -275,8 +277,9 @@ public class MethodBaseAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method IntMethod to be void because we want to test the error message " +
-                             "message, but it is \"System.Int32\".");
+                .WithMessage(
+                    "Expected the return type of method IntMethod to be void because we want to test the error message " +
+                    "message, but it is \"System.Int32\".");
         }
 
         [Fact]
@@ -380,12 +383,14 @@ public class MethodBaseAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the error {0}", "message");
+                methodInfo.Should()
+                    .HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the error {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method PrivateMethod to be Protected because we want to test the error message, but it is " +
-                             "Private.");
+                .WithMessage(
+                    "Expected method PrivateMethod to be Protected because we want to test the error message, but it is " +
+                    "Private.");
         }
 
         [Fact]
@@ -420,8 +425,9 @@ public class MethodBaseAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method set_ProtectedSetProperty to be Public because we want to test the error message, but it" +
-                             " is Protected.");
+                .WithMessage(
+                    "Expected method set_ProtectedSetProperty to be Public because we want to test the error message, but it" +
+                    " is Protected.");
         }
 
         [Fact]
@@ -456,8 +462,9 @@ public class MethodBaseAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method get_PublicGetProperty to be Internal because we want to test the error message, but it" +
-                             " is Public.");
+                .WithMessage(
+                    "Expected method get_PublicGetProperty to be Internal because we want to test the error message, but it" +
+                    " is Public.");
         }
 
         [Fact]
@@ -483,12 +490,13 @@ public class MethodBaseAssertionSpecs
             // Act
             Action act = () =>
                 methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "because we want to test the" +
-                                                                                                " error {0}", "message");
+                    " error {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method InternalMethod to be ProtectedInternal because we want to test the error message, but" +
-                             " it is Internal.");
+                .WithMessage(
+                    "Expected method InternalMethod to be ProtectedInternal because we want to test the error message, but" +
+                    " it is Internal.");
         }
 
         [Fact]
@@ -517,8 +525,9 @@ public class MethodBaseAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method ProtectedInternalMethod to be Private because we want to test the error message, but it is " +
-                             "ProtectedInternal.");
+                .WithMessage(
+                    "Expected method ProtectedInternalMethod to be Private because we want to test the error message, but it is " +
+                    "ProtectedInternal.");
         }
 
         [Fact]
@@ -590,7 +599,8 @@ public class MethodBaseAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.Private, "we want to test the error {0}", "message");
+                methodInfo.Should()
+                    .NotHaveAccessModifier(CSharpAccessModifier.Private, "we want to test the error {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -627,7 +637,8 @@ public class MethodBaseAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method set_ProtectedSetProperty not to be Protected*because we want to test the error message*");
+                .WithMessage(
+                    "Expected method set_ProtectedSetProperty not to be Protected*because we want to test the error message*");
         }
 
         [Fact]
@@ -701,7 +712,7 @@ public class MethodBaseAssertionSpecs
             // Act
             Action act = () =>
                 methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "because we want to test the" +
-                                                                                                " error {0}", "message");
+                    " error {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -730,11 +741,13 @@ public class MethodBaseAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "we want to test the error {0}", "message");
+                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "we want to test the error {0}",
+                    "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method ProtectedInternalMethod not to be ProtectedInternal*because we want to test the error message*");
+                .WithMessage(
+                    "Expected method ProtectedInternalMethod not to be ProtectedInternal*because we want to test the error message*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
@@ -114,7 +114,8 @@ public class MethodInfoAssertionSpecs
         public void When_asserting_a_method_is_decorated_with_attribute_and_it_is_it_succeeds()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () =>
@@ -142,7 +143,8 @@ public class MethodInfoAssertionSpecs
         public void When_asserting_a_constructor_is_decorated_with_MethodImpl_attribute_and_it_is_it_succeeds()
         {
             // Arrange
-            ConstructorInfo constructorMethodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetConstructor(Type.EmptyTypes);
+            ConstructorInfo constructorMethodInfo =
+                typeof(ClassWithMethodWithImplementationAttribute).GetConstructor(Type.EmptyTypes);
 
             // Act
             Action act = () =>
@@ -156,7 +158,8 @@ public class MethodInfoAssertionSpecs
         public void When_asserting_a_method_is_decorated_with_MethodImpl_attribute_and_it_is_not_it_throws()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () =>
@@ -166,7 +169,7 @@ public class MethodInfoAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method Void FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
-                        "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
+                    "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
         }
 
         [Fact]
@@ -183,7 +186,7 @@ public class MethodInfoAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.NoOptions to be decorated with " +
-                        "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
+                    "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
         }
 
         [Fact]
@@ -200,7 +203,7 @@ public class MethodInfoAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.ZeroOptions to be decorated with " +
-                        "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
+                    "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
         }
 
         [Fact]
@@ -217,14 +220,15 @@ public class MethodInfoAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected type FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute to be decorated with " +
-                        "System.Runtime.CompilerServices.MethodImplAttribute, but the attribute was not found.");
+                    "System.Runtime.CompilerServices.MethodImplAttribute, but the attribute was not found.");
         }
 
         [Fact]
         public void When_a_method_is_decorated_with_an_attribute_it_should_allow_chaining_assertions_on_it()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () => methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>().Which.Filter.Should().BeFalse();
@@ -237,7 +241,8 @@ public class MethodInfoAssertionSpecs
         public void When_asserting_a_method_is_decorated_with_an_attribute_but_it_is_not_it_throws_with_a_useful_message()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () =>
@@ -247,15 +252,16 @@ public class MethodInfoAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
-                        "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
-                        " but that attribute was not found.");
+                    "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
+                    " but that attribute was not found.");
         }
 
         [Fact]
         public void When_injecting_a_null_predicate_into_BeDecoratedWith_it_should_throw()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () => methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>(isMatchingAttributePredicate: null);
@@ -269,7 +275,8 @@ public class MethodInfoAssertionSpecs
         public void When_asserting_a_method_is_decorated_with_attribute_matching_a_predicate_and_it_is_it_succeeds()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () =>
@@ -294,45 +301,52 @@ public class MethodInfoAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_method_is_decorated_with_an_attribute_matching_a_predicate_but_it_is_not_it_throws_with_a_useful_message()
+        public void
+            When_asserting_a_method_is_decorated_with_an_attribute_matching_a_predicate_but_it_is_not_it_throws_with_a_useful_message()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () =>
-                methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>(d => !d.Filter, "because we want to test the error {0}", "message");
+                methodInfo.Should()
+                    .BeDecoratedWith<DummyMethodAttribute>(d => !d.Filter, "because we want to test the error {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
-                        "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
-                        " but that attribute was not found.");
+                    "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
+                    " but that attribute was not found.");
         }
 
         [Fact]
-        public void When_asserting_a_method_is_decorated_with_an_MethodImpl_attribute_matching_a_predicate_but_it_is_not_it_throws()
+        public void
+            When_asserting_a_method_is_decorated_with_an_MethodImpl_attribute_matching_a_predicate_but_it_is_not_it_throws()
         {
             // Arrange
             MethodInfo methodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetParameterlessMethod("DoNotInlineMe");
 
             // Act
             Action act = () =>
-               methodInfo.Should().BeDecoratedWith<MethodImplAttribute>(x => x.Value == MethodImplOptions.AggressiveInlining);
+                methodInfo.Should().BeDecoratedWith<MethodImplAttribute>(x => x.Value == MethodImplOptions.AggressiveInlining);
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.DoNotInlineMe to be decorated with " +
-                        "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
+                    "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
         }
 
         [Fact]
-        public void When_asserting_a_method_is_decorated_with_an_attribute_and_multiple_attributes_match_continuation_using_the_matched_value_should_fail()
+        public void
+            When_asserting_a_method_is_decorated_with_an_attribute_and_multiple_attributes_match_continuation_using_the_matched_value_should_fail()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothingWithSameAttributeTwice");
+            MethodInfo methodInfo =
+                typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod(
+                    "PublicDoNothingWithSameAttributeTwice");
 
             // Act
             Action act =
@@ -369,7 +383,8 @@ public class MethodInfoAssertionSpecs
         public void When_asserting_a_method_is_not_decorated_with_attribute_and_it_is_not_it_succeeds()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () =>
@@ -383,7 +398,8 @@ public class MethodInfoAssertionSpecs
         public void When_asserting_a_method_is_not_decorated_with_MethodImpl_attribute_and_it_is_not_it_succeeds()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () =>
@@ -397,7 +413,8 @@ public class MethodInfoAssertionSpecs
         public void When_asserting_a_constructor_is_not_decorated_with_MethodImpl_attribute_and_it_is_not_it_succeeds()
         {
             // Arrange
-            ConstructorInfo constructorMethodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetConstructor(new[] { typeof(string) });
+            ConstructorInfo constructorMethodInfo =
+                typeof(ClassWithMethodWithImplementationAttribute).GetConstructor(new[] { typeof(string) });
 
             // Act
             Action act = () =>
@@ -411,7 +428,8 @@ public class MethodInfoAssertionSpecs
         public void When_asserting_a_method_is_not_decorated_with_an_attribute_but_it_is_it_throws_with_a_useful_message()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () =>
@@ -421,8 +439,8 @@ public class MethodInfoAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method Void FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to not be decorated with " +
-                        "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
-                        " but that attribute was found.");
+                    "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
+                    " but that attribute was found.");
         }
 
         [Fact]
@@ -437,8 +455,8 @@ public class MethodInfoAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.DoNotInlineMe to not be decorated with " +
+                .WithMessage(
+                    "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.DoNotInlineMe to not be decorated with " +
                     "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was found.");
         }
 
@@ -446,7 +464,8 @@ public class MethodInfoAssertionSpecs
         public void When_asserting_a_method_is_not_decorated_with_attribute_matching_a_predicate_and_it_is_not_it_succeeds()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () =>
@@ -460,7 +479,8 @@ public class MethodInfoAssertionSpecs
         public void When_injecting_a_null_predicate_into_NotBeDecoratedWith_it_should_throw()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () => methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>(isMatchingAttributePredicate: null);
@@ -471,21 +491,24 @@ public class MethodInfoAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_method_is_not_decorated_with_an_attribute_matching_a_predicate_but_it_is_it_throws_with_a_useful_message()
+        public void
+            When_asserting_a_method_is_not_decorated_with_an_attribute_matching_a_predicate_but_it_is_it_throws_with_a_useful_message()
         {
             // Arrange
-            MethodInfo methodInfo = typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
+            MethodInfo methodInfo =
+                typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
             Action act = () =>
-                methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>(d => d.Filter, "because we want to test the error {0}", "message");
+                methodInfo.Should()
+                    .NotBeDecoratedWith<DummyMethodAttribute>(d => d.Filter, "because we want to test the error {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method Void FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to not be decorated with " +
-                        "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
-                        " but that attribute was found.");
+                    "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
+                    " but that attribute was found.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorAssertionSpecs.cs
@@ -39,7 +39,8 @@ public class MethodInfoSelectorAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_methods_are_virtual_but_non_virtual_methods_are_found_it_should_throw_with_descriptive_message()
+        public void
+            When_asserting_methods_are_virtual_but_non_virtual_methods_are_found_it_should_throw_with_descriptive_message()
         {
             // Arrange
             var methodSelector = new MethodInfoSelector(typeof(ClassWithNonVirtualPublicMethods));
@@ -51,11 +52,11 @@ public class MethodInfoSelectorAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods" +
-                             " to be virtual because we want to test the error message," +
-                             " but the following methods are not virtual:*" +
-                             "Void FluentAssertions*ClassWithNonVirtualPublicMethods.PublicDoNothing*" +
-                             "Void FluentAssertions*ClassWithNonVirtualPublicMethods.InternalDoNothing*" +
-                             "Void FluentAssertions*ClassWithNonVirtualPublicMethods.ProtectedDoNothing");
+                    " to be virtual because we want to test the error message," +
+                    " but the following methods are not virtual:*" +
+                    "Void FluentAssertions*ClassWithNonVirtualPublicMethods.PublicDoNothing*" +
+                    "Void FluentAssertions*ClassWithNonVirtualPublicMethods.InternalDoNothing*" +
+                    "Void FluentAssertions*ClassWithNonVirtualPublicMethods.ProtectedDoNothing");
         }
     }
 
@@ -90,7 +91,8 @@ public class MethodInfoSelectorAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_methods_are_not_virtual_but_virtual_methods_are_found_it_should_throw_with_descriptive_message()
+        public void
+            When_asserting_methods_are_not_virtual_but_virtual_methods_are_found_it_should_throw_with_descriptive_message()
         {
             // Arrange
             var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsVirtual));
@@ -102,11 +104,11 @@ public class MethodInfoSelectorAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods" +
-                             " not to be virtual because we want to test the error message," +
-                             " but the following methods are virtual" +
-                             "*ClassWithAllMethodsVirtual.PublicVirtualDoNothing" +
-                             "*ClassWithAllMethodsVirtual.InternalVirtualDoNothing" +
-                             "*ClassWithAllMethodsVirtual.ProtectedVirtualDoNothing*");
+                    " not to be virtual because we want to test the error message," +
+                    " but the following methods are virtual" +
+                    "*ClassWithAllMethodsVirtual.PublicVirtualDoNothing" +
+                    "*ClassWithAllMethodsVirtual.InternalVirtualDoNothing" +
+                    "*ClassWithAllMethodsVirtual.ProtectedVirtualDoNothing*");
         }
     }
 
@@ -158,7 +160,8 @@ public class MethodInfoSelectorAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_methods_are_decorated_with_attribute_but_they_are_not_it_should_throw_with_descriptive_message()
+        public void
+            When_asserting_methods_are_decorated_with_attribute_but_they_are_not_it_should_throw_with_descriptive_message()
         {
             // Arrange
             var methodSelector = new MethodInfoSelector(typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute));
@@ -170,11 +173,11 @@ public class MethodInfoSelectorAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods to be decorated with" +
-                             " FluentAssertions*DummyMethodAttribute because we want to test the error message," +
-                             " but the following methods are not:*" +
-                             "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing*" +
-                             "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.ProtectedDoNothing*" +
-                             "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PrivateDoNothing");
+                    " FluentAssertions*DummyMethodAttribute because we want to test the error message," +
+                    " but the following methods are not:*" +
+                    "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing*" +
+                    "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.ProtectedDoNothing*" +
+                    "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PrivateDoNothing");
         }
     }
 
@@ -226,22 +229,24 @@ public class MethodInfoSelectorAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_methods_are_not_decorated_with_attribute_but_they_are_it_should_throw_with_descriptive_message()
+        public void
+            When_asserting_methods_are_not_decorated_with_attribute_but_they_are_it_should_throw_with_descriptive_message()
         {
             // Arrange
             var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute));
 
             // Act
-            Action act = () =>
-                methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
+            Action act = () => methodSelector.Should()
+                    .NotBeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected methods to not be decorated*DummyMethodAttribute*because we want to test the error message" +
-                             "*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing*" +
-                             "*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothingWithSameAttributeTwice*" +
-                             "*ClassWithAllMethodsDecoratedWithDummyAttribute.ProtectedDoNothing*" +
-                             "*ClassWithAllMethodsDecoratedWithDummyAttribute.PrivateDoNothing");
+                .WithMessage(
+                    "Expected all selected methods to not be decorated*DummyMethodAttribute*because we want to test the error message" +
+                    "*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing*" +
+                    "*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothingWithSameAttributeTwice*" +
+                    "*ClassWithAllMethodsDecoratedWithDummyAttribute.ProtectedDoNothing*" +
+                    "*ClassWithAllMethodsDecoratedWithDummyAttribute.PrivateDoNothing");
         }
     }
 
@@ -274,10 +279,10 @@ public class MethodInfoSelectorAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods to be Public" +
-                             ", but the following methods are not:*" +
-                             "Void FluentAssertions*ClassWithNonPublicMethods.PublicDoNothing*" +
-                             "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithParameter*" +
-                             "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
+                    ", but the following methods are not:*" +
+                    "Void FluentAssertions*ClassWithNonPublicMethods.PublicDoNothing*" +
+                    "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithParameter*" +
+                    "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
         }
 
         [Fact]
@@ -293,11 +298,11 @@ public class MethodInfoSelectorAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods to be Public" +
-                             " because we want to test the error message" +
-                             ", but the following methods are not:*" +
-                             "Void FluentAssertions*ClassWithNonPublicMethods.PublicDoNothing*" +
-                             "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithParameter*" +
-                             "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
+                    " because we want to test the error message" +
+                    ", but the following methods are not:*" +
+                    "Void FluentAssertions*ClassWithNonPublicMethods.PublicDoNothing*" +
+                    "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithParameter*" +
+                    "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
         }
     }
 
@@ -330,8 +335,8 @@ public class MethodInfoSelectorAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods to not be Public" +
-                             ", but the following methods are:*" +
-                             "Void FluentAssertions*ClassWithPublicMethods.PublicDoNothing*");
+                    ", but the following methods are:*" +
+                    "Void FluentAssertions*ClassWithPublicMethods.PublicDoNothing*");
         }
 
         [Fact]
@@ -347,9 +352,9 @@ public class MethodInfoSelectorAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods to not be Public" +
-                             " because we want to test the error message" +
-                             ", but the following methods are:*" +
-                             "Void FluentAssertions*ClassWithPublicMethods.PublicDoNothing*");
+                    " because we want to test the error message" +
+                    ", but the following methods are:*" +
+                    "Void FluentAssertions*ClassWithPublicMethods.PublicDoNothing*");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -196,7 +196,8 @@ public class MethodInfoSelectorSpecs
     }
 
     [Fact]
-    public void When_selecting_methods_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_methods()
+    public void
+        When_selecting_methods_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_methods()
     {
         // Arrange
         Type type = typeof(TestClassForMethodSelectorWithInheritableAttributeDerived);
@@ -222,7 +223,8 @@ public class MethodInfoSelectorSpecs
     }
 
     [Fact]
-    public void When_selecting_methods_not_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_methods()
+    public void
+        When_selecting_methods_not_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_methods()
     {
         // Arrange
         Type type = typeof(TestClassForMethodSelectorWithInheritableAttributeDerived);
@@ -241,33 +243,38 @@ public class MethodInfoSelectorSpecs
         Type type = typeof(TestClassForMethodSelectorWithNonInheritableAttributeDerived);
 
         // Act
-        IEnumerable<MethodInfo> methods = type.Methods().ThatAreDecoratedWith<DummyMethodNonInheritableAttributeAttribute>().ToArray();
+        IEnumerable<MethodInfo> methods = type.Methods().ThatAreDecoratedWith<DummyMethodNonInheritableAttributeAttribute>()
+            .ToArray();
 
         // Assert
         methods.Should().BeEmpty();
     }
 
     [Fact]
-    public void When_selecting_methods_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_methods()
+    public void
+        When_selecting_methods_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_methods()
     {
         // Arrange
         Type type = typeof(TestClassForMethodSelectorWithNonInheritableAttributeDerived);
 
         // Act
-        IEnumerable<MethodInfo> methods = type.Methods().ThatAreDecoratedWithOrInherit<DummyMethodNonInheritableAttributeAttribute>().ToArray();
+        IEnumerable<MethodInfo> methods =
+            type.Methods().ThatAreDecoratedWithOrInherit<DummyMethodNonInheritableAttributeAttribute>().ToArray();
 
         // Assert
         methods.Should().BeEmpty();
     }
 
     [Fact]
-    public void When_selecting_methods_not_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_methods()
+    public void
+        When_selecting_methods_not_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_methods()
     {
         // Arrange
         Type type = typeof(TestClassForMethodSelectorWithNonInheritableAttributeDerived);
 
         // Act
-        IEnumerable<MethodInfo> methods = type.Methods().ThatAreNotDecoratedWith<DummyMethodNonInheritableAttributeAttribute>().ToArray();
+        IEnumerable<MethodInfo> methods = type.Methods().ThatAreNotDecoratedWith<DummyMethodNonInheritableAttributeAttribute>()
+            .ToArray();
 
         // Assert
         methods.Should().ContainSingle();
@@ -388,13 +395,15 @@ public class MethodInfoSelectorSpecs
     }
 
     [Fact]
-    public void When_selecting_methods_not_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_methods()
+    public void
+        When_selecting_methods_not_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_methods()
     {
         // Arrange
         Type type = typeof(TestClassForMethodSelectorWithNonInheritableAttributeDerived);
 
         // Act
-        IEnumerable<MethodInfo> methods = type.Methods().ThatAreNotDecoratedWithOrInherit<DummyMethodNonInheritableAttributeAttribute>().ToArray();
+        IEnumerable<MethodInfo> methods =
+            type.Methods().ThatAreNotDecoratedWithOrInherit<DummyMethodNonInheritableAttributeAttribute>().ToArray();
 
         // Assert
         methods.Should().ContainSingle();
@@ -427,7 +436,8 @@ public class MethodInfoSelectorSpecs
         Action action = () => type.Methods().Should().Equals(null);
 
         // Assert
-        action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+        action.Should().Throw<NotSupportedException>()
+            .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
     }
 }
 
@@ -490,7 +500,8 @@ internal class TestClassForMethodSelectorWithInheritableAttributeDerived : TestC
     public override void PublicVirtualVoidMethodWithAttribute() { }
 }
 
-internal class TestClassForMethodSelectorWithNonInheritableAttributeDerived : TestClassForMethodSelectorWithNonInheritableAttribute
+internal class TestClassForMethodSelectorWithNonInheritableAttributeDerived
+    : TestClassForMethodSelectorWithNonInheritableAttribute
 {
     public override void PublicVirtualVoidMethodWithAttribute() { }
 }
@@ -524,7 +535,7 @@ public class DummyMethodNonInheritableAttributeAttribute : Attribute
     public bool Filter { get; set; }
 }
 
-[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 public class DummyMethodAttribute : Attribute
 {
     public bool Filter { get; set; }

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
@@ -29,7 +29,8 @@ public class PropertyInfoAssertionSpecs
         public void When_asserting_that_a_property_is_virtual_and_it_is_not_then_it_fails_with_useful_message()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithNonVirtualPublicProperties).GetRuntimeProperty("PublicNonVirtualProperty");
+            PropertyInfo propertyInfo =
+                typeof(ClassWithNonVirtualPublicProperties).GetRuntimeProperty("PublicNonVirtualProperty");
 
             // Act
             Action act = () =>
@@ -37,10 +38,10 @@ public class PropertyInfoAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-               .WithMessage(
-                   "Expected property String FluentAssertions*ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty" +
-                       " to be virtual because we want to test the error message," +
-                       " but it is not.");
+                .WithMessage(
+                    "Expected property String FluentAssertions*ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty" +
+                    " to be virtual because we want to test the error message," +
+                    " but it is not.");
         }
 
         [Fact]
@@ -65,7 +66,8 @@ public class PropertyInfoAssertionSpecs
         public void When_asserting_that_a_property_is_not_virtual_and_it_is_not_then_it_succeeds()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithNonVirtualPublicProperties).GetRuntimeProperty("PublicNonVirtualProperty");
+            PropertyInfo propertyInfo =
+                typeof(ClassWithNonVirtualPublicProperties).GetRuntimeProperty("PublicNonVirtualProperty");
 
             // Act
             Action act = () =>
@@ -87,10 +89,10 @@ public class PropertyInfoAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-               .WithMessage(
-                   "Expected property *ClassWithAllPropertiesVirtual.PublicVirtualProperty" +
-                       " not to be virtual because we want to test the error message," +
-                       " but it is.");
+                .WithMessage(
+                    "Expected property *ClassWithAllPropertiesVirtual.PublicVirtualProperty" +
+                    " not to be virtual because we want to test the error message," +
+                    " but it is.");
         }
 
         [Fact]
@@ -115,7 +117,8 @@ public class PropertyInfoAssertionSpecs
         public void When_asserting_a_property_is_decorated_with_attribute_and_it_is_it_succeeds()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+            PropertyInfo propertyInfo =
+                typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
 
             // Act
             Action act = () =>
@@ -129,7 +132,8 @@ public class PropertyInfoAssertionSpecs
         public void When_a_property_is_decorated_with_an_attribute_it_allow_chaining_assertions()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+            PropertyInfo propertyInfo =
+                typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
 
             // Act
             Action act = () =>
@@ -140,10 +144,12 @@ public class PropertyInfoAssertionSpecs
         }
 
         [Fact]
-        public void When_a_property_is_decorated_with_an_attribute_and_multiple_attributes_match_continuation_using_the_matched_value_fail()
+        public void
+            When_a_property_is_decorated_with_an_attribute_and_multiple_attributes_match_continuation_using_the_matched_value_fail()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicPropertyWithSameAttributeTwice");
+            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty(
+                    "PublicPropertyWithSameAttributeTwice");
 
             // Act
             Action act = () =>
@@ -157,7 +163,8 @@ public class PropertyInfoAssertionSpecs
         public void When_asserting_a_property_is_decorated_with_attribute_and_it_is_not_it_throw_with_useful_message()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+            PropertyInfo propertyInfo =
+                typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
 
             // Act
             Action act = () =>
@@ -165,38 +172,41 @@ public class PropertyInfoAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-               .WithMessage("Expected property String " +
-                   "FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
-                   "FluentAssertions*DummyPropertyAttribute because we want to test the error message, but that attribute was not found.");
+                .WithMessage("Expected property String " +
+                    "FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
+                    "FluentAssertions*DummyPropertyAttribute because we want to test the error message, but that attribute was not found.");
         }
 
         [Fact]
-        public void When_asserting_a_property_is_decorated_with_an_attribute_matching_a_predicate_but_it_is_not_it_throw_with_useful_message()
+        public void
+            When_asserting_a_property_is_decorated_with_an_attribute_matching_a_predicate_but_it_is_not_it_throw_with_useful_message()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+            PropertyInfo propertyInfo =
+                typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
 
             // Act
             Action act = () =>
-                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>(d => d.Value == "NotARealValue", "because we want to test the error {0}", "message");
+                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>(d => d.Value == "NotARealValue",
+                    "because we want to test the error {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected property String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
-                        "FluentAssertions*DummyPropertyAttribute because we want to test the error message," +
-                        " but that attribute was not found.");
+                    "FluentAssertions*DummyPropertyAttribute because we want to test the error message," +
+                    " but that attribute was not found.");
         }
 
         [Fact]
         public void When_asserting_a_property_is_decorated_with_attribute_matching_a_predicate_and_it_is_it_succeeds()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+            PropertyInfo propertyInfo =
+                typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
 
             // Act
-            Action act = () =>
-                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>(d => d.Value == "Value");
+            Action act = () => propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>(d => d.Value == "Value");
 
             // Assert
             act.Should().NotThrow();
@@ -214,14 +224,16 @@ public class PropertyInfoAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected property to be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
+                .WithMessage(
+                    "Expected property to be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
         }
 
         [Fact]
         public void When_asserting_property_is_decorated_with_null_it_should_throw()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+            PropertyInfo propertyInfo =
+                typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
 
             // Act
             Action act = () =>
@@ -247,7 +259,8 @@ public class PropertyInfoAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected property to not be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
+                .WithMessage(
+                    "Expected property to not be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
         }
 
         [Fact]
@@ -280,7 +293,8 @@ public class PropertyInfoAssertionSpecs
             // Assert
             action
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo ReadOnlyProperty to have a setter because we want to test the error message.");
+                .WithMessage(
+                    "Expected propertyInfo ReadOnlyProperty to have a setter because we want to test the error message.");
         }
 
         [Fact]
@@ -365,7 +379,8 @@ public class PropertyInfoAssertionSpecs
             // Assert
             action
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected property WriteOnlyProperty to have a getter because we want to test the error message, but it does not.");
+                .WithMessage(
+                    "Expected property WriteOnlyProperty to have a getter because we want to test the error message, but it does not.");
         }
 
         [Fact]
@@ -411,7 +426,8 @@ public class PropertyInfoAssertionSpecs
             // Assert
             action
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo ReadWriteProperty not to have a setter because we want to test the error message.");
+                .WithMessage(
+                    "Expected propertyInfo ReadWriteProperty not to have a setter because we want to test the error message.");
         }
 
         [Fact]
@@ -426,7 +442,8 @@ public class PropertyInfoAssertionSpecs
             // Assert
             action
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo WriteOnlyProperty not to have a setter because we want to test the error message.");
+                .WithMessage(
+                    "Expected propertyInfo WriteOnlyProperty not to have a setter because we want to test the error message.");
         }
 
         [Fact]
@@ -459,7 +476,8 @@ public class PropertyInfoAssertionSpecs
             // Assert
             action
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo ReadOnlyProperty not to have a getter because we want to test the error message.");
+                .WithMessage(
+                    "Expected propertyInfo ReadOnlyProperty not to have a getter because we want to test the error message.");
         }
 
         [Fact]
@@ -474,7 +492,8 @@ public class PropertyInfoAssertionSpecs
             // Assert
             action
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo ReadWriteProperty not to have a getter because we want to test the error message.");
+                .WithMessage(
+                    "Expected propertyInfo ReadWriteProperty not to have a getter because we want to test the error message.");
         }
 
         [Fact]
@@ -528,11 +547,13 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WritePrivateReadProperty");
 
             // Act
-            Action action = () => propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+            Action action = () =>
+                propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected method get_WritePrivateReadProperty to be Public because we want to test the error message, but it is Private.");
+                .WithMessage(
+                    "Expected method get_WritePrivateReadProperty to be Public because we want to test the error message, but it is Private.");
         }
 
         [Fact]
@@ -588,11 +609,13 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadPrivateWriteProperty");
 
             // Act
-            Action action = () => propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+            Action action = () =>
+                propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected method set_ReadPrivateWriteProperty to be Public because we want to test the error message, but it is Private.");
+                .WithMessage(
+                    "Expected method set_ReadPrivateWriteProperty to be Public because we want to test the error message, but it is Private.");
         }
 
         [Fact]
@@ -653,7 +676,7 @@ public class PropertyInfoAssertionSpecs
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected Type of property StringProperty to be System.Int32 because we want to test the error " +
-                             "message, but it is System.String.");
+                    "message, but it is System.String.");
         }
 
         [Fact]
@@ -714,7 +737,7 @@ public class PropertyInfoAssertionSpecs
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected Type of property StringProperty to be System.Int32 because we want to test the error " +
-                             "message, but it is System.String.");
+                    "message, but it is System.String.");
         }
     }
 
@@ -745,7 +768,7 @@ public class PropertyInfoAssertionSpecs
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected Type of property StringProperty not to be*String*because we want to test the error " +
-                             "message, but it is.");
+                    "message, but it is.");
         }
 
         [Fact]
@@ -806,7 +829,7 @@ public class PropertyInfoAssertionSpecs
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected Type of property StringProperty not to be*String*because we want to test the error " +
-                             "message, but it is.");
+                    "message, but it is.");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorAssertionSpecs.cs
@@ -50,12 +50,12 @@ public class PropertyInfoSelectorAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-               .WithMessage("Expected all selected properties" +
-                   " to be virtual because we want to test the error message," +
-                   " but the following properties are not virtual:*" +
-                   "String FluentAssertions*ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty*" +
-                   "String FluentAssertions*ClassWithNonVirtualPublicProperties.InternalNonVirtualProperty*" +
-                   "String FluentAssertions*ClassWithNonVirtualPublicProperties.ProtectedNonVirtualProperty");
+                .WithMessage("Expected all selected properties" +
+                    " to be virtual because we want to test the error message," +
+                    " but the following properties are not virtual:*" +
+                    "String FluentAssertions*ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty*" +
+                    "String FluentAssertions*ClassWithNonVirtualPublicProperties.InternalNonVirtualProperty*" +
+                    "String FluentAssertions*ClassWithNonVirtualPublicProperties.ProtectedNonVirtualProperty");
         }
     }
 
@@ -102,12 +102,12 @@ public class PropertyInfoSelectorAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-               .WithMessage("Expected all selected properties" +
-                   " not to be virtual because we want to test the error message," +
-                   " but the following properties are virtual*" +
-                   "*ClassWithAllPropertiesVirtual.PublicVirtualProperty" +
-                   "*ClassWithAllPropertiesVirtual.InternalVirtualProperty" +
-                   "*ClassWithAllPropertiesVirtual.ProtectedVirtualProperty");
+                .WithMessage("Expected all selected properties" +
+                    " not to be virtual because we want to test the error message," +
+                    " but the following properties are virtual*" +
+                    "*ClassWithAllPropertiesVirtual.PublicVirtualProperty" +
+                    "*ClassWithAllPropertiesVirtual.InternalVirtualProperty" +
+                    "*ClassWithAllPropertiesVirtual.ProtectedVirtualProperty");
         }
     }
 
@@ -152,16 +152,16 @@ public class PropertyInfoSelectorAssertionSpecs
             // Act
             Action act = () =>
                 propertyInfoSelector.Should()
-                                    .BeDecoratedWith<DummyPropertyAttribute>("because we want to test the error {0}", "message");
+                    .BeDecoratedWith<DummyPropertyAttribute>("because we want to test the error {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected properties to be decorated with" +
-                   " FluentAssertions*DummyPropertyAttribute because we want to test the error message," +
-                   " but the following properties are not:*" +
-                   "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty*" +
-                   "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.InternalProperty*" +
-                   "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.ProtectedProperty");
+                    " FluentAssertions*DummyPropertyAttribute because we want to test the error message," +
+                    " but the following properties are not:*" +
+                    "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty*" +
+                    "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.InternalProperty*" +
+                    "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.ProtectedProperty");
         }
     }
 
@@ -206,16 +206,16 @@ public class PropertyInfoSelectorAssertionSpecs
             // Act
             Action act = () =>
                 propertyInfoSelector.Should()
-                                    .NotBeDecoratedWith<DummyPropertyAttribute>("because we want to test the error {0}", "message");
+                    .NotBeDecoratedWith<DummyPropertyAttribute>("because we want to test the error {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected properties not to be decorated*" +
-                   "DummyPropertyAttribute*" +
-                   "because we want to test the error message*" +
-                   "ClassWithAllPropertiesDecoratedWithDummyAttribute.PublicProperty*" +
-                   "ClassWithAllPropertiesDecoratedWithDummyAttribute.InternalProperty*" +
-                   "ClassWithAllPropertiesDecoratedWithDummyAttribute.ProtectedProperty*");
+                    "DummyPropertyAttribute*" +
+                    "because we want to test the error message*" +
+                    "ClassWithAllPropertiesDecoratedWithDummyAttribute.PublicProperty*" +
+                    "ClassWithAllPropertiesDecoratedWithDummyAttribute.InternalProperty*" +
+                    "ClassWithAllPropertiesDecoratedWithDummyAttribute.ProtectedProperty*");
         }
     }
 
@@ -301,7 +301,8 @@ public class PropertyInfoSelectorAssertionSpecs
             Action action = () => someObject.Equals(someObject);
 
             // Assert
-            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
         }
     }
 }
@@ -385,4 +386,5 @@ internal class ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute
 
     protected string ProtectedProperty { get; set; }
 }
+
 #endregion

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -216,7 +216,8 @@ public class PropertyInfoSelectorSpecs
     }
 
     [Fact]
-    public void When_selecting_properties_decorated_with_an_inheritable_attribute_it_should_only_return_the_applicable_properties()
+    public void
+        When_selecting_properties_decorated_with_an_inheritable_attribute_it_should_only_return_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertySelectorWithInheritableAttributeDerived);
@@ -229,20 +230,23 @@ public class PropertyInfoSelectorSpecs
     }
 
     [Fact]
-    public void When_selecting_properties_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_properties()
+    public void
+        When_selecting_properties_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertySelectorWithInheritableAttributeDerived);
 
         // Act
-        IEnumerable<PropertyInfo> properties = type.Properties().ThatAreDecoratedWithOrInherit<DummyPropertyAttribute>().ToArray();
+        IEnumerable<PropertyInfo> properties =
+            type.Properties().ThatAreDecoratedWithOrInherit<DummyPropertyAttribute>().ToArray();
 
         // Assert
         properties.Should().ContainSingle();
     }
 
     [Fact]
-    public void When_selecting_properties_not_decorated_with_an_inheritable_attribute_it_should_only_return_the_applicable_properties()
+    public void
+        When_selecting_properties_not_decorated_with_an_inheritable_attribute_it_should_only_return_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertySelectorWithInheritableAttributeDerived);
@@ -255,65 +259,75 @@ public class PropertyInfoSelectorSpecs
     }
 
     [Fact]
-    public void When_selecting_properties_not_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_properties()
+    public void
+        When_selecting_properties_not_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertySelectorWithInheritableAttributeDerived);
 
         // Act
-        IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotDecoratedWithOrInherit<DummyPropertyAttribute>().ToArray();
+        IEnumerable<PropertyInfo> properties =
+            type.Properties().ThatAreNotDecoratedWithOrInherit<DummyPropertyAttribute>().ToArray();
 
         // Assert
         properties.Should().BeEmpty();
     }
 
     [Fact]
-    public void When_selecting_properties_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_properties()
+    public void
+        When_selecting_properties_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertySelectorWithNonInheritableAttributeDerived);
 
         // Act
-        IEnumerable<PropertyInfo> properties = type.Properties().ThatAreDecoratedWith<DummyPropertyNonInheritableAttributeAttribute>().ToArray();
+        IEnumerable<PropertyInfo> properties =
+            type.Properties().ThatAreDecoratedWith<DummyPropertyNonInheritableAttributeAttribute>().ToArray();
 
         // Assert
         properties.Should().BeEmpty();
     }
 
     [Fact]
-    public void When_selecting_properties_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_properties()
+    public void
+        When_selecting_properties_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertySelectorWithNonInheritableAttributeDerived);
 
         // Act
-        IEnumerable<PropertyInfo> properties = type.Properties().ThatAreDecoratedWithOrInherit<DummyPropertyNonInheritableAttributeAttribute>().ToArray();
+        IEnumerable<PropertyInfo> properties = type.Properties()
+            .ThatAreDecoratedWithOrInherit<DummyPropertyNonInheritableAttributeAttribute>().ToArray();
 
         // Assert
         properties.Should().BeEmpty();
     }
 
     [Fact]
-    public void When_selecting_properties_not_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_properties()
+    public void
+        When_selecting_properties_not_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertySelectorWithNonInheritableAttributeDerived);
 
         // Act
-        IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotDecoratedWith<DummyPropertyNonInheritableAttributeAttribute>().ToArray();
+        IEnumerable<PropertyInfo> properties =
+            type.Properties().ThatAreNotDecoratedWith<DummyPropertyNonInheritableAttributeAttribute>().ToArray();
 
         // Assert
         properties.Should().ContainSingle();
     }
 
     [Fact]
-    public void When_selecting_properties_not_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_properties()
+    public void
+        When_selecting_properties_not_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_properties()
     {
         // Arrange
         Type type = typeof(TestClassForPropertySelectorWithNonInheritableAttributeDerived);
 
         // Act
-        IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotDecoratedWithOrInherit<DummyPropertyNonInheritableAttributeAttribute>().ToArray();
+        IEnumerable<PropertyInfo> properties = type.Properties()
+            .ThatAreNotDecoratedWithOrInherit<DummyPropertyNonInheritableAttributeAttribute>().ToArray();
 
         // Assert
         properties.Should().ContainSingle();
@@ -332,9 +346,8 @@ public class PropertyInfoSelectorSpecs
         returnTypes.Should()
             .BeEquivalentTo(new[]
             {
-                typeof(string), typeof(string), typeof(string), typeof(string)
-                , typeof(string), typeof(string), typeof(string)
-                , typeof(string), typeof(int), typeof(int), typeof(int), typeof(int)
+                typeof(string), typeof(string), typeof(string), typeof(string), typeof(string), typeof(string), typeof(string),
+                typeof(string), typeof(int), typeof(int), typeof(int), typeof(int)
             });
     }
 
@@ -505,4 +518,5 @@ public class DummyPropertyAttribute : Attribute
 
     public string Value { get; private set; }
 }
+
 #endregion

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.Be.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using FluentAssertions.Primitives;
-using FluentAssertions.Types;
+using AssemblyA;
+using AssemblyB;
 using Xunit;
 using Xunit.Sdk;
 
@@ -96,10 +96,10 @@ public partial class TypeAssertionSpecs
             // Arrange
 #pragma warning disable 436 // disable the warning on conflicting types, as this is the intention for the spec
 
-            Type typeFromThisAssembly = typeof(AssemblyB.ClassC);
+            Type typeFromThisAssembly = typeof(ClassC);
 
             Type typeFromOtherAssembly =
-                new AssemblyA.ClassA().ReturnClassC().GetType();
+                new ClassA().ReturnClassC().GetType();
 
 #pragma warning restore 436
 
@@ -109,7 +109,8 @@ public partial class TypeAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be [AssemblyB.ClassC, AssemblyB*] *failure message*, but found [AssemblyB.ClassC, FluentAssertions.Specs*].");
+                .WithMessage(
+                    "Expected type to be [AssemblyB.ClassC, AssemblyB*] *failure message*, but found [AssemblyB.ClassC, FluentAssertions.Specs*].");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeAssignableTo.cs
@@ -126,6 +126,7 @@ public partial class TypeAssertionSpecs
         {
             // Arrange
             Type someType = typeof(ClassWithAttribute);
+
             Action act = () =>
                 someType.Should().BeAssignableTo(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
 

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWith.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWith.cs
@@ -81,7 +81,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 typeWithAttribute.Should()
-                    .BeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
+                    .BeDecoratedWith<DummyClassAttribute>(a => a.Name == "Expected" && a.IsEnabled);
 
             // Assert
             act.Should().NotThrow();
@@ -97,7 +97,7 @@ public partial class TypeAssertionSpecs
             Action act = () =>
                 typeWithAttribute.Should()
                     .BeDecoratedWith<DummyClassAttribute>(a => a.Name == "Expected")
-                        .Which.IsEnabled.Should().BeTrue();
+                    .Which.IsEnabled.Should().BeTrue();
 
             // Assert
             act.Should().NotThrow();
@@ -112,7 +112,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 typeWithAttribute.Should()
-                    .BeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Unexpected") && a.IsEnabled);
+                    .BeDecoratedWith<DummyClassAttribute>(a => a.Name == "Unexpected" && a.IsEnabled);
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -179,7 +179,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 typeWithoutAttribute.Should()
-                    .NotBeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Unexpected") && a.IsEnabled);
+                    .NotBeDecoratedWith<DummyClassAttribute>(a => a.Name == "Unexpected" && a.IsEnabled);
 
             // Assert
             act.Should().NotThrow();
@@ -194,7 +194,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 typeWithoutAttribute.Should()
-                    .NotBeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
+                    .NotBeDecoratedWith<DummyClassAttribute>(a => a.Name == "Expected" && a.IsEnabled);
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWithOrInherit.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWithOrInherit.cs
@@ -81,7 +81,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 typeWithAttribute.Should()
-                    .BeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
+                    .BeDecoratedWithOrInherit<DummyClassAttribute>(a => a.Name == "Expected" && a.IsEnabled);
 
             // Assert
             act.Should().NotThrow();
@@ -97,7 +97,7 @@ public partial class TypeAssertionSpecs
             Action act = () =>
                 typeWithAttribute.Should()
                     .BeDecoratedWithOrInherit<DummyClassAttribute>(a => a.Name == "Expected")
-                        .Which.IsEnabled.Should().BeTrue();
+                    .Which.IsEnabled.Should().BeTrue();
 
             // Assert
             act.Should().NotThrow();
@@ -112,7 +112,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 typeWithAttribute.Should()
-                    .BeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Unexpected") && a.IsEnabled);
+                    .BeDecoratedWithOrInherit<DummyClassAttribute>(a => a.Name == "Unexpected" && a.IsEnabled);
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -180,7 +180,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 typeWithoutAttribute.Should()
-                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Unexpected") && a.IsEnabled);
+                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => a.Name == "Unexpected" && a.IsEnabled);
 
             // Assert
             act.Should().NotThrow();
@@ -195,7 +195,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 typeWithoutAttribute.Should()
-                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
+                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => a.Name == "Expected" && a.IsEnabled);
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveConstructor.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveConstructor.cs
@@ -21,9 +21,8 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should()
-                    .HaveConstructor(new Type[] { typeof(string) })
-                    .Which.Should()
-                        .HaveAccessModifier(CSharpAccessModifier.Private);
+                    .HaveConstructor(new[] { typeof(string) })
+                    .Which.Should().HaveAccessModifier(CSharpAccessModifier.Private);
 
             // Assert
             act.Should().NotThrow();
@@ -88,7 +87,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should()
-                    .NotHaveConstructor(new Type[] { typeof(string) });
+                    .NotHaveConstructor(new[] { typeof(string) });
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveDefaultConstructor.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveDefaultConstructor.cs
@@ -23,7 +23,7 @@ public partial class TypeAssertionSpecs
                 type.Should()
                     .HaveDefaultConstructor()
                     .Which.Should()
-                        .HaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
+                    .HaveAccessModifier(CSharpAccessModifier.ProtectedInternal);
 
             // Assert
             act.Should().NotThrow();
@@ -40,7 +40,7 @@ public partial class TypeAssertionSpecs
                 type.Should()
                     .HaveDefaultConstructor()
                     .Which.Should()
-                        .HaveAccessModifier(CSharpAccessModifier.Public);
+                    .HaveAccessModifier(CSharpAccessModifier.Public);
 
             // Assert
             act.Should().NotThrow();
@@ -54,14 +54,15 @@ public partial class TypeAssertionSpecs
 
             // Act
             type.Should()
-                    .HaveDefaultConstructor()
-                    .Which.Should()
-                        .HaveAccessModifier(CSharpAccessModifier.Public);
+                .HaveDefaultConstructor()
+                .Which.Should()
+                .HaveAccessModifier(CSharpAccessModifier.Public);
+
             Action act = () =>
                 type.Should()
                     .HaveDefaultConstructor()
                     .Which.Should()
-                        .HaveAccessModifier(CSharpAccessModifier.Public);
+                    .HaveAccessModifier(CSharpAccessModifier.Public);
 
             // Assert
             act.Should().NotThrow();
@@ -184,13 +185,10 @@ public partial class TypeAssertionSpecs
 
     internal class ClassWithCctor
     {
-        static ClassWithCctor() { }
     }
 
     internal class ClassWithCctorAndNonDefaultConstructor
     {
-        static ClassWithCctorAndNonDefaultConstructor() { }
-
         public ClassWithCctorAndNonDefaultConstructor(int _) { }
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitConversionOperator.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitConversionOperator.cs
@@ -24,7 +24,7 @@ public partial class TypeAssertionSpecs
                 type.Should()
                     .HaveExplicitConversionOperator(sourceType, targetType)
                     .Which.Should()
-                        .NotBeNull();
+                    .NotBeNull();
 
             // Assert
             act.Should().NotThrow();
@@ -112,7 +112,7 @@ public partial class TypeAssertionSpecs
                 type.Should()
                     .HaveExplicitConversionOperator<TypeWithConversionOperators, byte>()
                     .Which.Should()
-                        .NotBeNull();
+                    .NotBeNull();
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitMethod.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitMethod.cs
@@ -29,7 +29,8 @@ public partial class TypeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_method_which_it_implements_implicitly_and_explicitly_it_succeeds()
+        public void
+            When_asserting_a_type_explicitly_implements_a_method_which_it_implements_implicitly_and_explicitly_it_succeeds()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -288,7 +289,8 @@ public partial class TypeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_implements_implicitly_and_explicitly_it_fails()
+        public void
+            When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_implements_implicitly_and_explicitly_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitProperty.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitProperty.cs
@@ -29,7 +29,8 @@ public partial class TypeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_property_which_it_implements_implicitly_and_explicitly_it_succeeds()
+        public void
+            When_asserting_a_type_explicitly_implements_a_property_which_it_implements_implicitly_and_explicitly_it_succeeds()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -258,7 +259,8 @@ public partial class TypeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_implements_implicitly_and_explicitly_it_fails()
+        public void
+            When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_implements_implicitly_and_explicitly_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveImplicitConversionOperator.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveImplicitConversionOperator.cs
@@ -24,7 +24,7 @@ public partial class TypeAssertionSpecs
                 type.Should()
                     .HaveImplicitConversionOperator(sourceType, targetType)
                     .Which.Should()
-                        .NotBeNull();
+                    .NotBeNull();
 
             // Assert
             act.Should().NotThrow();
@@ -112,7 +112,7 @@ public partial class TypeAssertionSpecs
                 type.Should()
                     .HaveImplicitConversionOperator<TypeWithConversionOperators, int>()
                     .Which.Should()
-                        .NotBeNull();
+                    .NotBeNull();
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveIndexer.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveIndexer.cs
@@ -23,8 +23,8 @@ public partial class TypeAssertionSpecs
                 type.Should()
                     .HaveIndexer(typeof(string), new[] { typeof(string) })
                     .Which.Should()
-                        .BeWritable(CSharpAccessModifier.Internal)
-                        .And.BeReadable(CSharpAccessModifier.Private);
+                    .BeWritable(CSharpAccessModifier.Internal)
+                    .And.BeReadable(CSharpAccessModifier.Private);
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveMethod.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveMethod.cs
@@ -23,8 +23,8 @@ public partial class TypeAssertionSpecs
                 type.Should()
                     .HaveMethod("VoidMethod", new Type[] { })
                     .Which.Should()
-                        .HaveAccessModifier(CSharpAccessModifier.Private)
-                        .And.ReturnVoid();
+                    .HaveAccessModifier(CSharpAccessModifier.Private)
+                    .And.ReturnVoid();
 
             // Assert
             act.Should().NotThrow();
@@ -39,7 +39,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveMethod(
-                        "NonExistentMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                    "NonExistentMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveProperty.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveProperty.cs
@@ -23,8 +23,8 @@ public partial class TypeAssertionSpecs
                 type.Should()
                     .HaveProperty(typeof(string), "PrivateWriteProtectedReadProperty")
                     .Which.Should()
-                        .BeWritable(CSharpAccessModifier.Private)
-                        .And.BeReadable(CSharpAccessModifier.Protected);
+                    .BeWritable(CSharpAccessModifier.Private)
+                    .And.BeReadable(CSharpAccessModifier.Protected);
 
             // Assert
             act.Should().NotThrow();
@@ -137,8 +137,8 @@ public partial class TypeAssertionSpecs
                 type.Should()
                     .HaveProperty<string>("PrivateWriteProtectedReadProperty")
                     .Which.Should()
-                        .BeWritable(CSharpAccessModifier.Private)
-                        .And.BeReadable(CSharpAccessModifier.Protected);
+                    .BeWritable(CSharpAccessModifier.Private)
+                    .And.BeReadable(CSharpAccessModifier.Protected);
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -29,7 +29,7 @@ namespace FluentAssertions.Specs.Types
     {
     }
 
-    [AttributeUsage(AttributeTargets.Class, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Class)]
     public class DummyClassAttribute : Attribute
     {
         public string Name { get; }
@@ -132,15 +132,25 @@ namespace FluentAssertions.Specs.Types
         void ExplicitImplicitMethod(string overload);
     }
 
-    public class ClassWithoutMembers { }
+    public class ClassWithoutMembers
+    {
+    }
 
-    public interface IPublicInterface { }
+    public interface IPublicInterface
+    {
+    }
 
-    internal interface IInternalInterface { }
+    internal interface IInternalInterface
+    {
+    }
 
-    internal class InternalClass { }
+    internal class InternalClass
+    {
+    }
 
-    internal struct InternalStruct { }
+    internal struct InternalStruct
+    {
+    }
 
     internal enum InternalEnum
     {
@@ -150,15 +160,23 @@ namespace FluentAssertions.Specs.Types
 
     internal class Nested
     {
-        private class PrivateClass { }
+        private class PrivateClass
+        {
+        }
 
         protected enum ProtectedEnum { }
 
-        public interface IPublicInterface { }
+        public interface IPublicInterface
+        {
+        }
 
-        internal class InternalClass { }
+        internal class InternalClass
+        {
+        }
 
-        protected internal interface IProtectedInternalInterface { }
+        protected internal interface IProtectedInternalInterface
+        {
+        }
     }
 
     internal readonly struct TypeWithConversionOperators
@@ -170,24 +188,38 @@ namespace FluentAssertions.Specs.Types
             this.value = value;
         }
 
-        public static implicit operator int(TypeWithConversionOperators typeWithConversionOperators) => typeWithConversionOperators.value;
+        public static implicit operator int(TypeWithConversionOperators typeWithConversionOperators) =>
+            typeWithConversionOperators.value;
 
-        public static explicit operator byte(TypeWithConversionOperators typeWithConversionOperators) => (byte)typeWithConversionOperators.value;
+        public static explicit operator byte(TypeWithConversionOperators typeWithConversionOperators) =>
+            (byte)typeWithConversionOperators.value;
     }
 
-    internal sealed class Sealed { }
+    internal sealed class Sealed
+    {
+    }
 
-    internal abstract class Abstract { }
+    internal abstract class Abstract
+    {
+    }
 
-    internal static class Static { }
+    internal static class Static
+    {
+    }
 
-    internal struct Struct { }
+    internal struct Struct
+    {
+    }
 
     public delegate void ExampleDelegate();
 
-    internal class ClassNotInDummyNamespace { }
+    internal class ClassNotInDummyNamespace
+    {
+    }
 
-    internal class OtherClassNotInDummyNamespace { }
+    internal class OtherClassNotInDummyNamespace
+    {
+    }
 
     #endregion
 }
@@ -211,17 +243,23 @@ namespace AssemblyB
 
 namespace DummyNamespace
 {
-    internal class ClassInDummyNamespace { }
+    internal class ClassInDummyNamespace
+    {
+    }
 
     namespace InnerDummyNamespace
     {
-        internal class ClassInInnerDummyNamespace { }
+        internal class ClassInInnerDummyNamespace
+        {
+        }
     }
 }
 
 namespace DummyNamespaceTwo
 {
-    internal class ClassInDummyNamespaceTwo { }
+    internal class ClassInDummyNamespaceTwo
+    {
+    }
 }
 
 #endregion

--- a/Tests/FluentAssertions.Specs/Types/TypeExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeExtensionsSpecs.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
 using FluentAssertions.Common;
 using Xunit;
 
@@ -164,16 +166,21 @@ public class TypeExtensionsSpecs
     private static MethodInfo GetFakeConversionOperator(Type type, string name, BindingFlags bindingAttr, Type returnType)
     {
         MethodInfo[] methods = type.GetMethods(bindingAttr);
+
         return methods.SingleOrDefault(m =>
             m.Name == name
             && m.ReturnType == returnType
             && m.GetParameters().Select(p => p.ParameterType).SequenceEqual(new[] { type })
-            );
+        );
     }
 
-    private class InheritedType { }
+    private class InheritedType
+    {
+    }
 
-    private class InheritingType : InheritedType { }
+    private class InheritingType : InheritedType
+    {
+    }
 
     private readonly struct TypeWithFakeConversionOperators
     {
@@ -185,9 +192,11 @@ public class TypeExtensionsSpecs
         }
 
 #pragma warning disable IDE1006, SA1300 // These two functions mimic the compiler generated conversion operators
-        public static int op_Implicit(TypeWithFakeConversionOperators typeWithFakeConversionOperators) => typeWithFakeConversionOperators.value;
+        public static int op_Implicit(TypeWithFakeConversionOperators typeWithFakeConversionOperators) =>
+            typeWithFakeConversionOperators.value;
 
-        public static byte op_Explicit(TypeWithFakeConversionOperators typeWithFakeConversionOperators) => (byte)typeWithFakeConversionOperators.value;
+        public static byte op_Explicit(TypeWithFakeConversionOperators typeWithFakeConversionOperators) =>
+            (byte)typeWithFakeConversionOperators.value;
 #pragma warning restore SA1300, IDE1006
     }
 
@@ -197,6 +206,7 @@ public class TypeExtensionsSpecs
 
     private record struct MyRecordStructWithCustomPrintMembers(int Value)
     {
+        // ReSharper disable once RedundantNameQualifier
         private bool PrintMembers(System.Text.StringBuilder builder)
         {
             builder.Append(Value);
@@ -228,31 +238,37 @@ public class TypeExtensionsSpecs
 
         public override int GetHashCode() => Value;
 
-        [System.Runtime.CompilerServices.CompilerGenerated]
-        public static bool operator ==(MyStructWithFakeCompilerGeneratedEquality left, MyStructWithFakeCompilerGeneratedEquality right) => left.Equals(right);
+        [CompilerGenerated]
+        public static bool operator ==(MyStructWithFakeCompilerGeneratedEquality left,
+            MyStructWithFakeCompilerGeneratedEquality right) => left.Equals(right);
 
-        public static bool operator !=(MyStructWithFakeCompilerGeneratedEquality left, MyStructWithFakeCompilerGeneratedEquality right) => !left.Equals(right);
+        public static bool operator !=(MyStructWithFakeCompilerGeneratedEquality left,
+            MyStructWithFakeCompilerGeneratedEquality right) => !left.Equals(right);
     }
 
     // Note that this struct is mistakenly detected as a record struct by the current version of TypeExtensions.IsRecord.
     // This cannot be avoided at present, unless something is changed at language level,
     // or a smarter way to check for record structs is found.
-    private struct MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers : IEquatable<MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers>
+    private struct MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers
+        : IEquatable<MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers>
     {
         public int Value { get; set; }
 
         public bool Equals(MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers other) => Value == other.Value;
 
-        public override bool Equals(object obj) => obj is MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers other && Equals(other);
+        public override bool Equals(object obj) =>
+            obj is MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers other && Equals(other);
 
         public override int GetHashCode() => Value;
 
-        [System.Runtime.CompilerServices.CompilerGenerated]
-        public static bool operator ==(MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers left, MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers right) => left.Equals(right);
+        [CompilerGenerated]
+        public static bool operator ==(MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers left,
+            MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers right) => left.Equals(right);
 
-        public static bool operator !=(MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers left, MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers right) => !left.Equals(right);
+        public static bool operator !=(MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers left,
+            MyStructWithFakeCompilerGeneratedEqualityAndPrintMembers right) => !left.Equals(right);
 
-        private bool PrintMembers(System.Text.StringBuilder builder)
+        private bool PrintMembers(StringBuilder builder)
         {
             builder.Append(Value);
             return true;
@@ -269,9 +285,11 @@ public class TypeExtensionsSpecs
 
         public override int GetHashCode() => Value;
 
-        public static bool operator ==(MyStructWithOverriddenEquality left, MyStructWithOverriddenEquality right) => left.Equals(right);
+        public static bool operator ==(MyStructWithOverriddenEquality left, MyStructWithOverriddenEquality right) =>
+            left.Equals(right);
 
-        public static bool operator !=(MyStructWithOverriddenEquality left, MyStructWithOverriddenEquality right) => !left.Equals(right);
+        public static bool operator !=(MyStructWithOverriddenEquality left, MyStructWithOverriddenEquality right) =>
+            !left.Equals(right);
     }
 
     private class MyClass

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorAssertionSpecs.cs
@@ -151,7 +151,7 @@ public class TypeSelectorAssertionSpecs
             Action act = () =>
                 types.Should()
                     .BeDecoratedWith<DummyClassAttribute>(
-                        a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+                        a => a.Name == "Expected" && a.IsEnabled, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -220,7 +220,8 @@ public class TypeSelectorAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_selection_of_types_with_some_inheriting_attributes_with_unexpected_attribute_property_it_fails()
+        public void
+            When_asserting_a_selection_of_types_with_some_inheriting_attributes_with_unexpected_attribute_property_it_fails()
         {
             // Arrange
             var types = new TypeSelector(new[]
@@ -235,7 +236,7 @@ public class TypeSelectorAssertionSpecs
             Action act = () =>
                 types.Should()
                     .BeDecoratedWithOrInherit<DummyClassAttribute>(
-                        a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+                        a => a.Name == "Expected" && a.IsEnabled, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -316,7 +317,7 @@ public class TypeSelectorAssertionSpecs
             Action act = () =>
                 types.Should()
                     .NotBeDecoratedWith<DummyClassAttribute>(
-                        a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+                        a => a.Name == "Expected" && a.IsEnabled, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -377,7 +378,7 @@ public class TypeSelectorAssertionSpecs
             // Act
             Action act = () => types.Should()
                 .NotBeDecoratedWithOrInherit<DummyClassAttribute>(
-                    a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+                    a => a.Name == "Expected" && a.IsEnabled, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -395,7 +396,7 @@ public class TypeSelectorAssertionSpecs
 
             // Act
             Action act = () => types.Should()
-                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
+                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => a.Name == "Expected" && a.IsEnabled);
 
             // Assert
             act.Should().NotThrow();
@@ -642,7 +643,7 @@ public class TypeSelectorAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                    .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace\" *failure message*" +
+                .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace\" *failure message*" +
                     ", but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespaceTwo\".");
         }
 
@@ -805,7 +806,9 @@ public class TypeSelectorAssertionSpecs
             Action action = () => types.Should().Equals(types);
 
             // Assert
-            action.Should().Throw<NotSupportedException>().WithMessage("Equals is not part of Fluent Assertions. Did you mean BeInNamespace() or BeDecoratedWith() instead?");
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage(
+                    "Equals is not part of Fluent Assertions. Did you mean BeInNamespace() or BeDecoratedWith() instead?");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -15,7 +15,6 @@ using Internal.StaticAndNonStaticClasses.Test;
 using Internal.UnwrapSelectorTestTypes.Test;
 using Internal.ValueTypesAndNotValueTypes.Test;
 using Xunit;
-using ISomeInterface = Internal.Main.Test.ISomeInterface;
 
 namespace FluentAssertions.Specs.Types
 {
@@ -281,7 +280,7 @@ namespace FluentAssertions.Specs.Types
                 .ToArray()
                 .Should()
                 .ContainSingle()
-                    .Which.Should().Be(type);
+                .Which.Should().Be(type);
         }
 
         [Fact]
@@ -298,7 +297,8 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_selecting_types_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_types()
+        public void
+            When_selecting_types_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_types()
         {
             // Arrange
             Type type = typeof(ClassWithSomeAttributeDerived);
@@ -324,7 +324,8 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_selecting_types_not_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_types()
+        public void
+            When_selecting_types_not_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_types()
         {
             // Arrange
             Type type = typeof(ClassWithSomeAttributeDerived);
@@ -350,7 +351,8 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_selecting_types_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_types()
+        public void
+            When_selecting_types_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_types()
         {
             // Arrange
             Type type = typeof(ClassWithSomeNonInheritableAttributeDerived);
@@ -363,7 +365,8 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_selecting_types_not_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_types()
+        public void
+            When_selecting_types_not_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_types()
         {
             // Arrange
             Type type = typeof(ClassWithSomeNonInheritableAttributeDerived);
@@ -376,7 +379,8 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_selecting_types_not_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_types()
+        public void
+            When_selecting_types_not_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_types()
         {
             // Arrange
             Type type = typeof(ClassWithSomeNonInheritableAttributeDerived);
@@ -470,7 +474,10 @@ namespace FluentAssertions.Specs.Types
         public void When_selecting_types_that_are_classes_it_should_return_the_correct_types()
         {
             // Arrange
-            TypeSelector types = new[] { typeof(NotOnlyClassesClass), typeof(NotOnlyClassesEnumeration), typeof(INotOnlyClassesInterface) }.Types();
+            TypeSelector types = new[]
+            {
+                typeof(NotOnlyClassesClass), typeof(NotOnlyClassesEnumeration), typeof(INotOnlyClassesInterface)
+            }.Types();
 
             // Act
             IEnumerable<Type> filteredTypes = types.ThatAreClasses();
@@ -744,7 +751,7 @@ namespace Internal.Main.Test
     {
     }
 
-    [AttributeUsage(AttributeTargets.Class, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Class)]
     internal class SomeAttribute : Attribute
     {
     }
@@ -939,7 +946,9 @@ namespace Internal.ValueTypesAndNotValueTypes.Test
 }
 
 #pragma warning disable RCS1110 // Declare type inside namespace.
-internal class ClassInGlobalNamespace { }
+internal class ClassInGlobalNamespace
+{
+}
 #pragma warning restore RCS1110
 
 #endregion

--- a/Tests/FluentAssertions.Specs/UIFactsDefinition.cs
+++ b/Tests/FluentAssertions.Specs/UIFactsDefinition.cs
@@ -4,4 +4,6 @@ namespace FluentAssertions.Specs;
 
 // Try to stabilize UIFact tests
 [CollectionDefinition("UIFacts", DisableParallelization = true)]
-public class UIFactsDefinition { }
+public class UIFactsDefinition
+{
+}

--- a/Tests/FluentAssertions.Specs/Xml/XAttributeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XAttributeAssertionSpecs.cs
@@ -25,7 +25,8 @@ public class XAttributeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_attribute_is_equal_to_a_different_xml_attribute_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_attribute_is_equal_to_a_different_xml_attribute_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theAttribute = new XAttribute("name", "value");
@@ -69,7 +70,7 @@ public class XAttributeAssertionSpecs
         [Fact]
         public void When_the_attribute_is_expected_to_equal_null_it_fails()
         {
-            XAttribute theAttribute = new XAttribute("name", "value");
+            XAttribute theAttribute = new("name", "value");
 
             // Act
             Action act = () => theAttribute.Should().Be(null, "we want to test the failure {0}", "message");
@@ -114,7 +115,8 @@ public class XAttributeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_attribute_is_not_equal_to_the_same_xml_attribute_it_should_throw_with_descriptive_message()
+        public void
+            When_asserting_an_xml_attribute_is_not_equal_to_the_same_xml_attribute_it_should_throw_with_descriptive_message()
         {
             // Arrange
             var theAttribute = new XAttribute("name", "value");
@@ -146,7 +148,7 @@ public class XAttributeAssertionSpecs
         public void When_an_attribute_is_not_supposed_to_be_null_it_succeeds()
         {
             // Arrange
-            XAttribute theAttribute = new XAttribute("name", "value");
+            XAttribute theAttribute = new("name", "value");
 
             // Act
             Action act = () => theAttribute.Should().NotBe(null);
@@ -296,7 +298,8 @@ public class XAttributeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_attribute_has_a_specific_value_but_it_has_a_different_value_it_should_throw_with_descriptive_message()
+        public void
+            When_asserting_attribute_has_a_specific_value_but_it_has_a_different_value_it_should_throw_with_descriptive_message()
         {
             // Arrange
             var theAttribute = new XAttribute("age", "36");

--- a/Tests/FluentAssertions.Specs/Xml/XAttributeFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XAttributeFormatterSpecs.cs
@@ -1,5 +1,4 @@
 using System.Xml.Linq;
-
 using FluentAssertions.Formatting;
 using Xunit;
 

--- a/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -73,7 +73,7 @@ public class XDocumentAssertionSpecs
         public void When_a_document_is_expected_to_equal_null_it_fails()
         {
             // Arrange
-            XDocument theDocument = new XDocument();
+            XDocument theDocument = new();
 
             // Act
             Action act = () => theDocument.Should().Be(null, "we want to test the failure {0}", "message");
@@ -150,7 +150,7 @@ public class XDocumentAssertionSpecs
         public void When_a_document_is_not_supposed_to_be_null_it_succeeds()
         {
             // Arrange
-            XDocument theDocument = new XDocument();
+            XDocument theDocument = new();
 
             // Act
             Action act = () => theDocument.Should().NotBe(null);
@@ -208,7 +208,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_selfclosing_document_is_equivalent_to_a_different_xml_document_with_same_structure_it_should_succeed()
+        public void
+            When_asserting_a_xml_selfclosing_document_is_equivalent_to_a_different_xml_document_with_same_structure_it_should_succeed()
         {
             // Arrange
             var document = XDocument.Parse("<parent><child /></parent>");
@@ -223,7 +224,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_same_structure_it_should_succeed()
+        public void
+            When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_same_structure_it_should_succeed()
         {
             // Arrange
             var document = XDocument.Parse("<parent><child></child></parent>");
@@ -270,7 +272,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_document_with_selfclosing_child_is_equivalent_to_a_different_xml_document_with_subchild_child_it_should_fail()
+        public void
+            When_asserting_a_xml_document_with_selfclosing_child_is_equivalent_to_a_different_xml_document_with_subchild_child_it_should_fail()
         {
             // Arrange
             var theDocument = XDocument.Parse("<parent><child /></parent>");
@@ -286,7 +289,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_elements_missing_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_elements_missing_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = XDocument.Parse("<parent><child /><child2 /></parent>");
@@ -303,7 +307,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_extra_elements_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_extra_elements_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = XDocument.Parse("<parent><child /></parent>");
@@ -365,7 +370,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_assertion_an_xml_document_is_equivalent_to_a_different_xml_document_with_different_namespace_prefix_it_should_succeed()
+        public void
+            When_assertion_an_xml_document_is_equivalent_to_a_different_xml_document_with_different_namespace_prefix_it_should_succeed()
         {
             // Arrange
             var subject = XDocument.Parse("<xml xmlns=\"urn:a\"/>");
@@ -380,7 +386,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_a_different_xml_document_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
+        public void
+            When_asserting_an_xml_document_is_equivalent_to_a_different_xml_document_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
         {
             // Arrange
             var subject = XDocument.Parse("<xml xmlns:a=\"urn:a\"/>");
@@ -395,7 +402,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_lacks_attributes_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_lacks_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = XDocument.Parse("<xml><element b=\"1\"/></xml>");
@@ -411,7 +419,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_extra_attributes_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_extra_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = XDocument.Parse("<xml><element a=\"b\"/></xml>");
@@ -427,7 +436,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = XDocument.Parse("<xml><element a=\"b\"/></xml>");
@@ -443,7 +453,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = XDocument.Parse("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
@@ -459,7 +470,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_different_text_contents_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_different_text_contents_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = XDocument.Parse("<xml>a</xml>");
@@ -475,7 +487,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_with_different_comments_it_should_succeed()
+        public void
+            When_asserting_an_xml_document_is_equivalent_to_different_xml_document_with_different_comments_it_should_succeed()
         {
             // Arrange
             var subject = XDocument.Parse("<xml><!--Comment--><a/></xml>");
@@ -489,7 +502,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_equivalence_of_an_xml_document_but_has_different_attribute_value_it_should_fail_with_xpath_to_difference()
+        public void
+            When_asserting_equivalence_of_an_xml_document_but_has_different_attribute_value_it_should_fail_with_xpath_to_difference()
         {
             // Arrange
             XDocument actual = XDocument.Parse("<xml><a attr=\"x\"/><b id=\"foo\"/></xml>");
@@ -503,11 +517,13 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_equivalence_of_document_with_repeating_element_names_but_differs_it_should_fail_with_index_xpath_to_difference()
+        public void
+            When_asserting_equivalence_of_document_with_repeating_element_names_but_differs_it_should_fail_with_index_xpath_to_difference()
         {
             // Arrange
             XDocument actual = XDocument.Parse(
                 "<xml><xml2 /><xml2 /><xml2><a x=\"y\"/><b><sub /></b><a x=\"y\"/></xml2></xml>");
+
             XDocument expected = XDocument.Parse(
                 "<xml><xml2 /><xml2 /><xml2><a x=\"y\"/><b><sub /></b><a x=\"z\"/></xml2></xml>");
 
@@ -519,11 +535,13 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_equivalence_of_document_with_repeating_element_names_on_different_levels_but_differs_it_should_fail_with_index_xpath_to_difference()
+        public void
+            When_asserting_equivalence_of_document_with_repeating_element_names_on_different_levels_but_differs_it_should_fail_with_index_xpath_to_difference()
         {
             // Arrange
             XDocument actual = XDocument.Parse(
                 "<xml><xml /><xml /><xml><xml x=\"y\"/><xml2><xml /></xml2><xml x=\"y\"/></xml></xml>");
+
             XDocument expected = XDocument.Parse(
                 "<xml><xml /><xml /><xml><xml x=\"y\"/><xml2><xml /></xml2><xml x=\"z\"/></xml></xml>");
 
@@ -535,11 +553,13 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_equivalence_of_document_with_repeating_element_names_with_different_parents_but_differs_it_should_fail_with_index_xpath_to_difference()
+        public void
+            When_asserting_equivalence_of_document_with_repeating_element_names_with_different_parents_but_differs_it_should_fail_with_index_xpath_to_difference()
         {
             // Arrange
             XDocument actual = XDocument.Parse(
                 "<root><xml1 /><xml1><xml2 /><xml2 a=\"x\" /></xml1><xml1><xml2 /><xml2 a=\"x\" /></xml1></root>");
+
             XDocument expected = XDocument.Parse(
                 "<root><xml1 /><xml1><xml2 /><xml2 a=\"x\" /></xml1><xml1><xml2 /><xml2 a=\"y\" /></xml1></root>");
 
@@ -554,7 +574,8 @@ public class XDocumentAssertionSpecs
     public class NotBeEquivalentTo
     {
         [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_elements_missing_it_should_succeed()
+        public void
+            When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_elements_missing_it_should_succeed()
         {
             // Arrange
             var document = XDocument.Parse("<parent><child /><child2 /></parent>");
@@ -569,7 +590,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_extra_elements_it_should_succeed()
+        public void
+            When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_extra_elements_it_should_succeed()
         {
             // Arrange
             var document = XDocument.Parse("<parent><child /></parent>");
@@ -584,7 +606,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_structure_it_should_fail()
+        public void
+            When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_structure_it_should_fail()
         {
             // Arrange
             var theDocument = XDocument.Parse("<parent><child /></parent>");
@@ -616,7 +639,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_structure_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_structure_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = XDocument.Parse("<parent><child /></parent>");
@@ -632,7 +656,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_contents_but_different_ns_prefixes_it_should_fail()
+        public void
+            When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_contents_but_different_ns_prefixes_it_should_fail()
         {
             // Arrange
             var theDocument = XDocument.Parse(@"<parent xmlns:ns1=""a""><ns1:child /></parent>");
@@ -648,7 +673,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_contents_but_extra_unused_xmlns_declaration_it_should_fail()
+        public void
+            When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_contents_but_extra_unused_xmlns_declaration_it_should_fail()
         {
             // Arrange
             var theDocument = XDocument.Parse(@"<xml xmlns:ns1=""a"" />");
@@ -664,7 +690,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_document_is_not_equivalent_to_the_same_xml_document_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_a_xml_document_is_not_equivalent_to_the_same_xml_document_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = XDocument.Parse("<parent><child /></parent>");
@@ -860,8 +887,8 @@ public class XDocumentAssertionSpecs
 
             // Assert
             string expectedMessage = "Expected theDocument to have root element \"unknown\"" +
-                                     " because we want to test the failure message" +
-                                    $", but found {Formatter.ToString(theDocument)}.";
+                " because we want to test the failure message" +
+                $", but found {Formatter.ToString(theDocument)}.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
@@ -967,7 +994,7 @@ public class XDocumentAssertionSpecs
             string expectedMessage =
                 "Expected theDocument to have root element \"{http://www.example.com/2012/test}unknown\"" +
                 " because we want to test the failure message" +
-               $", but found {Formatter.ToString(theDocument)}.";
+                $", but found {Formatter.ToString(theDocument)}.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
@@ -1065,7 +1092,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_document_has_root_with_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_document_has_root_with_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = XDocument.Parse(
@@ -1085,7 +1113,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_document_has_root_with_child_element_with_attributes_it_should_be_possible_to_use_which_to_assert_on_the_element()
+        public void
+            When_asserting_document_has_root_with_child_element_with_attributes_it_should_be_possible_to_use_which_to_assert_on_the_element()
         {
             // Arrange
             var document = XDocument.Parse(
@@ -1201,7 +1230,8 @@ public class XDocumentAssertionSpecs
         }
 
         [Fact]
-        public void Asserting_with_document_root_null_inside_an_assertion_scope_it_checks_the_whole_assertion_scope_before_failing()
+        public void
+            Asserting_with_document_root_null_inside_an_assertion_scope_it_checks_the_whole_assertion_scope_before_failing()
         {
             // Arrange
             XDocument document = new();
@@ -1236,7 +1266,8 @@ public class XDocumentAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected document to have a root element containing a child \"child\"*exactly*2 times, but found it 3 times*");
+                .WithMessage(
+                    "Expected document to have a root element containing a child \"child\"*exactly*2 times, but found it 3 times*");
         }
 
         [Fact]
@@ -1298,7 +1329,7 @@ public class XDocumentAssertionSpecs
         {
             // Arrange
             var document = XDocument.Parse(
-                 @"<parent>
+                @"<parent>
                     <child />
                     <child />
                     <child />
@@ -1310,7 +1341,8 @@ public class XDocumentAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected document to have a root element containing a child \"child\"*exactly*1 time, but found it 3 times.");
+                .WithMessage(
+                    "Expected document to have a root element containing a child \"child\"*exactly*1 time, but found it 3 times.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Xml/XDocumentFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XDocumentFormatterSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System.Xml.Linq;
-
 using FluentAssertions.Formatting;
 using Xunit;
 

--- a/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -49,6 +49,7 @@ public class XElementAssertionSpecs
                 new XElement("parent",
                     new XElement("child",
                         new XElement("grandChild2")));
+
             var expected =
                 new XElement("parent",
                     new XElement("child",
@@ -81,7 +82,7 @@ public class XElementAssertionSpecs
         public void When_element_is_expected_to_equal_null_it_fails()
         {
             // Arrange
-            XElement theElement = new XElement("element");
+            XElement theElement = new("element");
 
             // Act
             Action act = () => theElement.Should().Be(null, "we want to test the failure {0}", "message");
@@ -130,6 +131,7 @@ public class XElementAssertionSpecs
                 new XElement("parent",
                     new XElement("child",
                         new XElement("grandChild")));
+
             var element =
                 new XElement("parent",
                     new XElement("child",
@@ -162,7 +164,7 @@ public class XElementAssertionSpecs
         public void When_an_element_is_not_supposed_to_be_null_it_succeeds()
         {
             // Arrange
-            XElement theElement = new XElement("element");
+            XElement theElement = new("element");
 
             // Act
             Action act = () => theElement.Should().NotBe(null);
@@ -387,7 +389,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_elements_missing_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_elements_missing_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse("<parent><child /><child2 /></parent>");
@@ -403,7 +406,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_with_extra_elements_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_with_extra_elements_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse("<parent><child /></parent>");
@@ -419,7 +423,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_empty_xml_element_is_equivalent_to_a_different_xml_element_with_text_content_it_should_fail()
+        public void
+            When_asserting_an_empty_xml_element_is_equivalent_to_a_different_xml_element_with_text_content_it_should_fail()
         {
             // Arrange
             var theElement = XElement.Parse("<parent><child /></parent>");
@@ -463,7 +468,7 @@ public class XElementAssertionSpecs
         [Fact]
         public void When_an_element_is_equivalent_to_null_it_fails()
         {
-            XElement theElement = new XElement("element");
+            XElement theElement = new("element");
 
             // Act
             Action act = () =>
@@ -476,7 +481,7 @@ public class XElementAssertionSpecs
 
         [Fact]
         public void
-           When_asserting_an_xml_element_is_equivalent_to_a_different_xml_element_with_different_namespace_prefix_it_should_succeed()
+            When_asserting_an_xml_element_is_equivalent_to_a_different_xml_element_with_different_namespace_prefix_it_should_succeed()
         {
             // Arrange
             var subject = XElement.Parse("<xml xmlns=\"urn:a\"/>");
@@ -491,7 +496,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_a_different_xml_element_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
+        public void
+            When_asserting_an_xml_element_is_equivalent_to_a_different_xml_element_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
         {
             // Arrange
             var subject = XElement.Parse("<xml xmlns:a=\"urn:a\"/>");
@@ -506,7 +512,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_lacks_attributes_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_lacks_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse("<xml><element b=\"1\"/></xml>");
@@ -522,7 +529,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_extra_attributes_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_extra_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse("<xml><element a=\"b\"/></xml>");
@@ -555,7 +563,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
@@ -571,7 +580,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_different_text_contents_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_different_text_contents_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse("<xml>a</xml>");
@@ -587,7 +597,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_with_different_comments_it_should_succeed()
+        public void
+            When_asserting_an_xml_element_is_equivalent_to_different_xml_element_with_different_comments_it_should_succeed()
         {
             // Arrange
             var subject = XElement.Parse("<xml><!--Comment--><a/></xml>");
@@ -604,7 +615,8 @@ public class XElementAssertionSpecs
     public class NotBeEquivalentTo
     {
         [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_elements_missing_it_should_succeed()
+        public void
+            When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_elements_missing_it_should_succeed()
         {
             // Arrange
             var element = XElement.Parse("<parent><child /><child2 /></parent>");
@@ -619,7 +631,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_extra_elements_it_should_succeed()
+        public void
+            When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_extra_elements_it_should_succeed()
         {
             // Arrange
             var element = XElement.Parse("<parent><child /></parent>");
@@ -650,7 +663,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_contents_but_different_ns_prefixes_it_should_fail()
+        public void
+            When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_contents_but_different_ns_prefixes_it_should_fail()
         {
             // Arrange
             var theElement = XElement.Parse(@"<parent xmlns:ns1=""a""><ns1:child /></parent>");
@@ -666,7 +680,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_contents_but_extra_unused_xmlns_declaration_it_should_fail()
+        public void
+            When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_contents_but_extra_unused_xmlns_declaration_it_should_fail()
         {
             // Arrange
             var theElement = XElement.Parse(@"<xml xmlns:ns1=""a"" />");
@@ -698,7 +713,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_structure_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_structure_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse("<parent><child /></parent>");
@@ -714,7 +730,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_a_xml_element_is_not_equivalent_to_the_same_xml_element_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_a_xml_element_is_not_equivalent_to_the_same_xml_element_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse("<parent><child /></parent>");
@@ -757,7 +774,7 @@ public class XElementAssertionSpecs
         [Fact]
         public void When_an_element_is_not_equivalent_to_null_it_succeeds()
         {
-            XElement theElement = new XElement("element");
+            XElement theElement = new("element");
 
             // Act
             Action act = () => theElement.Should().NotBeEquivalentTo(null);
@@ -799,7 +816,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_element_has_a_specific_value_but_it_has_a_different_value_it_should_throw_with_descriptive_message()
+        public void
+            When_asserting_element_has_a_specific_value_but_it_has_a_different_value_it_should_throw_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse("<user>grega</user>");
@@ -890,7 +908,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse(@"<user name=""martin"" />");
@@ -906,7 +925,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
@@ -939,7 +959,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
+        public void
+            When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
         {
             // Arrange
             var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
@@ -954,7 +975,8 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse(@"<user name=""martin"" />");
@@ -970,14 +992,15 @@ public class XElementAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
 
             // Act
             Action act = () =>
-                 theElement.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "dennis",
+                theElement.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "dennis",
                     "because we want to test the failure {0}", "message");
 
             // Assert
@@ -1021,7 +1044,7 @@ public class XElementAssertionSpecs
         [Fact]
         public void When_asserting_element_has_an_attribute_with_a_null_name_it_should_throw()
         {
-            XElement theElement = new XElement("element");
+            XElement theElement = new("element");
 
             // Act
             Action act = () =>
@@ -1035,7 +1058,7 @@ public class XElementAssertionSpecs
         [Fact]
         public void When_asserting_element_has_an_attribute_with_a_null_XName_it_should_throw()
         {
-            XElement theElement = new XElement("element");
+            XElement theElement = new("element");
 
             // Act
             Action act = () =>
@@ -1049,7 +1072,7 @@ public class XElementAssertionSpecs
         [Fact]
         public void When_asserting_element_has_an_attribute_with_an_empty_name_it_should_throw()
         {
-            XElement theElement = new XElement("element");
+            XElement theElement = new("element");
 
             // Act
             Action act = () =>
@@ -1187,13 +1210,14 @@ public class XElementAssertionSpecs
             // Assert
             matchedElement.Should().BeOfType<XElement>()
                 .And.HaveAttribute("attr", "1");
+
             matchedElement.Name.Should().Be(XName.Get("child"));
         }
 
         [Fact]
         public void When_asserting_element_has_a_child_element_with_a_null_name_it_should_throw()
         {
-            XElement theElement = new XElement("element");
+            XElement theElement = new("element");
 
             // Act
             Action act = () =>
@@ -1207,7 +1231,7 @@ public class XElementAssertionSpecs
         [Fact]
         public void When_asserting_element_has_a_child_element_with_a_null_XName_it_should_throw()
         {
-            XElement theElement = new XElement("element");
+            XElement theElement = new("element");
 
             // Act
             Action act = () =>
@@ -1221,7 +1245,7 @@ public class XElementAssertionSpecs
         [Fact]
         public void When_asserting_element_has_a_child_element_with_an_empty_name_it_should_throw()
         {
-            XElement theElement = new XElement("element");
+            XElement theElement = new("element");
 
             // Act
             Action act = () =>

--- a/Tests/FluentAssertions.Specs/Xml/XElementFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XElementFormatterSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System.Xml.Linq;
-
 using FluentAssertions.Formatting;
 using Xunit;
 

--- a/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
@@ -136,8 +136,8 @@ public class XmlElementAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected theElement to have attribute \"age\" with value \"36\"" +
-                             " because we want to test the failure message" +
-                             ", but found no such attribute in <user name=\"martin\"*");
+                    " because we want to test the failure message" +
+                    ", but found no such attribute in <user name=\"martin\"*");
         }
 
         [Fact]
@@ -173,8 +173,8 @@ public class XmlElementAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected attribute \"name\" in theElement to have value \"dennis\"" +
-                             " because we want to test the failure message" +
-                             ", but found \"martin\".");
+                    " because we want to test the failure message" +
+                    ", but found \"martin\".");
         }
     }
 
@@ -198,7 +198,7 @@ public class XmlElementAssertionSpecs
 
         [Fact]
         public void
-                When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail()
+            When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail()
         {
             // Arrange
             var xmlDoc = new XmlDocument();
@@ -215,7 +215,7 @@ public class XmlElementAssertionSpecs
 
         [Fact]
         public void
-                When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
+            When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var document = new XmlDocument();
@@ -237,7 +237,7 @@ public class XmlElementAssertionSpecs
 
         [Fact]
         public void
-                When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
+            When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
         {
             // Arrange
             var xmlDoc = new XmlDocument();
@@ -254,7 +254,7 @@ public class XmlElementAssertionSpecs
 
         [Fact]
         public void
-                    When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
+            When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var document = new XmlDocument();
@@ -282,10 +282,12 @@ public class XmlElementAssertionSpecs
         {
             // Arrange
             var xml = new XmlDocument();
+
             xml.LoadXml(
                 @"<parent>
                     <child />
                   </parent>");
+
             var element = xml.DocumentElement;
 
             // Act
@@ -301,10 +303,12 @@ public class XmlElementAssertionSpecs
         {
             // Arrange
             var xmlDoc = new XmlDocument();
+
             xmlDoc.LoadXml(
                 @"<parent>
                     <child />
                   </parent>");
+
             var element = xmlDoc.DocumentElement;
 
             // Act
@@ -320,10 +324,12 @@ public class XmlElementAssertionSpecs
         {
             // Arrange
             var document = new XmlDocument();
+
             document.LoadXml(
                 @"<parent>
                     <child />
                   </parent>");
+
             var theElement = document.DocumentElement;
 
             // Act
@@ -342,10 +348,12 @@ public class XmlElementAssertionSpecs
         {
             // Arrange
             var xmlDoc = new XmlDocument();
+
             xmlDoc.LoadXml(
                 @"<parent>
                     <child attr='1' />
                   </parent>");
+
             var element = xmlDoc.DocumentElement;
 
             // Act
@@ -354,6 +362,7 @@ public class XmlElementAssertionSpecs
             // Assert
             matchedElement.Should().BeOfType<XmlElement>()
                 .And.HaveAttribute("attr", "1");
+
             matchedElement.Name.Should().Be("child");
         }
 
@@ -362,10 +371,12 @@ public class XmlElementAssertionSpecs
         {
             // Arrange
             var xmlDoc = new XmlDocument();
+
             xmlDoc.LoadXml(
                 @"<parent xmlns=""test"">
                     <child>value</child>
                 </parent>");
+
             var element = xmlDoc.DocumentElement;
 
             // Act
@@ -381,10 +392,12 @@ public class XmlElementAssertionSpecs
         {
             // Arrange
             var xmlDoc = new XmlDocument();
+
             xmlDoc.LoadXml(
                 @"<parent>
                     <child xmlns=""test"">value</child>
                 </parent>");
+
             var element = xmlDoc.DocumentElement;
 
             // Act
@@ -403,10 +416,12 @@ public class XmlElementAssertionSpecs
         {
             // Arrange
             var xmlDoc = new XmlDocument();
+
             xmlDoc.LoadXml(
                 @"<parent xmlns:c='http://www.example.com/2012/test'>
                     <c:child />
                   </parent>");
+
             var element = xmlDoc.DocumentElement;
 
             // Act
@@ -422,10 +437,12 @@ public class XmlElementAssertionSpecs
         {
             // Arrange
             var xmlDoc = new XmlDocument();
+
             xmlDoc.LoadXml(
                 @"<parent>
                     <child />
                   </parent>");
+
             var element = xmlDoc.DocumentElement;
 
             // Act
@@ -441,10 +458,12 @@ public class XmlElementAssertionSpecs
         {
             // Arrange
             var document = new XmlDocument();
+
             document.LoadXml(
                 @"<parent>
                     <child />
                   </parent>");
+
             var theElement = document.DocumentElement;
 
             // Act

--- a/Tests/FluentAssertions.Specs/Xml/XmlNodeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlNodeAssertionSpecs.cs
@@ -43,7 +43,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_same_as_a_different_xml_node_it_should_fail_with_descriptive_message_and_truncate_xml()
+        public void
+            When_asserting_an_xml_node_is_same_as_a_different_xml_node_it_should_fail_with_descriptive_message_and_truncate_xml()
         {
             // Arrange
             var theDocument = new XmlDocument();
@@ -123,7 +124,7 @@ public class XmlNodeAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected theDocument to be <null> because we want to test the failure message," +
-                             " but found <xml />.");
+                    " but found <xml />.");
         }
     }
 
@@ -191,7 +192,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_with_other_contents_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_with_other_contents_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = new XmlDocument();
@@ -229,7 +231,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_assertion_an_xml_node_is_equivalent_to_a_different_xml_node_with_different_namespace_prefix_it_should_succeed()
+        public void
+            When_assertion_an_xml_node_is_equivalent_to_a_different_xml_node_with_different_namespace_prefix_it_should_succeed()
         {
             // Arrange
             var subject = new XmlDocument();
@@ -246,7 +249,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
         {
             // Arrange
             var subject = new XmlDocument();
@@ -263,7 +267,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_a_different_XmlDocument_which_differs_on_a_child_element_name_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_a_different_XmlDocument_which_differs_on_a_child_element_name_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = new XmlDocument();
@@ -282,7 +287,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_on_a_child_element_namespace_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_on_a_child_element_namespace_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = new XmlDocument();
@@ -301,7 +307,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_an_unexpected_node_type_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_an_unexpected_node_type_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = new XmlDocument();
@@ -320,7 +327,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_extra_elements_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_extra_elements_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = new XmlDocument();
@@ -339,7 +347,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_elements_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_elements_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = new XmlDocument();
@@ -358,7 +367,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_attributes_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = new XmlDocument();
@@ -377,7 +387,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_extra_attributes_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_extra_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = new XmlDocument();
@@ -396,7 +407,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = new XmlDocument();
@@ -415,7 +427,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = new XmlDocument();
@@ -434,7 +447,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_text_contents_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_text_contents_it_should_fail_with_descriptive_message()
         {
             // Arrange
             var theDocument = new XmlDocument();
@@ -469,12 +483,16 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_with_different_insignificant_whitespace_it_should_succeed()
+        public void
+            When_asserting_an_xml_node_is_equivalent_to_different_xml_node_with_different_insignificant_whitespace_it_should_succeed()
         {
             // Arrange
-            var subject = new XmlDocument() { PreserveWhitespace = true };
+            var subject = new XmlDocument { PreserveWhitespace = true };
+
             subject.LoadXml("<xml><a><b/></a></xml>");
-            var expected = new XmlDocument() { PreserveWhitespace = true };
+
+            var expected = new XmlDocument { PreserveWhitespace = true };
+
             expected.LoadXml("<xml>\n<a>   \n   <b/></a>\r\n</xml>");
 
             // Act
@@ -485,7 +503,8 @@ public class XmlNodeAssertionSpecs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_that_contains_an_unsupported_node_it_should_throw_a_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_that_contains_an_unsupported_node_it_should_throw_a_descriptive_message()
         {
             // Arrange
             var theDocument = new XmlDocument();

--- a/Tests/FluentAssertions.Specs/Xml/XmlNodeFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlNodeFormatterSpecs.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Xml;
-
 using FluentAssertions.Formatting;
 using Xunit;
 


### PR DESCRIPTION
The first commits change the `.editorconfig`. The final one used Rider and the "Safe Cleanup" profile to reformat.