### PR TITLE
Use ToString to format exceptions

### DIFF
--- a/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using static System.FormattableString;
 
 namespace FluentAssertions.Formatting;
 
@@ -19,16 +18,6 @@ public class ExceptionValueFormatter : IValueFormatter
 
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
-        var exception = (Exception)value;
-
-        formattedGraph.AddFragment(Invariant($"{exception.GetType().FullName} with message \"{exception.Message}\""));
-
-        if (exception.StackTrace is not null)
-        {
-            foreach (string line in exception.StackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.None))
-            {
-                formattedGraph.AddLine("  " + line);
-            }
-        }
+        formattedGraph.AddFragment(((Exception)value).ToString());
     }
 }

--- a/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
@@ -653,7 +653,7 @@ public class FunctionExceptionAssertionSpecs
         // Assert
         action.Should().Throw<XunitException>()
             .WithMessage(
-                "*Did not expect System.InvalidOperationException because it was so fast, but found System.InvalidOperationException with message*custom message*");
+                "*Did not expect System.InvalidOperationException because it was so fast, but found System.InvalidOperationException: custom message*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Exceptions/NotThrowSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/NotThrowSpecs.cs
@@ -45,7 +45,7 @@ public class NotThrowSpecs
         action
             .Should().Throw<XunitException>().WithMessage(
                 "Did not expect System.ArgumentException because we passed valid arguments, " +
-                "but found*with message \"An exception was forced\"*");
+                "but found System.ArgumentException: An exception was forced*");
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class NotThrowSpecs
         action
             .Should().Throw<XunitException>().WithMessage(
                 "Did not expect any exception because we passed valid arguments, " +
-                "but found System.ArgumentException with message \"An exception was forced\"*");
+                "but found System.ArgumentException: An exception was forced*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -156,6 +156,20 @@ public class FormatterSpecs
     }
 
     [Fact]
+    public void When_an_exception_contains_an_inner_exception_they_should_both_appear_in_the_error_message()
+    {
+        // Arrange
+        Exception subject = new("OuterExceptionMessage", new InvalidOperationException("InnerExceptionMessage"));
+
+        // Act
+        string result = Formatter.ToString(subject);
+
+        // Assert
+        result.Should().Contain("OuterExceptionMessage")
+            .And.Contain("InnerExceptionMessage");
+    }
+
+    [Fact]
     public void When_the_object_is_a_generic_type_without_custom_string_representation_it_should_show_the_properties()
     {
         // Arrange

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -252,7 +252,7 @@ public static class TaskAssertionSpecs
             // Assert
             await action.Should().ThrowAsync<XunitException>().WithMessage(
                 "Expected a <System.InvalidOperationException> to be thrown,"
-                + " but found <System.NotSupportedException>:*with message \"foo\"*");
+                + " but found <System.NotSupportedException>: *foo*");
         }
 
         [Fact]
@@ -440,7 +440,7 @@ public static class TaskAssertionSpecs
             // Assert
             await action.Should().ThrowAsync<XunitException>().WithMessage(
                 "Expected a <System.InvalidOperationException> to be thrown within 100ms,"
-                + " but found <System.NotSupportedException>:*with message \"foo\"*");
+                + " but found <System.NotSupportedException>: *foo*");
         }
 
         [Fact]
@@ -462,7 +462,7 @@ public static class TaskAssertionSpecs
             // Assert
             await action.Should().ThrowAsync<XunitException>().WithMessage(
                 "Expected a <System.InvalidOperationException> to be thrown within 1s,"
-                + " but found <System.NotSupportedException>:*with message \"foo\"*");
+                + " but found <System.NotSupportedException>: *foo*");
         }
     }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's new
 * Added `ThrowWithinAsync` for assertions on `Task` - [#1974](https://github.com/fluentassertions/fluentassertions/pull/1974)
 * Added support for converting integers to enums using `AutoConversion` - [#2147](https://github.com/fluentassertions/fluentassertions/pull/2147)
+* Changed exception formatting to include any inner exception - [#2150](https://github.com/fluentassertions/fluentassertions/pull/2150)
 
 ### Fixes
 * Improved robustness of several assertions when they're wrapped in an `AssertionScope` - [#2133](https://github.com/fluentassertions/fluentassertions/pull/2133)


### PR DESCRIPTION
Fixes #2015 

Also modified some tests so the new formatting matches. It turns out that the current formatting scheme was not as good as simply using ToString.

Formatter before:
```
System.Exception with message "OuterExceptionMessage"
```

After:
```
System.Exception: OuterExceptionMessage
 ---> System.InvalidOperationException: InnerExceptionMessage
   --- End of inner exception stack trace ---
```