### PR TITLE
Declare System.Net.Http as a framework dependency

### DIFF
--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -91,7 +91,10 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <TfmSpecificFrameworkAssemblyReferences Include="System.Net.Http">
+      <TargetFramework>$(TargetFramework)</TargetFramework>
+    </TfmSpecificFrameworkAssemblyReferences>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />

--- a/Tests/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks.csproj
@@ -15,5 +15,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Data.DataSetExtensions" Condition="'$(TargetFramework)' == 'net472'" />
+    <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
 </Project>

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,6 +16,8 @@ sidebar:
 
 * `BeEquivalentTo` no longer crashes on fields hiding base-class fields - [#1990](https://github.com/fluentassertions/fluentassertions/pull/1990)
 
+* Fixed System.Net.Http dependency declaration for net47 target framework to be a framework dependency instead of a nuget dependency - [#2122](https://github.com/fluentassertions/fluentassertions/pull/2122)
+
 ## 6.9.0
 
 ### What's new


### PR DESCRIPTION
Declaring System.Net.Http as a nuget dependency for net47 is problematic for some consuming projects because it offers assembly version 4.1.1.3, whereas the FluentAssertions assembly itself references 4.2.0.0 of that same assembly. This causes the C# compiler to break the build for these projects.

The fix is to declare that System.Net.Http comes from an ordinary `Reference` item that is supplied by the target framework (which in fact it should as it does for FluentAssertions itself) instead of from the NuGet package.

It is interesting to call out that although this project previously declared `System.Net.Http` as a `PackageReference`, msbuild nevertheless chose to use the targeting framework version instead of the nuget version. This is ... not something I can explain. And many other projects have the same behavior, which is why it typically works for consuming projects. I don't know why exactly, but some projects do _not_ share this behavior, and those that actually use the nuget dependency that was declared here (before this change) would fail to compile.

Fixes #2121

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome