### PR TITLE
Simplify `GenericDictionaryEquivalencyStep`

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -43,8 +43,7 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
         IEquivalencyValidationContext context,
         IEquivalencyValidator nestedValidator)
     {
-        if (AssertSubjectIsNotNull(comparands.Subject)
-            && AssertExpectationIsNotNull(comparands.Subject, comparands.Expectation))
+        if (AssertSubjectIsNotNull(comparands.Subject))
         {
             var (isDictionary, actualDictionary) = EnsureSubjectIsDictionary(comparands, expectedDictionary);
 
@@ -60,13 +59,6 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
         return AssertionScope.Current
             .ForCondition(subject is not null)
             .FailWith("Expected {context:Subject} not to be {0}{reason}.", new object[] { null });
-    }
-
-    private static bool AssertExpectationIsNotNull(object subject, object expectation)
-    {
-        return AssertionScope.Current
-            .ForCondition(expectation is not null)
-            .FailWith("Expected {context:Subject} to be {0}{reason}, but found {1}.", null, subject);
     }
 
     private static (bool isDictionary, DictionaryInterfaceInfo info) EnsureSubjectIsDictionary(Comparands comparands,

--- a/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -24,24 +24,17 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
             Type expectationType = comparands.GetExpectedType(context.Options);
             if (DictionaryInterfaceInfo.FindFrom(expectationType, "expectation") is { } expectedDictionary)
             {
-                Handle(comparands, expectedDictionary, context, nestedValidator);
+                if (AssertSubjectIsNotNull(comparands.Subject)
+                    && EnsureSubjectIsDictionary(comparands, expectedDictionary) is { } actualDictionary)
+                {
+                    AssertDictionaryEquivalence(comparands, context, nestedValidator, actualDictionary, expectedDictionary);
+                }
 
                 return EquivalencyResult.AssertionCompleted;
             }
         }
 
         return EquivalencyResult.ContinueWithNext;
-    }
-
-    private static void Handle(Comparands comparands, DictionaryInterfaceInfo expectedDictionary,
-        IEquivalencyValidationContext context,
-        IEquivalencyValidator nestedValidator)
-    {
-        if (AssertSubjectIsNotNull(comparands.Subject)
-            && EnsureSubjectIsDictionary(comparands, expectedDictionary) is { } actualDictionary)
-        {
-            AssertDictionaryEquivalence(comparands, context, nestedValidator, actualDictionary, expectedDictionary);
-        }
     }
 
     private static bool AssertSubjectIsNotNull(object subject)


### PR DESCRIPTION
In #2180 I spotted that `GenericDictionaryEquivalencyStep.AssertExpectationIsNotNull` checked if expectation was null, but that had already been done as the first thing in `EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)`.
This made it always true or from a mutation testing perspective, an unkillable mutation.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
