### PR TITLE
Improve the DateOnly and TimeOnly code coverage

### DIFF
--- a/Tests/FluentAssertions.Specs/Primitives/DateOnlyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateOnlyAssertionSpecs.cs
@@ -27,6 +27,16 @@ public class DateOnlyAssertionSpecs
         dateOnly.Should().NotBeNull();
     }
 
+    [Fact]
+    public void Should_succeed_when_asserting_nullable_dateonly_value_with_null_to_be_null()
+    {
+        // Arrange
+        DateOnly? dateOnly = null;
+
+        // Act/Assert
+        dateOnly.Should().BeNull();
+    }
+
     public class Be
     {
         [Fact]
@@ -599,6 +609,65 @@ public class DateOnlyAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Did not expect the month part of subject to be 12, but found a <null> DateOnly.");
+        }
+    }
+
+    public class NotBe
+    {
+        [Fact]
+        public void Different_dateonly_values_are_valid()
+        {
+            // Arrange
+            DateOnly date = new(2020, 06, 04);
+            DateOnly otherDate = new(2020, 06, 05);
+
+            // Act & Assert
+            date.Should().NotBe(otherDate);
+        }
+
+        [Fact]
+        public void Different_dateonly_values_with_different_nullability_are_valid()
+        {
+            // Arrange
+            DateOnly date = new(2020, 06, 04);
+            DateOnly? otherDate = new(2020, 07, 05);
+
+            // Act & Assert
+            date.Should().NotBe(otherDate);
+        }
+
+        [Fact]
+        public void Same_dateonly_values_are_invalid()
+        {
+            // Arrange
+            DateOnly date = new(2020, 06, 04);
+            DateOnly sameDate = new(2020, 06, 04);
+
+            // Act
+            Action act =
+                () => date.Should().NotBe(sameDate, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected date not to be <2020-06-04> because we want to test the failure message, but it is.");
+        }
+
+        [Fact]
+        public void Same_dateonly_values_with_different_nullability_are_invalid()
+        {
+            // Arrange
+            DateOnly date = new(2020, 06, 04);
+            DateOnly? sameDate = new(2020, 06, 04);
+
+            // Act
+            Action act =
+                () => date.Should().NotBe(sameDate, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected date not to be <2020-06-04> because we want to test the failure message, but it is.");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Primitives/TimeOnlyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/TimeOnlyAssertionSpecs.cs
@@ -29,6 +29,16 @@ public class TimeOnlyAssertionSpecs
         timeOnly.Should().NotBeNull();
     }
 
+    [Fact]
+    public void Should_succeed_when_asserting_nullable_timeonly_value_with_null_to_be_null()
+    {
+        // Arrange
+        TimeOnly? timeOnly = null;
+
+        // Act/Assert
+        timeOnly.Should().BeNull();
+    }
+
     public class Be
     {
         [Fact]
@@ -1288,6 +1298,65 @@ public class TimeOnlyAssertionSpecs
 
             // Act/Assert
             value.Should().BeOneOf(new TimeOnly(15, 1, 30), null);
+        }
+    }
+
+    public class NotBe
+    {
+        [Fact]
+        public void Different_timeonly_values_are_valid()
+        {
+            // Arrange
+            TimeOnly time = new(19, 06, 04);
+            TimeOnly otherTime = new(20, 06, 05);
+
+            // Act & Assert
+            time.Should().NotBe(otherTime);
+        }
+
+        [Fact]
+        public void Different_timeonly_values_with_different_nullability_are_valid()
+        {
+            // Arrange
+            TimeOnly time = new(19, 06, 04);
+            TimeOnly? otherTime = new(19, 07, 05);
+
+            // Act & Assert
+            time.Should().NotBe(otherTime);
+        }
+
+        [Fact]
+        public void Same_timeonly_values_are_invalid()
+        {
+            // Arrange
+            TimeOnly time = new(19, 06, 04);
+            TimeOnly sameTime = new(19, 06, 04);
+
+            // Act
+            Action act =
+                () => time.Should().NotBe(sameTime, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected time not to be <19:06:04.000> because we want to test the failure message, but it is.");
+        }
+
+        [Fact]
+        public void Same_timeonly_values_with_different_nullability_are_invalid()
+        {
+            // Arrange
+            TimeOnly time = new(19, 06, 04);
+            TimeOnly? sameTime = new(19, 06, 04);
+
+            // Act
+            Action act =
+                () => time.Should().NotBe(sameTime, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected time not to be <19:06:04.000> because we want to test the failure message, but it is.");
         }
     }
 


### PR DESCRIPTION
Mostly NotBe and BeNull that were missing coverage.

Part of #1823 