### PR TITLE
Prevent `InvalidOperationException` when formatting lambda expression

### DIFF
--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -37,7 +38,15 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
     /// </summary>
     private static Expression ReduceConstantSubExpressions(Expression expression)
     {
-        return new ConstantSubExpressionReductionVisitor().Visit(expression);
+        try
+        {
+            return new ConstantSubExpressionReductionVisitor().Visit(expression);
+        }
+        catch (InvalidOperationException)
+        {
+            // Fallback if we make an invalid rewrite of the expression.
+            return expression;
+        }
     }
 
     /// <summary>
@@ -104,6 +113,11 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
 
         private static bool ExpressionIsConstant(Expression expression)
         {
+            if (expression is NewExpression or MemberInitExpression)
+            {
+                return false;
+            }
+
             var visitor = new ParameterDetector();
             visitor.Visit(expression);
             return !visitor.HasParameters;

--- a/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
@@ -12,6 +12,38 @@ public class PredicateLambdaExpressionValueFormatterSpecs
     private readonly PredicateLambdaExpressionValueFormatter formatter = new();
 
     [Fact]
+    public void Constructor_expression_with_argument_can_be_formatted()
+    {
+        // Arrange
+        Expression expression = (string arg) => new TestItem { Value = arg };
+
+        // Act
+        string result = Formatter.ToString(expression);
+
+        // Assert
+        result.Should().Be("new TestItem() {Value = arg}");
+    }
+
+    [Fact]
+    public void Constructor_expression_can_be_simplified()
+    {
+        // Arrange
+        string value = "foo";
+        Expression expression = () => new TestItem { Value = value };
+
+        // Act
+        string result = Formatter.ToString(expression);
+
+        // Assert
+        result.Should().Be("new TestItem() {Value = \"foo\"}");
+    }
+
+    private sealed class TestItem
+    {
+        public string Value { get; set; }
+    }
+
+    [Fact]
     public void When_first_level_properties_are_tested_for_equality_against_constants_then_output_should_be_readable()
     {
         // Act

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,14 +13,13 @@ sidebar:
 * Added `ThrowWithinAsync` for assertions on `Task` - [#1974](https://github.com/fluentassertions/fluentassertions/pull/1974)
 * Added support for converting integers to enums using `AutoConversion` - [#2147](https://github.com/fluentassertions/fluentassertions/pull/2147)
 * Changed exception formatting to include any inner exception - [#2150](https://github.com/fluentassertions/fluentassertions/pull/2150)
-
 * Added an expression overload for `WithoutStrictOrderingFor` - [#2151](https://github.com/fluentassertions/fluentassertions/pull/2151)
 
 ### Fixes
 * Improved robustness of several assertions when they're wrapped in an `AssertionScope` - [#2133](https://github.com/fluentassertions/fluentassertions/pull/2133)
 * The maximum depth `BeEquivalentTo` uses for recursive comparisons was 9 instead of the expected 10 - [#2145](https://github.com/fluentassertions/fluentassertions/pull/2145)
-
 * Fixed `.Excluding()` and `.For().Exclude()` not working if root is a collection - [#2135](https://github.com/fluentassertions/fluentassertions/pull/2135)
+* Prevent `InvalidOperationException` when formatting a lambda expression calling a constructor - [#2176](https://github.com/fluentassertions/fluentassertions/pull/2176)
 
 ## 6.10.0
 


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

Prevent `InvalidOperationException` when formatting lambda expression calling a constructor

This fixes #2175 