### PR TITLE
Make Excluding() work on nested collections if root is a collection

### DIFF
--- a/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByPathSelectionRule.cs
@@ -11,7 +11,6 @@ internal class ExcludeMemberByPathSelectionRule : SelectMemberByPathSelectionRul
     private MemberPath memberToExclude;
 
     public ExcludeMemberByPathSelectionRule(MemberPath pathToExclude)
-        : base(pathToExclude.ToString())
     {
         memberToExclude = pathToExclude;
     }
@@ -26,7 +25,6 @@ internal class ExcludeMemberByPathSelectionRule : SelectMemberByPathSelectionRul
     public void AppendPath(MemberPath nextPath)
     {
         memberToExclude = memberToExclude.AsParentCollectionOf(nextPath);
-        SetSelectedPath(memberToExclude.ToString());
     }
 
     public override string ToString()

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
@@ -12,7 +12,6 @@ internal class IncludeMemberByPathSelectionRule : SelectMemberByPathSelectionRul
     private readonly MemberPath memberToInclude;
 
     public IncludeMemberByPathSelectionRule(MemberPath pathToInclude)
-        : base(pathToInclude.ToString())
     {
         memberToInclude = pathToInclude;
     }

--- a/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
@@ -11,7 +11,7 @@ internal abstract class SelectMemberByPathSelectionRule : IMemberSelectionRule
     public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
         MemberSelectionContext context)
     {
-        var currentPath = RemoveIndexQualifiers(currentNode.PathAndName);
+        var currentPath = RemoveRootIndexQualifier(currentNode.PathAndName);
         var members = selectedMembers.ToList();
         AddOrRemoveMembersFrom(members, currentNode, currentPath, context);
 
@@ -22,7 +22,7 @@ internal abstract class SelectMemberByPathSelectionRule : IMemberSelectionRule
         INode parent, string parentPath,
         MemberSelectionContext context);
 
-    private static string RemoveIndexQualifiers(string path)
+    private static string RemoveRootIndexQualifier(string path)
     {
         Match match = new Regex(@"^\[\d+]").Match(path);
 

--- a/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -7,32 +6,12 @@ namespace FluentAssertions.Equivalency.Selection;
 
 internal abstract class SelectMemberByPathSelectionRule : IMemberSelectionRule
 {
-    private string selectedPath;
-
-    protected SelectMemberByPathSelectionRule(string selectedPath)
-    {
-        this.selectedPath = selectedPath;
-    }
-
     public virtual bool IncludesMembers => false;
-
-    protected void SetSelectedPath(string path)
-    {
-        selectedPath = path;
-    }
 
     public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
         MemberSelectionContext context)
     {
-        string currentPath = currentNode.PathAndName;
-
-        // If we're part of a collection comparison, the selected path will not include an index,
-        // so we need to remove it from the current node as well.
-        if (!ContainsIndexingQualifiers(selectedPath))
-        {
-            currentPath = RemoveIndexQualifiers(currentPath);
-        }
-
+        var currentPath = RemoveIndexQualifiers(currentNode.PathAndName);
         var members = selectedMembers.ToList();
         AddOrRemoveMembersFrom(members, currentNode, currentPath, context);
 
@@ -42,11 +21,6 @@ internal abstract class SelectMemberByPathSelectionRule : IMemberSelectionRule
     protected abstract void AddOrRemoveMembersFrom(List<IMember> selectedMembers,
         INode parent, string parentPath,
         MemberSelectionContext context);
-
-    private static bool ContainsIndexingQualifiers(string path)
-    {
-        return path.Contains("[", StringComparison.Ordinal) && path.Contains("]", StringComparison.Ordinal);
-    }
 
     private static string RemoveIndexQualifiers(string path)
     {

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -598,6 +598,57 @@ public class CollectionSpecs
         }
 
         [Fact]
+        public void When_property_in_collection_is_excluded_it_should_not_throw_if_root_is_a_collection()
+        {
+            // Arrange
+            var subject = new
+            {
+                Level = new
+                {
+                    Collection = new[]
+                    {
+                        new
+                        {
+                            Number = 1,
+                            Text = "Text"
+                        },
+                        new
+                        {
+                            Number = 2,
+                            Text = "Actual"
+                        }
+                    }
+                }
+            };
+
+            var expected = new
+            {
+                Level = new
+                {
+                    Collection = new[]
+                    {
+                        new
+                        {
+                            Number = 1,
+                            Text = "Text"
+                        },
+                        new
+                        {
+                            Number = 3,
+                            Text = "Actual"
+                        }
+                    }
+                }
+            };
+
+            // Act / Assert
+            new[] { subject }.Should().BeEquivalentTo(new[] { expected },
+                options => options
+                    .For(x => x.Level.Collection)
+                    .Exclude(x => x.Number));
+        }
+
+        [Fact]
         public void When_collection_in_collection_is_excluded_it_should_not_throw()
         {
             // Arrange

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -15,7 +15,7 @@ sidebar:
 ### Fixes
 * Improved robustness of several assertions when they're wrapped in an `AssertionScope` - [#2133](https://github.com/fluentassertions/fluentassertions/pull/2133)
 
-* Fixed `.Excluding()`, `.For().Exclude()` not working if root is a collection - [#2101](https://github.com/fluentassertions/fluentassertions/pull/2135)
+* Fixed `.Excluding()` and `.For().Exclude()` not working if root is a collection - [#2135](https://github.com/fluentassertions/fluentassertions/pull/2135)
 
 ## 6.10.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,8 @@ sidebar:
 
 ### Fixes
 
+* Fixed `.Excluding()`, `.For().Exclude()` not working if root is a collection - [#2101](https://github.com/fluentassertions/fluentassertions/pull/2135)
+
 ## 6.10.0
 
 ### Fixes


### PR DESCRIPTION
Fixes #1989 #1919

I removed the `!ContainsIndexingQualifiers(selectedPath)` check on this piece of code which was introduced here: https://github.com/fluentassertions/fluentassertions/commit/aab3303a1a227b6c35d66278ed88547dbc58f97a#diff-53539b5c2a4cdb7276ff5e63cbe410a164938d3620ebf08f20797810d22b394c. I am 100% unsure what it does and what the implications are of me removing it. However, there are no failing tests with the condition removed.

```c#
if (!ContainsIndexingQualifiers(selectedPath))  // <-- removed this
{
    currentPath = RemoveIndexQualifiers(currentPath);
}
```

If removing this condition is bad for whatever reason, please tell me which test case I can add to cover this.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome