### PR TITLE
CA1860: Avoid using 'Enumerable.Any()' extension method

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -152,6 +152,8 @@ dotnet_diagnostic.CA1724.severity = none
 dotnet_diagnostic.CA1819.severity = none
 # CA1851: Possible multiple enumerations of IEnumerable collection. Related to GH-issue #2000
 dotnet_diagnostic.CA1851.severity = suggestion
+# CA1860: Avoid using 'Enumerable.Any()' extension method
+dotnet_diagnostic.CA1860.severity = warning
 # CA2007: Do not directly await a Task
 dotnet_diagnostic.CA2007.severity = none
 # CA2225: Operator overloads have named alternates
@@ -160,6 +162,8 @@ dotnet_diagnostic.CA2225.severity = none
 dotnet_diagnostic.CA3075.severity = none
 # CA5369: Use XmlReader for Deserialize
 dotnet_diagnostic.CA5369.severity = none
+
+dotnet_diagnostic.CA1859.severity = none
 
 # Banned API Analyzers
 dotnet_diagnostic.RS0030.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -163,8 +163,6 @@ dotnet_diagnostic.CA3075.severity = none
 # CA5369: Use XmlReader for Deserialize
 dotnet_diagnostic.CA5369.severity = none
 
-dotnet_diagnostic.CA1859.severity = none
-
 # Banned API Analyzers
 dotnet_diagnostic.RS0030.severity = error
 

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -896,7 +896,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
 
                 string[] failures = scope.Discard();
 
-                if (!failures.Any())
+                if (failures.Length == 0)
                 {
                     return new AndWhichConstraint<TAssertions, T>((TAssertions)this, actualItem);
                 }
@@ -1156,7 +1156,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             ICollection<T> actualItems = Subject.ConvertOrCastToCollection();
 
             Execute.Assertion
-                .ForCondition(actualItems.Any())
+                .ForCondition(actualItems.Count != 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(expectationPrefix + "but the collection is empty.", predicate);
 
@@ -2336,7 +2336,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
 
                     string[] failures = scope.Discard();
 
-                    if (!failures.Any())
+                    if (failures.Length == 0)
                     {
                         foundIndices.Add(index);
                     }
@@ -2786,7 +2786,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .FailWith("but the collection is <null>.")
             .Then
             .Given(subject => subject.ConvertOrCastToCollection())
-            .ForCondition(collection => collection.Any())
+            .ForCondition(collection => collection.Count != 0)
             .FailWith("but the collection is empty.")
             .Then
             .Given(collection => collection.Where(item => !compiledPredicate(item)))
@@ -2943,7 +2943,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
                 failuresFromInspectors = CollectFailuresFromInspectors(elementInspectors);
             }
 
-            if (failuresFromInspectors.Any())
+            if (failuresFromInspectors.Length != 0)
             {
                 string failureMessage = Environment.NewLine
                     + string.Join(Environment.NewLine, failuresFromInspectors.Select(x => x.IndentLines()));
@@ -3031,7 +3031,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
                 failuresFromInspectors = CollectFailuresFromInspectors(elementInspectors);
             }
 
-            if (failuresFromInspectors.Any())
+            if (failuresFromInspectors.Length != 0)
             {
                 string failureMessage = Environment.NewLine
                     + string.Join(Environment.NewLine, failuresFromInspectors.Select(x => x.IndentLines()));
@@ -3114,7 +3114,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
 
                 List<MaximumMatching.Predicate<T>> unmatchedPredicates = maximumMatchingSolution.GetUnmatchedPredicates();
 
-                if (unmatchedPredicates.Any())
+                if (unmatchedPredicates.Count != 0)
                 {
                     message += doubleNewLine + "The following predicates did not have matching elements:";
 
@@ -3125,7 +3125,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
 
                 List<Element<T>> unmatchedElements = maximumMatchingSolution.GetUnmatchedElements();
 
-                if (unmatchedElements.Any())
+                if (unmatchedElements.Count != 0)
                 {
                     message += doubleNewLine + "The following elements did not match any predicate:";
 

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1156,7 +1156,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             ICollection<T> actualItems = Subject.ConvertOrCastToCollection();
 
             Execute.Assertion
-                .ForCondition(actualItems.Count != 0)
+                .ForCondition(actualItems.Count > 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(expectationPrefix + "but the collection is empty.", predicate);
 
@@ -2786,7 +2786,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .FailWith("but the collection is <null>.")
             .Then
             .Given(subject => subject.ConvertOrCastToCollection())
-            .ForCondition(collection => collection.Count != 0)
+            .ForCondition(collection => collection.Count > 0)
             .FailWith("but the collection is empty.")
             .Then
             .Given(collection => collection.Where(item => !compiledPredicate(item)))
@@ -2943,7 +2943,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
                 failuresFromInspectors = CollectFailuresFromInspectors(elementInspectors);
             }
 
-            if (failuresFromInspectors.Length != 0)
+            if (failuresFromInspectors.Length > 0)
             {
                 string failureMessage = Environment.NewLine
                     + string.Join(Environment.NewLine, failuresFromInspectors.Select(x => x.IndentLines()));
@@ -3031,7 +3031,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
                 failuresFromInspectors = CollectFailuresFromInspectors(elementInspectors);
             }
 
-            if (failuresFromInspectors.Length != 0)
+            if (failuresFromInspectors.Length > 0)
             {
                 string failureMessage = Environment.NewLine
                     + string.Join(Environment.NewLine, failuresFromInspectors.Select(x => x.IndentLines()));
@@ -3114,7 +3114,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
 
                 List<MaximumMatching.Predicate<T>> unmatchedPredicates = maximumMatchingSolution.GetUnmatchedPredicates();
 
-                if (unmatchedPredicates.Count != 0)
+                if (unmatchedPredicates.Count > 0)
                 {
                     message += doubleNewLine + "The following predicates did not have matching elements:";
 
@@ -3125,7 +3125,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
 
                 List<Element<T>> unmatchedElements = maximumMatchingSolution.GetUnmatchedElements();
 
-                if (unmatchedElements.Count != 0)
+                if (unmatchedElements.Count > 0)
                 {
                     message += doubleNewLine + "The following elements did not match any predicate:";
 

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -720,7 +720,7 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
             KeyValuePair<TKey, TValue>[] keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs
                 .Where(keyValuePair => !areSameOrEqual(GetValue(Subject, keyValuePair.Key), keyValuePair.Value)).ToArray();
 
-            if (keyValuePairsNotSameOrEqualInSubject.Any())
+            if (keyValuePairsNotSameOrEqualInSubject.Length != 0)
             {
                 if (keyValuePairsNotSameOrEqualInSubject.Length > 1)
                 {
@@ -865,14 +865,14 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
             KeyValuePair<TKey, TValue>[] keyValuePairsFound =
                 keyValuePairs.Where(keyValuePair => ContainsKey(Subject, keyValuePair.Key)).ToArray();
 
-            if (keyValuePairsFound.Any())
+            if (keyValuePairsFound.Length != 0)
             {
                 Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
 
                 KeyValuePair<TKey, TValue>[] keyValuePairsSameOrEqualInSubject = keyValuePairsFound
                     .Where(keyValuePair => areSameOrEqual(GetValue(Subject, keyValuePair.Key), keyValuePair.Value)).ToArray();
 
-                if (keyValuePairsSameOrEqualInSubject.Any())
+                if (keyValuePairsSameOrEqualInSubject.Length != 0)
                 {
                     if (keyValuePairsSameOrEqualInSubject.Length > 1)
                     {

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -720,7 +720,7 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
             KeyValuePair<TKey, TValue>[] keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs
                 .Where(keyValuePair => !areSameOrEqual(GetValue(Subject, keyValuePair.Key), keyValuePair.Value)).ToArray();
 
-            if (keyValuePairsNotSameOrEqualInSubject.Length != 0)
+            if (keyValuePairsNotSameOrEqualInSubject.Length > 0)
             {
                 if (keyValuePairsNotSameOrEqualInSubject.Length > 1)
                 {
@@ -865,14 +865,14 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
             KeyValuePair<TKey, TValue>[] keyValuePairsFound =
                 keyValuePairs.Where(keyValuePair => ContainsKey(Subject, keyValuePair.Key)).ToArray();
 
-            if (keyValuePairsFound.Length != 0)
+            if (keyValuePairsFound.Length > 0)
             {
                 Func<TValue, TValue, bool> areSameOrEqual = ObjectExtensions.GetComparer<TValue>();
 
                 KeyValuePair<TKey, TValue>[] keyValuePairsSameOrEqualInSubject = keyValuePairsFound
                     .Where(keyValuePair => areSameOrEqual(GetValue(Subject, keyValuePair.Key), keyValuePair.Value)).ToArray();
 
-                if (keyValuePairsSameOrEqualInSubject.Length != 0)
+                if (keyValuePairsSameOrEqualInSubject.Length > 0)
                 {
                     if (keyValuePairsSameOrEqualInSubject.Length > 1)
                     {

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -275,7 +275,7 @@ public class StringCollectionAssertions<TCollection, TAssertions> : GenericColle
         return Subject.Any(item =>
         {
             item.Should().Match(wildcardPattern);
-            return !scope.Discard().Any();
+            return scope.Discard().Length == 0;
         });
     }
 
@@ -285,7 +285,7 @@ public class StringCollectionAssertions<TCollection, TAssertions> : GenericColle
         {
             using var scope = new AssertionScope();
             item.Should().Match(wildcardPattern);
-            return !scope.Discard().Any();
+            return scope.Discard().Length == 0;
         });
     }
 
@@ -357,7 +357,7 @@ public class StringCollectionAssertions<TCollection, TAssertions> : GenericColle
         return Subject.All(item =>
         {
             item.Should().NotMatch(wildcardPattern);
-            return !scope.Discard().Any();
+            return scope.Discard().Length == 0;
         });
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/ConstraintEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ConstraintEquivalencyStep.cs
@@ -212,7 +212,7 @@ public class ConstraintEquivalencyStep : EquivalencyStep<Constraint>
 
         var failureMessage = new StringBuilder();
 
-        if (missingColumnNames.Any())
+        if (missingColumnNames.Count != 0)
         {
             failureMessage.Append("Expected {context:constraint} to include ");
 
@@ -232,7 +232,7 @@ public class ConstraintEquivalencyStep : EquivalencyStep<Constraint>
                     : "these columns. ");
         }
 
-        if (extraColumnNames.Any())
+        if (extraColumnNames.Count != 0)
         {
             failureMessage.Append("Did not expect {context:constraint} to include ");
 

--- a/Src/FluentAssertions/Equivalency/Steps/ConstraintEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ConstraintEquivalencyStep.cs
@@ -212,7 +212,7 @@ public class ConstraintEquivalencyStep : EquivalencyStep<Constraint>
 
         var failureMessage = new StringBuilder();
 
-        if (missingColumnNames.Count != 0)
+        if (missingColumnNames.Count > 0)
         {
             failureMessage.Append("Expected {context:constraint} to include ");
 
@@ -232,7 +232,7 @@ public class ConstraintEquivalencyStep : EquivalencyStep<Constraint>
                     : "these columns. ");
         }
 
-        if (extraColumnNames.Count != 0)
+        if (extraColumnNames.Count > 0)
         {
             failureMessage.Append("Did not expect {context:constraint} to include ");
 

--- a/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -117,7 +117,7 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
         KeyDifference<TSubjectKey, TExpectedKey> keyDifference = CalculateKeyDifference(subject, expectation);
 
         bool hasMissingKeys = keyDifference.MissingKeys.Count > 0;
-        bool hasAdditionalKeys = keyDifference.AdditionalKeys.Any();
+        bool hasAdditionalKeys = keyDifference.AdditionalKeys.Count != 0;
 
         return Execute.Assertion
             .WithExpectation("Expected {context:subject} to be a dictionary with {0} item(s){reason}, ", expectation.Count)

--- a/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -117,7 +117,7 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
         KeyDifference<TSubjectKey, TExpectedKey> keyDifference = CalculateKeyDifference(subject, expectation);
 
         bool hasMissingKeys = keyDifference.MissingKeys.Count > 0;
-        bool hasAdditionalKeys = keyDifference.AdditionalKeys.Count != 0;
+        bool hasAdditionalKeys = keyDifference.AdditionalKeys.Count > 0;
 
         return Execute.Assertion
             .WithExpectation("Expected {context:subject} to be a dictionary with {0} item(s){reason}, ", expectation.Count)

--- a/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
@@ -87,7 +87,7 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
     {
         Type[] enumerableInterfaces = GetIEnumerableInterfaces(type);
 
-        return !typeof(string).IsAssignableFrom(type) && enumerableInterfaces.Any();
+        return !typeof(string).IsAssignableFrom(type) && enumerableInterfaces.Length != 0;
     }
 
     private static Type[] GetIEnumerableInterfaces(Type type)

--- a/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
@@ -87,7 +87,7 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
     {
         Type[] enumerableInterfaces = GetIEnumerableInterfaces(type);
 
-        return !typeof(string).IsAssignableFrom(type) && enumerableInterfaces.Length != 0;
+        return !typeof(string).IsAssignableFrom(type) && enumerableInterfaces.Length > 0;
     }
 
     private static Type[] GetIEnumerableInterfaces(Type type)

--- a/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
@@ -36,7 +36,7 @@ public class StructuralEqualityEquivalencyStep : IEquivalencyStep
         {
             IMember[] selectedMembers = GetMembersFromExpectation(context.CurrentNode, comparands, context.Options).ToArray();
 
-            if (context.CurrentNode.IsRoot && !selectedMembers.Any())
+            if (context.CurrentNode.IsRoot && selectedMembers.Length == 0)
             {
                 throw new InvalidOperationException(
                     "No members were found for comparison. " +

--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -27,7 +27,7 @@ public static class EventRaisingExtensions
         foreach (OccurredEvent @event in eventRecording)
         {
             bool hasSender = Execute.Assertion
-                .ForCondition(@event.Parameters.Length != 0)
+                .ForCondition(@event.Parameters.Length > 0)
                 .FailWith("Expected event from sender {0}, " +
                     $"but event {eventRecording.EventName} does not have any parameters", expectedSender);
 
@@ -47,7 +47,7 @@ public static class EventRaisingExtensions
         }
 
         Execute.Assertion
-            .ForCondition(eventsForSender.Count != 0)
+            .ForCondition(eventsForSender.Count > 0)
             .FailWith("Expected sender {0}, but found {1}.",
                 () => expectedSender,
                 () => otherSenders.Distinct());
@@ -81,7 +81,7 @@ public static class EventRaisingExtensions
             }
         }
 
-        bool foundMatchingEvent = eventsWithMatchingPredicate.Count != 0;
+        bool foundMatchingEvent = eventsWithMatchingPredicate.Count > 0;
 
         Execute.Assertion
             .ForCondition(foundMatchingEvent)
@@ -111,7 +111,7 @@ public static class EventRaisingExtensions
         foreach (OccurredEvent @event in eventRecording)
         {
             var typedParameters = @event.Parameters.OfType<T>().ToArray();
-            bool hasArgumentOfRightType = typedParameters.Length != 0;
+            bool hasArgumentOfRightType = typedParameters.Length > 0;
 
             if (predicates.Length > typedParameters.Length)
             {
@@ -132,7 +132,7 @@ public static class EventRaisingExtensions
             }
         }
 
-        bool foundMatchingEvent = eventsWithMatchingPredicate.Count != 0;
+        bool foundMatchingEvent = eventsWithMatchingPredicate.Count > 0;
 
         if (!foundMatchingEvent)
         {

--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -27,7 +27,7 @@ public static class EventRaisingExtensions
         foreach (OccurredEvent @event in eventRecording)
         {
             bool hasSender = Execute.Assertion
-                .ForCondition(@event.Parameters.Any())
+                .ForCondition(@event.Parameters.Length != 0)
                 .FailWith("Expected event from sender {0}, " +
                     $"but event {eventRecording.EventName} does not have any parameters", expectedSender);
 
@@ -47,7 +47,7 @@ public static class EventRaisingExtensions
         }
 
         Execute.Assertion
-            .ForCondition(eventsForSender.Any())
+            .ForCondition(eventsForSender.Count != 0)
             .FailWith("Expected sender {0}, but found {1}.",
                 () => expectedSender,
                 () => otherSenders.Distinct());
@@ -81,7 +81,7 @@ public static class EventRaisingExtensions
             }
         }
 
-        bool foundMatchingEvent = eventsWithMatchingPredicate.Any();
+        bool foundMatchingEvent = eventsWithMatchingPredicate.Count != 0;
 
         Execute.Assertion
             .ForCondition(foundMatchingEvent)
@@ -111,7 +111,7 @@ public static class EventRaisingExtensions
         foreach (OccurredEvent @event in eventRecording)
         {
             var typedParameters = @event.Parameters.OfType<T>().ToArray();
-            bool hasArgumentOfRightType = typedParameters.Any();
+            bool hasArgumentOfRightType = typedParameters.Length != 0;
 
             if (predicates.Length > typedParameters.Length)
             {
@@ -132,7 +132,7 @@ public static class EventRaisingExtensions
             }
         }
 
-        bool foundMatchingEvent = eventsWithMatchingPredicate.Any();
+        bool foundMatchingEvent = eventsWithMatchingPredicate.Count != 0;
 
         if (!foundMatchingEvent)
         {

--- a/Src/FluentAssertions/Events/EventMonitor.cs
+++ b/Src/FluentAssertions/Events/EventMonitor.cs
@@ -89,7 +89,7 @@ internal sealed class EventMonitor<T> : IMonitor<T>
 
         EventInfo[] events = GetPublicEvents(typeDefiningEventsToMonitor);
 
-        if (!events.Any())
+        if (events.Length == 0)
         {
             throw new InvalidOperationException($"Type {typeDefiningEventsToMonitor.Name} does not expose any events.");
         }

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -169,7 +169,7 @@ public sealed class AssertionScope : IAssertionScope
             {
                 string becauseOrEmpty = because ?? string.Empty;
 
-                return becauseArgs?.Any() == true
+                return becauseArgs?.Length != 0
                     ? string.Format(CultureInfo.InvariantCulture, becauseOrEmpty, becauseArgs)
                     : becauseOrEmpty;
             }

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -169,7 +169,7 @@ public sealed class AssertionScope : IAssertionScope
             {
                 string becauseOrEmpty = because ?? string.Empty;
 
-                return becauseArgs?.Length != 0
+                return becauseArgs?.Length > 0
                     ? string.Format(CultureInfo.InvariantCulture, becauseOrEmpty, becauseArgs)
                     : becauseOrEmpty;
             }

--- a/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
@@ -31,7 +31,7 @@ internal class CollectingAssertionStrategy : IAssertionStrategy
     /// </summary>
     public void ThrowIfAny(IDictionary<string, object> context)
     {
-        if (failureMessages.Any())
+        if (failureMessages.Count != 0)
         {
             var builder = new StringBuilder();
             builder.AppendJoin(Environment.NewLine, failureMessages).AppendLine();

--- a/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
@@ -31,7 +31,7 @@ internal class CollectingAssertionStrategy : IAssertionStrategy
     /// </summary>
     public void ThrowIfAny(IDictionary<string, object> context)
     {
-        if (failureMessages.Count != 0)
+        if (failureMessages.Count > 0)
         {
             var builder = new StringBuilder();
             builder.AppendJoin(Environment.NewLine, failureMessages).AppendLine();

--- a/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
@@ -37,7 +37,7 @@ public class TimeSpanValueFormatter : IValueFormatter
 
         List<string> fragments = GetNonZeroFragments(timeSpan);
 
-        if (!fragments.Any())
+        if (fragments.Count == 0)
         {
             formattedGraph.AddFragment("default");
         }

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -142,7 +142,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         using (var scope = new AssertionScope())
         {
             Subject.Should().BeEquivalentTo(unexpected);
-            notEquivalent = scope.Discard().Length != 0;
+            notEquivalent = scope.Discard().Length > 0;
         }
 
         Execute.Assertion

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -142,7 +142,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         using (var scope = new AssertionScope())
         {
             Subject.Should().BeEquivalentTo(unexpected);
-            notEquivalent = scope.Discard().Any();
+            notEquivalent = scope.Discard().Length != 0;
         }
 
         Execute.Assertion

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -225,7 +225,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
             .ForCondition(exception is not null)
             .FailWith("but no exception was thrown.")
             .Then
-            .ForCondition(expectedExceptions.Any())
+            .ForCondition(expectedExceptions.Length != 0)
             .FailWith("but found <{0}>: {1}{2}.",
                 exception?.GetType(),
                 Environment.NewLine,

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -225,7 +225,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
             .ForCondition(exception is not null)
             .FailWith("but no exception was thrown.")
             .Then
-            .ForCondition(expectedExceptions.Length != 0)
+            .ForCondition(expectedExceptions.Length > 0)
             .FailWith("but found <{0}>: {1}{2}.",
                 exception?.GetType(),
                 Environment.NewLine,

--- a/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
@@ -40,7 +40,7 @@ public abstract class DelegateAssertionsBase<TDelegate, TAssertions>
             .ForCondition(exception is not null)
             .FailWith("but no exception was thrown.")
             .Then
-            .ForCondition(expectedExceptions.Length != 0)
+            .ForCondition(expectedExceptions.Length > 0)
             .FailWith("but found <{0}>: {1}{2}.",
                 exception?.GetType(),
                 Environment.NewLine,

--- a/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
@@ -40,7 +40,7 @@ public abstract class DelegateAssertionsBase<TDelegate, TAssertions>
             .ForCondition(exception is not null)
             .FailWith("but no exception was thrown.")
             .Then
-            .ForCondition(expectedExceptions.Any())
+            .ForCondition(expectedExceptions.Length != 0)
             .FailWith("but found <{0}>: {1}{2}.",
                 exception?.GetType(),
                 Environment.NewLine,

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -211,7 +211,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
             .Where(e => e?.GetType() == innerException).ToArray();
 
         Execute.Assertion
-            .ForCondition(expectedExceptions.Any())
+            .ForCondition(expectedExceptions.Length != 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected inner {0}{reason}, but found {1}.", innerException, SingleSubject.InnerException);
 
@@ -232,7 +232,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(expectedInnerExceptions.Any())
+            .ForCondition(expectedInnerExceptions.Length != 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected inner {0}{reason}, but found {1}.", innerException, SingleSubject.InnerException);
 

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -211,7 +211,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
             .Where(e => e?.GetType() == innerException).ToArray();
 
         Execute.Assertion
-            .ForCondition(expectedExceptions.Length != 0)
+            .ForCondition(expectedExceptions.Length > 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected inner {0}{reason}, but found {1}.", innerException, SingleSubject.InnerException);
 
@@ -232,7 +232,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(expectedInnerExceptions.Length != 0)
+            .ForCondition(expectedInnerExceptions.Length > 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected inner {0}{reason}, but found {1}.", innerException, SingleSubject.InnerException);
 

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -54,7 +54,7 @@ public class MethodInfoSelectorAssertions
             GetDescriptionsFor(nonVirtualMethods);
 
         Execute.Assertion
-            .ForCondition(!nonVirtualMethods.Any())
+            .ForCondition(nonVirtualMethods.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(failureMessage);
 
@@ -81,7 +81,7 @@ public class MethodInfoSelectorAssertions
             GetDescriptionsFor(virtualMethods);
 
         Execute.Assertion
-            .ForCondition(!virtualMethods.Any())
+            .ForCondition(virtualMethods.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(failureMessage);
 
@@ -118,7 +118,7 @@ public class MethodInfoSelectorAssertions
             GetDescriptionsFor(nonAsyncMethods);
 
         Execute.Assertion
-            .ForCondition(!nonAsyncMethods.Any())
+            .ForCondition(nonAsyncMethods.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(failureMessage);
 
@@ -145,7 +145,7 @@ public class MethodInfoSelectorAssertions
             GetDescriptionsFor(asyncMethods);
 
         Execute.Assertion
-            .ForCondition(!asyncMethods.Any())
+            .ForCondition(asyncMethods.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(failureMessage);
 
@@ -198,7 +198,7 @@ public class MethodInfoSelectorAssertions
             GetDescriptionsFor(methodsWithoutAttribute);
 
         Execute.Assertion
-            .ForCondition(!methodsWithoutAttribute.Any())
+            .ForCondition(methodsWithoutAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(failureMessage, typeof(TAttribute));
 
@@ -251,7 +251,7 @@ public class MethodInfoSelectorAssertions
             GetDescriptionsFor(methodsWithAttribute);
 
         Execute.Assertion
-            .ForCondition(!methodsWithAttribute.Any())
+            .ForCondition(methodsWithAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(failureMessage, typeof(TAttribute));
 
@@ -278,7 +278,7 @@ public class MethodInfoSelectorAssertions
             Environment.NewLine + GetDescriptionsFor(methods);
 
         Execute.Assertion
-            .ForCondition(!methods.Any())
+            .ForCondition(methods.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(message);
 
@@ -305,7 +305,7 @@ public class MethodInfoSelectorAssertions
             Environment.NewLine + GetDescriptionsFor(methods);
 
         Execute.Assertion
-            .ForCondition(!methods.Any())
+            .ForCondition(methods.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(message);
 

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -48,7 +48,7 @@ public class PropertyInfoSelectorAssertions
         PropertyInfo[] nonVirtualProperties = GetAllNonVirtualPropertiesFromSelection();
 
         Execute.Assertion
-            .ForCondition(!nonVirtualProperties.Any())
+            .ForCondition(nonVirtualProperties.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(
                 "Expected all selected properties to be virtual{reason}, but the following properties are not virtual:" +
@@ -72,7 +72,7 @@ public class PropertyInfoSelectorAssertions
         PropertyInfo[] virtualProperties = GetAllVirtualPropertiesFromSelection();
 
         Execute.Assertion
-            .ForCondition(!virtualProperties.Any())
+            .ForCondition(virtualProperties.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(
                 "Expected all selected properties not to be virtual{reason}, but the following properties are virtual:" +
@@ -96,7 +96,7 @@ public class PropertyInfoSelectorAssertions
         PropertyInfo[] readOnlyProperties = GetAllReadOnlyPropertiesFromSelection();
 
         Execute.Assertion
-            .ForCondition(!readOnlyProperties.Any())
+            .ForCondition(readOnlyProperties.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(
                 "Expected all selected properties to have a setter{reason}, but the following properties do not:" +
@@ -120,7 +120,7 @@ public class PropertyInfoSelectorAssertions
         PropertyInfo[] writableProperties = GetAllWritablePropertiesFromSelection();
 
         Execute.Assertion
-            .ForCondition(!writableProperties.Any())
+            .ForCondition(writableProperties.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(
                 "Expected selected properties to not have a setter{reason}, but the following properties do:" +
@@ -166,7 +166,7 @@ public class PropertyInfoSelectorAssertions
         PropertyInfo[] propertiesWithoutAttribute = GetPropertiesWithout<TAttribute>();
 
         Execute.Assertion
-            .ForCondition(!propertiesWithoutAttribute.Any())
+            .ForCondition(propertiesWithoutAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(
                 "Expected all selected properties to be decorated with {0}{reason}" +
@@ -193,7 +193,7 @@ public class PropertyInfoSelectorAssertions
         PropertyInfo[] propertiesWithAttribute = GetPropertiesWith<TAttribute>();
 
         Execute.Assertion
-            .ForCondition(!propertiesWithAttribute.Any())
+            .ForCondition(propertiesWithAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(
                 "Expected all selected properties not to be decorated with {0}{reason}" +

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -330,7 +330,7 @@ public class TypeSelector : IEnumerable<Type>
                     .Select(ied => ied.GetGenericArguments().Single())
                     .ToList();
 
-                if (iEnumerableImplementations.Count != 0)
+                if (iEnumerableImplementations.Count > 0)
                 {
                     unwrappedTypes.AddRange(iEnumerableImplementations);
                 }

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -330,7 +330,7 @@ public class TypeSelector : IEnumerable<Type>
                     .Select(ied => ied.GetGenericArguments().Single())
                     .ToList();
 
-                if (iEnumerableImplementations.Any())
+                if (iEnumerableImplementations.Count != 0)
                 {
                     unwrappedTypes.AddRange(iEnumerableImplementations);
                 }

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -52,7 +52,7 @@ public class TypeSelectorAssertions
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(!typesWithoutAttribute.Any())
+            .ForCondition(typesWithoutAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be decorated with {0}{reason}," +
                 " but the attribute was not found on the following types:{1}{2}.",
@@ -89,7 +89,7 @@ public class TypeSelectorAssertions
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(!typesWithoutMatchingAttribute.Any())
+            .ForCondition(typesWithoutMatchingAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be decorated with {0} that matches {1}{reason}," +
                 " but no matching attribute was found on the following types:{2}{3}.",
@@ -120,7 +120,7 @@ public class TypeSelectorAssertions
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(!typesWithoutAttribute.Any())
+            .ForCondition(typesWithoutAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be decorated with or inherit {0}{reason}," +
                 " but the attribute was not found on the following types:{1}{2}.",
@@ -157,7 +157,7 @@ public class TypeSelectorAssertions
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(!typesWithoutMatchingAttribute.Any())
+            .ForCondition(typesWithoutMatchingAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be decorated with or inherit {0} that matches {1}{reason}," +
                 " but no matching attribute was found on the following types:{2}{3}.",
@@ -187,7 +187,7 @@ public class TypeSelectorAssertions
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(!typesWithAttribute.Any())
+            .ForCondition(typesWithAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to not be decorated with {0}{reason}," +
                 " but the attribute was found on the following types:{1}{2}.",
@@ -224,7 +224,7 @@ public class TypeSelectorAssertions
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(!typesWithMatchingAttribute.Any())
+            .ForCondition(typesWithMatchingAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to not be decorated with {0} that matches {1}{reason}," +
                 " but a matching attribute was found on the following types:{2}{3}.",
@@ -255,7 +255,7 @@ public class TypeSelectorAssertions
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(!typesWithAttribute.Any())
+            .ForCondition(typesWithAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to not be decorated with or inherit {0}{reason}," +
                 " but the attribute was found on the following types:{1}{2}.",
@@ -292,7 +292,7 @@ public class TypeSelectorAssertions
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(!typesWithMatchingAttribute.Any())
+            .ForCondition(typesWithMatchingAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to not be decorated with or inherit {0} that matches {1}{reason}," +
                 " but a matching attribute was found on the following types:{2}{3}.",
@@ -318,7 +318,7 @@ public class TypeSelectorAssertions
     {
         var notSealedTypes = Subject.Where(type => !type.IsCSharpSealed()).ToArray();
 
-        Execute.Assertion.ForCondition(!notSealedTypes.Any())
+        Execute.Assertion.ForCondition(notSealedTypes.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be sealed{reason}, but the following types are not:{0}{1}.", Environment.NewLine,
                 GetDescriptionsFor(notSealedTypes));
@@ -340,7 +340,7 @@ public class TypeSelectorAssertions
     {
         var sealedTypes = Subject.Where(type => type.IsCSharpSealed()).ToArray();
 
-        Execute.Assertion.ForCondition(!sealedTypes.Any())
+        Execute.Assertion.ForCondition(sealedTypes.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types not to be sealed{reason}, but the following types are:{0}{1}.", Environment.NewLine,
                 GetDescriptionsFor(sealedTypes));
@@ -369,7 +369,7 @@ public class TypeSelectorAssertions
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(!typesNotInNamespace.Any())
+            .ForCondition(typesNotInNamespace.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be in namespace {0}{reason}," +
                 " but the following types are in a different namespace:{1}{2}.",
@@ -401,7 +401,7 @@ public class TypeSelectorAssertions
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(!typesInNamespace.Any())
+            .ForCondition(typesInNamespace.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected no types to be in namespace {0}{reason}," +
                 " but the following types are in the namespace:{1}{2}.",
@@ -433,7 +433,7 @@ public class TypeSelectorAssertions
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(!typesNotUnderNamespace.Any())
+            .ForCondition(typesNotUnderNamespace.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected the namespaces of all types to start with {0}{reason}," +
                 " but the namespaces of the following types do not start with it:{1}{2}.",
@@ -466,7 +466,7 @@ public class TypeSelectorAssertions
             .ToArray();
 
         Execute.Assertion
-            .ForCondition(!typesUnderNamespace.Any())
+            .ForCondition(typesUnderNamespace.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected the namespaces of all types to not start with {0}{reason}," +
                 " but the namespaces of the following types start with it:{1}{2}.",

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -267,7 +267,7 @@ namespace FluentAssertions.Specs.Execution
 
             public void ThrowIfAny(IDictionary<string, object> context)
             {
-                if (failureMessages.Count != 0)
+                if (failureMessages.Count > 0)
                 {
                     var builder = new StringBuilder();
                     builder.AppendJoin(Environment.NewLine, failureMessages).AppendLine();

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -267,7 +267,7 @@ namespace FluentAssertions.Specs.Execution
 
             public void ThrowIfAny(IDictionary<string, object> context)
             {
-                if (failureMessages.Any())
+                if (failureMessages.Count != 0)
                 {
                     var builder = new StringBuilder();
                     builder.AppendJoin(Environment.NewLine, failureMessages).AppendLine();


### PR DESCRIPTION
Fixes newly enabled .NET analyzers CA1860 rule. More information about the rule at https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860

<!-- Please provide a description of your changes above the IMPORTANT checklist -->

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
