### PR TITLE
Ensured the maximum depth is properly respecting the "official" definition of depth

### DIFF
--- a/FluentAssertions.sln.DotSettings
+++ b/FluentAssertions.sln.DotSettings
@@ -182,4 +182,5 @@ public void When_$scenario$_it_should_$behavior$()&#xD;
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Scope/=C3001E7C0DA78E4487072B7E050D86C5/Type/@EntryValue">InCSharpFile</s:String>
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Scope/=C3001E7C0DA78E4487072B7E050D86C5/CustomProperties/=minimumLanguageVersion/@EntryIndexedValue">2.0</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparands/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=enumerables/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=enumerables/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=inequivalency/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -45,11 +45,11 @@ public class EquivalencyValidator : IEquivalencyValidator
     private static bool ShouldCompareNodesThisDeep(INode currentNode, IEquivalencyAssertionOptions options,
         AssertionScope assertionScope)
     {
-        bool shouldRecurse = options.AllowInfiniteRecursion || currentNode.Depth < MaxDepth;
+        bool shouldRecurse = options.AllowInfiniteRecursion || currentNode.Depth <= MaxDepth;
 
         if (!shouldRecurse)
         {
-            assertionScope.FailWith("The maximum recursion depth was reached.  ");
+            assertionScope.FailWith($"The maximum recursion depth of {MaxDepth} was reached.  ");
         }
 
         return shouldRecurse;

--- a/Src/FluentAssertions/Equivalency/INode.cs
+++ b/Src/FluentAssertions/Equivalency/INode.cs
@@ -56,6 +56,10 @@ public interface INode
     /// <summary>
     /// Gets a zero-based number representing the depth within the object graph
     /// </summary>
+    /// <remarks>
+    /// The root object has a depth of <c>0</c>, the next nested object a depth of <c>1</c>, etc.
+    /// See also <a href="https://www.geeksforgeeks.org/height-and-depth-of-a-node-in-a-binary-tree/">this article</a>
+    /// </remarks>
     int Depth { get; }
 
     /// <summary>

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -10,6 +10,36 @@ namespace FluentAssertions.Equivalency.Specs;
 public class BasicSpecs
 {
     [Fact]
+    public void A_null_configuration_is_invalid()
+    {
+        // Arrange
+        var actual = new { };
+        var expectation = new { };
+
+        // Act
+        Action act = () => actual.Should().BeEquivalentTo(expectation, config: null);
+
+        // Assert
+        act.Should().ThrowExactly<ArgumentNullException>()
+            .WithParameterName("config");
+    }
+
+    [Fact]
+    public void A_null_as_the_configuration_is_not_valid_for_inequivalency_assertions()
+    {
+        // Arrange
+        var actual = new { };
+        var expectation = new { };
+
+        // Act
+        Action act = () => actual.Should().NotBeEquivalentTo(expectation, config: null);
+
+        // Assert
+        act.Should().ThrowExactly<ArgumentNullException>()
+            .WithParameterName("config");
+    }
+
+    [Fact]
     public void When_expectation_is_null_it_should_throw()
     {
         // Arrange

--- a/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
@@ -9,6 +9,31 @@ namespace FluentAssertions.Equivalency.Specs;
 public class CyclicReferencesSpecs
 {
     [Fact]
+    public void Graphs_up_to_the_maximum_depth_are_supported()
+    {
+        // Arrange
+        var actual = new ClassWithFiniteRecursiveProperty(recursiveDepth: 10);
+        var expectation = new ClassWithFiniteRecursiveProperty(recursiveDepth: 10);
+
+        // Act/Assert
+        actual.Should().BeEquivalentTo(expectation);
+    }
+
+    [Fact]
+    public void Graphs_deeper_than_the_maximum_depth_are_not_supported()
+    {
+        // Arrange
+        var actual = new ClassWithFiniteRecursiveProperty(recursiveDepth: 11);
+        var expectation = new ClassWithFiniteRecursiveProperty(recursiveDepth: 11);
+
+        // Act
+        Action act = () => actual.Should().BeEquivalentTo(expectation);
+
+        // Assert
+        act.Should().Throw<XunitException>().WithMessage("*maximum*depth*10*");
+    }
+
+    [Fact]
     public void By_default_cyclic_references_are_not_valid()
     {
         // Arrange

--- a/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
@@ -142,34 +142,6 @@ internal struct StructWithNoMembers
 {
 }
 
-internal class ClassWithInfinitelyRecursiveProperty
-{
-    public ClassWithInfinitelyRecursiveProperty Self
-    {
-        get { return new ClassWithInfinitelyRecursiveProperty(); }
-    }
-}
-
-internal class ClassWithFiniteRecursiveProperty
-{
-    private readonly int depth;
-
-    public ClassWithFiniteRecursiveProperty(int recursiveDepth)
-    {
-        depth = recursiveDepth;
-    }
-
-    public ClassWithFiniteRecursiveProperty Self
-    {
-        get
-        {
-            return depth > 0
-                ? new ClassWithFiniteRecursiveProperty(depth - 1)
-                : null;
-        }
-    }
-}
-
 internal class ClassWithSomeFieldsAndProperties
 {
     public string Field1;

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,6 +16,7 @@ sidebar:
 
 ### Fixes
 * Improved robustness of several assertions when they're wrapped in an `AssertionScope` - [#2133](https://github.com/fluentassertions/fluentassertions/pull/2133)
+* The maximum depth `BeEquivalentTo` uses for recursive comparisons was 9 instead of the expected 10 - [#2145](https://github.com/fluentassertions/fluentassertions/pull/2145)
 
 ## 6.10.0
 


### PR DESCRIPTION
* Renamed some of the cyclic reference detection specs
* Removed two overlapping specs
* Moved two specs which had nothing to do with cyclic reference detection to `BasicSpecs`
* Added specs to properly cover the edge cases for deep object graphs.
* Ensured that the maximum depth is properly respecting the "official" definition of depth

Fixes #1993