### PR TITLE
Revert "Use builtin coveralls flag to ignore missing coverage file"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,12 +29,18 @@ jobs:
       env:
         NuGetApiKey: ${{ secrets.NUGETAPIKEY }}
 
+    - name: Check for 'lcov.info' existence
+      id: check_files
+      uses: andstor/file-existence-action@v2
+      with:
+        files: "TestResults/reports/lcov.info"
+
     - name: coveralls
       uses: coverallsapp/github-action@v2
+      if: steps.check_files.outputs.files_exists == 'true'
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         file: TestResults/reports/lcov.info
-        allow-empty: true
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
https://github.com/fluentassertions/fluentassertions/actions/runs/4713721247/jobs/8359603202?pr=2181
Fails with
> 🚨 ERROR: Couldn't find specified file: TestResults/reports/lcov.info

Seems I was wrong about what the new flag `allow-empty` meant.
Apparently it does not mean an empty _set_ of coverage files, but an empty _file_.

