### PR TITLE
Preparing upgrade of analyzers

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -374,7 +374,7 @@ class Build : NukeBuild
             .Select(x => x.Path)
             .ToArray();
 
-    Repository Repository => new Repository(GitRepository.LocalDirectory);
+    Repository Repository => new(GitRepository.LocalDirectory);
     Tree TargetBranch => Repository.Branches[PullRequestBase].Tip.Tree;
     Tree SourceBranch => Repository.Branches[Repository.Head.FriendlyName].Tip.Tree;
 

--- a/Build/Configuration.cs
+++ b/Build/Configuration.cs
@@ -4,9 +4,9 @@ using Nuke.Common.Tooling;
 [TypeConverter(typeof(TypeConverter<Configuration>))]
 public class Configuration : Enumeration
 {
-    public static Configuration Debug = new Configuration { Value = nameof(Debug) };
-    public static Configuration Release = new Configuration { Value = nameof(Release) };
-    public static Configuration CI = new Configuration { Value = nameof(CI) };
+    public static Configuration Debug = new() { Value = nameof(Debug) };
+    public static Configuration Release = new() { Value = nameof(Release) };
+    public static Configuration CI = new() { Value = nameof(CI) };
 
     public static implicit operator string(Configuration configuration)
     {

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -153,7 +153,7 @@ public static class CallerIdentifier
     private static bool IsDotNet(StackFrame frame)
     {
         var frameNamespace = frame.GetMethod()?.DeclaringType?.Namespace;
-        var comparisonType = StringComparison.OrdinalIgnoreCase;
+        const StringComparison comparisonType = StringComparison.OrdinalIgnoreCase;
 
         return frameNamespace?.StartsWith("system.", comparisonType) == true ||
             frameNamespace?.Equals("system", comparisonType) == true;

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1140,7 +1140,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     {
         Guard.ThrowIfArgumentIsNull(predicate);
 
-        string expectationPrefix =
+        const string expectationPrefix =
             "Expected {context:collection} to contain a single item matching {0}{reason}, ";
 
         bool success = Execute.Assertion

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -71,7 +71,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .FailWith("Expected type to be {0}{reason}, but found {context:the collection} is <null>.",
                 typeof(TExpectation).FullName);
 
-        IEnumerable<TExpectation> matches = new TExpectation[0];
+        IEnumerable<TExpectation> matches = Enumerable.Empty<TExpectation>();
 
         if (success)
         {
@@ -218,7 +218,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .FailWith("Expected type to be {0}{reason}, but found {context:collection} is <null>.",
                 typeof(TExpectation).FullName);
 
-        IEnumerable<TExpectation> matches = new TExpectation[0];
+        IEnumerable<TExpectation> matches = Enumerable.Empty<TExpectation>();
 
         if (success)
         {
@@ -701,7 +701,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .ForCondition(Subject is not null)
             .FailWith("Expected {context:collection} to contain {0}{reason}, but found <null>.", expected);
 
-        IEnumerable<T> matches = new T[0];
+        IEnumerable<T> matches = Enumerable.Empty<T>();
 
         if (success)
         {
@@ -740,7 +740,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .ForCondition(Subject is not null)
             .FailWith("Expected {context:collection} to contain {0}{reason}, but found <null>.", predicate.Body);
 
-        IEnumerable<T> matches = new T[0];
+        IEnumerable<T> matches = Enumerable.Empty<T>();
 
         if (success)
         {
@@ -1148,7 +1148,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .ForCondition(Subject is not null)
             .FailWith(expectationPrefix + "but found <null>.", predicate);
 
-        T[] matches = new T[0];
+        T[] matches = Array.Empty<T>();
 
         if (success)
         {
@@ -2134,7 +2134,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .ForCondition(Subject is not null)
             .FailWith("Expected {context:collection} to not contain {0}{reason}, but found <null>.", unexpected);
 
-        IEnumerable<T> matched = new T[0];
+        IEnumerable<T> matched = Enumerable.Empty<T>();
 
         if (success)
         {

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -401,11 +401,11 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         bool success = Execute.Assertion
             .ForCondition(Subject is not null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:dictionary} to not contain keys {0}{reason}, but found <null>.", unexpected);
+            .FailWith("Expected {context:dictionary} to not contain keys {0}{reason}, but found <null>.", unexpectedKeys);
 
         if (success)
         {
-            IEnumerable<TKey> foundKeys = unexpected.Where(key => ContainsKey(Subject, key));
+            IEnumerable<TKey> foundKeys = unexpectedKeys.Where(key => ContainsKey(Subject, key));
 
             if (foundKeys.Any())
             {
@@ -414,14 +414,14 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:dictionary} {0} to not contain keys {1}{reason}, but found {2}.", Subject,
-                            unexpected, foundKeys);
+                            unexpectedKeys, foundKeys);
                 }
                 else
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:dictionary} {0} to not contain key {1}{reason}.", Subject,
-                            unexpected.First());
+                            unexpectedKeys.First());
                 }
             }
         }

--- a/Src/FluentAssertions/Common/FullFrameworkReflector.cs
+++ b/Src/FluentAssertions/Common/FullFrameworkReflector.cs
@@ -47,11 +47,11 @@ internal class FullFrameworkReflector : IReflector
         }
         catch (FileLoadException)
         {
-            return new Type[0];
+            return Enumerable.Empty<Type>();
         }
         catch (Exception)
         {
-            return new Type[0];
+            return Array.Empty<Type>();
         }
     }
 }

--- a/Src/FluentAssertions/Common/Iterator.cs
+++ b/Src/FluentAssertions/Common/Iterator.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions.Common;
 /// A smarter enumerator that can provide information about the relative location (current, first, last)
 /// of the current item within the collection without unnecessarily iterating the collection.
 /// </summary>
-internal class Iterator<T> : IEnumerator<T>
+internal sealed class Iterator<T> : IEnumerator<T>
 {
     private const int InitialIndex = -1;
     private readonly IEnumerable<T> enumerable;

--- a/Src/FluentAssertions/Common/Services.cs
+++ b/Src/FluentAssertions/Common/Services.cs
@@ -24,12 +24,7 @@ public static class Services
         {
             lock (Lockable)
             {
-                if (configuration is null)
-                {
-                    configuration = new Configuration(ConfigurationStore);
-                }
-
-                return configuration;
+                return configuration ??= new Configuration(ConfigurationStore);
             }
         }
     }

--- a/Src/FluentAssertions/Common/StopwatchTimer.cs
+++ b/Src/FluentAssertions/Common/StopwatchTimer.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 
 namespace FluentAssertions.Common;
 
-internal class StopwatchTimer : ITimer
+internal sealed class StopwatchTimer : ITimer
 {
     private readonly Stopwatch stopwatch;
 

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -447,7 +447,7 @@ internal static class TypeExtensions
             .SingleOrDefault(m => m.GetParameters().Select(p => p.ParameterType).SequenceEqual(parameterTypes));
     }
 
-    public static IEnumerable<MethodInfo> GetConversionOperators(this Type type, Type sourceType, Type targetType,
+    private static IEnumerable<MethodInfo> GetConversionOperators(this Type type, Type sourceType, Type targetType,
         Func<string, bool> predicate)
     {
         return type

--- a/Src/FluentAssertions/Disposable.cs
+++ b/Src/FluentAssertions/Disposable.cs
@@ -2,7 +2,7 @@
 
 namespace FluentAssertions;
 
-internal class Disposable : IDisposable
+internal sealed class Disposable : IDisposable
 {
     private readonly Action action;
 

--- a/Src/FluentAssertions/Equivalency/INode.cs
+++ b/Src/FluentAssertions/Equivalency/INode.cs
@@ -24,7 +24,7 @@ public interface INode
     string Name { get; set; }
 
     /// <summary>
-    /// Gets the type of this node, e.g. the type of the field or property, or the type of the collection item. 
+    /// Gets the type of this node, e.g. the type of the field or property, or the type of the collection item.
     /// </summary>
     Type Type { get; }
 

--- a/Src/FluentAssertions/Equivalency/IObjectInfo.cs
+++ b/Src/FluentAssertions/Equivalency/IObjectInfo.cs
@@ -9,7 +9,7 @@ namespace FluentAssertions.Equivalency;
 public interface IObjectInfo
 {
     /// <summary>
-    /// Gets the type of the object 
+    /// Gets the type of the object
     /// </summary>
     [Obsolete("Use CompileTimeType or RuntimeType instead")]
     Type Type { get; }

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -9,23 +9,23 @@ namespace FluentAssertions.Equivalency.Matching;
 /// </summary>
 internal class MustMatchByNameRule : IMemberMatchingRule
 {
-    public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions config)
+    public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions options)
     {
         IMember subjectMember = null;
 
-        if (config.IncludedProperties != MemberVisibility.None)
+        if (options.IncludedProperties != MemberVisibility.None)
         {
             PropertyInfo propertyInfo = subject.GetType().FindProperty(expectedMember.Name);
             subjectMember = propertyInfo is not null && !propertyInfo.IsIndexer() ? new Property(propertyInfo, parent) : null;
         }
 
-        if (subjectMember is null && config.IncludedFields != MemberVisibility.None)
+        if (subjectMember is null && options.IncludedFields != MemberVisibility.None)
         {
             FieldInfo fieldInfo = subject.GetType().FindField(expectedMember.Name);
             subjectMember = fieldInfo is not null ? new Field(fieldInfo, parent) : null;
         }
 
-        if ((subjectMember is null || !config.UseRuntimeTyping) && ExpectationImplementsMemberExplicitly(subject, expectedMember))
+        if ((subjectMember is null || !options.UseRuntimeTyping) && ExpectationImplementsMemberExplicitly(subject, expectedMember))
         {
             subjectMember = expectedMember;
         }
@@ -36,7 +36,7 @@ internal class MustMatchByNameRule : IMemberMatchingRule
                 $"Expectation has {expectedMember.Description} that the other object does not have.");
         }
 
-        if (config.IgnoreNonBrowsableOnSubject && !subjectMember.IsBrowsable)
+        if (options.IgnoreNonBrowsableOnSubject && !subjectMember.IsBrowsable)
         {
             Execute.Assertion.FailWith(
                 $"Expectation has {expectedMember.Description} that is non-browsable in the other object, and non-browsable " +

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -40,7 +40,7 @@ internal class MustMatchByNameRule : IMemberMatchingRule
         {
             Execute.Assertion.FailWith(
                 $"Expectation has {expectedMember.Description} that is non-browsable in the other object, and non-browsable " +
-                $"members on the subject are ignored with the current configuration");
+                "members on the subject are ignored with the current configuration");
         }
 
         return subjectMember;

--- a/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions.Equivalency.Matching;
 /// </summary>
 internal class TryMatchByNameRule : IMemberMatchingRule
 {
-    public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions config)
+    public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions options)
     {
         PropertyInfo property = subject.GetType().FindProperty(expectedMember.Name);
 

--- a/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
@@ -40,7 +40,7 @@ internal class PathBasedOrderingRule : IOrderingRule
 
     private static bool ContainsIndexingQualifiers(string path)
     {
-        return path.Contains("[", StringComparison.Ordinal) && path.Contains("]", StringComparison.Ordinal);
+        return path.Contains('[', StringComparison.Ordinal) && path.Contains(']', StringComparison.Ordinal);
     }
 
     private string RemoveInitialIndexQualifier(string sourcePath)

--- a/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
@@ -45,7 +45,7 @@ internal abstract class SelectMemberByPathSelectionRule : IMemberSelectionRule
 
     private static bool ContainsIndexingQualifiers(string path)
     {
-        return path.Contains("[", StringComparison.Ordinal) && path.Contains("]", StringComparison.Ordinal);
+        return path.Contains('[', StringComparison.Ordinal) && path.Contains(']', StringComparison.Ordinal);
     }
 
     private static string RemoveIndexQualifiers(string path)

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -178,31 +178,31 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
 
     public bool? CompareRecordsByValue => compareRecordsByValue;
 
-    EqualityStrategy IEquivalencyAssertionOptions.GetEqualityStrategy(Type requestedType)
+    EqualityStrategy IEquivalencyAssertionOptions.GetEqualityStrategy(Type type)
     {
         // As the valueFactory parameter captures instance members,
         // be aware if the cache must be cleared on mutating the members.
-        return equalityStrategyCache.GetOrAdd(requestedType, type =>
+        return equalityStrategyCache.GetOrAdd(type, typeKey =>
         {
             EqualityStrategy strategy;
 
-            if (!type.IsPrimitive && referenceTypes.Count > 0 && referenceTypes.Any(t => type.IsSameOrInherits(t)))
+            if (!typeKey.IsPrimitive && referenceTypes.Count > 0 && referenceTypes.Any(t => typeKey.IsSameOrInherits(t)))
             {
                 strategy = EqualityStrategy.ForceMembers;
             }
-            else if (valueTypes.Count > 0 && valueTypes.Any(t => type.IsSameOrInherits(t)))
+            else if (valueTypes.Count > 0 && valueTypes.Any(t => typeKey.IsSameOrInherits(t)))
             {
                 strategy = EqualityStrategy.ForceEquals;
             }
-            else if (!type.IsPrimitive && referenceTypes.Count > 0 && referenceTypes.Any(t => type.IsAssignableToOpenGeneric(t)))
+            else if (!typeKey.IsPrimitive && referenceTypes.Count > 0 && referenceTypes.Any(t => typeKey.IsAssignableToOpenGeneric(t)))
             {
                 strategy = EqualityStrategy.ForceMembers;
             }
-            else if (valueTypes.Count > 0 && valueTypes.Any(t => type.IsAssignableToOpenGeneric(t)))
+            else if (valueTypes.Count > 0 && valueTypes.Any(t => typeKey.IsAssignableToOpenGeneric(t)))
             {
                 strategy = EqualityStrategy.ForceEquals;
             }
-            else if ((compareRecordsByValue.HasValue || getDefaultEqualityStrategy is null) && type.IsRecord())
+            else if ((compareRecordsByValue.HasValue || getDefaultEqualityStrategy is null) && typeKey.IsRecord())
             {
                 strategy = compareRecordsByValue is true ? EqualityStrategy.ForceEquals : EqualityStrategy.ForceMembers;
             }
@@ -210,11 +210,11 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
             {
                 if (getDefaultEqualityStrategy is not null)
                 {
-                    strategy = getDefaultEqualityStrategy(type);
+                    strategy = getDefaultEqualityStrategy(typeKey);
                 }
                 else
                 {
-                    strategy = type.HasValueSemantics() ? EqualityStrategy.Equals : EqualityStrategy.Members;
+                    strategy = typeKey.HasValueSemantics() ? EqualityStrategy.Equals : EqualityStrategy.Members;
                 }
             }
 

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -613,7 +613,7 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
     }
 
     /// <summary>
-    /// Ensures records by default are compared by their members even though they override 
+    /// Ensures records by default are compared by their members even though they override
     /// the <see cref="object.Equals(object)" /> method.
     /// </summary>
     /// <remarks>

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -64,7 +64,7 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
 
     #endregion
 
-    internal SelfReferenceEquivalencyAssertionOptions()
+    private protected SelfReferenceEquivalencyAssertionOptions()
     {
         AddMatchingRule(new MustMatchByNameRule());
 

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionResultSet.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionResultSet.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions.Execution;
@@ -32,7 +33,7 @@ internal class AssertionResultSet
     {
         if (ContainsSuccessfulSet())
         {
-            return new string[0];
+            return Array.Empty<string>();
         }
 
         KeyValuePair<object, string[]>[] bestResultSets = GetBestResultSets();

--- a/Src/FluentAssertions/Equivalency/Steps/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRowEquivalencyStep.cs
@@ -195,9 +195,9 @@ public class DataRowEquivalencyStep : EquivalencyStep<DataRow>
     {
         var cacheKey = (comparands.CompileTimeType, comparands.RuntimeType, config);
 
-        if (!SelectedMembersCache.TryGetValue(cacheKey, out SelectedDataRowMembers selectedMembers))
+        if (!SelectedMembersCache.TryGetValue(cacheKey, out SelectedDataRowMembers selectedDataRowMembers))
         {
-            var members = Enumerable.Empty<IMember>();
+            IEnumerable<IMember> members = Enumerable.Empty<IMember>();
 
             foreach (IMemberSelectionRule rule in config.SelectionRules)
             {
@@ -205,15 +205,17 @@ public class DataRowEquivalencyStep : EquivalencyStep<DataRow>
                     new MemberSelectionContext(comparands.CompileTimeType, comparands.RuntimeType, config));
             }
 
-            selectedMembers = new SelectedDataRowMembers
+            IMember[] selectedMembers = members.ToArray();
+
+            selectedDataRowMembers = new SelectedDataRowMembers
             {
-                HasErrors = members.Any(m => m.Name == nameof(DataRow.HasErrors)),
-                RowState = members.Any(m => m.Name == nameof(DataRow.RowState))
+                HasErrors = selectedMembers.Any(m => m.Name == nameof(DataRow.HasErrors)),
+                RowState = selectedMembers.Any(m => m.Name == nameof(DataRow.RowState))
             };
 
-            SelectedMembersCache.TryAdd(cacheKey, selectedMembers);
+            SelectedMembersCache.TryAdd(cacheKey, selectedDataRowMembers);
         }
 
-        return selectedMembers;
+        return selectedDataRowMembers;
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -100,7 +100,7 @@ internal class DictionaryInterfaceInfo
         {
             if (Type.GetTypeCode(key) != TypeCode.Object)
             {
-                return new DictionaryInterfaceInfo[0];
+                return Array.Empty<DictionaryInterfaceInfo>();
             }
             else
             {

--- a/Src/FluentAssertions/Events/EventMonitor.cs
+++ b/Src/FluentAssertions/Events/EventMonitor.cs
@@ -12,7 +12,7 @@ namespace FluentAssertions.Events;
 /// <summary>
 /// Tracks the events an object raises.
 /// </summary>
-internal class EventMonitor<T> : IMonitor<T>
+internal sealed class EventMonitor<T> : IMonitor<T>
 {
     private readonly WeakReference subject;
 

--- a/Src/FluentAssertions/Events/EventRecorder.cs
+++ b/Src/FluentAssertions/Events/EventRecorder.cs
@@ -65,9 +65,10 @@ internal sealed class EventRecorder : IEventRecording, IDisposable
 
     public void Dispose()
     {
-        if (cleanup is not null)
+        Action localCleanup = cleanup;
+        if (localCleanup is not null)
         {
-            cleanup?.Invoke();
+            localCleanup();
             cleanup = null;
             EventObject = null;
             raisedEvents.Dispose();

--- a/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
@@ -34,7 +34,7 @@ internal class CollectingAssertionStrategy : IAssertionStrategy
         if (failureMessages.Any())
         {
             var builder = new StringBuilder();
-            builder.AppendLine(string.Join(Environment.NewLine, failureMessages));
+            builder.AppendJoin(Environment.NewLine, failureMessages).AppendLine();
 
             if (context.Any())
             {

--- a/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using FluentAssertions.Common;
 
@@ -12,7 +13,7 @@ internal class DefaultAssertionStrategy : IAssertionStrategy
     {
         get
         {
-            return new string[0];
+            return Array.Empty<string>();
         }
     }
 
@@ -29,7 +30,7 @@ internal class DefaultAssertionStrategy : IAssertionStrategy
     /// </summary>
     public IEnumerable<string> DiscardFailures()
     {
-        return new string[0];
+        return Array.Empty<string>();
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -62,7 +62,7 @@ public class GivenSelector<T>
     /// <inheritdoc cref="IAssertionScope.FailWith(string)"/>
     public ContinuationOfGiven<T> FailWith(string message)
     {
-        return FailWith(message, new object[0]);
+        return FailWith(message, Array.Empty<object>());
     }
 
     /// <remarks>

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -512,7 +512,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
                 .ForConstraint(occurrenceConstraint, actual)
                 .UsingLineBreaks
                 .BecauseOf(because, becauseArgs)
-                .FailWith($"Expected {{context:string}} {{0}} to match regex {{1}} {{expectedOccurrence}}{{reason}}, " +
+                .FailWith("Expected {context:string} {0} to match regex {1} {expectedOccurrence}{reason}, " +
                     $"but found it {actual.Times()}.",
                     Subject, regexStr);
         }

--- a/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
@@ -205,7 +205,7 @@ public class TimeOnlyAssertions<TAssertions>
             .ForCondition(Subject is not null)
             .FailWith("but found <null>.")
             .Then
-            .ForCondition(!Subject?.IsCloseTo(distantTime, precision) == true)
+            .ForCondition(Subject?.IsCloseTo(distantTime, precision) == false)
             .FailWith("but it was {0}.", Subject)
             .Then
             .ClearExpectation();

--- a/Src/FluentAssertions/Specialized/FunctionAssertionHelpers.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertionHelpers.cs
@@ -15,7 +15,6 @@ internal static class FunctionAssertionHelpers
         catch (Exception exception)
         {
             Execute.Assertion
-                .ForCondition(exception is null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect any exception{reason}, but found {0}.", exception);
 

--- a/Src/FluentAssertions/StringBuilderExtensions.cs
+++ b/Src/FluentAssertions/StringBuilderExtensions.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Since net6.0 StringBuilder has additional overloads taking an AppendInterpolatedStringHandler
 /// and optionally an IFormatProvider.
-/// The overload here is polyfill for older target frameworks to avoid littering the code base with #ifs 
+/// The overload here is polyfill for older target frameworks to avoid littering the code base with #ifs
 /// in order to silence analyzers about dependending on the current culture instead of an invariant culture.
 /// </summary>
 internal static class StringBuilderExtensions

--- a/Src/FluentAssertions/StringBuilderExtensions.cs
+++ b/Src/FluentAssertions/StringBuilderExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace System.Text;
+﻿using System.Collections.Generic;
+
+namespace System.Text;
 
 /// <summary>
 /// Since net6.0 StringBuilder has additional overloads taking an AppendInterpolatedStringHandler
@@ -10,4 +12,9 @@ internal static class StringBuilderExtensions
 {
     public static StringBuilder AppendLine(this StringBuilder stringBuilder, IFormatProvider _, string value) =>
         stringBuilder.AppendLine(value);
+
+#if NET47 || NETSTANDARD2_0
+    public static StringBuilder AppendJoin<T>(this StringBuilder stringBuilder, string separator, IEnumerable<T> values) =>
+        stringBuilder.Append(string.Join(Environment.NewLine, values));
+#endif
 }

--- a/Src/FluentAssertions/Types/MemberInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MemberInfoAssertions.cs
@@ -84,7 +84,7 @@ public abstract class MemberInfoAssertions<TSubject, TAssertions> : ReferenceTyp
             .ForCondition(Subject is not null)
             .FailWith(
                 $"Expected {Identifier} to be decorated with {typeof(TAttribute)}{{reason}}" +
-                $", but {{context:member}} is <null>.");
+                ", but {context:member} is <null>.");
 
         IEnumerable<TAttribute> attributes = new TAttribute[0];
 
@@ -97,7 +97,7 @@ public abstract class MemberInfoAssertions<TSubject, TAssertions> : ReferenceTyp
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     $"Expected {Identifier} {SubjectDescription} to be decorated with {typeof(TAttribute)}{{reason}}" +
-                    $", but that attribute was not found.");
+                    ", but that attribute was not found.");
         }
 
         return new AndWhichConstraint<MemberInfoAssertions<TSubject, TAssertions>, TAttribute>(this, attributes);
@@ -130,7 +130,7 @@ public abstract class MemberInfoAssertions<TSubject, TAssertions> : ReferenceTyp
             .ForCondition(Subject is not null)
             .FailWith(
                 $"Expected {Identifier} to not be decorated with {typeof(TAttribute)}{{reason}}" +
-                $", but {{context:member}} is <null>.");
+                ", but {context:member} is <null>.");
 
         if (success)
         {
@@ -141,7 +141,7 @@ public abstract class MemberInfoAssertions<TSubject, TAssertions> : ReferenceTyp
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     $"Expected {Identifier} {SubjectDescription} to not be decorated with {typeof(TAttribute)}{{reason}}" +
-                    $", but that attribute was found.");
+                    ", but that attribute was found.");
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Types/MemberInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MemberInfoAssertions.cs
@@ -86,7 +86,7 @@ public abstract class MemberInfoAssertions<TSubject, TAssertions> : ReferenceTyp
                 $"Expected {Identifier} to be decorated with {typeof(TAttribute)}{{reason}}" +
                 ", but {context:member} is <null>.");
 
-        IEnumerable<TAttribute> attributes = new TAttribute[0];
+        IEnumerable<TAttribute> attributes = Array.Empty<TAttribute>();
 
         if (success)
         {

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1457,7 +1457,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveDefaultConstructor(
         string because = "", params object[] becauseArgs)
     {
-        return HaveConstructor(new Type[0], because, becauseArgs);
+        return HaveConstructor(Array.Empty<Type>(), because, becauseArgs);
     }
 
     /// <summary>
@@ -1514,7 +1514,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     public AndWhichConstraint<TypeAssertions, ConstructorInfo> NotHaveDefaultConstructor(
         string because = "", params object[] becauseArgs)
     {
-        return NotHaveConstructor(new Type[0], because, becauseArgs);
+        return NotHaveConstructor(Array.Empty<Type>(), because, becauseArgs);
     }
 
     private static string GetParameterString(IEnumerable<Type> parameterTypes)

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -969,7 +969,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
             .ForCondition(Subject is not null)
             .FailWith(
                 $"Expected {{context:type}} to explicitly implement {interfaceType}.{name}{{reason}}" +
-                $", but {{context:type}} is <null>.");
+                ", but {context:type} is <null>.");
 
         if (success)
         {
@@ -1036,7 +1036,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
             .ForCondition(Subject is not null)
             .FailWith(
                 $"Expected {{context:type}} to not explicitly implement {interfaceType}.{name}{{reason}}" +
-                $", but {{context:type}} is <null>.");
+                ", but {context:type} is <null>.");
 
         if (success)
         {
@@ -1049,7 +1049,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                 .ForCondition(!explicitlyImplementsProperty)
                 .FailWith(
                     $"Expected {Subject} to not explicitly implement {interfaceType}.{name}{{reason}}" +
-                    $", but it does.");
+                    ", but it does.");
         }
 
         return new AndConstraint<TypeAssertions>(this);
@@ -1249,7 +1249,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
             .ForCondition(Subject is not null)
             .FailWith(
                 $"Expected {indexerType.Name} {{context:type}}[{GetParameterString(parameterTypes)}] to exist{{reason}}" +
-                $", but {{context:type}} is <null>.");
+                ", but {context:type} is <null>.");
 
         PropertyInfo propertyInfo = null;
 
@@ -1263,7 +1263,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                 .ForCondition(propertyInfo is not null)
                 .FailWith(
                     $"Expected {indexerType.Name} {Subject}[{GetParameterString(parameterTypes)}] to exist{{reason}}" +
-                    $", but it does not.")
+                    ", but it does not.")
                 .Then
                 .ForCondition(propertyInfo.PropertyType == indexerType)
                 .FailWith($"Expected {propertyInfoDescription} to be of type {indexerType}{{reason}}, but it is not.");
@@ -1295,7 +1295,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
             .ForCondition(Subject is not null)
             .FailWith(
                 $"Expected indexer {{context:type}}[{GetParameterString(parameterTypes)}] to not exist{{reason}}" +
-                $", but {{context:type}} is <null>.");
+                ", but {context:type} is <null>.");
 
         if (success)
         {
@@ -1306,7 +1306,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                 .ForCondition(propertyInfo is null)
                 .FailWith(
                     $"Expected indexer {Subject}[{GetParameterString(parameterTypes)}] to not exist{{reason}}" +
-                    $", but it does.");
+                    ", but it does.");
         }
 
         return new AndConstraint<TypeAssertions>(this);
@@ -1339,7 +1339,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
             .ForCondition(Subject is not null)
             .FailWith(
                 $"Expected method {{context:type}}.{name}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
-                $", but {{context:type}} is <null>.");
+                ", but {context:type} is <null>.");
 
         MethodInfo methodInfo = null;
 
@@ -1352,7 +1352,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                 .ForCondition(methodInfo is not null)
                 .FailWith(
                     $"Expected method {Subject}.{name}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
-                    $", but it does not.");
+                    ", but it does not.");
         }
 
         return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
@@ -1385,7 +1385,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
             .ForCondition(Subject is not null)
             .FailWith(
                 $"Expected method {{context:type}}.{name}({GetParameterString(parameterTypes)}) to not exist{{reason}}" +
-                $", but {{context:type}} is <null>.");
+                ", but {context:type} is <null>.");
 
         if (success)
         {
@@ -1397,7 +1397,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                 .ForCondition(methodInfo is null)
                 .FailWith(
                     $"Expected method {methodInfoDescription}({GetParameterString(parameterTypes)}) to not exist{{reason}}" +
-                    $", but it does.");
+                    ", but it does.");
         }
 
         return new AndConstraint<TypeAssertions>(this);
@@ -1425,7 +1425,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
             .ForCondition(Subject is not null)
             .FailWith(
                 $"Expected constructor {{context:type}}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
-                $", but {{context:type}} is <null>.");
+                ", but {context:type} is <null>.");
 
         ConstructorInfo constructorInfo = null;
 
@@ -1438,7 +1438,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                 .ForCondition(constructorInfo is not null)
                 .FailWith(
                     $"Expected constructor {Subject}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
-                    $", but it does not.");
+                    ", but it does not.");
         }
 
         return new AndWhichConstraint<TypeAssertions, ConstructorInfo>(this, constructorInfo);
@@ -1482,7 +1482,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
             .ForCondition(Subject is not null)
             .FailWith(
                 $"Expected constructor {{context:type}}({GetParameterString(parameterTypes)}) not to exist{{reason}}" +
-                $", but {{context:type}} is <null>.");
+                ", but {context:type} is <null>.");
 
         ConstructorInfo constructorInfo = null;
 
@@ -1495,7 +1495,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                 .ForCondition(constructorInfo is null)
                 .FailWith(
                     $"Expected constructor {Subject}({GetParameterString(parameterTypes)}) not to exist{{reason}}" +
-                    $", but it does.");
+                    ", but it does.");
         }
 
         return new AndWhichConstraint<TypeAssertions, ConstructorInfo>(this, constructorInfo);

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -330,7 +330,7 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
                     .ForConstraint(occurrenceConstraint, actual)
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
-                        $"Expected {{context:subject}} to have a root element containing a child {{0}} " +
+                        "Expected {context:subject} to have a root element containing a child {0} " +
                         $"{{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
                         expected.ToString());
             }

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -338,7 +338,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
                 .ForConstraint(occurrenceConstraint, actual)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
-                    $"Expected {{context:subject}} to have an element {{0}} {{expectedOccurrence}}" +
+                    "Expected {context:subject} to have an element {0} {expectedOccurrence}" +
                     $"{{reason}}, but found it {actual.Times()}.",
                     expected.ToString());
         }

--- a/Tests/Approval.Tests/ApiApproval.cs
+++ b/Tests/Approval.Tests/ApiApproval.cs
@@ -67,6 +67,7 @@ public class ApiApproval
                     // omit unchanged files
                     continue;
             }
+
             builder.AppendLine(line.Text);
         }
 

--- a/Tests/Benchmarks/Program.cs
+++ b/Tests/Benchmarks/Program.cs
@@ -17,9 +17,9 @@ internal static class Program
             new SummaryStyle(
                 cultureInfo: CultureInfo.GetCultureInfo("nl-NL"),
                 printUnitsInHeader: true,
-                printUnitsInContent: false,
+                sizeUnit: SizeUnit.KB,
                 timeUnit: TimeUnit.Microsecond,
-                sizeUnit: SizeUnit.KB
+                printUnitsInContent: false
             ));
 
         var config = ManualConfig.CreateMinimumViable().AddExporter(exporter);

--- a/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
+++ b/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
@@ -91,98 +91,60 @@ public class UsersOfGetClosedGenericInterfaces
         dictionaryStep = new GenericDictionaryEquivalencyStep();
         enumerableStep = new GenericEnumerableEquivalencyStep();
 
-        values = new object[ValueCount];
-
-        var faker = new Faker();
-
-        faker.Random = new Randomizer(localSeed: 1);
-
-        for (int i = 0; i < values.Length; i++)
+        var faker = new Faker
         {
-            switch (Type.GetTypeCode(DataType))
-            {
-                case TypeCode.DBNull:
-                    values[i] = DBNull.Value;
-                    break;
-                case TypeCode.Boolean:
-                    values[i] = faker.Random.Bool();
-                    break;
-                case TypeCode.Char:
-                    values[i] = faker.Lorem.Letter().Single();
-                    break;
-                case TypeCode.SByte:
-                    values[i] = faker.Random.SByte();
-                    break;
-                case TypeCode.Byte:
-                    values[i] = faker.Random.Byte();
-                    break;
-                case TypeCode.Int16:
-                    values[i] = faker.Random.Short();
-                    break;
-                case TypeCode.UInt16:
-                    values[i] = faker.Random.UShort();
-                    break;
-                case TypeCode.Int32:
-                    values[i] = faker.Random.Int();
-                    break;
-                case TypeCode.UInt32:
-                    values[i] = faker.Random.UInt();
-                    break;
-                case TypeCode.Int64:
-                    values[i] = faker.Random.Long();
-                    break;
-                case TypeCode.UInt64:
-                    values[i] = faker.Random.ULong();
-                    break;
-                case TypeCode.Single:
-                    values[i] = faker.Random.Float();
-                    break;
-                case TypeCode.Double:
-                    values[i] = faker.Random.Double();
-                    break;
-                case TypeCode.Decimal:
-                    values[i] = faker.Random.Decimal();
-                    break;
-                case TypeCode.DateTime:
-                    values[i] = faker.Date.Between(DateTime.UtcNow.AddDays(-30), DateTime.UtcNow.AddDays(+30));
-                    break;
-                case TypeCode.String:
-                    values[i] = faker.Lorem.Lines(1);
-                    break;
+            Random = new Randomizer(localSeed: 1)
+        };
 
-                default:
-                {
-                    if (DataType == typeof(TimeSpan))
-                    {
-                        values[i] = faker.Date.Future() - faker.Date.Future();
-                    }
-                    else if (DataType == typeof(Guid))
-                    {
-                        values[i] = faker.Random.Guid();
-                    }
-                    else if (DataType == typeof(Dictionary<int, int>))
-                    {
-                        values[i] = new Dictionary<int, int>
-                            { { faker.Random.Int(), faker.Random.Int() } };
-                    }
-                    else if (DataType == typeof(IEnumerable<int>))
-                    {
-                        values[i] = new[] { faker.Random.Int(), faker.Random.Int() };
-                    }
-                    else
-                    {
-                        throw new Exception("Unable to populate data of type " + DataType);
-                    }
-
-                    break;
-                }
-            }
-        }
+        values = Enumerable.Range(0, ValueCount).Select(_ => CreateValue(faker)).ToArray();
 
         context = new Context
         {
             Options = new Config()
         };
+    }
+
+    private object CreateValue(Faker faker) => Type.GetTypeCode(DataType) switch
+    {
+        TypeCode.DBNull => DBNull.Value,
+        TypeCode.Boolean => faker.Random.Bool(),
+        TypeCode.Char => faker.Lorem.Letter().Single(),
+        TypeCode.SByte => faker.Random.SByte(),
+        TypeCode.Byte => faker.Random.Byte(),
+        TypeCode.Int16 => faker.Random.Short(),
+        TypeCode.UInt16 => faker.Random.UShort(),
+        TypeCode.Int32 => faker.Random.Int(),
+        TypeCode.UInt32 => faker.Random.UInt(),
+        TypeCode.Int64 => faker.Random.Long(),
+        TypeCode.UInt64 => faker.Random.ULong(),
+        TypeCode.Single => faker.Random.Float(),
+        TypeCode.Double => faker.Random.Double(),
+        TypeCode.Decimal => faker.Random.Decimal(),
+        TypeCode.DateTime => faker.Date.Between(DateTime.UtcNow.AddDays(-30), DateTime.UtcNow.AddDays(+30)),
+        TypeCode.String => faker.Lorem.Lines(1),
+        _ => CustomValue(faker),
+    };
+
+    private object CustomValue(Faker faker)
+    {
+        if (DataType == typeof(TimeSpan))
+        {
+            return faker.Date.Future() - faker.Date.Future();
+        }
+        else if (DataType == typeof(Guid))
+        {
+            return faker.Random.Guid();
+        }
+        else if (DataType == typeof(Dictionary<int, int>))
+        {
+            return new Dictionary<int, int> { { faker.Random.Int(), faker.Random.Int() } };
+        }
+        else if (DataType == typeof(IEnumerable<int>))
+        {
+            return new[] { faker.Random.Int(), faker.Random.Int() };
+        }
+
+        throw new Exception("Unable to populate data of type " + DataType);
     }
 
     [Benchmark]

--- a/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
@@ -124,24 +124,22 @@ public class CyclicReferencesSpecs
         // Arrange
         var actual = new CyclicRoot
         {
-            Text = null
-        };
-
-        actual.Level = new CyclicLevel1
-        {
             Text = null,
-            Root = null
+            Level = new CyclicLevel1
+            {
+                Text = null,
+                Root = null
+            }
         };
 
         var expectation = new CyclicRootDto
         {
-            Text = null
-        };
-
-        expectation.Level = new CyclicLevel1Dto
-        {
             Text = null,
-            Root = null
+            Level = new CyclicLevel1Dto
+            {
+                Text = null,
+                Root = null
+            }
         };
 
         // Act
@@ -157,24 +155,22 @@ public class CyclicReferencesSpecs
         // Arrange
         var actual = new CyclicRootWithValueObject
         {
-            Value = new ValueObject("MyValue")
-        };
-
-        actual.Level = new CyclicLevelWithValueObject
-        {
             Value = new ValueObject("MyValue"),
-            Root = null
+            Level = new CyclicLevelWithValueObject
+            {
+                Value = new ValueObject("MyValue"),
+                Root = null
+            }
         };
 
         var expectation = new CyclicRootWithValueObject
         {
-            Value = new ValueObject("MyValue")
-        };
-
-        expectation.Level = new CyclicLevelWithValueObject
-        {
             Value = new ValueObject("MyValue"),
-            Root = null
+            Level = new CyclicLevelWithValueObject
+            {
+                Value = new ValueObject("MyValue"),
+                Root = null
+            }
         };
 
         // Act

--- a/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
@@ -157,23 +157,23 @@ public class CyclicReferencesSpecs
         // Arrange
         var actual = new CyclicRootWithValueObject
         {
-            Object = new ValueObject("MyValue")
+            Value = new ValueObject("MyValue")
         };
 
         actual.Level = new CyclicLevelWithValueObject
         {
-            Object = new ValueObject("MyValue"),
+            Value = new ValueObject("MyValue"),
             Root = null
         };
 
         var expectation = new CyclicRootWithValueObject
         {
-            Object = new ValueObject("MyValue")
+            Value = new ValueObject("MyValue")
         };
 
         expectation.Level = new CyclicLevelWithValueObject
         {
-            Object = new ValueObject("MyValue"),
+            Value = new ValueObject("MyValue"),
             Root = null
         };
 

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -372,7 +372,7 @@ public class DataRowSpecs : DataSpecs
     [Fact]
     public void Any_type_is_not_equivalent_to_data_row_colletion()
     {
-        // Arrange 
+        // Arrange
         var o = new object();
 
         // Act

--- a/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataRowSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using FluentAssertions.Execution;
@@ -518,10 +517,7 @@ public class DataRowSpecs : DataSpecs
 
         var dataRow = dataSet.TypedDataTable1[0];
 
-        var columnNames = new List<string>();
-
-        columnNames.Add("Unicorn");
-        columnNames.Add("Dragon");
+        var columnNames = new[] { "Unicorn", "Dragon" };
 
         // Act
         Action action =

--- a/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
@@ -572,7 +572,7 @@ public class CyclicRoot
 
 public class CyclicRootWithValueObject
 {
-    public ValueObject Object { get; set; }
+    public ValueObject Value { get; set; }
 
     public CyclicLevelWithValueObject Level { get; set; }
 }
@@ -606,7 +606,7 @@ public class CyclicLevel1
 
 public class CyclicLevelWithValueObject
 {
-    public ValueObject Object { get; set; }
+    public ValueObject Value { get; set; }
 
     public CyclicRootWithValueObject Root { get; set; }
 }

--- a/Tests/FluentAssertions.Specs/AndWhichConstraintSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AndWhichConstraintSpecs.cs
@@ -14,10 +14,7 @@ public class AndWhichConstraintSpecs
         var continuation = new AndWhichConstraint<StringCollectionAssertions, string>(null, new[] { "hello", "world" });
 
         // Act
-        Action act = () =>
-        {
-            _ = continuation.Which;
-        };
+        Action act = () => _ = continuation.Which;
 
         // Assert
         act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -35,7 +35,7 @@ public class AssertionOptionsSpecs
     {
         public When_injecting_a_null_configurer()
         {
-            When(() => { return () => AssertionOptions.AssertEquivalencyUsing(defaultsConfigurer: null); });
+            When(() => () => AssertionOptions.AssertEquivalencyUsing(defaultsConfigurer: null));
         }
 
         [Fact]
@@ -80,7 +80,7 @@ public class AssertionOptionsSpecs
                 new MyValueType { Value = 1 }.Should().BeEquivalentTo(new MyValueType { Value = 2 });
             });
 
-            When(() => { AssertionOptions.AssertEquivalencyUsing(o => o.ComparingByMembers<MyValueType>()); });
+            When(() => AssertionOptions.AssertEquivalencyUsing(o => o.ComparingByMembers<MyValueType>()));
         }
 
         [Fact]
@@ -113,7 +113,7 @@ public class AssertionOptionsSpecs
                 new MyClass { Value = 1 }.Should().BeEquivalentTo(new MyClass { Value = 1 });
             });
 
-            When(() => { AssertionOptions.AssertEquivalencyUsing(o => o.ComparingByValue<MyClass>()); });
+            When(() => AssertionOptions.AssertEquivalencyUsing(o => o.ComparingByValue<MyClass>()));
         }
 
         [Fact]
@@ -388,7 +388,7 @@ public class AssertionOptionsSpecs
 
         public When_global_formatting_settings_are_modified()
         {
-            Given(() => { oldSettings = AssertionOptions.FormattingOptions.Clone(); });
+            Given(() => oldSettings = AssertionOptions.FormattingOptions.Clone());
 
             When(() =>
             {

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -181,14 +181,14 @@ public partial class CollectionAssertionSpecs
         }
     }
 
-    private class InfiniteEnumerable : IEnumerable<object>
+    private sealed class InfiniteEnumerable : IEnumerable<object>
     {
         public IEnumerator<object> GetEnumerator() => new InfiniteEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
-    private class InfiniteEnumerator : IEnumerator<object>
+    private sealed class InfiniteEnumerator : IEnumerator<object>
     {
         public bool MoveNext() => true;
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -293,7 +293,7 @@ internal class CountingGenericCollection<TElement> : ICollection<TElement>
     public bool IsReadOnly { get; private set; }
 }
 
-internal class TrackingTestEnumerable : IEnumerable<int>
+internal sealed class TrackingTestEnumerable : IEnumerable<int>
 {
     private readonly int[] values;
 
@@ -315,7 +315,7 @@ internal class TrackingTestEnumerable : IEnumerable<int>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }
 
-internal class TrackingEnumerator : IEnumerator<int>
+internal sealed class TrackingEnumerator : IEnumerator<int>
 {
     private readonly int[] values;
     private int index;

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1726,10 +1726,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         IEnumerable<string> collection = new[] { "build succeded", "test failed", "pack failed" };
 
         // Act
-        Action action = () =>
-        {
-            _ = collection.Should().ContainMatch("* failed").Which;
-        };
+        Action action = () => _ = collection.Should().ContainMatch("* failed").Which;
 
         // Assert
         action.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -3011,7 +3011,7 @@ internal class TrackingTestDictionary : IDictionary<int, string>
     }
 }
 
-internal class TrackingDictionaryEnumerator : IEnumerator<KeyValuePair<int, string>>
+internal sealed class TrackingDictionaryEnumerator : IEnumerator<KeyValuePair<int, string>>
 {
     private readonly KeyValuePair<int, string>[] values;
     private int index;

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -912,7 +912,7 @@ public class EventAssertionSpecs
             a.OnEvent(new C());
 
             // Act / Assert
-            IEventRecording filteredEvents = aMonitor.GetRecordingFor(nameof(A.Event)).WithArgs<B>(b => true);
+            IEventRecording filteredEvents = aMonitor.GetRecordingFor(nameof(A.Event)).WithArgs<B>(_ => true);
             filteredEvents.Should().HaveCount(1);
         }
 
@@ -927,7 +927,7 @@ public class EventAssertionSpecs
             a.OnEvent(new C());
 
             // Act
-            Action act = () => aMonitor.GetRecordingFor(nameof(A.Event)).WithArgs<B>(b => true);
+            Action act = () => aMonitor.GetRecordingFor(nameof(A.Event)).WithArgs<B>(_ => true);
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -945,7 +945,7 @@ public class EventAssertionSpecs
             a.OnEvent(new C());
 
             // Act
-            Action act = () => aMonitor.GetRecordingFor(nameof(A.Event)).WithArgs<B>(b => true, b => false);
+            Action act = () => aMonitor.GetRecordingFor(nameof(A.Event)).WithArgs<B>(_ => true, _ => false);
 
             // Assert
             act.Should().Throw<ArgumentException>()
@@ -963,7 +963,7 @@ public class EventAssertionSpecs
             a.OnEvent(new B());
 
             // Act
-            Action act = () => aMonitor.GetRecordingFor(nameof(A.Event)).WithArgs<B>(b => true, b => false);
+            Action act = () => aMonitor.GetRecordingFor(nameof(A.Event)).WithArgs<B>(_ => true, _ => false);
 
             // Assert
             act.Should().Throw<ArgumentException>()

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -272,7 +272,7 @@ namespace FluentAssertions.Specs.Execution
                 if (failureMessages.Any())
                 {
                     var builder = new StringBuilder();
-                    builder.AppendLine(string.Join(Environment.NewLine, failureMessages));
+                    builder.AppendJoin(Environment.NewLine, failureMessages).AppendLine();
 
                     if (context.Any())
                     {

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -240,18 +240,16 @@ namespace FluentAssertions.Specs.Execution
         public void When_nested_scope_is_disposed_it_passes_reports_to_parent_scope()
         {
             // Arrange/Act
-            using (var outerScope = new AssertionScope())
+            using var outerScope = new AssertionScope();
+            outerScope.AddReportable("outerReportable", "foo");
+
+            using (var innerScope = new AssertionScope())
             {
-                outerScope.AddReportable("outerReportable", "foo");
-
-                using (var innerScope = new AssertionScope())
-                {
-                    innerScope.AddReportable("innerReportable", "bar");
-                }
-
-                // Assert
-                outerScope.Get<string>("innerReportable").Should().Be("bar");
+                innerScope.AddReportable("innerReportable", "bar");
             }
+
+            // Assert
+            outerScope.Get<string>("innerReportable").Should().Be("bar");
         }
 
         public class CustomAssertionStrategy : IAssertionStrategy

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -9,6 +9,8 @@ using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
+#pragma warning disable RCS1192, RCS1214 // verbatim string literals and interpolated strings
+
 namespace FluentAssertions.Specs.Execution
 {
     public class CallerIdentifierSpecs
@@ -223,10 +225,12 @@ namespace FluentAssertions.Specs.Execution
             var foo = new Foo();
 
             // Act
+#pragma warning disable format
             Action act = () =>
             {
                 var foo2 = foo; foo2.Should().BeNull();
             };
+#pragma warning restore format
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -1331,7 +1331,7 @@ internal class DummyBaseClass
 {
 }
 
-internal class DummyImplementingClass : DummyBaseClass, IDisposable
+internal sealed class DummyImplementingClass : DummyBaseClass, IDisposable
 {
     public void Dispose()
     {

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
@@ -347,7 +347,9 @@ public partial class StringAssertionSpecs
             string subject = "a";
 
             // Act
+#pragma warning disable RE0001 // Invalid regex pattern
             Action act = () => subject.Should().MatchRegex(".**", Exactly.Times(0));
+#pragma warning restore RE0001 // Invalid regex pattern
 
             // Assert
             act.Should().ThrowExactly<XunitException>()

--- a/Tests/FluentAssertions.Specs/TestTimer.cs
+++ b/Tests/FluentAssertions.Specs/TestTimer.cs
@@ -3,7 +3,7 @@ using FluentAssertions.Common;
 
 namespace FluentAssertions.Specs;
 
-internal class TestTimer : ITimer
+internal sealed class TestTimer : ITimer
 {
     private readonly Func<TimeSpan> getElapsed;
 

--- a/Tests/UWP.Specs/App.xaml.cs
+++ b/Tests/UWP.Specs/App.xaml.cs
@@ -16,7 +16,7 @@ internal sealed partial class App : Application
         Suspending += OnSuspending;
     }
 
-    protected override void OnLaunched(LaunchActivatedEventArgs e)
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
         if (Window.Current.Content is not Frame rootFrame)
         {
@@ -25,7 +25,7 @@ internal sealed partial class App : Application
             Window.Current.Content = rootFrame;
         }
 
-        UnitTestClient.Run(e.Arguments);
+        UnitTestClient.Run(args.Arguments);
     }
 
     private void OnNavigationFailed(object sender, NavigationFailedEventArgs e) =>

--- a/Tests/UWP.Specs/Properties/AssemblyInfo.cs
+++ b/Tests/UWP.Specs/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("UWP.Specs")]


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

I'm working on migrating our code from the now deprecated `Microsoft.CodeAnalysis.FxCopAnalyzers` and into [.NET analyzers](https://learn.microsoft.com/en-gb/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers?view=vs-2019).

This PR focuses on the lowest hanging fruit as the remaining ones might require a discussion about whether we should disable the diagnostics globally or on a case by case basis.