### PR TITLE
Code coverage improvements

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -114,11 +114,6 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
         // the AssertSameLength method.
         where TExpectedKey : TSubjectKey
     {
-        if (expectation.Count == subject.Count)
-        {
-            return true;
-        }
-
         KeyDifference<TSubjectKey, TExpectedKey> keyDifference = CalculateKeyDifference(subject, expectation);
 
         bool hasMissingKeys = keyDifference.MissingKeys.Count > 0;

--- a/Tests/FluentAssertions.Equivalency.Specs/DataColumnSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataColumnSpecs.cs
@@ -79,6 +79,24 @@ public class DataColumnSpecs : DataSpecs
     }
 
     [Fact]
+    public void Can_exclude_a_column_from_all_tables()
+    {
+        // Arrange
+        var subjectDataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+        var expectationDataSet = new TypedDataSetSubclass(subjectDataSet);
+
+        var subject = subjectDataSet.TypedDataTable1.DecimalColumn;
+        var expectation = expectationDataSet.TypedDataTable1.DecimalColumn;
+
+        expectation.Unique = true;
+        expectation.Caption = "Test";
+
+        // Act & Assert
+        subject.Should().BeEquivalentTo(expectation, options => options
+            .ExcludingColumnInAllTables(expectation.ColumnName));
+    }
+
+    [Fact]
     public void When_DataColumn_has_changes_but_is_excluded_as_params_it_should_succeed()
     {
         // Arrange

--- a/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DataTableSpecs.cs
@@ -238,6 +238,24 @@ public class DataTableSpecs : DataSpecs
     }
 
     [Fact]
+    public void When_excluding_invalid_constraint_it_should_throw()
+    {
+        // Arrange
+        var typedDataSet = CreateDummyDataSet<TypedDataSetSubclass>();
+
+        var subject = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
+        var expectation = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+        // Act
+        Action action = () => subject.Should().BeEquivalentTo(expectation, options => options
+            .ExcludingRelated((Constraint constraint) => new object()));
+
+        // Assert
+        action.Should().Throw<ArgumentException>().WithMessage(
+            "*Expression must be a simple member access*");
+    }
+
+    [Fact]
     public void When_data_table_name_does_not_match_but_the_corresponding_property_is_excluded_equivalence_test_should_succeed()
     {
         // Arrange


### PR DESCRIPTION
This improves coverage in 3 small cases.

For the generic dictionary one, it turns out that the other version of the method was length checking already which made the check redundant as it wasn't possible to hit that line in general.

Part of #1823 