### PR TITLE
Ensure explicitly implemented members are discoverable in BeEquivalentTo

### DIFF
--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -184,10 +184,10 @@ internal static class TypeExtensions
     /// </returns>
     public static PropertyInfo FindProperty(this Type type, string propertyName, MemberVisibility memberVisibility)
     {
-        var properties = type.GetNonPrivateProperties(memberVisibility);
+        var properties = type.GetProperties(memberVisibility);
 
         return Array.Find(properties, p =>
-            p.Name == propertyName || p.Name.EndsWith("." + propertyName, StringComparison.OrdinalIgnoreCase));
+            p.Name == propertyName || p.Name.EndsWith("." + propertyName, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -198,24 +198,24 @@ internal static class TypeExtensions
     /// </returns>
     public static FieldInfo FindField(this Type type, string fieldName, MemberVisibility memberVisibility)
     {
-        var fields = type.GetNonPrivateFields(memberVisibility);
+        var fields = type.GetFields(memberVisibility);
 
         return Array.Find(fields, p => p.Name == fieldName);
     }
 
-    public static MemberInfo[] GetNonPrivateMembers(this Type typeToReflect, MemberVisibility visibility)
+    public static MemberInfo[] GetMembers(this Type typeToReflect, MemberVisibility visibility)
     {
-        return GetTypeReflectorFor(typeToReflect, visibility).NonPrivateMembers;
+        return GetTypeReflectorFor(typeToReflect, visibility).Members;
     }
 
-    public static PropertyInfo[] GetNonPrivateProperties(this Type typeToReflect, MemberVisibility visibility)
+    public static PropertyInfo[] GetProperties(this Type typeToReflect, MemberVisibility visibility)
     {
-        return GetTypeReflectorFor(typeToReflect, visibility).NonPrivateProperties;
+        return GetTypeReflectorFor(typeToReflect, visibility).Properties;
     }
 
-    public static FieldInfo[] GetNonPrivateFields(this Type typeToReflect, MemberVisibility visibility)
+    public static FieldInfo[] GetFields(this Type typeToReflect, MemberVisibility visibility)
     {
-        return GetTypeReflectorFor(typeToReflect, visibility).NonPrivateFields;
+        return GetTypeReflectorFor(typeToReflect, visibility).Fields;
     }
 
     private static TypeMemberReflector GetTypeReflectorFor(Type typeToReflect, MemberVisibility visibility)

--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -16,22 +16,22 @@ internal sealed class TypeMemberReflector
 
     public TypeMemberReflector(Type typeToReflect, MemberVisibility visibility)
     {
-        NonPrivateProperties = LoadNonPrivateProperties(typeToReflect, visibility);
-        NonPrivateFields = LoadNonPrivateFields(typeToReflect, visibility);
-        NonPrivateMembers = NonPrivateProperties.Concat<MemberInfo>(NonPrivateFields).ToArray();
+        Properties = LoadProperties(typeToReflect, visibility);
+        Fields = LoadFields(typeToReflect, visibility);
+        Members = Properties.Concat<MemberInfo>(Fields).ToArray();
     }
 
-    public MemberInfo[] NonPrivateMembers { get; }
+    public MemberInfo[] Members { get; }
 
-    public PropertyInfo[] NonPrivateProperties { get; }
+    public PropertyInfo[] Properties { get; }
 
-    public FieldInfo[] NonPrivateFields { get; }
+    public FieldInfo[] Fields { get; }
 
-    private static PropertyInfo[] LoadNonPrivateProperties(Type typeToReflect, MemberVisibility visibility)
+    private static PropertyInfo[] LoadProperties(Type typeToReflect, MemberVisibility visibility)
     {
         IEnumerable<PropertyInfo> query =
             from propertyInfo in GetPropertiesFromHierarchy(typeToReflect, visibility)
-            where HasNonPrivateGetter(propertyInfo, visibility)
+            where HasGetter(propertyInfo, visibility)
             where !propertyInfo.IsIndexer()
             select propertyInfo;
 
@@ -64,7 +64,7 @@ internal sealed class TypeMemberReflector
             property.Name.Contains('.', StringComparison.Ordinal);
     }
 
-    private static FieldInfo[] LoadNonPrivateFields(Type typeToReflect, MemberVisibility visibility)
+    private static FieldInfo[] LoadFields(Type typeToReflect, MemberVisibility visibility)
     {
         IEnumerable<FieldInfo> query =
             from fieldInfo in GetFieldsFromHierarchy(typeToReflect, visibility)
@@ -165,7 +165,7 @@ internal sealed class TypeMemberReflector
         return members;
     }
 
-    private static bool HasNonPrivateGetter(PropertyInfo propertyInfo, MemberVisibility visibility)
+    private static bool HasGetter(PropertyInfo propertyInfo, MemberVisibility visibility)
     {
         MethodInfo getMethod = propertyInfo.GetGetMethod(nonPublic: true);
 

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -15,19 +15,20 @@ internal class MustMatchByNameRule : IMemberMatchingRule
 
         if (options.IncludedProperties != MemberVisibility.None)
         {
-            PropertyInfo propertyInfo = subject.GetType().FindProperty(expectedMember.Name);
+            PropertyInfo propertyInfo = subject.GetType().FindProperty(
+                expectedMember.Name,
+                options.IncludedProperties | MemberVisibility.ExplicitlyImplemented);
+
             subjectMember = propertyInfo is not null && !propertyInfo.IsIndexer() ? new Property(propertyInfo, parent) : null;
         }
 
         if (subjectMember is null && options.IncludedFields != MemberVisibility.None)
         {
-            FieldInfo fieldInfo = subject.GetType().FindField(expectedMember.Name);
-            subjectMember = fieldInfo is not null ? new Field(fieldInfo, parent) : null;
-        }
+            FieldInfo fieldInfo = subject.GetType().FindField(
+                expectedMember.Name,
+                options.IncludedFields);
 
-        if ((subjectMember is null || !options.UseRuntimeTyping) && ExpectationImplementsMemberExplicitly(subject, expectedMember))
-        {
-            subjectMember = expectedMember;
+            subjectMember = fieldInfo is not null ? new Field(fieldInfo, parent) : null;
         }
 
         if (subjectMember is null)
@@ -47,11 +48,6 @@ internal class MustMatchByNameRule : IMemberMatchingRule
         }
 
         return subjectMember;
-    }
-
-    private static bool ExpectationImplementsMemberExplicitly(object expectation, IMember subjectMember)
-    {
-        return subjectMember.DeclaringType.IsInstanceOfType(expectation);
     }
 
     /// <inheritdoc />

--- a/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
@@ -10,14 +10,20 @@ internal class TryMatchByNameRule : IMemberMatchingRule
 {
     public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions options)
     {
-        PropertyInfo property = subject.GetType().FindProperty(expectedMember.Name);
-
-        if (property is not null && !property.IsIndexer())
+        if (options.IncludedProperties != MemberVisibility.None)
         {
-            return new Property(property, parent);
+            PropertyInfo property = subject.GetType().FindProperty(expectedMember.Name,
+                options.IncludedProperties | MemberVisibility.ExplicitlyImplemented);
+
+            if (property is not null && !property.IsIndexer())
+            {
+                return new Property(property, parent);
+            }
         }
 
-        FieldInfo field = subject.GetType().FindField(expectedMember.Name);
+        FieldInfo field = subject.GetType()
+            .FindField(expectedMember.Name, options.IncludedFields);
+
         return field is not null ? new Field(field, parent) : null;
     }
 

--- a/Src/FluentAssertions/Equivalency/MemberFactory.cs
+++ b/Src/FluentAssertions/Equivalency/MemberFactory.cs
@@ -18,14 +18,14 @@ public static class MemberFactory
 
     internal static IMember Find(object target, string memberName, INode parent)
     {
-        PropertyInfo property = target.GetType().FindProperty(memberName);
+        PropertyInfo property = target.GetType().FindProperty(memberName, MemberVisibility.Public | MemberVisibility.ExplicitlyImplemented);
 
         if (property is not null && !property.IsIndexer())
         {
             return new Property(property, parent);
         }
 
-        FieldInfo field = target.GetType().FindField(memberName);
+        FieldInfo field = target.GetType().FindField(memberName, MemberVisibility.Public);
         return field is not null ? new Field(field, parent) : null;
     }
 }

--- a/Src/FluentAssertions/Equivalency/MemberVisibility.cs
+++ b/Src/FluentAssertions/Equivalency/MemberVisibility.cs
@@ -11,5 +11,6 @@ public enum MemberVisibility
 {
     None = 0,
     Internal = 1,
-    Public = 2
+    Public = 2,
+    ExplicitlyImplemented = 4
 }

--- a/Src/FluentAssertions/Equivalency/Selection/AllFieldsSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/AllFieldsSelectionRule.cs
@@ -14,11 +14,11 @@ internal class AllFieldsSelectionRule : IMemberSelectionRule
     public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
         MemberSelectionContext context)
     {
-        IEnumerable<IMember> selectedNonPrivateFields = context.Type
-            .GetNonPrivateFields(context.IncludedFields)
+        IEnumerable<IMember> selectedFields = context.Type
+            .GetFields(context.IncludedFields)
             .Select(info => new Field(info, currentNode));
 
-        return selectedMembers.Union(selectedNonPrivateFields).ToList();
+        return selectedMembers.Union(selectedFields).ToList();
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/Selection/AllPropertiesSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/AllPropertiesSelectionRule.cs
@@ -14,11 +14,11 @@ internal class AllPropertiesSelectionRule : IMemberSelectionRule
     public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
         MemberSelectionContext context)
     {
-        IEnumerable<IMember> selectedNonPrivateProperties = context.Type
-            .GetNonPrivateProperties(context.IncludedProperties)
+        IEnumerable<IMember> selectedProperties = context.Type
+            .GetProperties(context.IncludedProperties)
             .Select(info => new Property(context.Type, info, currentNode));
 
-        return selectedMembers.Union(selectedNonPrivateProperties).ToList();
+        return selectedMembers.Union(selectedProperties).ToList();
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
@@ -21,7 +21,7 @@ internal class IncludeMemberByPathSelectionRule : SelectMemberByPathSelectionRul
     protected override void AddOrRemoveMembersFrom(List<IMember> selectedMembers, INode parent, string parentPath,
         MemberSelectionContext context)
     {
-        foreach (MemberInfo memberInfo in context.Type.GetNonPrivateMembers(MemberVisibility.Public | MemberVisibility.Internal))
+        foreach (MemberInfo memberInfo in context.Type.GetMembers(MemberVisibility.Public | MemberVisibility.Internal))
         {
             var memberPath = new MemberPath(context.Type, memberInfo.DeclaringType, parentPath.Combine(memberInfo.Name));
 

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPredicateSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPredicateSelectionRule.cs
@@ -27,7 +27,7 @@ internal class IncludeMemberByPredicateSelectionRule : IMemberSelectionRule
     {
         var members = new List<IMember>(selectedMembers);
 
-        foreach (MemberInfo memberInfo in currentNode.Type.GetNonPrivateMembers(MemberVisibility.Public |
+        foreach (MemberInfo memberInfo in currentNode.Type.GetMembers(MemberVisibility.Public |
                      MemberVisibility.Internal))
         {
             IMember member = MemberFactory.Create(memberInfo, currentNode);

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -50,7 +50,7 @@ public class DefaultValueFormatter : IValueFormatter
     /// <remarks>The default is all non-private members.</remarks>
     protected virtual MemberInfo[] GetMembers(Type type)
     {
-        return type.GetNonPrivateMembers(MemberVisibility.Public);
+        return type.GetMembers(MemberVisibility.Public);
     }
 
     private static bool HasCompilerGeneratedToStringImplementation(object value)

--- a/Tests/Approval.Tests/ApiApproval.cs
+++ b/Tests/Approval.Tests/ApiApproval.cs
@@ -28,10 +28,12 @@ public class ApiApproval
         string assemblyPath = Uri.UnescapeDataString(uri.Path);
         var containingDirectory = Path.GetDirectoryName(assemblyPath);
         var configurationName = new DirectoryInfo(containingDirectory).Parent.Name;
+
         var assemblyFile = Path.GetFullPath(
             Path.Combine(
                 GetSourceDirectory(),
-                Path.Combine("..", "..", "Src", "FluentAssertions", "bin", configurationName, frameworkVersion, "FluentAssertions.dll")));
+                Path.Combine("..", "..", "Src", "FluentAssertions", "bin", configurationName, frameworkVersion,
+                    "FluentAssertions.dll")));
 
         var assembly = Assembly.LoadFile(Path.GetFullPath(assemblyFile));
         var publicApi = assembly.GeneratePublicApi(options: null);
@@ -53,6 +55,7 @@ public class ApiApproval
         var diff = InlineDiffBuilder.Diff(verified, received);
 
         var builder = new StringBuilder();
+
         foreach (var line in diff.Lines)
         {
             switch (line.Type)
@@ -79,9 +82,12 @@ public class ApiApproval
     {
         public TargetFrameworksTheoryData()
         {
-            var csproj = Path.Combine(GetSourceDirectory(), Path.Combine("..", "..", "Src", "FluentAssertions", "FluentAssertions.csproj"));
+            var csproj = Path.Combine(GetSourceDirectory(),
+                Path.Combine("..", "..", "Src", "FluentAssertions", "FluentAssertions.csproj"));
+
             var project = XDocument.Load(csproj);
             var targetFrameworks = project.XPathSelectElement("/Project/PropertyGroup/TargetFrameworks");
+
             foreach (string targetFramework in targetFrameworks!.Value.Split(';'))
             {
                 Add(targetFramework);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -847,6 +847,7 @@ namespace FluentAssertions.Equivalency
         None = 0,
         Internal = 1,
         Public = 2,
+        ExplicitlyImplemented = 4,
     }
     public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -860,6 +860,7 @@ namespace FluentAssertions.Equivalency
         None = 0,
         Internal = 1,
         Public = 2,
+        ExplicitlyImplemented = 4,
     }
     public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -840,6 +840,7 @@ namespace FluentAssertions.Equivalency
         None = 0,
         Internal = 1,
         Public = 2,
+        ExplicitlyImplemented = 4,
     }
     public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -847,6 +847,7 @@ namespace FluentAssertions.Equivalency
         None = 0,
         Internal = 1,
         Public = 2,
+        ExplicitlyImplemented = 4,
     }
     public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
     {

--- a/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
+++ b/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Chill" Version="4.1.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="Xunit.StaFact" Version="1.1.11" />

--- a/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
@@ -62,8 +62,8 @@ public class MemberMatchingSpecs
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ParentOfSubjectWithProperty1>(
-                    e => e.Parent[0].Property2,
-                    s => s.Parent[0].Property1));
+                    e => e.Children[0].Property2,
+                    s => s.Children[0].Property1));
     }
 
     [Fact]
@@ -81,6 +81,25 @@ public class MemberMatchingSpecs
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ExpectationWithProperty2, SubjectWithProperty1>("Property2", "Property1"));
+    }
+
+    [Fact]
+    public void Nested_explicitly_implemented_properties_can_be_mapped_using_a_nested_type_and_property_names()
+    {
+        // Arrange
+        var subject = new ParentOfSubjectWithExplicitlyImplementedProperty(new[] { new SubjectWithExplicitImplementedProperty() });
+
+        ((IProperty)subject.Children[0]).Property = "Hello";
+
+        var expectation = new ParentOfExpectationWithProperty2(new[]
+        {
+            new ExpectationWithProperty2 { Property2 = "Hello" }
+        });
+
+        // Act / Assert
+        subject.Should()
+            .BeEquivalentTo(expectation, opt => opt
+                .WithMapping<ExpectationWithProperty2, SubjectWithExplicitImplementedProperty>("Property2", "Property"));
     }
 
     [Fact]
@@ -142,6 +161,25 @@ public class MemberMatchingSpecs
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Property2", "Property1"));
+    }
+
+    [Fact]
+    public void Properties_can_be_mapped_by_name_to_an_explicitly_implemented_property()
+    {
+        // Arrange
+        var subject = new SubjectWithExplicitImplementedProperty();
+
+        ((IProperty)subject).Property = "Hello";
+
+        var expectation = new ExpectationWithProperty2
+        {
+            Property2 = "Hello"
+        };
+
+        // Act / Assert
+        subject.Should()
+            .BeEquivalentTo(expectation, opt => opt
+                .WithMapping("Property2", "Property"));
     }
 
     [Fact]
@@ -515,27 +553,47 @@ public class MemberMatchingSpecs
 
     internal class ParentOfExpectationWithProperty2
     {
-        public ExpectationWithProperty2[] Parent { get; }
+        public ExpectationWithProperty2[] Children { get; }
 
-        public ParentOfExpectationWithProperty2(ExpectationWithProperty2[] parent)
+        public ParentOfExpectationWithProperty2(ExpectationWithProperty2[] children)
         {
-            Parent = parent;
+            Children = children;
         }
     }
 
     internal class ParentOfSubjectWithProperty1
     {
-        public SubjectWithProperty1[] Parent { get; }
+        public SubjectWithProperty1[] Children { get; }
 
-        public ParentOfSubjectWithProperty1(SubjectWithProperty1[] parent)
+        public ParentOfSubjectWithProperty1(SubjectWithProperty1[] children)
         {
-            Parent = parent;
+            Children = children;
+        }
+    }
+
+    internal class ParentOfSubjectWithExplicitlyImplementedProperty
+    {
+        public SubjectWithExplicitImplementedProperty[] Children { get; }
+
+        public ParentOfSubjectWithExplicitlyImplementedProperty(SubjectWithExplicitImplementedProperty[] children)
+        {
+            Children = children;
         }
     }
 
     internal class SubjectWithProperty1
     {
         public string Property1 { get; set; }
+    }
+
+    internal class SubjectWithExplicitImplementedProperty : IProperty
+    {
+        string IProperty.Property { get; set; }
+    }
+
+    internal interface IProperty
+    {
+        string Property { get; set; }
     }
 
     internal class ExpectationWithProperty2

--- a/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
@@ -43,7 +43,7 @@ public class ClassWithWriteOnlyProperty
 
     public int WriteOnlyProperty
     {
-        set { writeOnlyPropertyValue = value; }
+        set => writeOnlyPropertyValue = value;
     }
 
     public string SomeOtherProperty { get; set; }
@@ -616,9 +616,33 @@ public class Vehicle : IVehicle
     public int VehicleId { get; set; }
 }
 
+public class VehicleWithField
+{
+    public int VehicleId;
+}
+
 public class ExplicitVehicle : IVehicle
 {
     int IVehicle.VehicleId { get; set; }
+
+    public int VehicleId { get; set; }
+}
+
+public interface IReadOnlyVehicle
+{
+    int VehicleId { get; }
+}
+
+public class ExplicitReadOnlyVehicle : IReadOnlyVehicle
+{
+    private readonly int explicitValue;
+
+    public ExplicitReadOnlyVehicle(int explicitValue)
+    {
+        this.explicitValue = explicitValue;
+    }
+
+    int IReadOnlyVehicle.VehicleId => explicitValue;
 
     public int VehicleId { get; set; }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,6 +16,7 @@ sidebar:
 ### Fixes
 * Fixed formatting error when checking nullable `DateTimeOffset` with 
 `BeWithin(...).Before(...)` - [#2312](https://github.com/fluentassertions/fluentassertions/pull/2312)
+* `BeEquivalentTo` will now find and can map subject properties that are implemented through an explicitly-implemented interface - [#2152](https://github.com/fluentassertions/fluentassertions/pull/2152)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION
* When trying to find a property on the subject to match the one on the expectation, if a normal property exists next to an implicitly implemented one, the normal property will be selected.
* Some tests related to explicit interface implementations assumed a dependency on whether or not `RespectingDeclaredTypes` and `RespectingRuntimeTypes` was used. But those options don't affect the subject.
* The `WithMapping` construct also didn't support mapping to properties implemented through explicitly-implemented interfaces.
* Removed the "non-private" part names since visibility is now used to find members

**Note**   I had to extend `MemberVisibility` to optionally include explicitly implemented members. This _could_ be perceived as a breaking change. But it won't affect consumers, so for now, I treat it as non-breaking.

**Review**
Review by commit and with whitespace changes hidden

Fixes #2146 

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome