### PR TITLE
MSBuild improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ packages/**
 *.tmp
 *.tmp_proj
 *.log
+*.binlog
 *.vspscc
 *.vssscc
 .builds

--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,0 +1,15 @@
+#------------------------------------------------------------------------------
+# This file contains command-line options that MSBuild will process as part of
+# every build, unless the "/noautoresponse" switch is specified.
+#
+# MSBuild processes the options in this file first, before processing the
+# options on the command line. As a result, options on the command line can
+# override the options in this file. However, depending on the options being
+# set, the overriding can also result in conflicts.
+#
+# NOTE: The "/noautoresponse" switch cannot be specified in this file, nor in
+# any response file that is referenced by this file.
+#------------------------------------------------------------------------------
+/m
+/verbosity:minimal
+/clp:Summary;ForceNoAlign


### PR DESCRIPTION
## Add a default msbuild switches response file

- `/m` speeds up the build by building with multiple processors
- `verbosity: minimal` gives a clean, succinct console log that matches what VS prints it the output window by default.
- `clp:Summary` reminds you of any errors/warnings at the end of the console log in case it scrolled off screen during the build.
- `ForceNoAlign` prevents line breaks being forced into the console log, so that resizing the console window will allow proper word wrapping.

##  Add .binlog files to .gitignore

This is a relatively new msbuild log format that is very popular and easy to review. We should not check these in any more than we check in .log files.