### PR TITLE
Styling to please both VS and Rider

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -116,6 +116,7 @@ csharp_space_before_comma = false
 csharp_space_before_dot = false
 csharp_space_before_open_square_brackets = false
 csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_attribute_sections = false
 csharp_space_between_empty_square_brackets = false
 csharp_space_between_method_call_empty_parameter_list_parentheses = false
 csharp_space_between_method_call_name_and_opening_parenthesis = false

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -42,7 +42,7 @@ class Build : NukeBuild
     string PullRequestBase => GitHubActions?.BaseRef;
 
     [Parameter("Use this parameter if you encounter build problems in any way, " +
-        "to generate a .binlog file which holds some useful information.")] 
+        "to generate a .binlog file which holds some useful information.")]
     readonly bool? GenerateBinLog;
 
     [Parameter("The key to push to Nuget")]

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -406,7 +406,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="regularExpression"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> MatchRegex([RegexPattern] [StringSyntax("Regex")] string regularExpression,
+    public AndConstraint<TAssertions> MatchRegex([RegexPattern][StringSyntax("Regex")] string regularExpression,
         OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression),
@@ -443,7 +443,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="regularExpression"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> MatchRegex([RegexPattern] [StringSyntax("Regex")] string regularExpression,
+    public AndConstraint<TAssertions> MatchRegex([RegexPattern][StringSyntax("Regex")] string regularExpression,
         string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression),
@@ -578,7 +578,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="regularExpression"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> NotMatchRegex([RegexPattern] [StringSyntax("Regex")] string regularExpression,
+    public AndConstraint<TAssertions> NotMatchRegex([RegexPattern][StringSyntax("Regex")] string regularExpression,
         string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression),

--- a/Tests/Benchmarks/CheckIfMemberIsBrowsable.cs
+++ b/Tests/Benchmarks/CheckIfMemberIsBrowsable.cs
@@ -19,9 +19,8 @@ public class CheckIfMemberIsBrowsableBenchmarks
         .GetField(IsBrowsable ? nameof(BrowsableField) : nameof(NonBrowsableField));
 
     [Benchmark]
-    public void CheckIfMemberIsBrowsable()
+    public bool CheckIfMemberIsBrowsable()
     {
-        bool _ =
-            SubjectField.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
+        return SubjectField.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -84,27 +84,6 @@ public class CollectionSpecs
         public bool IsSynchronized => ((ICollection)inner).IsSynchronized;
     }
 
-    private class MultiEnumerable : IEnumerable<int>, IEnumerable<long>
-    {
-        private readonly List<int> ints = new();
-        private readonly List<long> longs = new();
-
-        IEnumerator<int> IEnumerable<int>.GetEnumerator()
-        {
-            return ints.GetEnumerator();
-        }
-
-        public IEnumerator GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        IEnumerator<long> IEnumerable<long>.GetEnumerator()
-        {
-            return longs.GetEnumerator();
-        }
-    }
-
     private class EnumerableOfStringAndObject : IEnumerable<object>, IEnumerable<string>
     {
         IEnumerator IEnumerable.GetEnumerator()

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -1245,13 +1245,17 @@ public class CollectionSpecs
         };
 
         // Act
-        Action action = () => subject.Should().AllBeEquivalentTo(new
+        Action action = () =>
+        {
+            var expectation = new
             {
                 Name = "someDto",
                 Age = 1,
                 Birthdate = default(DateTime)
-            })
-            .And.HaveCount(3);
+            };
+
+            subject.Should().AllBeEquivalentTo(expectation).And.HaveCount(3);
+        };
 
         // Assert
         action.Should().NotThrow();
@@ -2649,7 +2653,8 @@ public class CollectionSpecs
             new int?[] { null, 1 }, new int?[] { 1, null }, new object[] { null, 1 }, new object[] { 1, null }
         };
 
-        return from x in arrays
+        return
+            from x in arrays
             from y in arrays
             select new[] { x, y };
     }

--- a/Tests/FluentAssertions.Equivalency.Specs/EnumSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/EnumSpecs.cs
@@ -101,8 +101,7 @@ public class EnumSpecs
         // Arrange
         var subject = new ClassWithEnumOne { Enum = EnumOne.Two };
 
-        var expectation = new ClassWithEnumThree
-            { Enum = EnumThree.Two };
+        var expectation = new ClassWithEnumThree { Enum = EnumThree.Two };
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, config => config.ComparingEnumsByName());

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -2759,7 +2759,8 @@ public class GenericDictionaryAssertionSpecs
 
         public static IEnumerable<object[]> DictionariesData()
         {
-            return from x in Dictionaries()
+            return
+                from x in Dictionaries()
                 from y in Dictionaries()
                 select new[] { x, y };
         }

--- a/Tests/FluentAssertions.Specs/Extensions/ObjectExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/ObjectExtensionsSpecs.cs
@@ -80,7 +80,8 @@ public class ObjectExtensionsSpecs
 
     public static IEnumerable<object[]> GetNonNumericAndNumericData()
     {
-        return from x in GetNonNumericIConvertibles()
+        return
+            from x in GetNonNumericIConvertibles()
             from y in GetNumericIConvertibles()
             select new[] { x, y };
     }
@@ -101,7 +102,8 @@ public class ObjectExtensionsSpecs
 
     public static IEnumerable<object[]> GetNumericAndNonNumericData()
     {
-        return from x in GetNumericIConvertibles()
+        return
+            from x in GetNumericIConvertibles()
             from y in GetNonNumericIConvertibles()
             select new[] { x, y };
     }


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome


My VS seems to prefer not having a space between attributes.
I don't care if there is space or not but I cannot find a e.ditorconfig setting that VS respects.
But found [`csharp_space_between_attribute_sections`](https://www.jetbrains.com/help/resharper/EditorConfig_CSHARP_SpacesPageSchema.html#resharper_csharp_space_between_attribute_sections) for ReSharper.

My VS also complains about this wanting a space between the commas which is contrary to e.g. https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/arrays/multidimensional-arrays#array-initialization 😞  
https://github.com/fluentassertions/fluentassertions/blob/454f16b54a88e2ebb5debbf7e40fab2937dfc147/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs#L1992