### PR TITLE
Update to C# 11

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/FluentAssertions.sln
+++ b/FluentAssertions.sln
@@ -7,6 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Tests\Default.testsettings = Tests\Default.testsettings
+		Directory.Build.props = Directory.Build.props
 		Src\JetBrainsAnnotations.cs = Src\JetBrainsAnnotations.cs
 		nuget.config = nuget.config
 		README.md = README.md

--- a/Src/FluentAssertions/CallerIdentification/MultiLineCommentParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/MultiLineCommentParsingStrategy.cs
@@ -26,10 +26,9 @@ internal class MultiLineCommentParsingStrategy : IParsingStrategy
             return ParsingState.GoToNextSymbol;
         }
 
-        var isStartOfMultilineComment =
-            symbol is '*'
-            && statement.Length > 0
-            && statement[^1] is '/';
+#pragma warning disable SA1010 // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3507
+        var isStartOfMultilineComment = symbol is '*' && statement is [.., '/'];
+#pragma warning restore SA1010
 
         if (isStartOfMultilineComment)
         {

--- a/Src/FluentAssertions/CallerIdentification/QuotesParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/QuotesParsingStrategy.cs
@@ -54,7 +54,9 @@ internal class QuotesParsingStrategy : IParsingStrategy
 
     private bool IsVerbatim(StringBuilder statement)
     {
-        return (previousChar is '@' && statement.Length >= 2 && statement[^2] is '$' && statement[^1] is '@')
-            || (previousChar is '$' && statement.Length >= 2 && statement[^2] is '@' && statement[^1] is '$');
+#pragma warning disable SA1010 // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3507
+        return (previousChar is '@' && statement is [.., '$', '@'])
+            || (previousChar is '$' && statement is [.., '@', '$']);
+#pragma warning restore SA1010
     }
 }

--- a/Src/FluentAssertions/CallerIdentification/SingleLineCommentParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/SingleLineCommentParsingStrategy.cs
@@ -13,7 +13,9 @@ internal class SingleLineCommentParsingStrategy : IParsingStrategy
             return ParsingState.GoToNextSymbol;
         }
 
-        var doesSymbolStartComment = symbol is '/' && statement.Length > 0 && statement[^1] is '/';
+#pragma warning disable SA1010 // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3507
+        var doesSymbolStartComment = symbol is '/' && statement is [.., '/'];
+#pragma warning restore SA1010
 
         if (!doesSymbolStartComment)
         {

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -74,10 +74,10 @@ internal static class ExpressionExtensions
 
                 case ExpressionType.ArrayIndex:
                     var binaryExpression = (BinaryExpression)node;
-                    var constantExpression = (ConstantExpression)binaryExpression.Right;
+                    var indexExpression = (ConstantExpression)binaryExpression.Right;
                     node = binaryExpression.Left;
 
-                    segments.Add("[" + constantExpression.Value + "]");
+                    segments.Add("[" + indexExpression.Value + "]");
                     break;
 
                 case ExpressionType.Parameter:
@@ -87,15 +87,15 @@ internal static class ExpressionExtensions
                 case ExpressionType.Call:
                     var methodCallExpression = (MethodCallExpression)node;
 
-                    if (methodCallExpression.Method.Name != "get_Item" || methodCallExpression.Arguments.Count != 1 ||
-                        methodCallExpression.Arguments[0] is not ConstantExpression)
+#pragma warning disable SA1010 // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3507
+                    if (methodCallExpression is not { Method.Name: "get_Item", Arguments: [ConstantExpression argumentExpression] })
                     {
                         throw new ArgumentException(GetUnsupportedExpressionMessage(expression.Body), nameof(expression));
                     }
+#pragma warning restore SA1010
 
-                    constantExpression = (ConstantExpression)methodCallExpression.Arguments[0];
                     node = methodCallExpression.Object;
-                    segments.Add("[" + constantExpression.Value + "]");
+                    segments.Add("[" + argumentExpression.Value + "]");
                     break;
 
                 default:
@@ -158,11 +158,12 @@ internal static class ExpressionExtensions
                 case ExpressionType.Call:
                     var methodCallExpression = (MethodCallExpression)node;
 
-                    if (methodCallExpression.Method.Name != "get_Item" || methodCallExpression.Arguments.Count != 1 ||
-                        methodCallExpression.Arguments[0] is not ConstantExpression)
+#pragma warning disable SA1010 // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3507
+                    if (methodCallExpression is not { Method.Name: "get_Item", Arguments: [ConstantExpression] })
                     {
                         throw new ArgumentException(GetUnsupportedExpressionMessage(expression.Body), nameof(expression));
                     }
+#pragma warning restore SA1010
 
                     node = methodCallExpression.Object;
                     break;


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

Updates to C# 11 and switches to list patterns a few places.