### PR TITLE
Add WithoutStrictOrderingFor overload with an expression

### DIFF
--- a/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
@@ -75,6 +75,21 @@ public class EquivalencyAssertionOptions<TExpectation> :
     }
 
     /// <summary>
+    /// Causes the collection identified by <paramref name="expression"/> to be compared in the order
+    /// in which the items appear in the expectation.
+    /// </summary>
+    public EquivalencyAssertionOptions<TExpectation> WithoutStrictOrderingFor(
+        Expression<Func<TExpectation, object>> expression)
+    {
+        string expressionMemberPath = expression.GetMemberPath().ToString();
+        OrderingRules.Add(new PathBasedOrderingRule(expressionMemberPath)
+        {
+            Invert = true
+        });
+        return this;
+    }
+
+    /// <summary>
     /// Creates a new set of options based on the current instance which acts on a a collection of the <typeparamref name="TExpectation"/>.
     /// </summary>
     public EquivalencyAssertionOptions<IEnumerable<TExpectation>> AsCollection()

--- a/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
@@ -75,7 +75,7 @@ public class EquivalencyAssertionOptions<TExpectation> :
     }
 
     /// <summary>
-    /// Causes the collection identified by <paramref name="expression"/> to be compared in the order
+    /// Causes the collection identified by <paramref name="expression"/> to be compared ignoring the order
     /// in which the items appear in the expectation.
     /// </summary>
     public EquivalencyAssertionOptions<TExpectation> WithoutStrictOrderingFor(

--- a/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 namespace FluentAssertions.Equivalency.Ordering;
@@ -62,6 +63,7 @@ internal class PathBasedOrderingRule : IOrderingRule
 
     public override string ToString()
     {
-        return $"Be {(Invert ? "not strict" : "strict")} about the order of collection items when path is " + path;
+        Debug.Assert(!Invert, "When Invert is true, we should never raise errors related to the order.");
+        return "Be struct about the order of collection items when path is " + path;
     }
 }

--- a/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
@@ -16,6 +16,8 @@ internal class PathBasedOrderingRule : IOrderingRule
         this.path = path;
     }
 
+    public bool Invert { get; set; }
+
     /// <summary>
     /// Determines if ordering of the member referred to by the current <paramref name="objectInfo"/> is relevant.
     /// </summary>
@@ -29,7 +31,7 @@ internal class PathBasedOrderingRule : IOrderingRule
 
         if (currentPropertyPath.Equals(path, StringComparison.OrdinalIgnoreCase))
         {
-            return OrderStrictness.Strict;
+            return Invert ? OrderStrictness.NotStrict : OrderStrictness.Strict;
         }
         else
         {
@@ -60,6 +62,6 @@ internal class PathBasedOrderingRule : IOrderingRule
 
     public override string ToString()
     {
-        return "Be strict about the order of collection items when path is " + path;
+        return $"Be {(Invert ? "not strict" : "strict")} about the order of collection items when path is " + path;
     }
 }

--- a/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
@@ -64,6 +64,6 @@ internal class PathBasedOrderingRule : IOrderingRule
     public override string ToString()
     {
         Debug.Assert(!Invert, "When Invert is true, we should never raise errors related to the order.");
-        return "Be struct about the order of collection items when path is " + path;
+        return "Be strict about the order of collection items when path is " + path;
     }
 }

--- a/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 namespace FluentAssertions.Equivalency.Ordering;
@@ -63,7 +62,6 @@ internal class PathBasedOrderingRule : IOrderingRule
 
     public override string ToString()
     {
-        Debug.Assert(!Invert, "When Invert is true, we should never raise errors related to the order.");
-        return "Be strict about the order of collection items when path is " + path;
+        return $"Be {(Invert ? "not strict" : "strict")} about the order of collection items when path is " + path;
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -807,6 +807,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(System.Linq.Expressions.Expression<System.Func<TNestedExpectation, object>> expectationMember, System.Linq.Expressions.Expression<System.Func<TNestedSubject, object>> subjectMember) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(string expectationMemberName, string subjectMemberName) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
     }
     public enum EquivalencyResult
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -820,6 +820,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(System.Linq.Expressions.Expression<System.Func<TNestedExpectation, object>> expectationMember, System.Linq.Expressions.Expression<System.Func<TNestedSubject, object>> subjectMember) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(string expectationMemberName, string subjectMemberName) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
     }
     public enum EquivalencyResult
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -807,6 +807,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(System.Linq.Expressions.Expression<System.Func<TNestedExpectation, object>> expectationMember, System.Linq.Expressions.Expression<System.Func<TNestedSubject, object>> subjectMember) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(string expectationMemberName, string subjectMemberName) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
     }
     public enum EquivalencyResult
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -807,6 +807,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(System.Linq.Expressions.Expression<System.Func<TNestedExpectation, object>> expectationMember, System.Linq.Expressions.Expression<System.Func<TNestedSubject, object>> subjectMember) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(string expectationMemberName, string subjectMemberName) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
     }
     public enum EquivalencyResult
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -800,6 +800,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(System.Linq.Expressions.Expression<System.Func<TNestedExpectation, object>> expectationMember, System.Linq.Expressions.Expression<System.Func<TNestedSubject, object>> subjectMember) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(string expectationMemberName, string subjectMemberName) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
     }
     public enum EquivalencyResult
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -807,6 +807,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(System.Linq.Expressions.Expression<System.Func<TNestedExpectation, object>> expectationMember, System.Linq.Expressions.Expression<System.Func<TNestedSubject, object>> subjectMember) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithMapping<TNestedExpectation, TNestedSubject>(string expectationMemberName, string subjectMemberName) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
     }
     public enum EquivalencyResult
     {

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -1485,6 +1485,31 @@ public class CollectionSpecs
     }
 
     [Fact]
+    public void When_an_unordered_collection_must_not_be_strict_using_an_expression_it_should_not_throw()
+    {
+        // Arrange
+        var subject = new[]
+        {
+            new { Name = "John", UnorderedCollection = new[] { 1, 2, 3, 4, 5 } },
+            new { Name = "Jane", UnorderedCollection = new int[0] }
+        };
+
+        var expectation = new[]
+        {
+            new { Name = "John", UnorderedCollection = new[] { 5, 4, 3, 2, 1 } },
+            new { Name = "Jane", UnorderedCollection = new int[0] }
+        };
+
+        // Act
+        Action action = () => subject.Should().BeEquivalentTo(expectation, options => options
+            .WithStrictOrdering()
+            .WithoutStrictOrderingFor(x => x.UnorderedCollection));
+
+        // Assert
+        action.Should().NotThrow();
+    }
+
+    [Fact]
     public void
         When_an_unordered_collection_must_not_be_strict_using_a_predicate_and_order_was_reset_to_strict_it_should_throw()
     {

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -1539,6 +1539,30 @@ public class CollectionSpecs
     }
 
     [Fact]
+    public void When_an_unordered_collection_must_not_be_strict_using_an_expression_and_collection_is_not_equal_it_should_throw()
+    {
+        // Arrange
+        var subject = new
+        {
+            UnorderedCollection = new[] { 1 }
+        };
+
+        var expectation = new
+        {
+            UnorderedCollection = new[] { 2 }
+        };
+
+        // Act
+        Action action = () => subject.Should().BeEquivalentTo(expectation, options => options
+            .WithStrictOrdering()
+            .WithoutStrictOrderingFor(x => x.UnorderedCollection));
+
+        // Assert
+        action.Should().Throw<XunitException>()
+            .WithMessage("*not strict*");
+    }
+
+    [Fact]
     public void
         When_asserting_equivalence_of_collections_and_configured_to_use_runtime_properties_it_should_respect_the_runtime_type()
     {

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,8 @@ sidebar:
 
 ### What's new
 
+* Added an expression overload for `WithoutStrictOrderingFor` - [#2151](https://github.com/fluentassertions/fluentassertions/pull/2151)
+
 ### Fixes
 
 ## 6.10.0


### PR DESCRIPTION
I hope it's okay that I circumvented the "separate issue with api-approved label" since the feature I'm adding is essentially already there for "WithStrictOrderingFor".