### PR TITLE
Extracts the type reflection logic into a dedicated class

### DIFF
--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions.Equivalency;
+
+namespace FluentAssertions.Common;
+
+/// <summary>
+/// Helper class to get all the public and internal fields and properties from a type.
+/// </summary>
+internal sealed class TypeMemberReflector
+{
+    private const BindingFlags AllInstanceMembersFlag =
+        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+    public TypeMemberReflector(Type typeToReflect, MemberVisibility visibility)
+    {
+        NonPrivateProperties = LoadNonPrivateProperties(typeToReflect, visibility);
+        NonPrivateFields = LoadNonPrivateFields(typeToReflect, visibility);
+        NonPrivateMembers = NonPrivateProperties.Concat<MemberInfo>(NonPrivateFields).ToArray();
+    }
+
+    public MemberInfo[] NonPrivateMembers { get; }
+
+    public PropertyInfo[] NonPrivateProperties { get; }
+
+    public FieldInfo[] NonPrivateFields { get; }
+
+    private static PropertyInfo[] LoadNonPrivateProperties(Type typeToReflect, MemberVisibility visibility)
+    {
+        IEnumerable<PropertyInfo> query =
+            from propertyInfo in GetPropertiesFromHierarchy(typeToReflect, visibility)
+            where HasNonPrivateGetter(propertyInfo)
+            where !propertyInfo.IsIndexer()
+            select propertyInfo;
+
+        return query.ToArray();
+    }
+
+    private static IEnumerable<PropertyInfo> GetPropertiesFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
+    {
+        bool includeInternals = memberVisibility.HasFlag(MemberVisibility.Internal);
+
+        return GetMembersFromHierarchy(typeToReflect, type =>
+        {
+            return type
+                .GetProperties(AllInstanceMembersFlag | BindingFlags.DeclaredOnly)
+                .Where(property => property.GetMethod?.IsPrivate == false)
+                .Where(property => includeInternals || property.GetMethod is { IsAssembly: false, IsFamilyOrAssembly: false })
+                .ToArray();
+        });
+    }
+
+    private static FieldInfo[] LoadNonPrivateFields(Type typeToReflect, MemberVisibility visibility)
+    {
+        IEnumerable<FieldInfo> query =
+            from fieldInfo in GetFieldsFromHierarchy(typeToReflect, visibility)
+            where !fieldInfo.IsPrivate
+            where !fieldInfo.IsFamily
+            select fieldInfo;
+
+        return query.ToArray();
+    }
+
+    private static IEnumerable<FieldInfo> GetFieldsFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
+    {
+        bool includeInternals = memberVisibility.HasFlag(MemberVisibility.Internal);
+
+        return GetMembersFromHierarchy(typeToReflect, type =>
+        {
+            return type
+                .GetFields(AllInstanceMembersFlag)
+                .Where(field => !field.IsPrivate)
+                .Where(field => includeInternals || (!field.IsAssembly && !field.IsFamilyOrAssembly))
+                .ToArray();
+        });
+    }
+
+    private static IEnumerable<TMemberInfo> GetMembersFromHierarchy<TMemberInfo>(
+        Type typeToReflect,
+        Func<Type, IEnumerable<TMemberInfo>> getMembers)
+        where TMemberInfo : MemberInfo
+    {
+        if (typeToReflect.IsInterface)
+        {
+            return GetInterfaceMembers(typeToReflect, getMembers);
+        }
+
+        return GetClassMembers(typeToReflect, getMembers);
+    }
+
+    private static List<TMemberInfo> GetInterfaceMembers<TMemberInfo>(Type typeToReflect,
+        Func<Type, IEnumerable<TMemberInfo>> getMembers)
+        where TMemberInfo : MemberInfo
+    {
+        List<TMemberInfo> members = new();
+
+        var considered = new List<Type>();
+        var queue = new Queue<Type>();
+        considered.Add(typeToReflect);
+        queue.Enqueue(typeToReflect);
+
+        while (queue.Count > 0)
+        {
+            Type subType = queue.Dequeue();
+
+            foreach (Type subInterface in subType.GetInterfaces())
+            {
+                if (considered.Contains(subInterface))
+                {
+                    continue;
+                }
+
+                considered.Add(subInterface);
+                queue.Enqueue(subInterface);
+            }
+
+            IEnumerable<TMemberInfo> typeMembers = getMembers(subType);
+
+            IEnumerable<TMemberInfo> newPropertyInfos = typeMembers.Where(x => !members.Contains(x));
+
+            members.InsertRange(0, newPropertyInfos);
+        }
+
+        return members;
+    }
+
+    private static List<TMemberInfo> GetClassMembers<TMemberInfo>(Type typeToReflect,
+        Func<Type, IEnumerable<TMemberInfo>> getMembers)
+        where TMemberInfo : MemberInfo
+    {
+        List<TMemberInfo> members = new();
+
+        while (typeToReflect != null)
+        {
+            foreach (var memberInfo in getMembers(typeToReflect))
+            {
+                if (members.All(mi => mi.Name != memberInfo.Name))
+                {
+                    members.Add(memberInfo);
+                }
+            }
+
+            typeToReflect = typeToReflect.BaseType;
+        }
+
+        return members;
+    }
+
+    private static bool HasNonPrivateGetter(PropertyInfo propertyInfo)
+    {
+        MethodInfo getMethod = propertyInfo.GetGetMethod(nonPublic: true);
+        return getMethod is { IsPrivate: false, IsFamily: false };
+    }
+}

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -56,7 +56,7 @@ public class DefaultValueFormatter : IValueFormatter
     /// <remarks>The default is all non-private members.</remarks>
     protected virtual MemberInfo[] GetMembers(Type type)
     {
-        return type.GetNonPrivateMembers(MemberVisibility.Public).ToArray();
+        return type.GetNonPrivateMembers(MemberVisibility.Public);
     }
 
     private static bool HasDefaultToStringImplementation(object value)


### PR DESCRIPTION
As preparation for #2152, I've extracted all the logic to identify the members of a type into a dedicated class.

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
* [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome