### PR TITLE
Include because+becauseArgs when comparing collections of enums for equivalency

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumEqualityStep.cs
@@ -20,6 +20,7 @@ public class EnumEqualityStep : IEquivalencyStep
 
         bool succeeded = Execute.Assertion
             .ForCondition(comparands.Subject?.GetType().IsEnum == true)
+            .BecauseOf(context.Reason)
             .FailWith(() =>
             {
                 decimal? expectationsUnderlyingValue = ExtractDecimal(comparands.Expectation);
@@ -35,11 +36,11 @@ public class EnumEqualityStep : IEquivalencyStep
             switch (context.Options.EnumEquivalencyHandling)
             {
                 case EnumEquivalencyHandling.ByValue:
-                    HandleByValue(comparands);
+                    HandleByValue(comparands, context.Reason);
                     break;
 
                 case EnumEquivalencyHandling.ByName:
-                    HandleByName(comparands);
+                    HandleByName(comparands, context.Reason);
                     break;
 
                 default:
@@ -50,13 +51,14 @@ public class EnumEqualityStep : IEquivalencyStep
         return EquivalencyResult.AssertionCompleted;
     }
 
-    private static void HandleByValue(Comparands comparands)
+    private static void HandleByValue(Comparands comparands, Reason reason)
     {
         decimal? subjectsUnderlyingValue = ExtractDecimal(comparands.Subject);
         decimal? expectationsUnderlyingValue = ExtractDecimal(comparands.Expectation);
 
         Execute.Assertion
             .ForCondition(subjectsUnderlyingValue == expectationsUnderlyingValue)
+            .BecauseOf(reason)
             .FailWith(() =>
             {
                 string subjectsName = GetDisplayNameForEnumComparison(comparands.Subject, subjectsUnderlyingValue);
@@ -67,13 +69,14 @@ public class EnumEqualityStep : IEquivalencyStep
             });
     }
 
-    private static void HandleByName(Comparands comparands)
+    private static void HandleByName(Comparands comparands, Reason reason)
     {
         string subject = comparands.Subject.ToString();
         string expected = comparands.Expectation.ToString();
 
         Execute.Assertion
             .ForCondition(subject == expected)
+            .BecauseOf(reason)
             .FailWith(() =>
             {
                 decimal? subjectsUnderlyingValue = ExtractDecimal(comparands.Subject);

--- a/Tests/FluentAssertions.Equivalency.Specs/EnumSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/EnumSpecs.cs
@@ -68,6 +68,54 @@ public class EnumSpecs
     }
 
     [Fact]
+    public void Comparing_collections_of_enums_by_value_includes_custom_message()
+    {
+        // Arrange
+        var subject = new[] { EnumOne.One };
+        var expectation = new[] { EnumOne.Two };
+
+        // Act
+        Action act = () => subject.Should().BeEquivalentTo(expectation, "some {0}", "reason");
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected *EnumOne.Two {value: 3}*some reason*but*EnumOne.One {value: 0}*");
+    }
+
+    [Fact]
+    public void Comparing_collections_of_enums_by_name_includes_custom_message()
+    {
+        // Arrange
+        var subject = new[] { EnumOne.Two };
+        var expectation = new[] { EnumFour.Three };
+
+        // Act
+        Action act = () => subject.Should().BeEquivalentTo(expectation, config => config.ComparingEnumsByName(),
+            "some {0}", "reason");
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected*to equal EnumFour.Three {value: 3} by name*some reason*but found EnumOne.Two {value: 3}*");
+    }
+
+    [Fact]
+    public void Comparing_collections_of_numerics_with_collections_of_enums_includes_custom_message()
+    {
+        // Arrange
+        var actual = new[] { 1 };
+
+        var expected = new[] { TestEnum.First };
+
+        // Act
+        Action act = () => actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByValue(),
+            "some {0}", "reason");
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("*some reason*");
+    }
+
+    [Fact]
     public void When_asserting_members_from_different_enum_types_are_equivalent_it_should_compare_by_value_by_default()
     {
         // Arrange

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -9,6 +9,9 @@ sidebar:
 
 ## Unreleased
 
+### Fixes
+* `because` and `becauseArgs` were not included in the error message when collections of enums were not equivalent - [#2214](https://github.com/fluentassertions/fluentassertions/pull/2214)
+
 ## 6.11.0
 
 ### What's new


### PR DESCRIPTION
Include because+becauseArgs when comparing collections of enums for equivalency.

When comparing just instances of enums, the reason was already set on the `AssertionScope` when entering `EnumEqualitySteps`.
I noticed that `EnumerableEquivalencyValidator.TryToMatch` and `EnumerableEquivalencyValidator.StrictlyMatchAgainst` creates a new `AssertionScope` without calling `scope.BecauseOf(context.Reason)`.
Couldn't tell on first sight if this was right 🤷‍♂️ 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
