### PR TITLE
Add optional parameter to generate a `binlog` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ packages/**
 *.tmp
 *.tmp_proj
 *.log
+*.binlog
 *.vspscc
 *.vssscc
 .builds

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -11,7 +11,8 @@
           "description": "Indicates to continue a previously failed build attempt"
         },
         "GenerateBinLog": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Use this parameter if you encounter build problems in any way, to generate a .binlog file which holds some useful information"
         },
         "Help": {
           "type": "boolean",

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -10,6 +10,9 @@
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
         },
+        "GenerateBinLog": {
+          "type": "boolean"
+        },
         "Help": {
           "type": "boolean",
           "description": "Shows the help text for this build assembly"

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -41,6 +41,8 @@ class Build : NukeBuild
     string BuildNumber => GitHubActions?.RunNumber.ToString();
     string PullRequestBase => GitHubActions?.BaseRef;
 
+    [Parameter] readonly bool? GenerateBinLog;
+
     [Parameter("The key to push to Nuget")]
     [Secret]
     readonly string NuGetApiKey;
@@ -124,6 +126,9 @@ class Build : NukeBuild
             DotNetBuild(s => s
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration.CI)
+                .When(GenerateBinLog is true, _ => _
+                    .SetBinaryLog(ArtifactsDirectory / $"{Solution.Core.FluentAssertions.Name}.binlog")
+                )
                 .EnableNoLogo()
                 .EnableNoRestore()
                 .SetAssemblyVersion(GitVersion.AssemblySemVer)

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -41,7 +41,9 @@ class Build : NukeBuild
     string BuildNumber => GitHubActions?.RunNumber.ToString();
     string PullRequestBase => GitHubActions?.BaseRef;
 
-    [Parameter] readonly bool? GenerateBinLog;
+    [Parameter("Use this parameter if you encounter build problems in any way, " +
+        "to generate a .binlog file which holds some useful information.")] 
+    readonly bool? GenerateBinLog;
 
     [Parameter("The key to push to Nuget")]
     [Secret]


### PR DESCRIPTION
### How to use the new parameter

`build(.sh|.ps1) --generate-bin-log` or `build(.sh|.ps1) --generate-bin-log true` (same outcome)

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome