### PR TITLE
Increase robustness of assertions when wrapped in an `AssertionScope`

### DIFF
--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -56,45 +56,46 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         string because = "", params object[] becauseArgs)
         where T : IEnumerable<KeyValuePair<TKey, TValue>>
     {
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but found {1}.", expected, Subject);
-        }
-
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare dictionary with <null>.");
 
-        IEnumerable<TKey> subjectKeys = GetKeys(Subject);
-        IEnumerable<TKey> expectedKeys = GetKeys(expected);
-        IEnumerable<TKey> missingKeys = expectedKeys.Except(subjectKeys);
-        IEnumerable<TKey> additionalKeys = subjectKeys.Except(expectedKeys);
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but found {1}.", expected, Subject);
 
-        if (missingKeys.Any())
+        if (success)
         {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but could not find keys {1}.", expected,
-                    missingKeys);
-        }
+            IEnumerable<TKey> subjectKeys = GetKeys(Subject);
+            IEnumerable<TKey> expectedKeys = GetKeys(expected);
+            IEnumerable<TKey> missingKeys = expectedKeys.Except(subjectKeys);
+            IEnumerable<TKey> additionalKeys = subjectKeys.Except(expectedKeys);
 
-        if (additionalKeys.Any())
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but found additional keys {1}.", expected,
-                    additionalKeys);
-        }
+            if (missingKeys.Any())
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but could not find keys {1}.", expected,
+                        missingKeys);
+            }
 
-        Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
+            if (additionalKeys.Any())
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but found additional keys {1}.", expected,
+                        additionalKeys);
+            }
 
-        foreach (var key in expectedKeys)
-        {
-            Execute.Assertion
-                .ForCondition(areSameOrEqual(GetValue(Subject, key), GetValue(expected, key)))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but {1} differs at key {2}.",
-                    expected, Subject, key);
+            Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
+
+            foreach (var key in expectedKeys)
+            {
+                Execute.Assertion
+                    .ForCondition(areSameOrEqual(GetValue(Subject, key), GetValue(expected, key)))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but {1} differs at key {2}.",
+                        expected, Subject, key);
+            }
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -118,38 +119,39 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         string because = "", params object[] becauseArgs)
         where T : IEnumerable<KeyValuePair<TKey, TValue>>
     {
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected dictionaries not to be equal{reason}, but found {0}.", Subject);
-        }
-
         Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare dictionary with <null>.");
 
-        if (ReferenceEquals(Subject, unexpected))
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected dictionaries not to be equal{reason}, but found {0}.", Subject);
+
+        if (success)
         {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected dictionaries not to be equal{reason}, but they both reference the same object.");
-        }
+            if (ReferenceEquals(Subject, unexpected))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected dictionaries not to be equal{reason}, but they both reference the same object.");
+            }
 
-        IEnumerable<TKey> subjectKeys = GetKeys(Subject);
-        IEnumerable<TKey> unexpectedKeys = GetKeys(unexpected);
-        IEnumerable<TKey> missingKeys = unexpectedKeys.Except(subjectKeys);
-        IEnumerable<TKey> additionalKeys = subjectKeys.Except(unexpectedKeys);
+            IEnumerable<TKey> subjectKeys = GetKeys(Subject);
+            IEnumerable<TKey> unexpectedKeys = GetKeys(unexpected);
+            IEnumerable<TKey> missingKeys = unexpectedKeys.Except(subjectKeys);
+            IEnumerable<TKey> additionalKeys = subjectKeys.Except(unexpectedKeys);
 
-        Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
+            Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
 
-        bool foundDifference = missingKeys.Any()
-            || additionalKeys.Any()
-            || subjectKeys.Any(key => !areSameOrEqual(GetValue(Subject, key), GetValue(unexpected, key)));
+            bool foundDifference = missingKeys.Any()
+                || additionalKeys.Any()
+                || subjectKeys.Any(key => !areSameOrEqual(GetValue(Subject, key), GetValue(unexpected, key)));
 
-        if (!foundDifference)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect dictionaries {0} and {1} to be equal{reason}.", unexpected, Subject);
+            if (!foundDifference)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Did not expect dictionaries {0} and {1} to be equal{reason}.", unexpected, Subject);
+            }
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -292,30 +294,31 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         ICollection<TKey> expectedKeys = expected.ConvertOrCastToCollection();
         Guard.ThrowIfArgumentIsEmpty(expectedKeys, nameof(expected), "Cannot verify key containment against an empty sequence");
 
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to contain keys {0}{reason}, but found {1}.", expected, Subject);
-        }
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:dictionary} to contain keys {0}{reason}, but found <null>.", expected);
 
-        IEnumerable<TKey> missingKeys = expectedKeys.Where(key => !ContainsKey(Subject, key));
-
-        if (missingKeys.Any())
+        if (success)
         {
-            if (expectedKeys.Count > 1)
+            IEnumerable<TKey> missingKeys = expectedKeys.Where(key => !ContainsKey(Subject, key));
+
+            if (missingKeys.Any())
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}, but could not find {2}.", Subject,
-                        expected, missingKeys);
-            }
-            else
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}.", Subject,
-                        expected.Cast<object>().First());
+                if (expectedKeys.Count > 1)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}, but could not find {2}.", Subject,
+                            expected, missingKeys);
+                }
+                else
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}.", Subject,
+                            expected.Cast<object>().First());
+                }
             }
         }
 
@@ -341,19 +344,20 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     public AndConstraint<TAssertions> NotContainKey(TKey unexpected,
         string because = "", params object[] becauseArgs)
     {
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} not to contain key {0}{reason}, but found {1}.", unexpected, Subject);
-        }
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:dictionary} not to contain key {0}{reason}, but found <null>.", unexpected);
 
-        if (ContainsKey(Subject, unexpected))
+        if (success)
         {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} {0} not to contain key {1}{reason}, but found it anyhow.", Subject,
-                    unexpected);
+            if (ContainsKey(Subject, unexpected))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} {0} not to contain key {1}{reason}, but found it anyhow.", Subject,
+                        unexpected);
+            }
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -394,30 +398,31 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         Guard.ThrowIfArgumentIsEmpty(unexpectedKeys, nameof(unexpected),
             "Cannot verify key containment against an empty sequence");
 
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to contain keys {0}{reason}, but found {1}.", unexpected, Subject);
-        }
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:dictionary} to not contain keys {0}{reason}, but found <null>.", unexpected);
 
-        IEnumerable<TKey> foundKeys = unexpected.Where(key => ContainsKey(Subject, key));
-
-        if (foundKeys.Any())
+        if (success)
         {
-            if (unexpectedKeys.Count > 1)
+            IEnumerable<TKey> foundKeys = unexpected.Where(key => ContainsKey(Subject, key));
+
+            if (foundKeys.Any())
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to not contain key {1}{reason}, but found {2}.", Subject,
-                        unexpected, foundKeys);
-            }
-            else
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to not contain key {1}{reason}.", Subject,
-                        unexpected.Cast<object>().First());
+                if (unexpectedKeys.Count > 1)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to not contain key {1}{reason}, but found {2}.", Subject,
+                            unexpected, foundKeys);
+                }
+                else
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to not contain key {1}{reason}.", Subject,
+                            unexpected.Cast<object>().First());
+                }
             }
         }
 
@@ -493,38 +498,40 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         Guard.ThrowIfArgumentIsEmpty(expectedValues, nameof(expected),
             "Cannot verify value containment against an empty sequence");
 
-        if (Subject is null)
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:dictionary} to contain values {0}{reason}, but found {1}.", expected, Subject);
+
+        IEnumerable<TValue> matchedConstraint = null;
+
+        if (success)
         {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to contain value {0}{reason}, but found {1}.", expected, Subject);
+            IEnumerable<TValue> subjectValues = GetValues(Subject);
+            IEnumerable<TValue> missingValues = expectedValues.Except(subjectValues);
+
+            if (missingValues.Any())
+            {
+                if (expectedValues.Count > 1)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to contain value {1}{reason}, but could not find {2}.", Subject,
+                            expected, missingValues);
+                }
+                else
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to contain value {1}{reason}.", Subject,
+                            expected.Cast<object>().First());
+                }
+            }
+
+            matchedConstraint = RepetitionPreservingIntersect(subjectValues, expectedValues);
         }
 
-        IEnumerable<TValue> subjectValues = GetValues(Subject);
-        IEnumerable<TValue> missingValues = expectedValues.Except(subjectValues);
-
-        if (missingValues.Any())
-        {
-            if (expectedValues.Count > 1)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to contain value {1}{reason}, but could not find {2}.", Subject,
-                        expected, missingValues);
-            }
-            else
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to contain value {1}{reason}.", Subject,
-                        expected.Cast<object>().First());
-            }
-        }
-
-        return
-            new AndWhichConstraint<TAssertions,
-                IEnumerable<TValue>>((TAssertions)this,
-                RepetitionPreservingIntersect(subjectValues, expectedValues));
+        return new AndWhichConstraint<TAssertions, IEnumerable<TValue>>((TAssertions)this, matchedConstraint);
     }
 
     /// <summary>
@@ -557,19 +564,20 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     public AndConstraint<TAssertions> NotContainValue(TValue unexpected,
         string because = "", params object[] becauseArgs)
     {
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} not to contain value {0}{reason}, but found {1}.", unexpected, Subject);
-        }
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:dictionary} not to contain value {0}{reason}, but found <null>.", unexpected);
 
-        if (GetValues(Subject).Contains(unexpected))
+        if (success)
         {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} {0} not to contain value {1}{reason}, but found it anyhow.", Subject,
-                    unexpected);
+            if (GetValues(Subject).Contains(unexpected))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} {0} not to contain value {1}{reason}, but found it anyhow.", Subject,
+                        unexpected);
+            }
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -610,30 +618,31 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         Guard.ThrowIfArgumentIsEmpty(unexpectedValues, nameof(unexpected),
             "Cannot verify value containment with an empty sequence");
 
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to not contain value {0}{reason}, but found {1}.", unexpected, Subject);
-        }
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:dictionary} to not contain values {0}{reason}, but found <null>.", unexpected);
 
-        IEnumerable<TValue> foundValues = unexpectedValues.Intersect(GetValues(Subject));
-
-        if (foundValues.Any())
+        if (success)
         {
-            if (unexpectedValues.Count > 1)
+            IEnumerable<TValue> foundValues = unexpectedValues.Intersect(GetValues(Subject));
+
+            if (foundValues.Any())
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to not contain value {1}{reason}, but found {2}.", Subject,
-                        unexpected, foundValues);
-            }
-            else
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to not contain value {1}{reason}.", Subject,
-                        unexpected.Cast<object>().First());
+                if (unexpectedValues.Count > 1)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to not contain value {1}{reason}, but found {2}.", Subject,
+                            unexpected, foundValues);
+                }
+                else
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to not contain value {1}{reason}.", Subject,
+                            unexpected.Cast<object>().First());
+                }
             }
         }
 
@@ -680,60 +689,61 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         Guard.ThrowIfArgumentIsEmpty(expectedKeyValuePairs, nameof(expected),
             "Cannot verify key containment against an empty collection of key/value pairs");
 
-        if (Subject is null)
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:dictionary} to contain key/value pairs {0}{reason}, but dictionary is <null>.",
+                expected);
+
+        if (success)
         {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to contain key/value pairs {0}{reason}, but dictionary is {1}.",
-                    expected, Subject);
-        }
+            TKey[] expectedKeys = expectedKeyValuePairs.Select(keyValuePair => keyValuePair.Key).ToArray();
+            IEnumerable<TKey> missingKeys = expectedKeys.Where(key => !ContainsKey(Subject, key));
 
-        TKey[] expectedKeys = expectedKeyValuePairs.Select(keyValuePair => keyValuePair.Key).ToArray();
-        IEnumerable<TKey> missingKeys = expectedKeys.Where(key => !ContainsKey(Subject, key));
-
-        if (missingKeys.Any())
-        {
-            if (expectedKeyValuePairs.Count > 1)
+            if (missingKeys.Any())
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to contain key(s) {1}{reason}, but could not find keys {2}.",
-                        Subject,
-                        expectedKeys, missingKeys);
+                if (expectedKeyValuePairs.Count > 1)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to contain key(s) {1}{reason}, but could not find keys {2}.",
+                            Subject,
+                            expectedKeys, missingKeys);
+                }
+                else
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}.", Subject,
+                            expectedKeys.Cast<object>().First());
+                }
             }
-            else
+
+            Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
+
+            KeyValuePair<TKey, TValue>[] keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs
+                .Where(keyValuePair => !areSameOrEqual(GetValue(Subject, keyValuePair.Key), keyValuePair.Value)).ToArray();
+
+            if (keyValuePairsNotSameOrEqualInSubject.Any())
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}.", Subject,
-                        expectedKeys.Cast<object>().First());
-            }
-        }
+                if (keyValuePairsNotSameOrEqualInSubject.Length > 1)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith(
+                            "Expected {context:dictionary} to contain {0}{reason}, but {context:dictionary} differs at keys {1}.",
+                            expectedKeyValuePairs, keyValuePairsNotSameOrEqualInSubject.Select(keyValuePair => keyValuePair.Key));
+                }
+                else
+                {
+                    KeyValuePair<TKey, TValue> expectedKeyValuePair = keyValuePairsNotSameOrEqualInSubject[0];
+                    TValue actual = GetValue(Subject, expectedKeyValuePair.Key);
 
-        Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
-
-        KeyValuePair<TKey, TValue>[] keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs
-            .Where(keyValuePair => !areSameOrEqual(GetValue(Subject, keyValuePair.Key), keyValuePair.Value)).ToArray();
-
-        if (keyValuePairsNotSameOrEqualInSubject.Any())
-        {
-            if (keyValuePairsNotSameOrEqualInSubject.Length > 1)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith(
-                        "Expected {context:dictionary} to contain {0}{reason}, but {context:dictionary} differs at keys {1}.",
-                        expectedKeyValuePairs, keyValuePairsNotSameOrEqualInSubject.Select(keyValuePair => keyValuePair.Key));
-            }
-            else
-            {
-                KeyValuePair<TKey, TValue> expectedKeyValuePair = keyValuePairsNotSameOrEqualInSubject[0];
-                TValue actual = GetValue(Subject, expectedKeyValuePair.Key);
-
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.",
-                        expectedKeyValuePair.Value, expectedKeyValuePair.Key, actual);
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.",
+                            expectedKeyValuePair.Value, expectedKeyValuePair.Key, actual);
+                }
             }
         }
 
@@ -777,32 +787,32 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     public AndConstraint<TAssertions> Contain(TKey key, TValue value,
         string because = "", params object[] becauseArgs)
     {
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but dictionary is {2}.", value,
-                    key,
-                    Subject);
-        }
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but dictionary is <null>.",
+                value, key);
 
-        if (TryGetValue(Subject, key, out TValue actual))
+        if (success)
         {
-            Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
+            if (TryGetValue(Subject, key, out TValue actual))
+            {
+                Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
 
-            Execute.Assertion
-                .ForCondition(areSameOrEqual(actual, value))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.", value, key,
-                    actual);
-        }
-        else
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but the key was not found.",
-                    value,
-                    key);
+                Execute.Assertion
+                    .ForCondition(areSameOrEqual(actual, value))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.", value, key,
+                        actual);
+            }
+            else
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but the key was not found.",
+                        value,
+                        key);
+            }
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -848,43 +858,44 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         Guard.ThrowIfArgumentIsEmpty(keyValuePairs, nameof(items),
             "Cannot verify key containment against an empty collection of key/value pairs");
 
-        if (Subject is null)
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but dictionary is <null>.",
+                items);
+
+        if (success)
         {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but dictionary is {1}.",
-                    items, Subject);
-        }
+            KeyValuePair<TKey, TValue>[] keyValuePairsFound =
+                keyValuePairs.Where(keyValuePair => ContainsKey(Subject, keyValuePair.Key)).ToArray();
 
-        KeyValuePair<TKey, TValue>[] keyValuePairsFound =
-            keyValuePairs.Where(keyValuePair => ContainsKey(Subject, keyValuePair.Key)).ToArray();
-
-        if (keyValuePairsFound.Any())
-        {
-            Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
-
-            KeyValuePair<TKey, TValue>[] keyValuePairsSameOrEqualInSubject = keyValuePairsFound
-                .Where(keyValuePair => areSameOrEqual(GetValue(Subject, keyValuePair.Key), keyValuePair.Value)).ToArray();
-
-            if (keyValuePairsSameOrEqualInSubject.Any())
+            if (keyValuePairsFound.Any())
             {
-                if (keyValuePairsSameOrEqualInSubject.Length > 1)
-                {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith(
-                            "Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but found them anyhow.",
-                            keyValuePairs);
-                }
-                else
-                {
-                    KeyValuePair<TKey, TValue> keyValuePair = keyValuePairsSameOrEqualInSubject[0];
+                Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
 
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith(
-                            "Expected {context:dictionary} to not contain value {0} at key {1}{reason}, but found it anyhow.",
-                            keyValuePair.Value, keyValuePair.Key);
+                KeyValuePair<TKey, TValue>[] keyValuePairsSameOrEqualInSubject = keyValuePairsFound
+                    .Where(keyValuePair => areSameOrEqual(GetValue(Subject, keyValuePair.Key), keyValuePair.Value)).ToArray();
+
+                if (keyValuePairsSameOrEqualInSubject.Any())
+                {
+                    if (keyValuePairsSameOrEqualInSubject.Length > 1)
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith(
+                                "Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but found them anyhow.",
+                                keyValuePairs);
+                    }
+                    else
+                    {
+                        KeyValuePair<TKey, TValue> keyValuePair = keyValuePairsSameOrEqualInSubject[0];
+
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith(
+                                "Expected {context:dictionary} to not contain value {0} at key {1}{reason}, but found it anyhow.",
+                                keyValuePair.Value, keyValuePair.Key);
+                    }
                 }
             }
         }
@@ -929,22 +940,22 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     public AndConstraint<TAssertions> NotContain(TKey key, TValue value,
         string because = "", params object[] becauseArgs)
     {
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but dictionary is {2}.",
-                    value,
-                    key, Subject);
-        }
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but dictionary is <null>.",
+                value, key);
 
-        if (TryGetValue(Subject, key, out TValue actual))
+        if (success)
         {
-            Execute.Assertion
-                .ForCondition(!ObjectExtensions.GetComparer<TValue>()(actual, value))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but found it anyhow.",
-                    value, key);
+            if (TryGetValue(Subject, key, out TValue actual))
+            {
+                Execute.Assertion
+                    .ForCondition(!ObjectExtensions.GetComparer<TValue>()(actual, value))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but found it anyhow.",
+                        value, key);
+            }
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Data/DataRowAssertions.cs
+++ b/Src/FluentAssertions/Data/DataRowAssertions.cs
@@ -84,22 +84,23 @@ public class DataRowAssertions<TDataRow> : ReferenceTypeAssertions<TDataRow, Dat
     public AndConstraint<DataRowAssertions<TDataRow>> HaveColumns(IEnumerable<string> expectedColumnNames, string because = "",
         params object[] becauseArgs)
     {
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith(
-                    "Expected {context:DataRow} to be in a table containing {0} column(s) with specific names{reason}, but found <null>.",
-                    expectedColumnNames.Count());
-        }
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith(
+                "Expected {context:DataRow} to be in a table containing {0} column(s) with specific names{reason}, but found <null>.",
+                () => expectedColumnNames.Count());
 
-        foreach (var expectedColumnName in expectedColumnNames)
+        if (success)
         {
-            Execute.Assertion
-                .ForCondition(Subject.Table.Columns.Contains(expectedColumnName))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected table containing {context:DataRow} to contain a column named {0}{reason}, but it does not.",
-                    expectedColumnName);
+            foreach (var expectedColumnName in expectedColumnNames)
+            {
+                Execute.Assertion
+                    .ForCondition(Subject.Table.Columns.Contains(expectedColumnName))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected table containing {context:DataRow} to contain a column named {0}{reason}, but it does not.",
+                        expectedColumnName);
+            }
         }
 
         return new AndConstraint<DataRowAssertions<TDataRow>>(this);

--- a/Src/FluentAssertions/Data/DataSetAssertions.cs
+++ b/Src/FluentAssertions/Data/DataSetAssertions.cs
@@ -37,20 +37,21 @@ public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, Data
     public AndConstraint<DataSetAssertions<TDataSet>> HaveTableCount(int expected, string because = "",
         params object[] becauseArgs)
     {
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataSet} to contain exactly {0} table(s){reason}, but found <null>.", expected);
-        }
-
-        int actualCount = Subject.Tables.Count;
-
-        Execute.Assertion
-            .ForCondition(actualCount == expected)
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:DataSet} to contain exactly {0} table(s){reason}, but found {1}.", expected,
-                actualCount);
+            .FailWith("Expected {context:DataSet} to contain exactly {0} table(s){reason}, but found <null>.", expected);
+
+        if (success)
+        {
+            int actualCount = Subject.Tables.Count;
+
+            Execute.Assertion
+                .ForCondition(actualCount == expected)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:DataSet} to contain exactly {0} table(s){reason}, but found {1}.", expected,
+                    actualCount);
+        }
 
         return new AndConstraint<DataSetAssertions<TDataSet>>(this);
     }
@@ -115,20 +116,21 @@ public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, Data
     public AndConstraint<DataSetAssertions<TDataSet>> HaveTables(IEnumerable<string> expectedTableNames, string because = "",
         params object[] becauseArgs)
     {
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataSet} to contain {0} table(s) with specific names{reason}, but found <null>.",
-                    expectedTableNames.Count());
-        }
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:DataSet} to contain {0} table(s) with specific names{reason}, but found <null>.",
+                () => expectedTableNames.Count());
 
-        foreach (var expectedTableName in expectedTableNames)
+        if (success)
         {
-            Execute.Assertion
-                .ForCondition(Subject.Tables.Contains(expectedTableName))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataSet} to contain a table named {0}{reason}, but it does not.", expectedTableName);
+            foreach (var expectedTableName in expectedTableNames)
+            {
+                Execute.Assertion
+                    .ForCondition(Subject.Tables.Contains(expectedTableName))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataSet} to contain a table named {0}{reason}, but it does not.", expectedTableName);
+            }
         }
 
         return new AndConstraint<DataSetAssertions<TDataSet>>(this);

--- a/Src/FluentAssertions/Data/DataTableAssertions.cs
+++ b/Src/FluentAssertions/Data/DataTableAssertions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Linq;
+using System.Xml.Schema;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
@@ -37,20 +38,21 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
     public AndConstraint<DataTableAssertions<TDataTable>> HaveRowCount(int expected, string because = "",
         params object[] becauseArgs)
     {
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataTable} to contain exactly {0} row(s){reason}, but found <null>.", expected);
-        }
-
-        int actualCount = Subject.Rows.Count;
-
-        Execute.Assertion
-            .ForCondition(actualCount == expected)
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:DataTable} to contain exactly {0} row(s){reason}, but found {1}.", expected,
-                actualCount);
+            .FailWith("Expected {context:DataTable} to contain exactly {0} row(s){reason}, but found <null>.", expected);
+
+        if (success)
+        {
+            int actualCount = Subject.Rows.Count;
+
+            Execute.Assertion
+                .ForCondition(actualCount == expected)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:DataTable} to contain exactly {0} row(s){reason}, but found {1}.", expected,
+                    actualCount);
+        }
 
         return new AndConstraint<DataTableAssertions<TDataTable>>(this);
     }
@@ -116,21 +118,22 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
     public AndConstraint<DataTableAssertions<TDataTable>> HaveColumns(IEnumerable<string> expectedColumnNames,
         string because = "", params object[] becauseArgs)
     {
-        if (Subject is null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataTable} to contain {0} column(s) with specific names{reason}, but found <null>.",
-                    expectedColumnNames.Count());
-        }
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:DataTable} to contain {0} column(s) with specific names{reason}, but found <null>.",
+                () => expectedColumnNames.Count());
 
-        foreach (var expectedColumnName in expectedColumnNames)
+        if (success)
         {
-            Execute.Assertion
-                .ForCondition(Subject.Columns.Contains(expectedColumnName))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:DataTable} to contain a column named {0}{reason}, but it does not.",
-                    expectedColumnName);
+            foreach (var expectedColumnName in expectedColumnNames)
+            {
+                Execute.Assertion
+                    .ForCondition(Subject.Columns.Contains(expectedColumnName))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataTable} to contain a column named {0}{reason}, but it does not.",
+                        expectedColumnName);
+            }
         }
 
         return new AndConstraint<DataTableAssertions<TDataTable>>(this);

--- a/Src/FluentAssertions/Events/EventAssertions.cs
+++ b/Src/FluentAssertions/Events/EventAssertions.cs
@@ -100,26 +100,27 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
 
         IEventRecording recording = Monitor.GetRecordingFor(PropertyChangedEventName);
 
-        if (!recording.Any())
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .FailWith(
-                    "Expected object {0} to raise event {1} for property {2}{reason}, but it did not raise that event at all.",
-                    Monitor.Subject, PropertyChangedEventName, propertyName);
-        }
-
-        var actualPropertyNames = recording
-            .SelectMany(@event => @event.Parameters.OfType<PropertyChangedEventArgs>())
-            .Select(eventArgs => eventArgs.PropertyName)
-            .Distinct()
-            .ToArray();
-
-        Execute.Assertion
-            .ForCondition(actualPropertyNames.Contains(propertyName))
+        bool success = Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected object {0} to raise event {1} for property {2}{reason}, but it was only raised for {3}.",
-                Monitor.Subject, PropertyChangedEventName, propertyName, actualPropertyNames);
+            .ForCondition(recording.Any())
+            .FailWith(
+                "Expected object {0} to raise event {1} for property {2}{reason}, but it did not raise that event at all.",
+                Monitor.Subject, PropertyChangedEventName, propertyName);
+
+        if (success)
+        {
+            var actualPropertyNames = recording
+                .SelectMany(@event => @event.Parameters.OfType<PropertyChangedEventArgs>())
+                .Select(eventArgs => eventArgs.PropertyName)
+                .Distinct()
+                .ToArray();
+
+            Execute.Assertion
+                .ForCondition(actualPropertyNames.Contains(propertyName))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected object {0} to raise event {1} for property {2}{reason}, but it was only raised for {3}.",
+                    Monitor.Subject, PropertyChangedEventName, propertyName, actualPropertyNames);
+        }
 
         return recording;
     }

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -254,21 +254,26 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected),
             "Cannot assert the document has an element if the expected name is <null>.");
 
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject.Root is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith(
                 "Expected {context:subject} to have root element with child {0}{reason}, but it has no root element.",
                 expected.ToString());
 
-        XElement xElement = Subject.Root.Element(expected);
+        XElement xElement = null;
 
-        Execute.Assertion
-            .ForCondition(xElement is not null)
-            .BecauseOf(because, becauseArgs)
-            .FailWith(
-                "Expected {context:subject} to have root element with child {0}{reason}, but no such child element was found.",
-                expected.ToString());
+        if (success)
+        {
+            xElement = Subject.Root.Element(expected);
+
+            Execute.Assertion
+                .ForCondition(xElement is not null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected {context:subject} to have root element with child {0}{reason}, but no such child element was found.",
+                    expected.ToString());
+        }
 
         return new AndWhichConstraint<XDocumentAssertions, XElement>(this, xElement);
     }

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -209,7 +209,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
         {
             XAttribute attribute = Subject.Attribute(expectedName);
 
-            Execute.Assertion
+            success = Execute.Assertion
                 .ForCondition(attribute is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
@@ -217,12 +217,15 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
                     + " but found no such attribute in {2}",
                     expectedText, expectedValue, Subject);
 
-            Execute.Assertion
-                .ForCondition(attribute.Value == expectedValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith(
-                    "Expected attribute {0} in {context:subject} to have value {1}{reason}, but found {2}.",
-                    expectedText, expectedValue, attribute.Value);
+            if (success)
+            {
+                Execute.Assertion
+                    .ForCondition(attribute.Value == expectedValue)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected attribute {0} in {context:subject} to have value {1}{reason}, but found {2}.",
+                        expectedText, expectedValue, attribute.Value);
+            }
         }
 
         return new AndConstraint<XElementAssertions>(this);

--- a/Src/FluentAssertions/Xml/XmlElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlElementAssertions.cs
@@ -93,7 +93,7 @@ public class XmlElementAssertions : XmlNodeAssertions<XmlElement, XmlElementAsse
             (string.IsNullOrEmpty(expectedNamespace) ? string.Empty : $"{{{expectedNamespace}}}")
             + expectedName;
 
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(attribute is not null)
             .BecauseOf(because, becauseArgs)
             .FailWith(
@@ -101,12 +101,15 @@ public class XmlElementAssertions : XmlNodeAssertions<XmlElement, XmlElementAsse
                 + " with value {1}{reason}, but found no such attribute in {2}",
                 expectedFormattedName, expectedValue, Subject);
 
-        Execute.Assertion
-            .ForCondition(attribute.Value == expectedValue)
-            .BecauseOf(because, becauseArgs)
-            .FailWith(
-                "Expected attribute {0} in {context:subject} to have value {1}{reason}, but found {2}.",
-                expectedFormattedName, expectedValue, attribute.Value);
+        if (success)
+        {
+            Execute.Assertion
+                .ForCondition(attribute.Value == expectedValue)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected attribute {0} in {context:subject} to have value {1}{reason}, but found {2}.",
+                    expectedFormattedName, expectedValue, attribute.Value);
+        }
 
         return new AndConstraint<XmlElementAssertions>(this);
     }

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -476,7 +477,11 @@ public class DataRowSpecs : DataSpecs
             .ToArray();
 
         // Act
-        Action act = () => actual.Should().HaveColumns(subsetOfColumnNames);
+        Action act = () =>
+        {
+            using var _ = new AssertionScope();
+            actual.Should().HaveColumns(subsetOfColumnNames);
+        };
 
         // Assert
         act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataSetSpecs.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -684,7 +685,11 @@ public class DataSetSpecs : DataSpecs
         var correctTableCount = -1;
 
         // Act
-        Action act = () => dataSet.Should().HaveTableCount(correctTableCount);
+        Action act = () =>
+        {
+            using var _ = new AssertionScope();
+            dataSet.Should().HaveTableCount(correctTableCount);
+        };
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -777,7 +782,11 @@ public class DataSetSpecs : DataSpecs
             .Select(table => table.TableName);
 
         // Act
-        Action act = () => actual.Should().HaveTables(existingTableNames);
+        Action act = () =>
+        {
+            using var _ = new AssertionScope();
+            actual.Should().HaveTables(existingTableNames);
+        };
 
         // Assert
         act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Globalization;
 using System.Linq;
 using FluentAssertions.Data;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -806,7 +807,11 @@ public class DataTableSpecs : DataSpecs
         int correctRowCount = -1;
 
         // Act
-        Action act = () => dataTable.Should().HaveRowCount(correctRowCount);
+        Action act = () =>
+        {
+            using var _ = new AssertionScope();
+            dataTable.Should().HaveRowCount(correctRowCount);
+        };
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -919,7 +924,11 @@ public class DataTableSpecs : DataSpecs
         var existingColumnName = "Does not matter";
 
         // Act
-        Action act = () => actual.Should().HaveColumns(existingColumnName);
+        Action act = () =>
+        {
+            using var _ = new AssertionScope();
+            actual.Should().HaveColumns(existingColumnName);
+        };
 
         // Assert
         act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -1094,7 +1094,10 @@ public class GenericDictionaryAssertionSpecs
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 dictionary1.Should().Equal(dictionary2, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1247,8 +1250,11 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act =
-                () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                dictionary1.Should().NotEqual(dictionary2, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1401,6 +1407,24 @@ public class GenericDictionaryAssertionSpecs
         }
 
         [Fact]
+        public void Null_dictionaries_do_not_contain_any_keys()
+        {
+            // Arrange
+            Dictionary<int, string> dictionary = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                dictionary.Should().ContainKeys(new[] { 2, 3 }, "because {0}", "we do");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dictionary to contain keys {2, 3} because we do, but found <null>.");
+        }
+
+        [Fact]
         public void
             When_the_contents_of_a_dictionary_are_checked_against_an_empty_list_of_keys_it_should_throw_clear_explanation()
         {
@@ -1481,8 +1505,11 @@ public class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should()
-                .NotContainKey(1, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                dictionary.Should().NotContainKey(1, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1523,6 +1550,24 @@ public class GenericDictionaryAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain key 2 because we do.");
+        }
+
+        [Fact]
+        public void Null_dictionaries_do_not_contain_any_keys()
+        {
+            // Arrange
+            Dictionary<int, string> dictionary = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                dictionary.Should().NotContainKeys(new[] { 2 }, "because {0}", "we do");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dictionary to not contain keys {2} because we do, but found <null>.");
         }
 
         [Fact]
@@ -1650,6 +1695,24 @@ public class GenericDictionaryAssertionSpecs
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Null_dictionaries_do_not_contain_any_values()
+        {
+            // Arrange
+            Dictionary<int, string> dictionary = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                dictionary.Should().ContainValue("One", "because {0}", "we do");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected dictionary to contain values {\"One\"} because we do, but found <null>.");
         }
 
         [Fact]
@@ -1830,8 +1893,11 @@ public class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should()
-                .NotContainValue("One", "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                dictionary.Should().NotContainValue("One", "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1908,6 +1974,24 @@ public class GenericDictionaryAssertionSpecs
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
                 "Cannot verify value containment with an empty sequence*");
+        }
+
+        [Fact]
+        public void Null_dictionaries_do_not_contain_any_values()
+        {
+            // Arrange
+            Dictionary<int, string> dictionary = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                dictionary.Should().NotContainValues(new[] { "Two", "Three" }, "because {0}", "we do");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dictionary to not contain values {\"Two\", \"Three\"} because we do, but found <null>.");
         }
     }
 
@@ -2081,8 +2165,11 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().Contain(keyValuePairs,
-                "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                dictionary.Should().Contain(keyValuePairs, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -2280,8 +2367,11 @@ public class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().Contain(1, "One",
-                "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                dictionary.Should().Contain(1, "One", "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -2462,8 +2552,11 @@ public class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContain(keyValuePairs,
-                "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                dictionary.Should().NotContain(keyValuePairs, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -2662,8 +2755,11 @@ public class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().NotContain(1, "One",
-                "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                dictionary.Should().NotContain(1, "One", "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Linq;
 using FluentAssertions.Events;
+using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using FluentAssertions.Formatting;
 using Xunit;
@@ -507,7 +508,11 @@ public class EventAssertionSpecs
             using var monitor = subject.Monitor();
 
             // Act
-            Action act = () => monitor.Should().RaisePropertyChangeFor(null);
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                monitor.Should().RaisePropertyChangeFor(null);
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -1151,7 +1151,11 @@ public class XDocumentAssertionSpecs
             XDocument document = new();
 
             // Act
-            Action act = () => document.Should().HaveElement("unknown");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                document.Should().HaveElement("unknown");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -916,7 +916,10 @@ public class XElementAssertionSpecs
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 theElement.Should().HaveAttribute("age", "36", "because we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Xml;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -224,8 +225,11 @@ public class XmlElementAssertionSpecs
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 theElement.Should().HaveAttributeWithNamespace("age", "http://www.example.com/2012/test", "36",
                     "because we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's new
 
 ### Fixes
+* Improved robustness of several assertions when they're wrapped in an `AssertionScope` - [#2133](https://github.com/fluentassertions/fluentassertions/pull/2133)
 
 ## 6.10.0
 


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

Found a few places, where we would throw an NRE if the assertion was wrapped in an `AssertionScope`.