### PR TITLE
Some internal naming improvements

### DIFF
--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -71,10 +71,10 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
 
     public bool IsCyclicReference(object expectation)
     {
-        bool isComplexType = expectation is not null && Options.GetEqualityStrategy(expectation.GetType())
+        bool compareByMembers = expectation is not null && Options.GetEqualityStrategy(expectation.GetType())
             is EqualityStrategy.Members or EqualityStrategy.ForceMembers;
 
-        var reference = new ObjectReference(expectation, CurrentNode.PathAndName, isComplexType);
+        var reference = new ObjectReference(expectation, CurrentNode.PathAndName, compareByMembers);
         return CyclicReferenceDetector.IsCyclicReference(reference, Options.CyclicReferenceHandling, Reason);
     }
 

--- a/Src/FluentAssertions/Equivalency/Execution/CyclicReferenceDetector.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CyclicReferenceDetector.cs
@@ -26,7 +26,7 @@ internal class CyclicReferenceDetector : ICloneable2
     {
         bool isCyclic = false;
 
-        if (reference.IsComplexType)
+        if (reference.CompareByMembers)
         {
             isCyclic = !observedReferences.Add(reference);
 

--- a/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs
@@ -13,14 +13,14 @@ internal class ObjectReference
 {
     private readonly object @object;
     private readonly string path;
-    private readonly bool? isComplexType;
+    private readonly bool? compareByMembers;
     private string[] pathElements;
 
-    public ObjectReference(object @object, string path, bool? isComplexType = null)
+    public ObjectReference(object @object, string path, bool? compareByMembers = null)
     {
         this.@object = @object;
         this.path = path;
-        this.isComplexType = isComplexType;
+        this.compareByMembers = compareByMembers;
     }
 
     /// <summary>
@@ -69,5 +69,5 @@ internal class ObjectReference
         return Invariant($"{{\"{path}\", {@object}}}");
     }
 
-    public bool IsComplexType => isComplexType ?? (@object?.GetType().OverridesEquals() == false);
+    public bool CompareByMembers => compareByMembers ?? (@object?.GetType().OverridesEquals() == false);
 }


### PR DESCRIPTION
Some minor internal naming changes that I found while using the code in a workshop 

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
* [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome