### PR TITLE
Exception cleanup

### DIFF
--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -220,14 +220,8 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
 
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected inner {0}{reason}, but ", innerException)
-            .ForCondition(Subject is not null)
-            .FailWith("no exception was thrown.")
-            .Then
             .ForCondition(Subject.Any(e => e.InnerException is not null))
-            .FailWith("the thrown exception has no inner exception.")
-            .Then
-            .ClearExpectation();
+            .FailWith("Expected inner {0}{reason}, but the thrown exception has no inner exception.", innerException);
 
         Exception[] expectedInnerExceptions = Subject
             .Select(e => e.InnerException)

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -125,6 +125,8 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
     public ExceptionAssertions<Exception> WithInnerException(Type innerException, string because = "",
         params object[] becauseArgs)
     {
+        Guard.ThrowIfArgumentIsNull(innerException);
+
         return new ExceptionAssertions<Exception>(AssertInnerExceptions(innerException, because, becauseArgs));
     }
 
@@ -161,6 +163,8 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
     public ExceptionAssertions<Exception> WithInnerExceptionExactly(Type innerException, string because = "",
         params object[] becauseArgs)
     {
+        Guard.ThrowIfArgumentIsNull(innerException);
+
         return new ExceptionAssertions<Exception>(AssertInnerExceptionExactly(innerException, because, becauseArgs));
     }
 
@@ -197,8 +201,6 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
     private IEnumerable<Exception> AssertInnerExceptionExactly(Type innerException, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(innerException);
-
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.Any(e => e.InnerException is not null))
@@ -219,8 +221,6 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
     private IEnumerable<Exception> AssertInnerExceptions(Type innerException, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(innerException);
-
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.Any(e => e.InnerException is not null))

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -199,7 +199,10 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
     {
         Guard.ThrowIfArgumentIsNull(innerException);
 
-        AssertInnerExceptions(innerException, because, becauseArgs);
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject.Any(e => e.InnerException is not null))
+            .FailWith("Expected inner {0}{reason}, but the thrown exception has no inner exception.", innerException);
 
         Exception[] expectedExceptions = Subject
             .Select(e => e.InnerException)

--- a/Tests/FluentAssertions.Specs/Exceptions/InnerExceptionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/InnerExceptionSpecs.cs
@@ -166,6 +166,21 @@ public class InnerExceptionSpecs
     }
 
     [Fact]
+    public void An_exception_without_the_expected_inner_exception_has_a_descriptive_message()
+    {
+        // Arrange
+        Action subject = () => throw new BadImageFormatException("");
+
+        // Act
+        Action act = () => subject.Should().Throw<BadImageFormatException>()
+            .WithInnerExceptionExactly<ArgumentNullException>("some {0}", "message");
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("*some message*no inner exception*");
+    }
+
+    [Fact]
     public void When_subject_throws_an_exception_with_an_unexpected_inner_exception_it_should_throw_with_clear_description()
     {
         // Arrange

--- a/Tests/FluentAssertions.Specs/Exceptions/InnerExceptionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/InnerExceptionSpecs.cs
@@ -214,26 +214,6 @@ public class InnerExceptionSpecs
             Does testSubject = Does.Throw<Exception>();
 
             testSubject.Invoking(x => x.Do()).Should().Throw<Exception>()
-                .WithInnerException<InvalidOperationException>();
-
-            throw new XunitException("This point should not be reached");
-        }
-        catch (XunitException ex)
-        {
-            ex.Message.Should().Be(
-                "Expected inner System.InvalidOperationException, but the thrown exception has no inner exception.");
-        }
-    }
-
-    [Fact]
-    public void
-        When_subject_throws_an_exception_without_expected_inner_exception_and_has_reason_it_should_throw_with_clear_description()
-    {
-        try
-        {
-            Does testSubject = Does.Throw<Exception>();
-
-            testSubject.Invoking(x => x.Do()).Should().Throw<Exception>()
                 .WithInnerException<InvalidOperationException>("because {0} should do that", "Does.Do");
 
             throw new XunitException("This point should not be reached");


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

The null checking of `Subject` in `AssertInnerExceptions` seems to irrelevant since https://github.com/fluentassertions/fluentassertions/commit/5f4f371e691d04cb4b205b6e195b450eb6e4207f where `ExceptionAssertions` was changed to having a more pure constructor.

No other assertions in `ExceptionAssertions` null checks `Subject`.

The second commit is a micro-optimization when asserting for an exact type.

The last two commits are cleanups