### PR TITLE
Use init properties

### DIFF
--- a/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
@@ -16,7 +16,7 @@ internal class PathBasedOrderingRule : IOrderingRule
         this.path = path;
     }
 
-    public bool Invert { get; set; }
+    public bool Invert { get; init; }
 
     /// <summary>
     /// Determines if ordering of the member referred to by the current <paramref name="objectInfo"/> is relevant.

--- a/Src/FluentAssertions/Equivalency/Ordering/PredicateBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PredicateBasedOrderingRule.cs
@@ -14,7 +14,7 @@ internal class PredicateBasedOrderingRule : IOrderingRule
         this.predicate = predicate.Compile();
     }
 
-    public bool Invert { get; set; }
+    public bool Invert { get; init; }
 
     public OrderStrictness Evaluate(IObjectInfo objectInfo)
     {

--- a/Src/FluentAssertions/Equivalency/Steps/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRowEquivalencyStep.cs
@@ -182,9 +182,9 @@ public class DataRowEquivalencyStep : EquivalencyStep<DataRow>
 
     private sealed class SelectedDataRowMembers
     {
-        public bool HasErrors { get; set; }
+        public bool HasErrors { get; init; }
 
-        public bool RowState { get; set; }
+        public bool RowState { get; init; }
     }
 
     private static readonly ConcurrentDictionary<(Type CompileTimeType, Type RuntimeType, IEquivalencyAssertionOptions Config),

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -28,9 +28,9 @@ internal class EnumerableEquivalencyValidator
         Recursive = false;
     }
 
-    public bool Recursive { get; set; }
+    public bool Recursive { get; init; }
 
-    public OrderingRuleCollection OrderingRules { get; set; }
+    public OrderingRuleCollection OrderingRules { get; init; }
 
     public void Execute<T>(object[] subject, T[] expectation)
     {

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
@@ -70,15 +70,15 @@ internal class StringWildcardMatchingValidator : StringValidator
     /// <summary>
     /// Gets or sets a value indicating whether the subject should not match the pattern.
     /// </summary>
-    public bool Negate { get; set; }
+    public bool Negate { get; init; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the matching process should ignore any casing difference.
     /// </summary>
-    public bool IgnoreCase { get; set; }
+    public bool IgnoreCase { get; init; }
 
     /// <summary>
     /// Ignores the difference between environment newline differences
     /// </summary>
-    public bool IgnoreNewLineDifferences { get; set; }
+    public bool IgnoreNewLineDifferences { get; init; }
 }


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

As PolySharp generates `IsExternalInit` for older runtimes we can use init properties for at minimum internal types    