### PR TITLE
Avoid quoting newlines

### DIFF
--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -68,9 +68,9 @@ public static class ObjectAssertionsExtensions
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:{1}{1}{2}.",
+                .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:"
+                            + Environment.NewLine + Environment.NewLine + "{1}.",
                     assertions.Subject,
-                    Environment.NewLine,
                     exc.Message);
         }
 
@@ -133,9 +133,9 @@ public static class ObjectAssertionsExtensions
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:{1}{1}{2}.",
+                .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:"
+                            + Environment.NewLine + Environment.NewLine + "{1}.",
                     assertions.Subject,
-                    Environment.NewLine,
                     exc.Message);
         }
 
@@ -213,9 +213,9 @@ public static class ObjectAssertionsExtensions
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:{1}{1}{2}.",
+                .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:"
+                            + Environment.NewLine + Environment.NewLine + "{1}.",
                     assertions.Subject,
-                    Environment.NewLine,
                     exc.Message);
         }
 

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -226,9 +226,8 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
             .FailWith("but no exception was thrown.")
             .Then
             .ForCondition(expectedExceptions.Any())
-            .FailWith("but found <{0}>: {1}{2}.",
+            .FailWith("but found <{0}>:" + Environment.NewLine + "{1}.",
                 exception?.GetType(),
-                Environment.NewLine,
                 exception)
             .Then
             .ClearExpectation();

--- a/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
@@ -41,9 +41,8 @@ public abstract class DelegateAssertionsBase<TDelegate, TAssertions>
             .FailWith("but no exception was thrown.")
             .Then
             .ForCondition(expectedExceptions.Any())
-            .FailWith("but found <{0}>: {1}{2}.",
+            .FailWith("but found <{0}>:" + Environment.NewLine + "{1}.",
                 exception?.GetType(),
-                Environment.NewLine,
                 exception)
             .Then
             .ClearExpectation();

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -192,8 +192,9 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
         Execute.Assertion
             .ForCondition(condition(SingleSubject))
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected exception where {0}{reason}, but the condition was not met by:{1}{1}{2}.",
-                exceptionExpression, Environment.NewLine, Subject);
+            .FailWith("Expected exception where {0}{reason}, but the condition was not met by:"
+                        + Environment.NewLine + Environment.NewLine + "{1}.",
+                exceptionExpression, Subject);
 
         return this;
     }

--- a/Src/FluentAssertions/Streams/StreamAssertions.cs
+++ b/Src/FluentAssertions/Streams/StreamAssertions.cs
@@ -232,8 +232,9 @@ public class StreamAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected the position of {context:stream} to be {0}{reason}, but it failed with:{1}{2}",
-                        expected, Environment.NewLine, exception.Message);
+                    .FailWith("Expected the position of {context:stream} to be {0}{reason}, but it failed with:"
+                                + Environment.NewLine + "{1}",
+                        expected, exception.Message);
 
                 return new AndConstraint<TAssertions>((TAssertions)this);
             }
@@ -280,8 +281,9 @@ public class StreamAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected the position of {context:stream} not to be {0}{reason}, but it failed with:{1}{2}",
-                        unexpected, Environment.NewLine, exception.Message);
+                    .FailWith("Expected the position of {context:stream} not to be {0}{reason}, but it failed with:"
+                                + Environment.NewLine + "{1}",
+                        unexpected, exception.Message);
 
                 return new AndConstraint<TAssertions>((TAssertions)this);
             }
@@ -328,8 +330,9 @@ public class StreamAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected the length of {context:stream} to be {0}{reason}, but it failed with:{1}{2}",
-                        expected, Environment.NewLine, exception.Message);
+                    .FailWith("Expected the length of {context:stream} to be {0}{reason}, but it failed with:"
+                                + Environment.NewLine + "{1}",
+                        expected, exception.Message);
 
                 return new AndConstraint<TAssertions>((TAssertions)this);
             }
@@ -376,8 +379,9 @@ public class StreamAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected the length of {context:stream} not to be {0}{reason}, but it failed with:{1}{2}",
-                        unexpected, Environment.NewLine, exception.Message);
+                    .FailWith("Expected the length of {context:stream} not to be {0}{reason}, but it failed with:"
+                                + Environment.NewLine + "{1}",
+                        unexpected, exception.Message);
 
                 return new AndConstraint<TAssertions>((TAssertions)this);
             }

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -55,9 +55,8 @@ public class TypeSelectorAssertions
             .ForCondition(!typesWithoutAttribute.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be decorated with {0}{reason}," +
-                " but the attribute was not found on the following types:{1}{2}.",
+                " but the attribute was not found on the following types:" + Environment.NewLine + "{1}.",
                 typeof(TAttribute),
-                Environment.NewLine,
                 GetDescriptionsFor(typesWithoutAttribute));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -92,10 +91,9 @@ public class TypeSelectorAssertions
             .ForCondition(!typesWithoutMatchingAttribute.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be decorated with {0} that matches {1}{reason}," +
-                " but no matching attribute was found on the following types:{2}{3}.",
+                " but no matching attribute was found on the following types:" + Environment.NewLine + "{2}.",
                 typeof(TAttribute),
                 isMatchingAttributePredicate,
-                Environment.NewLine,
                 GetDescriptionsFor(typesWithoutMatchingAttribute));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -123,9 +121,8 @@ public class TypeSelectorAssertions
             .ForCondition(!typesWithoutAttribute.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be decorated with or inherit {0}{reason}," +
-                " but the attribute was not found on the following types:{1}{2}.",
+                " but the attribute was not found on the following types:" + Environment.NewLine + "{1}.",
                 typeof(TAttribute),
-                Environment.NewLine,
                 GetDescriptionsFor(typesWithoutAttribute));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -160,10 +157,9 @@ public class TypeSelectorAssertions
             .ForCondition(!typesWithoutMatchingAttribute.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be decorated with or inherit {0} that matches {1}{reason}," +
-                " but no matching attribute was found on the following types:{2}{3}.",
+                " but no matching attribute was found on the following types:" + Environment.NewLine + "{2}.",
                 typeof(TAttribute),
                 isMatchingAttributePredicate,
-                Environment.NewLine,
                 GetDescriptionsFor(typesWithoutMatchingAttribute));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -190,9 +186,8 @@ public class TypeSelectorAssertions
             .ForCondition(!typesWithAttribute.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to not be decorated with {0}{reason}," +
-                " but the attribute was found on the following types:{1}{2}.",
+                " but the attribute was found on the following types:" + Environment.NewLine + "{1}.",
                 typeof(TAttribute),
-                Environment.NewLine,
                 GetDescriptionsFor(typesWithAttribute));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -227,10 +222,9 @@ public class TypeSelectorAssertions
             .ForCondition(!typesWithMatchingAttribute.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to not be decorated with {0} that matches {1}{reason}," +
-                " but a matching attribute was found on the following types:{2}{3}.",
+                " but a matching attribute was found on the following types:" + Environment.NewLine + "{2}.",
                 typeof(TAttribute),
                 isMatchingAttributePredicate,
-                Environment.NewLine,
                 GetDescriptionsFor(typesWithMatchingAttribute));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -258,9 +252,8 @@ public class TypeSelectorAssertions
             .ForCondition(!typesWithAttribute.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to not be decorated with or inherit {0}{reason}," +
-                " but the attribute was found on the following types:{1}{2}.",
+                " but the attribute was found on the following types:" + Environment.NewLine + "{1}.",
                 typeof(TAttribute),
-                Environment.NewLine,
                 GetDescriptionsFor(typesWithAttribute));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -295,10 +288,9 @@ public class TypeSelectorAssertions
             .ForCondition(!typesWithMatchingAttribute.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to not be decorated with or inherit {0} that matches {1}{reason}," +
-                " but a matching attribute was found on the following types:{2}{3}.",
+                " but a matching attribute was found on the following types:" + Environment.NewLine + "{2}.",
                 typeof(TAttribute),
                 isMatchingAttributePredicate,
-                Environment.NewLine,
                 GetDescriptionsFor(typesWithMatchingAttribute));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -320,7 +312,7 @@ public class TypeSelectorAssertions
 
         Execute.Assertion.ForCondition(!notSealedTypes.Any())
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types to be sealed{reason}, but the following types are not:{0}{1}.", Environment.NewLine,
+            .FailWith("Expected all types to be sealed{reason}, but the following types are not:" + Environment.NewLine + "{0}.",
                 GetDescriptionsFor(notSealedTypes));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -342,7 +334,7 @@ public class TypeSelectorAssertions
 
         Execute.Assertion.ForCondition(!sealedTypes.Any())
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types not to be sealed{reason}, but the following types are:{0}{1}.", Environment.NewLine,
+            .FailWith("Expected all types not to be sealed{reason}, but the following types are:" + Environment.NewLine + "{0}.",
                 GetDescriptionsFor(sealedTypes));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -372,9 +364,8 @@ public class TypeSelectorAssertions
             .ForCondition(!typesNotInNamespace.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be in namespace {0}{reason}," +
-                " but the following types are in a different namespace:{1}{2}.",
+                " but the following types are in a different namespace:" + Environment.NewLine + "{1}.",
                 @namespace,
-                Environment.NewLine,
                 GetDescriptionsFor(typesNotInNamespace));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -404,9 +395,8 @@ public class TypeSelectorAssertions
             .ForCondition(!typesInNamespace.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected no types to be in namespace {0}{reason}," +
-                " but the following types are in the namespace:{1}{2}.",
+                " but the following types are in the namespace:" + Environment.NewLine + "{1}.",
                 @namespace,
-                Environment.NewLine,
                 GetDescriptionsFor(typesInNamespace));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -436,9 +426,8 @@ public class TypeSelectorAssertions
             .ForCondition(!typesNotUnderNamespace.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected the namespaces of all types to start with {0}{reason}," +
-                " but the namespaces of the following types do not start with it:{1}{2}.",
+                " but the namespaces of the following types do not start with it:" + Environment.NewLine + "{1}.",
                 @namespace,
-                Environment.NewLine,
                 GetDescriptionsFor(typesNotUnderNamespace));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
@@ -469,9 +458,8 @@ public class TypeSelectorAssertions
             .ForCondition(!typesUnderNamespace.Any())
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected the namespaces of all types to not start with {0}{reason}," +
-                " but the namespaces of the following types start with it:{1}{2}.",
+                " but the namespaces of the following types start with it:" + Environment.NewLine + "{1}.",
                 @namespace,
-                Environment.NewLine,
                 GetDescriptionsFor(typesUnderNamespace));
 
         return new AndConstraint<TypeSelectorAssertions>(this);

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -252,7 +252,7 @@ public static class TaskAssertionSpecs
             // Assert
             await action.Should().ThrowAsync<XunitException>().WithMessage(
                 "Expected a <System.InvalidOperationException> to be thrown,"
-                + " but found <System.NotSupportedException>: *foo*");
+                + " but found <System.NotSupportedException>:*foo*");
         }
 
         [Fact]
@@ -440,7 +440,7 @@ public static class TaskAssertionSpecs
             // Assert
             await action.Should().ThrowAsync<XunitException>().WithMessage(
                 "Expected a <System.InvalidOperationException> to be thrown within 100ms,"
-                + " but found <System.NotSupportedException>: *foo*");
+                + " but found <System.NotSupportedException>:*foo*");
         }
 
         [Fact]
@@ -462,7 +462,7 @@ public static class TaskAssertionSpecs
             // Assert
             await action.Should().ThrowAsync<XunitException>().WithMessage(
                 "Expected a <System.InvalidOperationException> to be thrown within 1s,"
-                + " but found <System.NotSupportedException>: *foo*");
+                + " but found <System.NotSupportedException>:*foo*");
         }
     }
 


### PR DESCRIPTION
https://github.com/fluentassertions/fluentassertions/pull/2144#discussion_r1177338724 pointed out that we incorrectly added `Environment.Newline` as an argument, which due to how `StringValueFormatter` format strings, adds double quotes around the newline.
This bug was added in #712 by yours truly.


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
