### PR TITLE
Use a fixed seed for random generator

### DIFF
--- a/Tests/FluentAssertions.Equivalency.Specs/DataSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSpecs.cs
@@ -442,7 +442,7 @@ public class DataSpecs
 
     #endregion
 
-    private static readonly Random Random = new();
+    private static readonly Random Random = new(0);
 
     internal static TDataSet CreateDummyDataSet<TDataSet>(bool identicalTables = false, bool includeDummyData = true,
         bool includeRelation = true)


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

In this recent [run](https://github.com/fluentassertions/fluentassertions/actions/runs/4152072760) `FluentAssertions.Equivalency.Specs.DataColumnSpecs.When_MaxLength_does_not_match_and_property_is_not_excluded_it_should_fail` failed.

```
Error: [xUnit.net 00:00:01.14]     FluentAssertions.Equivalency.Specs.DataColumnSpecs.When_MaxLength_does_not_match_and_property_is_not_excluded_it_should_fail [FAIL]
  16:00:47 [ERR] [xUnit.net 00:00:01.14]     FluentAssertions.Equivalency.Specs.DataColumnSpecs.When_MaxLength_does_not_match_and_property_is_not_excluded_it_should_fail [FAIL]
  16:00:47 [DBG]   Failed FluentAssertions.Equivalency.Specs.DataColumnSpecs.When_MaxLength_does_not_match_and_property_is_not_excluded_it_should_fail [3 ms]
  16:00:47 [DBG]   Error Message:
  16:00:47 [DBG]    System.Data.ConstraintException : Column 'RowID' is constrained to be unique.  Value '763363273' is already present.
  16:00:47 [DBG]   Stack Trace:
  16:00:47 [DBG]      at System.Data.UniqueConstraint.CheckConstraint(DataRow row, DataRowAction action)
  16:00:47 [DBG]    at System.Data.DataTable.RaiseRowChanging(DataRowChangeEventArgs args, DataRow eRow, DataRowAction eAction, Boolean fireEvent)
  16:00:47 [DBG]    at System.Data.DataTable.SetNewRecordWorker(DataRow row, Int32 proposedRecord, DataRowAction action, Boolean isInMerge, Boolean suppressEnsurePropertyChanged, Int32 position, Boolean fireEvent, Exception& deferredException)
  16:00:47 [DBG]    at System.Data.DataTable.InsertRow(DataRow row, Int64 proposedID, Int32 pos, Boolean fireEvent)
  16:00:47 [DBG]    at System.Data.DataRowCollection.Add(DataRow row)
  16:00:47 [DBG]    at FluentAssertions.Equivalency.Specs.DataSpecs.InsertDummyRow(DataTable table, DataRow foreignRow) in D:\a\fluentassertions\fluentassertions\Tests\FluentAssertions.Equivalency.Specs\DataSpecs.cs:line 540
  16:00:47 [DBG]    at FluentAssertions.Equivalency.Specs.DataSpecs.InsertDummyRows(DataTable table, DataTable foreignRows) in D:\a\fluentassertions\fluentassertions\Tests\FluentAssertions.Equivalency.Specs\DataSpecs.cs:line 518
  16:00:47 [DBG]    at FluentAssertions.Equivalency.Specs.DataSpecs.CreateDummyDataSet[TDataSet](Boolean identicalTables, Boolean includeDummyData, Boolean includeRelation) in D:\a\fluentassertions\fluentassertions\Tests\FluentAssertions.Equivalency.Specs\DataSpecs.cs:line 448
  16:00:47 [DBG]    at FluentAssertions.Equivalency.Specs.DataColumnSpecs.When_MaxLength_does_not_match_and_property_is_not_excluded_it_should_fail() in D:\a\fluentassertions\fluentassertions\Tests\FluentAssertions.Equivalency.Specs\DataColumnSpecs.cs:line 529
  16:00:53 [DBG] Results File: D:\a\fluentassertions\fluentassertions\TestResults\FluentAssertions.Equivalency.Specs_netcoreapp2.1.trx
  16:00:53 [DBG]
  16:00:53 [DBG] Failed!  - Failed:     1, Passed:   778, Skipped:     0, Total:   779, Duration: 4 s - FluentAssertions.Equivalency.Specs.dll (netcoreapp2.1)
```

I spotted that we construct an instance of `Random` without a fixed seed, so for each test run it will pick a new seed.
This is highly undesirable for creating deterministic tests, so I've fixed the seed to the arbitrary value `0`.

This is still not perfect as what values are created depends on the order tests are run, but for now I don't want to spend more time on this.