### PR TITLE
Bump all dependencies

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
   "$ref": "#/definitions/build",
+  "title": "Build Schema",
   "definitions": {
     "build": {
       "type": "object",

--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
@@ -19,12 +19,12 @@
   <ItemGroup>
     <PackageDownload Include="GitVersion.Tool" Version="[5.12.0]" />
     <PackageDownload Include="NSpec" Version="[3.1.0]" />
-    <PackageDownload Include="ReportGenerator" Version="[5.1.19]" />
+    <PackageDownload Include="ReportGenerator" Version="[5.1.20]" />
     <PackageDownload Include="xunit.runner.console" Version="[2.4.2]" />
     <PackageDownload Include="Node.js.redist" Version="[16.17.1]" />
-    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
-    <PackageReference Include="Nuke.Common" Version="6.3.0" />
-    <PackageReference Include="Nuke.Components" Version="6.3.0" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
+    <PackageReference Include="Nuke.Common" Version="7.0.0" />
+    <PackageReference Include="Nuke.Components" Version="7.0.0" />
     <PackageDownload Include="Yarn.MSBuild" Version="[1.22.19]" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,11 +30,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.2.0">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.26">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.46">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -49,7 +49,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="PolySharp" Version="1.12.1" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.13.1" PrivateAssets="all" />
     <None Include="..\FluentAssertions.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/Tests/Approval.Tests/Approval.Tests.csproj
+++ b/Tests/Approval.Tests/Approval.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -11,9 +11,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
-    <PackageReference Include="Verify.DiffPlex" Version="2.2.0" />
-    <PackageReference Include="Verify.Xunit" Version="19.10.0" />
+    <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
+    <PackageReference Include="Verify.DiffPlex" Version="2.2.1" />
+    <PackageReference Include="Verify.Xunit" Version="19.14.1" />
   </ItemGroup>
 
 </Project>

--- a/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
+++ b/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net47;net6.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
@@ -49,7 +49,7 @@
 
   <ItemGroup>
     <PackageReference Include="Chill" Version="4.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="Xunit.StaFact" Version="1.1.11" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -14,7 +14,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_nullable_datetimeoffset_value_with_a_value_to_have_a_value_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset? nullableDateTime = new DateTime(2016, 06, 04);
+            DateTimeOffset? nullableDateTime = new DateTime(2016, 06, 04).ToDateTimeOffset();
 
             // Act
             Action action = () => nullableDateTime.Should().HaveValue();
@@ -57,7 +57,7 @@ public class DateTimeOffsetAssertionSpecs
         public void Should_fail_when_asserting_nullable_datetimeoffset_value_with_a_value_to_not_have_a_value()
         {
             // Arrange
-            DateTimeOffset? nullableDateTime = new DateTime(2016, 06, 04);
+            DateTimeOffset? nullableDateTime = new DateTime(2016, 06, 04).ToDateTimeOffset();
 
             // Act
             Action action = () =>
@@ -74,7 +74,7 @@ public class DateTimeOffsetAssertionSpecs
         public void When_nullable_datetimeoffset_value_with_a_value_not_be_null_it_should_succeed()
         {
             // Arrange
-            DateTimeOffset? nullableDateTime = new DateTime(2016, 06, 04);
+            DateTimeOffset? nullableDateTime = new DateTime(2016, 06, 04).ToDateTimeOffset();
 
             // Act
             Action action = () => nullableDateTime.Should().NotBeNull();
@@ -117,7 +117,7 @@ public class DateTimeOffsetAssertionSpecs
         public void Should_fail_when_asserting_nullable_datetimeoffset_value_with_a_value_to_be_null()
         {
             // Arrange
-            DateTimeOffset? nullableDateTime = new DateTime(2016, 06, 04);
+            DateTimeOffset? nullableDateTime = new DateTime(2016, 06, 04).ToDateTimeOffset();
 
             // Act
             Action action = () =>
@@ -134,8 +134,8 @@ public class DateTimeOffsetAssertionSpecs
         public void Should_succeed_when_asserting_datetimeoffset_value_is_equal_to_the_same_value()
         {
             // Arrange
-            DateTimeOffset dateTime = new DateTime(2016, 06, 04);
-            DateTimeOffset sameDateTime = new DateTime(2016, 06, 04);
+            DateTimeOffset dateTime = new DateTime(2016, 06, 04).ToDateTimeOffset();
+            DateTimeOffset sameDateTime = new DateTime(2016, 06, 04).ToDateTimeOffset();
 
             // Act
             Action act = () => dateTime.Should().Be(sameDateTime);
@@ -148,8 +148,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_datetimeoffset_value_is_equal_to_the_same_nullable_value_be_should_succeed()
         {
             // Arrange
-            DateTimeOffset dateTime = 4.June(2016);
-            DateTimeOffset? sameDateTime = 4.June(2016);
+            DateTimeOffset dateTime = 4.June(2016).ToDateTimeOffset();
+            DateTimeOffset? sameDateTime = 4.June(2016).ToDateTimeOffset();
 
             // Act
             Action act = () => dateTime.Should().Be(sameDateTime);
@@ -220,8 +220,8 @@ public class DateTimeOffsetAssertionSpecs
         public void Should_succeed_when_asserting_nullable_datetimeoffset_value_equals_the_same_value()
         {
             // Arrange
-            DateTimeOffset? nullableDateTimeA = new DateTime(2016, 06, 04);
-            DateTimeOffset? nullableDateTimeB = new DateTime(2016, 06, 04);
+            DateTimeOffset? nullableDateTimeA = new DateTime(2016, 06, 04).ToDateTimeOffset();
+            DateTimeOffset? nullableDateTimeB = new DateTime(2016, 06, 04).ToDateTimeOffset();
 
             // Act
             Action action = () =>
@@ -246,8 +246,8 @@ public class DateTimeOffsetAssertionSpecs
         public void Should_fail_when_asserting_nullable_datetimeoffset_value_equals_a_different_value()
         {
             // Arrange
-            DateTimeOffset? nullableDateTimeA = new DateTime(2016, 06, 04);
-            DateTimeOffset? nullableDateTimeB = new DateTime(2016, 06, 06);
+            DateTimeOffset? nullableDateTimeA = new DateTime(2016, 06, 04).ToDateTimeOffset();
+            DateTimeOffset? nullableDateTimeB = new DateTime(2016, 06, 06).ToDateTimeOffset();
 
             // Act
             Action action = () =>
@@ -313,8 +313,8 @@ public class DateTimeOffsetAssertionSpecs
         public void Should_succeed_when_asserting_datetimeoffset_value_is_not_equal_to_a_different_value()
         {
             // Arrange
-            DateTimeOffset dateTime = new DateTime(2016, 06, 04);
-            DateTimeOffset otherDateTime = new DateTime(2016, 06, 05);
+            DateTimeOffset dateTime = new DateTime(2016, 06, 04).ToDateTimeOffset();
+            DateTimeOffset otherDateTime = new DateTime(2016, 06, 05).ToDateTimeOffset();
 
             // Act
             Action act = () => dateTime.Should().NotBe(otherDateTime);
@@ -327,8 +327,8 @@ public class DateTimeOffsetAssertionSpecs
         public void When_datetimeoffset_value_is_not_equal_to_a_nullable_different_value_notbe_should_succeed()
         {
             // Arrange
-            DateTimeOffset dateTime = 4.June(2016);
-            DateTimeOffset? otherDateTime = 5.June(2016);
+            DateTimeOffset dateTime = 4.June(2016).ToDateTimeOffset();
+            DateTimeOffset? otherDateTime = 5.June(2016).ToDateTimeOffset();
 
             // Act
             Action act = () => dateTime.Should().NotBe(otherDateTime);
@@ -390,8 +390,8 @@ public class DateTimeOffsetAssertionSpecs
         public void Should_succeed_when_asserting_value_is_exactly_equal_to_the_same_value()
         {
             // Arrange
-            DateTimeOffset dateTime = new DateTime(2016, 06, 04);
-            DateTimeOffset sameDateTime = new DateTime(2016, 06, 04);
+            DateTimeOffset dateTime = new DateTime(2016, 06, 04).ToDateTimeOffset();
+            DateTimeOffset sameDateTime = new DateTime(2016, 06, 04).ToDateTimeOffset();
 
             // Act / Assert
             dateTime.Should().BeExactly(sameDateTime);
@@ -401,8 +401,8 @@ public class DateTimeOffsetAssertionSpecs
         public void Should_succeed_when_asserting_value_is_exactly_equal_to_the_same_nullable_value()
         {
             // Arrange
-            DateTimeOffset dateTime = 4.June(2016);
-            DateTimeOffset? sameDateTime = 4.June(2016);
+            DateTimeOffset dateTime = 4.June(2016).ToDateTimeOffset();
+            DateTimeOffset? sameDateTime = 4.June(2016).ToDateTimeOffset();
 
             // Act / Assert
             dateTime.Should().BeExactly(sameDateTime);
@@ -442,8 +442,8 @@ public class DateTimeOffsetAssertionSpecs
         public void Should_succeed_when_asserting_nullable_value_is_exactly_equal_to_the_same_nullable_value()
         {
             // Arrange
-            DateTimeOffset? nullableDateTimeA = new DateTime(2016, 06, 04);
-            DateTimeOffset? nullableDateTimeB = new DateTime(2016, 06, 04);
+            DateTimeOffset? nullableDateTimeA = new DateTime(2016, 06, 04).ToDateTimeOffset();
+            DateTimeOffset? nullableDateTimeB = new DateTime(2016, 06, 04).ToDateTimeOffset();
 
             // Act / Assert
             nullableDateTimeA.Should().BeExactly(nullableDateTimeB);
@@ -464,8 +464,8 @@ public class DateTimeOffsetAssertionSpecs
         public void Should_fail_when_asserting_nullable_value_exactly_equals_a_different_value()
         {
             // Arrange
-            DateTimeOffset? nullableDateTimeA = new DateTime(2016, 06, 04);
-            DateTimeOffset? nullableDateTimeB = new DateTime(2016, 06, 06);
+            DateTimeOffset? nullableDateTimeA = new DateTime(2016, 06, 04).ToDateTimeOffset();
+            DateTimeOffset? nullableDateTimeB = new DateTime(2016, 06, 06).ToDateTimeOffset();
 
             // Act
             Action action = () =>
@@ -2490,8 +2490,8 @@ public class DateTimeOffsetAssertionSpecs
         public void Should_support_chaining_constraints_with_and()
         {
             // Arrange
-            DateTimeOffset yesterday = new DateTime(2016, 06, 03);
-            DateTimeOffset? nullableDateTime = new DateTime(2016, 06, 04);
+            DateTimeOffset yesterday = new DateTime(2016, 06, 03).ToDateTimeOffset();
+            DateTimeOffset? nullableDateTime = new DateTime(2016, 06, 04).ToDateTimeOffset();
 
             // Act
             Action action = () =>

--- a/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
+++ b/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>MSTestV2.Specs</RootNamespace>
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
   </ItemGroup>
 </Project>

--- a/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
+++ b/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>MSpec.Specs</RootNamespace>
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Machine.Specifications" Version="1.1.0" />
+    <PackageReference Include="Machine.Specifications" Version="1.1.1" />
     <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.10.2" />
   </ItemGroup>
 </Project>

--- a/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
+++ b/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
* Bumps Nuke to 7.0.0
* Bumps the Roslyn analyzers and disables a new rule we don't care about in tests
* Bump the remainder of our dependencies

## IMPORTANT 

~~* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.~~
~~* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).~~
~~* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).~~
~~* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).~~
~~* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).~~
~~* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).~~
~~    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome~~
