### PR TITLE
Add missing xml docs for parameters

### DIFF
--- a/Src/FluentAssertions/DataColumnCollectionAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataColumnCollectionAssertionExtensions.cs
@@ -12,6 +12,7 @@ public static class DataColumnCollectionAssertionExtensions
     /// <summary>
     /// Asserts that an object reference refers to the exact same object as another object reference.
     /// </summary>
+    /// <param name="assertion">The <see cref="GenericCollectionAssertions{T}"/> object that is being extended.</param>
     /// <param name="expected">The expected object</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -56,6 +57,7 @@ public static class DataColumnCollectionAssertionExtensions
     /// <summary>
     /// Asserts that an object reference refers to a different object than another object reference refers to.
     /// </summary>
+    /// <param name="assertion">The <see cref="GenericCollectionAssertions{T}"/> object that is being extended.</param>
     /// <param name="unexpected">The unexpected object</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -98,6 +100,7 @@ public static class DataColumnCollectionAssertionExtensions
     /// <summary>
     /// Assert that the current collection has the same number of elements as <paramref name="otherCollection" />.
     /// </summary>
+    /// <param name="assertion">The <see cref="GenericCollectionAssertions{T}"/> object that is being extended.</param>
     /// <param name="otherCollection">The other collection with the same expected number of elements</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -134,6 +137,7 @@ public static class DataColumnCollectionAssertionExtensions
     /// Assert that the current collection of <see cref="DataColumn"/>s does not have the same number of columns as
     /// <paramref name="otherCollection" />.
     /// </summary>
+    /// <param name="assertion">The <see cref="GenericCollectionAssertions{T}"/> object that is being extended.</param>
     /// <param name="otherCollection">The other <see cref="DataColumnCollection"/> with the unexpected number of
     /// elements</param>
     /// <param name="because">

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -112,8 +112,9 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
     }
 
     /// <summary>
-    /// Asserts that the thrown exception contains an inner exception of type <param name="innerException" />.
+    /// Asserts that the thrown exception contains an inner exception of type <paramref name="innerException" />.
     /// </summary>
+    /// <param name="innerException">The expected type of the inner exception.</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -147,8 +148,9 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
     }
 
     /// <summary>
-    /// Asserts that the thrown exception contains an inner exception of the exact type <param name="innerException" /> (and not a derived exception type).
+    /// Asserts that the thrown exception contains an inner exception of the exact type <paramref name="innerException" /> (and not a derived exception type).
     /// </summary>
+    /// <param name="innerException">The expected type of the inner exception.</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome