### PR TITLE
Update to Coveralls v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,11 @@ jobs:
         files: "TestResults/reports/lcov.info"
 
     - name: coveralls
-      uses: coverallsapp/github-action@1.1.3
+      uses: coverallsapp/github-action@v2
       if: steps.check_files.outputs.files_exists == 'true'
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: TestResults/reports/lcov.info
+        file: TestResults/reports/lcov.info
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageDownload Include="GitVersion.Tool" Version="[5.12.0]" />
     <PackageDownload Include="NSpec" Version="[3.1.0]" />
-    <PackageDownload Include="ReportGenerator" Version="[5.1.17]" />
+    <PackageDownload Include="ReportGenerator" Version="[5.1.19]" />
     <PackageDownload Include="xunit.runner.console" Version="[2.4.2]" />
     <PackageDownload Include="Node.js.redist" Version="[16.17.1]" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome


This switches the underlying coveralls reporter from [node-coveralls](https://github.com/nickmerwin/node-coveralls) to
[coverage-reporter](https://github.com/coverallsapp/coverage-reporter) which fixes two problems.

1) A deprecation notice in the github action output:
> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

2) Files containing multiple types did not have coverage information on coveralls.io.
https://github.com/fluentassertions/fluentassertions/commit/9625e1f23773ad58d54e4b7ec4ad7bbfaed5229c partly fixed this by separating most types to separate files.
Left are files with multiple generic variants which we want to keep in the same file.

The update of ReportGenerator was because I was in here anyways.

develop:
![image](https://user-images.githubusercontent.com/919634/230382968-c8932b56-e5a8-4bfa-b59a-a78193d5f095.png)


PR:
![image](https://user-images.githubusercontent.com/919634/230383026-0c13a0b6-6ce5-49be-b445-895607c8b33f.png)
