### PR TITLE
Regex cleanup

### DIFF
--- a/Src/FluentAssertions/Common/MemberPathSegmentEqualityComparer.cs
+++ b/Src/FluentAssertions/Common/MemberPathSegmentEqualityComparer.cs
@@ -12,7 +12,7 @@ namespace FluentAssertions.Common;
 internal class MemberPathSegmentEqualityComparer : IEqualityComparer<string>
 {
     private const string AnyIndexQualifier = "*";
-    private static readonly Regex IndexQualifierRegex = new(@"^\d+$");
+    private static readonly Regex IndexQualifierRegex = new("^[0-9]+$");
 
     /// <summary>
     /// Compares two segments of a <see cref="MemberPath"/>.

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -47,7 +47,7 @@ internal static class StringExtensions
     /// </summary>
     public static string WithoutSpecificCollectionIndices(this string indexedPath)
     {
-        return Regex.Replace(indexedPath, @"\[\d+\]", "[]");
+        return Regex.Replace(indexedPath, @"\[[0-9]+\]", "[]");
     }
 
     /// <summary>
@@ -55,7 +55,7 @@ internal static class StringExtensions
     /// </summary>
     public static bool ContainsSpecificCollectionIndex(this string indexedPath)
     {
-        return Regex.IsMatch(indexedPath, @"\[\d+\]");
+        return Regex.IsMatch(indexedPath, @"\[[0-9]+\]");
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Equivalency/Node.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions.Equivalency;
 
 public class Node : INode
 {
-    private static readonly Regex MatchFirstIndex = new(@"^\[\d+\]$");
+    private static readonly Regex MatchFirstIndex = new(@"^\[[0-9]+\]$");
 
     private string path;
     private string name;

--- a/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
@@ -47,7 +47,7 @@ internal class PathBasedOrderingRule : IOrderingRule
 
     private string RemoveInitialIndexQualifier(string sourcePath)
     {
-        var indexQualifierRegex = new Regex(@"^\[\d+]\.");
+        var indexQualifierRegex = new Regex(@"^\[[0-9]+]\.");
 
         if (!indexQualifierRegex.IsMatch(path))
         {

--- a/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
@@ -50,7 +50,7 @@ internal abstract class SelectMemberByPathSelectionRule : IMemberSelectionRule
 
     private static string RemoveIndexQualifiers(string path)
     {
-        Match match = new Regex(@"^\[\d+]").Match(path);
+        Match match = new Regex(@"^\[[0-9]+]").Match(path);
 
         if (match.Success)
         {

--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -33,7 +33,7 @@ internal class MessageBuilder
     public string Build(string message, object[] messageArgs, string reason, ContextDataItems contextData, string identifier,
         string fallbackIdentifier)
     {
-        message = Regex.Replace(message, "{reason}", SanitizeReason(reason));
+        message = message.Replace("{reason}", SanitizeReason(reason), StringComparison.Ordinal);
 
         message = SubstituteIdentifier(message, identifier?.EscapePlaceholders(), fallbackIdentifier);
 


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

Per default `\d` and `[0-9]` is not the same.
See https://www.meziantou.net/dotnet-regex-d-is-different-from-0-9.htm