### PR TITLE
Add missing tests for `int.Seconds(TimeSpan)`

### DIFF
--- a/Tests/FluentAssertions.Specs/Extensions/TimeSpanConversionExtensionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/TimeSpanConversionExtensionSpecs.cs
@@ -88,6 +88,26 @@ public class TimeSpanConversionExtensionSpecs
     }
 
     [Fact]
+    public void Add_time_span_to_given_seconds()
+    {
+        // Act
+        TimeSpan time = 4.Seconds(TimeSpan.FromSeconds(1));
+
+        // Assert
+        time.Should().Be(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void Subtract_time_span_from_given_seconds()
+    {
+        // Act
+        TimeSpan time = 4.Seconds(TimeSpan.FromSeconds(-1));
+
+        // Assert
+        time.Should().Be(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
     public void When_getting_the_nanoseconds_component_it_should_return_the_correct_value()
     {
         // Arrange


### PR DESCRIPTION
In `FluentTimeSpanExtensions`

Main reason why I not simply deleted this method was, that this is part of the public API, and would be a potential "breaking" change.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome