### PR TITLE
Introduce Roslynator with adjusted rules and addressed issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -302,3 +302,38 @@ resharper_blank_lines_before_multiline_statements = 1
 
 resharper_parentheses_non_obvious_operations = arithmetic, multiplicative, equality, relational, additive
 resharper_parentheses_redundancy_style = remove_if_not_clarifies_precedence
+
+dotnet_analyzer_diagnostic.category-roslynator.severity = error
+
+# Remove suffix 'Async' from non-asynchronous method name. Disabled because we like that suffix for now.
+dotnet_diagnostic.RCS1047.severity = none
+
+# Combine 'Enumerable.Where' method chain. It doesn't make it more readable in all cases.
+dotnet_diagnostic.RCS1112.severity = suggestion
+
+# Inline local variable.
+dotnet_diagnostic.RCS1124.severity = suggestion
+
+# Add exception to documentation comment. Nice suggestion, but we don't want to document exceptions for internal code.
+dotnet_diagnostic.RCS1140.severity = suggestion
+
+# Use conditional access. Suggestion because it doesn't always improve readability
+dotnet_diagnostic.RCS1146.severity = suggestion
+
+# Enum should declare explicit values. Disabled because we're not storing them.
+dotnet_diagnostic.RCS1161.severity = none
+
+# Static member in generic type should use a type parameter. Disabled because it's not always applicable.
+dotnet_diagnostic.RCS1158.severity = none
+
+# Add region name to #endregion.
+dotnet_diagnostic.RCS1189.severity = none
+
+# Convert comment to documentation comment. Disabled because it also complains about SMELL/REFACTOR comments
+dotnet_diagnostic.RCS1181.severity = none
+
+# Use Regex instance instead of static method. Disabled because it's not always worth it.
+dotnet_diagnostic.RCS1186.severity = none
+
+# Use bit shift operator.
+dotnet_diagnostic.RCS1237.severity = none

--- a/Src/FluentAssertions/CallerIdentification/IParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/IParsingStrategy.cs
@@ -4,10 +4,11 @@ namespace FluentAssertions.CallerIdentification;
 
 /// <summary>
 /// Represents a stateful parsing strategy that is used to help identify the "caller" to use in an assertion message.
-///
+/// </summary>
+/// <remarks>
 /// The strategies will be instantiated at the beginning of a "caller identification" task, and will live until
 /// the statement can be identified (and thus some are stateful).
-/// </summary>
+/// </remarks>
 internal interface IParsingStrategy
 {
     /// <summary>

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -3347,9 +3347,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     {
         string orderString = propertyExpression.GetMemberPath().ToString();
 
-        orderString = orderString is "\"\"" ? string.Empty : "by " + orderString;
-
-        return orderString;
+        return orderString is "\"\"" ? string.Empty : "by " + orderString;
     }
 
     private static Type GetType<TType>(TType o)

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -715,7 +715,7 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}.", Subject,
-                            expectedKeys.First());
+                            expectedKeys[0]);
                 }
             }
 

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -349,15 +349,12 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:dictionary} not to contain key {0}{reason}, but found <null>.", unexpected);
 
-        if (success)
+        if (success && ContainsKey(Subject, unexpected))
         {
-            if (ContainsKey(Subject, unexpected))
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} not to contain key {1}{reason}, but found it anyhow.", Subject,
-                        unexpected);
-            }
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:dictionary} {0} not to contain key {1}{reason}, but found it anyhow.", Subject,
+                    unexpected);
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -569,15 +566,12 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:dictionary} not to contain value {0}{reason}, but found <null>.", unexpected);
 
-        if (success)
+        if (success && GetValues(Subject).Contains(unexpected))
         {
-            if (GetValues(Subject).Contains(unexpected))
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} not to contain value {1}{reason}, but found it anyhow.", Subject,
-                        unexpected);
-            }
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:dictionary} {0} not to contain value {1}{reason}, but found it anyhow.", Subject,
+                    unexpected);
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -946,16 +940,13 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
             .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but dictionary is <null>.",
                 value, key);
 
-        if (success)
+        if (success && TryGetValue(Subject, key, out TValue actual))
         {
-            if (TryGetValue(Subject, key, out TValue actual))
-            {
-                Execute.Assertion
-                    .ForCondition(!ObjectExtensions.GetComparer<TValue>()(actual, value))
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but found it anyhow.",
-                        value, key);
-            }
+            Execute.Assertion
+                .ForCondition(!ObjectExtensions.GetComparer<TValue>()(actual, value))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but found it anyhow.",
+                    value, key);
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Collections/SubsequentOrderingAssertions.cs
+++ b/Src/FluentAssertions/Collections/SubsequentOrderingAssertions.cs
@@ -172,11 +172,9 @@ public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAsse
         {
             Func<T, TSelector> keySelector = propertyExpression.Compile();
 
-            IOrderedEnumerable<T> expectation = direction == SortOrder.Ascending
+            return direction == SortOrder.Ascending
                 ? previousOrderedEnumerable.ThenBy(keySelector, comparer)
                 : previousOrderedEnumerable.ThenByDescending(keySelector, comparer);
-
-            return expectation;
         }
 
         return base.GetOrderedEnumerable(propertyExpression, comparer, direction, unordered);

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/Src/FluentAssertions/Common/Iterator.cs
+++ b/Src/FluentAssertions/Common/Iterator.cs
@@ -71,13 +71,10 @@ internal sealed class Iterator<T> : IEnumerator<T>
 
     public bool MoveNext()
     {
-        if (!hasCompleted)
+        if (!hasCompleted && FetchCurrent())
         {
-            if (FetchCurrent())
-            {
-                PrefetchNext();
-                return true;
-            }
+            PrefetchNext();
+            return true;
         }
 
         hasCompleted = true;
@@ -101,11 +98,10 @@ internal sealed class Iterator<T> : IEnumerator<T>
 
             return true;
         }
-        else
-        {
-            hasCompleted = true;
-            return false;
-        }
+
+        hasCompleted = true;
+
+        return false;
     }
 
     public bool HasReachedMaxItems => Index == maxItems;

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -292,10 +292,8 @@ internal static class TypeExtensions
         {
             return GetInterfaceMembers(typeToReflect, getMembers);
         }
-        else
-        {
-            return GetClassMembers(typeToReflect, getMembers);
-        }
+
+        return GetClassMembers(typeToReflect, getMembers);
     }
 
     private static List<TMemberInfo> GetInterfaceMembers<TMemberInfo>(Type typeToReflect,
@@ -471,10 +469,8 @@ internal static class TypeExtensions
         {
             return type.IsImplementationOfOpenGeneric(definition);
         }
-        else
-        {
-            return type == definition || type.IsDerivedFromOpenGeneric(definition);
-        }
+
+        return type == definition || type.IsDerivedFromOpenGeneric(definition);
     }
 
     private static bool IsImplementationOfOpenGeneric(this Type type, Type definition)

--- a/Src/FluentAssertions/Data/DataColumnAssertions.cs
+++ b/Src/FluentAssertions/Data/DataColumnAssertions.cs
@@ -88,12 +88,15 @@ public class DataColumnAssertions : ReferenceTypeAssertions<DataColumn, DataColu
     ///   <item><description>Unique</description></item>
     /// </list>
     ///
+    /// <para>
     /// Testing of any property can be overridden using the <paramref name="config"/> callback. Exclude specific properties using
     /// <see cref="IDataEquivalencyAssertionOptions{T}.Excluding(System.Linq.Expressions.Expression{Func{T, object}})"/>.
-    ///
+    /// </para>
+    /// <para>
     /// If <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumn(DataColumn)"/> or a related function is
     /// used and the exclusion matches the subject <see cref="DataColumn"/>, then the equivalency test will never
     /// fail.
+    /// </para>
     /// </remarks>
     /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
     /// <param name="config">

--- a/Src/FluentAssertions/Data/DataRowAssertions.cs
+++ b/Src/FluentAssertions/Data/DataRowAssertions.cs
@@ -153,16 +153,19 @@ public class DataRowAssertions<TDataRow> : ReferenceTypeAssertions<TDataRow, Dat
     ///   <item><description>RowState</description></item>
     /// </list>
     ///
+    /// <para>
     /// The <see cref="DataRow"/> objects must be of the same type; if two <see cref="DataRow"/> objects
     /// are equivalent in all ways, except that one is part of a typed <see cref="DataTable"/> and is of a subclass
     /// of <see cref="DataRow"/>, then by default, they will not be considered equivalent.
-    ///
+    /// </para>
+    /// <para>
     /// This, as well as testing of any property can be overridden using the <paramref name="config"/> callback.
     /// By calling <see cref="IDataEquivalencyAssertionOptions{T}.AllowingMismatchedTypes"/>, two <see cref="DataRow"/>
     /// objects of differing types can be considered equivalent. Exclude specific properties using
     /// <see cref="IDataEquivalencyAssertionOptions{T}.Excluding(System.Linq.Expressions.Expression{Func{T, object}})"/>.
     /// Exclude columns of the data table (which also excludes the related field data in <see cref="DataRow"/>
     /// objects) using <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumn(DataColumn)"/> or a related function.
+    /// </para>
     /// </remarks>
     ///
     /// You can use <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingRelated(System.Linq.Expressions.Expression{Func{DataTable, object}})"/>

--- a/Src/FluentAssertions/Data/DataSetAssertions.cs
+++ b/Src/FluentAssertions/Data/DataSetAssertions.cs
@@ -198,16 +198,19 @@ public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, Data
     ///   <item><description>SchemaSerializationMode</description></item>
     /// </list>
     ///
+    /// <para>
     /// The <see cref="DataSet"/> objects must be of the same type; if two <see cref="DataSet"/> objects
     /// are equivalent in all ways, except that one is a custom subclass of <see cref="DataSet"/> (e.g. to provide
     /// typed accessors for <see cref="DataTable"/> values contained by the <see cref="DataSet"/>), then by default,
     /// they will not be considered equivalent.
-    ///
+    /// </para>
+    /// <para>
     /// This, as well as testing of any property can be overridden using the <paramref name="config"/> callback.
     /// By calling <see cref="IDataEquivalencyAssertionOptions{T}.AllowingMismatchedTypes"/>, two <see cref="DataSet"/>
     /// objects of differing types can be considered equivalent. This setting applies to all types recursively tested
     /// as part of the <see cref="DataSet"/>.
-    ///
+    /// </para>
+    /// <para>
     /// Exclude specific properties using <see cref="IDataEquivalencyAssertionOptions{T}.Excluding(System.Linq.Expressions.Expression{Func{T, object}})"/>.
     /// Exclude specific tables within the data set using <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingTable(string)"/>
     /// or a related function. You can also indicate that columns should be excluded within the <see cref="DataTable"/>
@@ -215,9 +218,11 @@ public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, Data
     /// or a related function. The <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumnInAllTables(string)"/> method
     /// can be used to exclude columns across all <see cref="DataTable"/> objects in the <see cref="DataSet"/> that share
     /// the same name.
-    ///
+    /// </para>
+    /// <para>
     /// You can use <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingRelated(System.Linq.Expressions.Expression{Func{DataTable, object}})"/>
     /// and related functions to exclude properties on other related System.Data types.
+    /// </para>
     /// </remarks>
     /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
     /// <param name="config">

--- a/Src/FluentAssertions/Data/DataTableAssertions.cs
+++ b/Src/FluentAssertions/Data/DataTableAssertions.cs
@@ -219,11 +219,12 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
     ///   <item><description>PrimaryKey</description></item>
     ///   <item><description>Rows</description></item>
     /// </list>
-    ///
+    /// <para>
     /// The <see cref="DataTable"/> objects must be of the same type; if two <see cref="DataTable"/> objects
     /// are equivalent in all ways, except that one is a typed <see cref="DataTable"/> that is a subclass
     /// of <see cref="DataTable"/>, then by default, they will not be considered equivalent.
-    ///
+    /// </para>
+    /// <para>
     /// This, as well as testing of any property can be overridden using the <paramref name="config"/> callback.
     /// By calling <see cref="IDataEquivalencyAssertionOptions{T}.AllowingMismatchedTypes"/>, two <see cref="DataTable"/>
     /// objects of differing types can be considered equivalent. Exclude specific properties using
@@ -231,9 +232,11 @@ public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable
     /// Exclude columns of the data table using <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumn(DataColumn)"/>
     /// or a related function -- this excludes both the <see cref="DataColumn"/> objects in <see cref="DataTable.Columns"/>
     /// and associated field data in <see cref="DataRow"/> objects within the <see cref="DataTable"/>.
-    ///
+    /// </para>
+    /// <para>
     /// You can use <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingRelated(System.Linq.Expressions.Expression{Func{DataTable, object}})"/>
     /// and related functions to exclude properties on other related System.Data types.
+    /// </para>
     /// </remarks>
     /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
     /// <param name="config">

--- a/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs
@@ -69,5 +69,5 @@ internal class ObjectReference
         return Invariant($"{{\"{path}\", {@object}}}");
     }
 
-    public bool IsComplexType => isComplexType ?? (@object is not null && !@object.GetType().OverridesEquals());
+    public bool IsComplexType => isComplexType ?? (@object?.GetType().OverridesEquals() == false);
 }

--- a/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
@@ -31,20 +31,18 @@ internal class MappedMemberMatchingRule<TExpectation, TSubject> : IMemberMatchin
 
     public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions options)
     {
-        if (parent.Type.IsSameOrInherits(typeof(TExpectation)) && subject is TSubject)
+        if (parent.Type.IsSameOrInherits(typeof(TExpectation)) && subject is TSubject &&
+            expectedMember.Name == expectationMemberName)
         {
-            if (expectedMember.Name == expectationMemberName)
+            var member = MemberFactory.Find(subject, subjectMemberName, parent);
+
+            if (member is null)
             {
-                var member = MemberFactory.Find(subject, subjectMemberName, parent);
-
-                if (member is null)
-                {
-                    throw new ArgumentException(
-                        $"Subject of type {typeof(TSubject)} does not have member {subjectMemberName}");
-                }
-
-                return member;
+                throw new ArgumentException(
+                    $"Subject of type {typeof(TSubject)} does not have member {subjectMemberName}");
             }
+
+            return member;
         }
 
         return null;

--- a/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
@@ -36,13 +36,8 @@ internal class MappedMemberMatchingRule<TExpectation, TSubject> : IMemberMatchin
         {
             var member = MemberFactory.Find(subject, subjectMemberName, parent);
 
-            if (member is null)
-            {
-                throw new ArgumentException(
-                    $"Subject of type {typeof(TSubject)} does not have member {subjectMemberName}");
-            }
-
-            return member;
+            return member ?? throw new ArgumentException(
+                $"Subject of type {typeof(TSubject)} does not have member {subjectMemberName}");
         }
 
         return null;

--- a/Src/FluentAssertions/Equivalency/Ordering/ByteArrayOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/ByteArrayOrderingRule.cs
@@ -9,9 +9,9 @@ namespace FluentAssertions.Equivalency.Ordering;
 /// </summary>
 internal class ByteArrayOrderingRule : IOrderingRule
 {
-    public OrderStrictness Evaluate(IObjectInfo memberInfo)
+    public OrderStrictness Evaluate(IObjectInfo objectInfo)
     {
-        return memberInfo.CompileTimeType.IsSameOrInherits(typeof(IEnumerable<byte>))
+        return objectInfo.CompileTimeType.IsSameOrInherits(typeof(IEnumerable<byte>))
             ? OrderStrictness.Strict
             : OrderStrictness.Irrelevant;
     }

--- a/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
@@ -34,10 +34,8 @@ internal class PathBasedOrderingRule : IOrderingRule
         {
             return Invert ? OrderStrictness.NotStrict : OrderStrictness.Strict;
         }
-        else
-        {
-            return OrderStrictness.Irrelevant;
-        }
+
+        return OrderStrictness.Irrelevant;
     }
 
     private static bool ContainsIndexingQualifiers(string path)

--- a/Src/FluentAssertions/Equivalency/Ordering/PredicateBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PredicateBasedOrderingRule.cs
@@ -22,10 +22,8 @@ internal class PredicateBasedOrderingRule : IOrderingRule
         {
             return Invert ? OrderStrictness.NotStrict : OrderStrictness.Strict;
         }
-        else
-        {
-            return OrderStrictness.Irrelevant;
-        }
+
+        return OrderStrictness.Irrelevant;
     }
 
     public override string ToString()

--- a/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
+++ b/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
@@ -67,7 +67,7 @@ public class OrderingRuleCollection : IEnumerable<IOrderingRule>
     /// </summary>
     public bool IsOrderingStrictFor(IObjectInfo objectInfo)
     {
-        List<OrderStrictness> results = rules.Select(r => r.Evaluate(objectInfo)).ToList();
+        List<OrderStrictness> results = rules.ConvertAll(r => r.Evaluate(objectInfo));
         return results.Contains(OrderStrictness.Strict) && !results.Contains(OrderStrictness.NotStrict);
     }
 }

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPredicateSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPredicateSelectionRule.cs
@@ -33,12 +33,9 @@ internal class IncludeMemberByPredicateSelectionRule : IMemberSelectionRule
         {
             IMember member = MemberFactory.Create(memberInfo, currentNode);
 
-            if (predicate(new MemberToMemberInfoAdapter(member)))
+            if (predicate(new MemberToMemberInfoAdapter(member)) && !members.Any(p => p.IsEquivalentTo(member)))
             {
-                if (!members.Any(p => p.IsEquivalentTo(member)))
-                {
-                    members.Add(member);
-                }
+                members.Add(member);
             }
         }
 

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionContext.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionContext.cs
@@ -1,6 +1,6 @@
 namespace FluentAssertions.Equivalency.Steps;
 
-internal class AssertionContext<TSubject> : IAssertionContext<TSubject>
+internal sealed class AssertionContext<TSubject> : IAssertionContext<TSubject>
 {
     private AssertionContext(INode currentNode, TSubject subject, TSubject expectation, string because,
         object[] becauseArgs)

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionResultSet.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionResultSet.cs
@@ -38,7 +38,7 @@ internal class AssertionResultSet
 
         KeyValuePair<object, string[]>[] bestResultSets = GetBestResultSets();
 
-        KeyValuePair<object, string[]> bestMatch = bestResultSets.FirstOrDefault(r => r.Key.Equals(key));
+        KeyValuePair<object, string[]> bestMatch = Array.Find(bestResultSets, r => r.Key.Equals(key));
 
         if ((bestMatch.Key, bestMatch.Value) == default)
         {

--- a/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
@@ -63,10 +63,8 @@ public class AutoConversionStep : IEquivalencyStep
                     conversionResult = Enum.ToObject(expectationType, subject);
                     return true;
                 }
-                else
-                {
-                    return false;
-                }
+
+                return false;
             }
 
             conversionResult = Convert.ChangeType(subject, expectationType, CultureInfo.InvariantCulture);

--- a/Src/FluentAssertions/Equivalency/Steps/ConstraintEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ConstraintEquivalencyStep.cs
@@ -223,11 +223,11 @@ public class ConstraintEquivalencyStep : EquivalencyStep<Constraint>
                 failureMessage.Append("columns ").Append(missingColumnNames.JoinUsingWritingStyle());
             }
 
-            failureMessage.Append("{reason}, but constraint does not include ");
-
-            failureMessage.Append(missingColumnNames.Count == 1
-                ? "that column. "
-                : "these columns. ");
+            failureMessage
+                .Append("{reason}, but constraint does not include ")
+                .Append(missingColumnNames.Count == 1
+                    ? "that column. "
+                    : "these columns. ");
         }
 
         if (extraColumnNames.Any())

--- a/Src/FluentAssertions/Equivalency/Steps/DataColumnEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataColumnEquivalencyStep.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -25,20 +25,20 @@ public class DataColumnEquivalencyStep : EquivalencyStep<DataColumn>
         }
         else if (subject is null)
         {
-                if (comparands.Subject is null)
-                {
-                    AssertionScope.Current.FailWith("Expected {context:DataColumn} to be non-null, but found null");
-                }
-                else
-                {
-                    AssertionScope.Current.FailWith("Expected {context:DataColumn} to be of type {0}, but found {1} instead",
-                        expectation.GetType(), comparands.Subject.GetType());
-                }
+            if (comparands.Subject is null)
+            {
+                AssertionScope.Current.FailWith("Expected {context:DataColumn} to be non-null, but found null");
             }
             else
             {
-                CompareSubjectAndExpectationOfTypeDataColumn(comparands, context, nestedValidator, subject);
+                AssertionScope.Current.FailWith("Expected {context:DataColumn} to be of type {0}, but found {1} instead",
+                    expectation.GetType(), comparands.Subject.GetType());
             }
+        }
+        else
+        {
+            CompareSubjectAndExpectationOfTypeDataColumn(comparands, context, nestedValidator, subject);
+        }
 
         return EquivalencyResult.AssertionCompleted;
     }
@@ -103,7 +103,7 @@ public class DataColumnEquivalencyStep : EquivalencyStep<DataColumn>
         return query.FirstOrDefault();
     }
 
-    // Note: This list of candidate members is duplicated in the XML documentation for the
+    // NOTE: This list of candidate members is duplicated in the XML documentation for the
     // DataColumn.BeEquivalentTo extension method in DataColumnAssertions.cs. If this ever
     // needs to change, keep them in sync.
     private static readonly ISet<string> CandidateMembers =

--- a/Src/FluentAssertions/Equivalency/Steps/DataColumnEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataColumnEquivalencyStep.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -141,8 +141,6 @@ public class DataColumnEquivalencyStep : EquivalencyStep<DataColumn>
                 new MemberSelectionContext(comparands.CompileTimeType, comparands.RuntimeType, config));
         }
 
-        members = members.Where(member => CandidateMembers.Contains(member.Name));
-
-        return members;
+        return members.Where(member => CandidateMembers.Contains(member.Name));
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/DataColumnEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataColumnEquivalencyStep.cs
@@ -23,10 +23,8 @@ public class DataColumnEquivalencyStep : EquivalencyStep<DataColumn>
                 AssertionScope.Current.FailWith("Expected {context:DataColumn} value to be null, but found {0}", subject);
             }
         }
-        else
+        else if (subject is null)
         {
-            if (subject is null)
-            {
                 if (comparands.Subject is null)
                 {
                     AssertionScope.Current.FailWith("Expected {context:DataColumn} to be non-null, but found null");
@@ -41,7 +39,6 @@ public class DataColumnEquivalencyStep : EquivalencyStep<DataColumn>
             {
                 CompareSubjectAndExpectationOfTypeDataColumn(comparands, context, nestedValidator, subject);
             }
-        }
 
         return EquivalencyResult.AssertionCompleted;
     }

--- a/Src/FluentAssertions/Equivalency/Steps/DataRelationEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRelationEquivalencyStep.cs
@@ -23,31 +23,28 @@ public class DataRelationEquivalencyStep : EquivalencyStep<DataRelation>
                 AssertionScope.Current.FailWith("Expected {context:DataRelation} to be null, but found {0}", subject);
             }
         }
-        else
+        else if (subject is null)
         {
-            if (subject is null)
+            if (comparands.Subject is null)
             {
-                if (comparands.Subject is null)
-                {
-                    AssertionScope.Current.FailWith("Expected {context:DataRelation} value to be non-null, but found null");
-                }
-                else
-                {
-                    AssertionScope.Current.FailWith("Expected {context:DataRelation} of type {0}, but found {1} instead",
-                        expectation.GetType(), comparands.Subject.GetType());
-                }
+                AssertionScope.Current.FailWith("Expected {context:DataRelation} value to be non-null, but found null");
             }
             else
             {
-                var selectedMembers = GetMembersFromExpectation(context.CurrentNode, comparands, context.Options)
-                    .ToDictionary(member => member.Name);
-
-                CompareScalarProperties(subject, expectation, selectedMembers);
-
-                CompareCollections(context, comparands, nestedValidator, context.Options, selectedMembers);
-
-                CompareRelationConstraints(context, nestedValidator, subject, expectation, selectedMembers);
+                AssertionScope.Current.FailWith("Expected {context:DataRelation} of type {0}, but found {1} instead",
+                    expectation.GetType(), comparands.Subject.GetType());
             }
+        }
+        else
+        {
+            var selectedMembers = GetMembersFromExpectation(context.CurrentNode, comparands, context.Options)
+                .ToDictionary(member => member.Name);
+
+            CompareScalarProperties(subject, expectation, selectedMembers);
+
+            CompareCollections(context, comparands, nestedValidator, context.Options, selectedMembers);
+
+            CompareRelationConstraints(context, nestedValidator, subject, expectation, selectedMembers);
         }
 
         return EquivalencyResult.AssertionCompleted;

--- a/Src/FluentAssertions/Equivalency/Steps/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRowEquivalencyStep.cs
@@ -25,44 +25,41 @@ public class DataRowEquivalencyStep : EquivalencyStep<DataRow>
                 AssertionScope.Current.FailWith("Expected {context:DataRow} value to be null, but found {0}", subject);
             }
         }
-        else
+        else if (subject is null)
         {
-            if (subject is null)
+            if (comparands.Subject is null)
             {
-                if (comparands.Subject is null)
-                {
-                    AssertionScope.Current.FailWith("Expected {context:DataRow} to be non-null, but found null");
-                }
-                else
-                {
-                    AssertionScope.Current.FailWith("Expected {context:DataRow} to be of type {0}, but found {1} instead",
-                        expectation.GetType(), comparands.Subject.GetType());
-                }
+                AssertionScope.Current.FailWith("Expected {context:DataRow} to be non-null, but found null");
             }
             else
             {
-                var dataSetConfig = context.Options as DataEquivalencyAssertionOptions<DataSet>;
-                var dataTableConfig = context.Options as DataEquivalencyAssertionOptions<DataTable>;
-                var dataRowConfig = context.Options as DataEquivalencyAssertionOptions<DataRow>;
-
-                if (dataSetConfig?.AllowMismatchedTypes != true
-                    && dataTableConfig?.AllowMismatchedTypes != true
-                    && dataRowConfig?.AllowMismatchedTypes != true)
-                {
-                    AssertionScope.Current
-                        .ForCondition(subject.GetType() == expectation.GetType())
-                        .FailWith("Expected {context:DataRow} to be of type {0}{reason}, but found {1}",
-                            expectation.GetType(), subject.GetType());
-                }
-
-                SelectedDataRowMembers selectedMembers =
-                    GetMembersFromExpectation(comparands, context.CurrentNode, context.Options);
-
-                CompareScalarProperties(subject, expectation, selectedMembers);
-
-                CompareFieldValues(context, nestedValidator, subject, expectation, dataSetConfig, dataTableConfig,
-                    dataRowConfig);
+                AssertionScope.Current.FailWith("Expected {context:DataRow} to be of type {0}, but found {1} instead",
+                    expectation.GetType(), comparands.Subject.GetType());
             }
+        }
+        else
+        {
+            var dataSetConfig = context.Options as DataEquivalencyAssertionOptions<DataSet>;
+            var dataTableConfig = context.Options as DataEquivalencyAssertionOptions<DataTable>;
+            var dataRowConfig = context.Options as DataEquivalencyAssertionOptions<DataRow>;
+
+            if (dataSetConfig?.AllowMismatchedTypes != true
+                && dataTableConfig?.AllowMismatchedTypes != true
+                && dataRowConfig?.AllowMismatchedTypes != true)
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.GetType() == expectation.GetType())
+                    .FailWith("Expected {context:DataRow} to be of type {0}{reason}, but found {1}",
+                        expectation.GetType(), subject.GetType());
+            }
+
+            SelectedDataRowMembers selectedMembers =
+                GetMembersFromExpectation(comparands, context.CurrentNode, context.Options);
+
+            CompareScalarProperties(subject, expectation, selectedMembers);
+
+            CompareFieldValues(context, nestedValidator, subject, expectation, dataSetConfig, dataTableConfig,
+                dataRowConfig);
         }
 
         return EquivalencyResult.AssertionCompleted;

--- a/Src/FluentAssertions/Equivalency/Steps/DataSetEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataSetEquivalencyStep.cs
@@ -20,39 +20,36 @@ public class DataSetEquivalencyStep : EquivalencyStep<DataSet>
                 AssertionScope.Current.FailWith("Expected {context:DataSet} value to be null, but found {0}", subject);
             }
         }
-        else
+        else if (subject is null)
         {
-            if (subject is null)
+            if (comparands.Subject is null)
             {
-                if (comparands.Subject is null)
-                {
-                    AssertionScope.Current.FailWith("Expected {context:DataSet} to be non-null, but found null");
-                }
-                else
-                {
-                    AssertionScope.Current.FailWith("Expected {context:DataSet} to be of type {0}, but found {1} instead",
-                        expectation.GetType(), comparands.Subject.GetType());
-                }
+                AssertionScope.Current.FailWith("Expected {context:DataSet} to be non-null, but found null");
             }
             else
             {
-                var dataConfig = context.Options as DataEquivalencyAssertionOptions<DataSet>;
-
-                if (dataConfig?.AllowMismatchedTypes != true)
-                {
-                    AssertionScope.Current
-                        .ForCondition(subject.GetType() == expectation.GetType())
-                        .FailWith("Expected {context:DataSet} to be of type {0}{reason}, but found {1}", expectation.GetType(),
-                            subject.GetType());
-                }
-
-                var selectedMembers = GetMembersFromExpectation(comparands, context.CurrentNode, context.Options)
-                    .ToDictionary(member => member.Name);
-
-                CompareScalarProperties(subject, expectation, selectedMembers);
-
-                CompareCollections(context, nestedValidator, context.Options, subject, expectation, dataConfig, selectedMembers);
+                AssertionScope.Current.FailWith("Expected {context:DataSet} to be of type {0}, but found {1} instead",
+                    expectation.GetType(), comparands.Subject.GetType());
             }
+        }
+        else
+        {
+            var dataConfig = context.Options as DataEquivalencyAssertionOptions<DataSet>;
+
+            if (dataConfig?.AllowMismatchedTypes != true)
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.GetType() == expectation.GetType())
+                    .FailWith("Expected {context:DataSet} to be of type {0}{reason}, but found {1}", expectation.GetType(),
+                        subject.GetType());
+            }
+
+            var selectedMembers = GetMembersFromExpectation(comparands, context.CurrentNode, context.Options)
+                .ToDictionary(member => member.Name);
+
+            CompareScalarProperties(subject, expectation, selectedMembers);
+
+            CompareCollections(context, nestedValidator, context.Options, subject, expectation, dataConfig, selectedMembers);
         }
 
         return EquivalencyResult.AssertionCompleted;

--- a/Src/FluentAssertions/Equivalency/Steps/DataTableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataTableEquivalencyStep.cs
@@ -23,41 +23,38 @@ public class DataTableEquivalencyStep : EquivalencyStep<DataTable>
                 AssertionScope.Current.FailWith("Expected {context:DataTable} value to be null, but found {0}", subject);
             }
         }
-        else
+        else if (subject is null)
         {
-            if (subject is null)
+            if (comparands.Subject is null)
             {
-                if (comparands.Subject is null)
-                {
-                    AssertionScope.Current.FailWith("Expected {context:DataTable} to be non-null, but found null");
-                }
-                else
-                {
-                    AssertionScope.Current.FailWith("Expected {context:DataTable} to be of type {0}, but found {1} instead",
-                        expectation.GetType(), comparands.Subject.GetType());
-                }
+                AssertionScope.Current.FailWith("Expected {context:DataTable} to be non-null, but found null");
             }
             else
             {
-                var dataSetConfig = context.Options as DataEquivalencyAssertionOptions<DataSet>;
-                var dataTableConfig = context.Options as DataEquivalencyAssertionOptions<DataTable>;
-
-                if (dataSetConfig?.AllowMismatchedTypes != true
-                    && dataTableConfig?.AllowMismatchedTypes != true)
-                {
-                    AssertionScope.Current
-                        .ForCondition(subject.GetType() == expectation.GetType())
-                        .FailWith("Expected {context:DataTable} to be of type {0}{reason}, but found {1}", expectation.GetType(),
-                            subject.GetType());
-                }
-
-                var selectedMembers = GetMembersFromExpectation(context.CurrentNode, comparands, context.Options)
-                    .ToDictionary(member => member.Name);
-
-                CompareScalarProperties(subject, expectation, selectedMembers);
-
-                CompareCollections(comparands, context, nestedValidator, context.Options, selectedMembers);
+                AssertionScope.Current.FailWith("Expected {context:DataTable} to be of type {0}, but found {1} instead",
+                    expectation.GetType(), comparands.Subject.GetType());
             }
+        }
+        else
+        {
+            var dataSetConfig = context.Options as DataEquivalencyAssertionOptions<DataSet>;
+            var dataTableConfig = context.Options as DataEquivalencyAssertionOptions<DataTable>;
+
+            if (dataSetConfig?.AllowMismatchedTypes != true
+                && dataTableConfig?.AllowMismatchedTypes != true)
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.GetType() == expectation.GetType())
+                    .FailWith("Expected {context:DataTable} to be of type {0}{reason}, but found {1}", expectation.GetType(),
+                        subject.GetType());
+            }
+
+            var selectedMembers = GetMembersFromExpectation(context.CurrentNode, comparands, context.Options)
+                .ToDictionary(member => member.Name);
+
+            CompareScalarProperties(subject, expectation, selectedMembers);
+
+            CompareCollections(comparands, context, nestedValidator, context.Options, selectedMembers);
         }
 
         return EquivalencyResult.AssertionCompleted;

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
@@ -14,28 +14,25 @@ public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
         var subject = comparands.Subject as IDictionary;
         var expectation = comparands.Expectation as IDictionary;
 
-        if (PreconditionsAreMet(expectation, subject))
+        if (PreconditionsAreMet(expectation, subject) && expectation is not null)
         {
-            if (expectation is not null)
+            foreach (object key in expectation.Keys)
             {
-                foreach (object key in expectation.Keys)
+                if (context.Options.IsRecursive)
                 {
-                    if (context.Options.IsRecursive)
-                    {
-                        context.Tracer.WriteLine(member =>
-                            Invariant($"Recursing into dictionary item {key} at {member.Description}"));
+                    context.Tracer.WriteLine(member =>
+                        Invariant($"Recursing into dictionary item {key} at {member.Description}"));
 
-                        nestedValidator.RecursivelyAssertEquality(new Comparands(subject[key], expectation[key], typeof(object)),
-                            context.AsDictionaryItem<object, IDictionary>(key));
-                    }
-                    else
-                    {
-                        context.Tracer.WriteLine(member =>
-                            Invariant(
-                                $"Comparing dictionary item {key} at {member.Description} between subject and expectation"));
+                    nestedValidator.RecursivelyAssertEquality(new Comparands(subject[key], expectation[key], typeof(object)),
+                        context.AsDictionaryItem<object, IDictionary>(key));
+                }
+                else
+                {
+                    context.Tracer.WriteLine(member =>
+                        Invariant(
+                            $"Comparing dictionary item {key} at {member.Description} between subject and expectation"));
 
-                        subject[key].Should().Be(expectation[key], context.Reason.FormattedMessage, context.Reason.Arguments);
-                    }
+                    subject[key].Should().Be(expectation[key], context.Reason.FormattedMessage, context.Reason.Arguments);
                 }
             }
         }

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -102,14 +102,12 @@ internal sealed class DictionaryInterfaceInfo
             {
                 return Array.Empty<DictionaryInterfaceInfo>();
             }
-            else
-            {
-                return key
-                    .GetClosedGenericInterfaces(typeof(IDictionary<,>))
-                    .Select(@interface => @interface.GetGenericArguments())
-                    .Select(arguments => new DictionaryInterfaceInfo(arguments[0], arguments[1]))
-                    .ToArray();
-            }
+
+            return key
+                .GetClosedGenericInterfaces(typeof(IDictionary<,>))
+                .Select(@interface => @interface.GetGenericArguments())
+                .Select(arguments => new DictionaryInterfaceInfo(arguments[0], arguments[1]))
+                .ToArray();
         });
     }
 

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +11,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// <summary>
 /// Provides Reflection-backed meta-data information about a type implementing the <see cref="IDictionary{TKey,TValue}"/> interface.
 /// </summary>
-internal class DictionaryInterfaceInfo
+internal sealed class DictionaryInterfaceInfo
 {
     // ReSharper disable once PossibleNullReferenceException
     private static readonly MethodInfo ConvertToDictionaryMethod =

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -126,7 +126,7 @@ internal class DictionaryInterfaceInfo
         var suitableKeyValuePairCollection = enumerables
             .Select(enumerable => enumerable.GenericTypeArguments[0])
             .Where(itemType => itemType.IsGenericType && itemType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
-            .SingleOrDefault(itemType => itemType.GenericTypeArguments.First() == Key);
+            .SingleOrDefault(itemType => itemType.GenericTypeArguments[0] == Key);
 
         if (suitableKeyValuePairCollection != null)
         {

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -175,10 +175,8 @@ internal class EnumerableEquivalencyValidator
                 indexToBeRemoved = metaIndex;
                 break;
             }
-            else
-            {
-                context.Tracer.WriteLine(_ => $"Contained {failures.Length} failures");
-            }
+
+            context.Tracer.WriteLine(_ => $"Contained {failures.Length} failures");
         }
 
         if (indexToBeRemoved != -1)

--- a/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -48,12 +48,9 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
         {
             var (isDictionary, actualDictionary) = EnsureSubjectIsDictionary(comparands, expectedDictionary);
 
-            if (isDictionary)
+            if (isDictionary && AssertSameLength(comparands, actualDictionary, expectedDictionary))
             {
-                if (AssertSameLength(comparands, actualDictionary, expectedDictionary))
-                {
-                    AssertDictionaryEquivalence(comparands, context, nestedValidator, actualDictionary, expectedDictionary);
-                }
+                AssertDictionaryEquivalence(comparands, context, nestedValidator, actualDictionary, expectedDictionary);
             }
         }
     }
@@ -78,13 +75,10 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
         bool isDictionary = DictionaryInterfaceInfo.TryGetFromWithKey(comparands.Subject.GetType(), "subject",
             expectedDictionary.Key, out var actualDictionary);
 
-        if (!isDictionary)
+        if (!isDictionary && expectedDictionary.TryConvertFrom(comparands.Subject, out var convertedSubject))
         {
-            if (expectedDictionary.TryConvertFrom(comparands.Subject, out var convertedSubject))
-            {
-                comparands.Subject = convertedSubject;
-                isDictionary = DictionaryInterfaceInfo.TryGetFrom(comparands.Subject.GetType(), "subject", out actualDictionary);
-            }
+            comparands.Subject = convertedSubject;
+            isDictionary = DictionaryInterfaceInfo.TryGetFrom(comparands.Subject.GetType(), "subject", out actualDictionary);
         }
 
         if (!isDictionary)

--- a/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
@@ -30,9 +30,7 @@ public class ValueTypeEquivalencyStep : IEquivalencyStep
 
             return EquivalencyResult.AssertionCompleted;
         }
-        else
-        {
-            return EquivalencyResult.ContinueWithNext;
-        }
+
+        return EquivalencyResult.ContinueWithNext;
     }
 }

--- a/Src/FluentAssertions/Equivalency/Tracing/Tracer.cs
+++ b/Src/FluentAssertions/Equivalency/Tracing/Tracer.cs
@@ -41,10 +41,8 @@ public class Tracer
         {
             return traceWriter.AddBlock(getTraceMessage(currentNode));
         }
-        else
-        {
-            return new Disposable(() => { });
-        }
+
+        return new Disposable(() => { });
     }
 
     public override string ToString() => traceWriter is not null ? traceWriter.ToString() : string.Empty;

--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -33,7 +33,7 @@ public static class EventRaisingExtensions
 
             if (hasSender)
             {
-                object sender = @event.Parameters.First();
+                object sender = @event.Parameters[0];
 
                 if (ReferenceEquals(sender, expectedSender))
                 {

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -29,9 +29,8 @@ internal abstract class LateBoundTestFramework : ITestFramework
         {
             string prefix = AssemblyName + ",";
 
-            assembly = AppDomain.CurrentDomain
-                .GetAssemblies()
-                .FirstOrDefault(a => a.FullName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+            assembly = Array.Find(AppDomain.CurrentDomain
+                .GetAssemblies(), a => a.FullName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
 
             return assembly is not null;
         }

--- a/Src/FluentAssertions/Execution/NSpecFramework.cs
+++ b/Src/FluentAssertions/Execution/NSpecFramework.cs
@@ -13,9 +13,8 @@ internal class NSpecFramework : ITestFramework
     {
         get
         {
-            assembly = AppDomain.CurrentDomain
-                .GetAssemblies()
-                .FirstOrDefault(a => a.FullName.StartsWith("nspec,", StringComparison.OrdinalIgnoreCase));
+            assembly = Array.Find(AppDomain.CurrentDomain
+                .GetAssemblies(), a => a.FullName.StartsWith("nspec,", StringComparison.OrdinalIgnoreCase));
 
             if (assembly is null)
             {

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -117,5 +117,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Roslynator.Analyzers" Version="4.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -89,7 +89,7 @@ public class AttributeBasedFormatter : IValueFormatter
             where method.IsDecoratedWithOrInherit<ValueFormatterAttribute>()
             let methodParameters = method.GetParameters()
             where methodParameters.Length == 2
-            select new { Type = methodParameters.First().ParameterType, Method = method }
+            select new { Type = methodParameters[0].ParameterType, Method = method }
             into formatter
             group formatter by formatter.Type
             into formatterGroup

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -38,16 +38,13 @@ public class DefaultValueFormatter : IValueFormatter
         {
             WriteTypeAndMemberValues(value, formattedGraph, formatChild);
         }
+        else if (context.UseLineBreaks)
+        {
+            formattedGraph.AddFragmentOnNewLine(value.ToString());
+        }
         else
         {
-            if (context.UseLineBreaks)
-            {
-                formattedGraph.AddFragmentOnNewLine(value.ToString());
-            }
-            else
-            {
-                formattedGraph.AddFragment(value.ToString());
-            }
+            formattedGraph.AddFragment(value.ToString());
         }
     }
 

--- a/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Xml.Linq;
 using FluentAssertions.Common;
@@ -39,7 +39,7 @@ public class XElementValueFormatter : IValueFormatter
 
         // Can't use env.newline because the input doc may have unix or windows style
         // line-breaks
-        string firstLine = lines.First().RemoveNewLines();
+        string firstLine = lines[0].RemoveNewLines();
         string lastLine = lines.Last().RemoveNewLines();
 
         string formattedElement = firstLine + "…" + lastLine;

--- a/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Xml.Linq;
 using FluentAssertions.Common;

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -1483,11 +1483,19 @@ public static class NumericAssertionsExtensions
 
     private static long GetMinValue(long value, ulong delta)
     {
-        long minValue = delta <= (ulong.MaxValue / 2)
-            ? value - (long)delta
-            : value < 0
-                ? long.MinValue
-                : -(long)(delta - (ulong)value);
+        long minValue;
+        if (delta <= (ulong.MaxValue / 2))
+        {
+            minValue = value - (long)delta;
+        }
+        else if (value < 0)
+        {
+            minValue = long.MinValue;
+        }
+        else
+        {
+            minValue = -(long)(delta - (ulong)value);
+        }
 
         if (minValue > value)
         {
@@ -1499,11 +1507,19 @@ public static class NumericAssertionsExtensions
 
     private static long GetMaxValue(long value, ulong delta)
     {
-        long maxValue = delta <= (ulong.MaxValue / 2)
-            ? value + (long)delta
-            : value >= 0
-                ? long.MaxValue
-                : (long)((ulong)value + delta);
+        long maxValue;
+        if (delta <= (ulong.MaxValue / 2))
+        {
+            maxValue = value + (long)delta;
+        }
+        else if (value >= 0)
+        {
+            maxValue = long.MaxValue;
+        }
+        else
+        {
+            maxValue = (long)((ulong)value + delta);
+        }
 
         if (maxValue < value)
         {

--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -173,10 +173,8 @@ public static class ObjectAssertionsExtensions
             {
                 return type;
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
     }
 

--- a/Src/FluentAssertions/Primitives/StringValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringValidator.cs
@@ -39,12 +39,9 @@ internal abstract class StringValidator
                     Assertion = Assertion.UsingLineBreaks;
                 }
 
-                if (ValidateAgainstSuperfluousWhitespace())
+                if (ValidateAgainstSuperfluousWhitespace() && ValidateAgainstLengthDifferences())
                 {
-                    if (ValidateAgainstLengthDifferences())
-                    {
-                        ValidateAgainstMismatch();
-                    }
+                    ValidateAgainstMismatch();
                 }
             }
         }

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
@@ -58,10 +58,11 @@ internal class StringWildcardMatchingValidator : StringValidator
         get
         {
             var builder = new StringBuilder();
-            builder.Append(Negate ? "Did not expect " : "Expected ");
-            builder.Append("{context:string}");
-            builder.Append(IgnoreCase ? " to match the equivalent of" : " to match");
-            builder.Append(" {0}{reason}, ");
+            builder
+                .Append(Negate ? "Did not expect " : "Expected ")
+                .Append("{context:string}")
+                .Append(IgnoreCase ? " to match the equivalent of" : " to match")
+                .Append(" {0}{reason}, ");
 
             return builder.ToString();
         }

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -291,7 +291,7 @@ public class TypeSelector : IEnumerable<Type>
     /// </summary>
     public TypeSelector UnwrapTaskTypes()
     {
-        types = types.Select(type =>
+        types = types.ConvertAll(type =>
         {
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Task<>))
             {
@@ -304,7 +304,7 @@ public class TypeSelector : IEnumerable<Type>
             }
 
             return type == typeof(Task) || type == typeof(ValueTask) ? typeof(void) : type;
-        }).ToList();
+        });
 
         return this;
     }

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -150,3 +150,9 @@ resharper_expression_is_always_null_highlighting = none
 
 # ReSharper properties
 resharper_keep_user_linebreaks = true
+
+# Use EventHandler<T>. We have some special cases for testing.
+dotnet_diagnostic.RCS1159.severity = error
+
+# Implement IComparable when implementing IComparable<T><T>. Disabled since we don't want to be so strict in tests.
+dotnet_diagnostic.RCS1241.severity = none

--- a/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
+++ b/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
@@ -79,6 +79,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Roslynator.Analyzers" Version="4.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Linq;
 using FluentAssertions.Events;
@@ -385,7 +385,7 @@ public class EventAssertionSpecs
                 .Raise(nameof(observable.PropertyChanged))
                 .WithSender(observable);
 
-            recording.Should().ContainSingle().Which.Parameters.First().Should().BeSameAs(observable);
+            recording.Should().ContainSingle().Which.Parameters[0].Should().BeSameAs(observable);
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Linq;
 using FluentAssertions.Events;
@@ -991,7 +991,9 @@ public class EventAssertionSpecs
 
     public class ClassThatRaisesEventsItself : IInheritsEventRaisingInterface
     {
+#pragma warning disable RCS1159
         public event PropertyChangedEventHandler PropertyChanged;
+#pragma warning restore RCS1159
 
         public event EventHandler InterfaceEvent;
 

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -460,7 +460,7 @@ namespace FluentAssertions.Specs.Execution
         }
 
         [Collection("UIFacts")]
-        public partial class UIFacts
+        public class UIFacts
         {
             [UIFact]
             public async Task Caller_identification_should_also_work_for_statements_following_async_code()

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -82,6 +82,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Roslynator.Analyzers" Version="4.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -691,9 +691,9 @@ public class FormatterSpecs
         public string Description { get; set; }
 
         public string Field;
-#pragma warning disable 169, CA1823, IDE0044
+#pragma warning disable 169, CA1823, IDE0044, RCS1169
         private string privateField;
-#pragma warning restore 169, CA1823, IDE0044
+#pragma warning restore 169, CA1823, IDE0044, RCS1169
     }
 
     public class Stuff<TChild> : BaseStuff


### PR DESCRIPTION
To prevent the issues #2157 fixes from happening again, I've introduced [Roslynator](https://github.com/JosefPihrt/Roslynator) to add a bunch of useful Roslyn code and styling rules to the project. 

* Improve nested `if`s and `if`/`else` constructs by merging them or removing an unnecessary `else`
* Replace nested conditional statements with `if`/`else` constructs for readability
* Sealed internal classes
* Use the parameter names from the interface that it implements
* Use chaining if possible
* Replace LINQ usage with faster alternatives
* Replace `First()` with the much faster `[0]` indexer
* Remove unnecessary intermediate variables
* Remove unnecessary use of partial for non-partial classes
* Use <para> tags in XML comments to nicely format paragraphs

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome