### PR TITLE
Use builtin coveralls flag to ignore missing coverage file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,18 +29,12 @@ jobs:
       env:
         NuGetApiKey: ${{ secrets.NUGETAPIKEY }}
 
-    - name: Check for 'lcov.info' existence
-      id: check_files
-      uses: andstor/file-existence-action@v2
-      with:
-        files: "TestResults/reports/lcov.info"
-
     - name: coveralls
       uses: coverallsapp/github-action@v2
-      if: steps.check_files.outputs.files_exists == 'true'
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         file: TestResults/reports/lcov.info
+        allow-empty: true
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

The new version of [coverallsapp](https://github.com/coverallsapp/github-action/releases/tag/v2.1.0) adds a new flag `allow-empty`, which returns error code `0`, i.e. no error, when the coverage file did not exist.