### PR TITLE
Prevent `NullReferenceException`

### DIFF
--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -35,12 +35,15 @@ internal class MustMatchByNameRule : IMemberMatchingRule
             Execute.Assertion.FailWith(
                 $"Expectation has {expectedMember.Description} that the other object does not have.");
         }
-
-        if (options.IgnoreNonBrowsableOnSubject && !subjectMember.IsBrowsable)
+        else if (options.IgnoreNonBrowsableOnSubject && !subjectMember.IsBrowsable)
         {
             Execute.Assertion.FailWith(
                 $"Expectation has {expectedMember.Description} that is non-browsable in the other object, and non-browsable " +
                 "members on the subject are ignored with the current configuration");
+        }
+        else
+        {
+            // Everything is fine
         }
 
         return subjectMember;

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -2231,6 +2231,27 @@ public class SelectionRulesSpecs
         }
 
         [Fact]
+        public void Only_ignore_non_browsable_matching_members()
+        {
+            // Arrange
+            var subject = new
+            {
+                NonExisting = 0
+            };
+
+            var expectation = new
+            {
+                Existing = 1
+            };
+
+            // Act
+            Action action = () => subject.Should().BeEquivalentTo(expectation, config => config.IgnoringNonBrowsableMembersOnSubject());
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
         public void When_property_is_non_browsable_only_in_expectation_excluding_non_browsable_members_should_make_it_succeed()
         {
             // Arrange


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

When `FailWith` does not cause immediate termination we must guard against it.
On line 33 we checked if `subjectMember` was null, but we might continue execution, so this PR guards against executing `subjectMember.IsBrowsable`.

The test _triggers_ the problem, but I failed to find a way to properly verify it in the assertion part 🤔 