### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+<!-- Please provide a description of your changes above the IMPORTANT checklist -->
+
+
 ## IMPORTANT 
 
 * [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.


### PR DESCRIPTION
## Description

Often, people tend to write the description of the PR under the important sections. This makes it much harder to read the important reason of the PR when using GitHub on smaller devices.

This PR adds a comment above `IMPORTANT`

## Current situation

1. Inbox only shows one line, which now shows the IMPORTANT header
   <img src="https://user-images.githubusercontent.com/10671831/233453574-92d01371-dfd2-4d0b-b26f-343a8c73bba8.jpg" width="50%" />

2. PR overview still only shows the checklist
   <img src="https://user-images.githubusercontent.com/10671831/233453600-3076291c-5a5a-4f04-b502-fe2f72545a1c.jpg" width="50%" />

3. Only after extending the content, **and** scrolling down, the change description becomes visible,
   <img src="https://user-images.githubusercontent.com/10671831/233454014-b5d7b0ec-681a-4ce2-8766-e1db58d8a35f.jpg" width="50%" />

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome