### PR TITLE
await `Task` when inside using block

### DIFF
--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -40,11 +40,11 @@ public static class TaskOfTAssertionSpecs
             Func<Task<int>> action = null;
 
             // Act
-            Func<Task> testAction = () =>
+            Func<Task> testAction = async () =>
             {
                 using var _ = new AssertionScope();
 
-                return action.Should().CompleteWithinAsync(
+                await action.Should().CompleteWithinAsync(
                     timeSpan, "because we want to test the failure {0}", "message");
             };
 
@@ -152,12 +152,12 @@ public static class TaskOfTAssertionSpecs
             var taskFactory = new TaskCompletionSource<int>();
 
             // Act
-            Func<Task> action = () =>
+            Func<Task> action = async () =>
             {
                 Func<Task<int>> func = () => taskFactory.Task;
 
                 using var _ = new AssertionScope();
-                return func.Should(timer).CompleteWithinAsync(100.Milliseconds());
+                await func.Should(timer).CompleteWithinAsync(100.Milliseconds());
             };
 
             timer.Complete();
@@ -174,18 +174,18 @@ public static class TaskOfTAssertionSpecs
             var taskFactory = new TaskCompletionSource<int>();
 
             // Act
-            Func<Task> action = () =>
+            Func<Task> action = async () =>
             {
                 Func<Task<int>> func = () => taskFactory.Task;
                 using var _ = new AssertionScope();
-                return func.Should(timer).CompleteWithinAsync(100.Milliseconds()).WithResult(2);
+                await func.Should(timer).CompleteWithinAsync(100.Milliseconds()).WithResult(2);
             };
 
             timer.Complete();
 
             // Assert
             var assertionTask = action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Expected*to complete within 100ms.*Expected return*to be 2, but found 0.");
+                .WithMessage("Expected*to complete within 100ms.*Expected*to be 2, but found 0.");
 
             await Awaiting(() => assertionTask).Should().CompleteWithinAsync(200.Seconds());
         }


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

Some analyzer I played around with some time ago pointed out that we weren't awaiting these `Task`s.