### PR TITLE
Prepare for .NET 8 analyzers

### DIFF
--- a/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolver.cs
+++ b/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolver.cs
@@ -79,7 +79,7 @@ internal class MaximumMatchingSolver<TValue>
         return Enumerable.Empty<Match>();
     }
 
-    private IEnumerable<Element<TValue>> GetMatchingElements(Predicate<TValue> predicate)
+    private List<Element<TValue>> GetMatchingElements(Predicate<TValue> predicate)
     {
         if (!matchingElementsByPredicate.TryGetValue(predicate, out var matchingElements))
         {

--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -38,7 +38,7 @@ internal sealed class TypeMemberReflector
         return query.ToArray();
     }
 
-    private static IEnumerable<PropertyInfo> GetPropertiesFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
+    private static List<PropertyInfo> GetPropertiesFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
     {
         bool includeInternals = memberVisibility.HasFlag(MemberVisibility.Internal);
 
@@ -63,7 +63,7 @@ internal sealed class TypeMemberReflector
         return query.ToArray();
     }
 
-    private static IEnumerable<FieldInfo> GetFieldsFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
+    private static List<FieldInfo> GetFieldsFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
     {
         bool includeInternals = memberVisibility.HasFlag(MemberVisibility.Internal);
 
@@ -77,7 +77,7 @@ internal sealed class TypeMemberReflector
         });
     }
 
-    private static IEnumerable<TMemberInfo> GetMembersFromHierarchy<TMemberInfo>(
+    private static List<TMemberInfo> GetMembersFromHierarchy<TMemberInfo>(
         Type typeToReflect,
         Func<Type, IEnumerable<TMemberInfo>> getMembers)
         where TMemberInfo : MemberInfo

--- a/Src/FluentAssertions/Equivalency/Steps/DataColumnEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataColumnEquivalencyStep.cs
@@ -106,7 +106,7 @@ public class DataColumnEquivalencyStep : EquivalencyStep<DataColumn>
     // NOTE: This list of candidate members is duplicated in the XML documentation for the
     // DataColumn.BeEquivalentTo extension method in DataColumnAssertions.cs. If this ever
     // needs to change, keep them in sync.
-    private static readonly ISet<string> CandidateMembers =
+    private static readonly HashSet<string> CandidateMembers =
         new HashSet<string>
         {
             nameof(DataColumn.AllowDBNull),

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -15,7 +15,7 @@ internal sealed class DictionaryInterfaceInfo
 {
     // ReSharper disable once PossibleNullReferenceException
     private static readonly MethodInfo ConvertToDictionaryMethod =
-        new Func<IEnumerable<KeyValuePair<object, object>>, IDictionary<object, object>>(ConvertToDictionaryInternal)
+        new Func<IEnumerable<KeyValuePair<object, object>>, Dictionary<object, object>>(ConvertToDictionaryInternal)
             .GetMethodInfo().GetGenericMethodDefinition();
 
     private static readonly ConcurrentDictionary<Type, DictionaryInterfaceInfo[]> Cache = new();
@@ -140,7 +140,7 @@ internal sealed class DictionaryInterfaceInfo
         return false;
     }
 
-    private static IDictionary<TKey, TValue> ConvertToDictionaryInternal<TKey, TValue>(
+    private static Dictionary<TKey, TValue> ConvertToDictionaryInternal<TKey, TValue>(
         IEnumerable<KeyValuePair<TKey, TValue>> collection)
     {
         return collection.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);

--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -56,7 +56,7 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
     /// This simplification is only implemented for the chain of AND operators because this is the most common predicate scenario.
     /// Similar logic can be implemented in the future for other operators.
     /// </summary>
-    private static IEnumerable<Expression> ExtractChainOfExpressionsJoinedWithAndOperator(BinaryExpression binaryExpression)
+    private static List<Expression> ExtractChainOfExpressionsJoinedWithAndOperator(BinaryExpression binaryExpression)
     {
         var visitor = new AndOperatorChainExtractor();
         visitor.Visit(binaryExpression);


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

I installed the latest .NET 8 preview SDK to see what new buit-in analyzers we can expect when .NET 8 is released later this year.

CA1859 suggests using concrete types instead of interfaces for (micro) performance reasons.