### PR TITLE
Add documentation for `IComparer<T>` overload

### DIFF
--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -98,6 +98,16 @@ collection.Should().NotBeInAscendingOrder();
 collection.Should().NotBeInDescendingOrder();
 ```
 
+Since **6.9.0** there is a slight change in how culture is taken into comparison. Now by default `StringComparer.Ordinal` is used to compare strings.
+If you want to overrule this behaviour use the `IComparer<T>` overload. The use case is e.g. if you get data from a database ordered by culture aware sort order.
+
+```csharp
+collection.Should().BeInAscendingOrder(item => item.SomeProp, StringComparer.CurrentCulture);
+collection.Should().BeInDescendingOrder(item => item.SomeProp, StringComparer.CurrentCulture);
+collection.Should().NotBeInAscendingOrder(item => item.SomeProp, StringComparer.CurrentCulture);
+collection.Should().NotBeInDescendingOrder(item => item.SomeProp, StringComparer.CurrentCulture);
+```
+ 
 For `String` collections there are specific methods to assert the items. For the `ContainMatch` and `NotContainMatch` methods we support wildcards.
 
 The pattern can be a combination of literal and wildcard characters, but it doesn't support regular expressions.

--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -99,7 +99,7 @@ collection.Should().NotBeInDescendingOrder();
 ```
 
 Since **6.9.0** there is a slight change in how culture is taken into comparison. Now by default `StringComparer.Ordinal` is used to compare strings.
-If you want to overrule this behaviour use the `IComparer<T>` overload. The use case is e.g. if you get data from a database ordered by culture aware sort order.
+If you want to overrule this behavior use the `IComparer<T>` overload. The use case is e.g. if you get data from a database ordered by culture aware sort order.
 
 ```csharp
 collection.Should().BeInAscendingOrder(item => item.SomeProp, StringComparer.CurrentCulture);


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Since this new behaviour leads to some confusion, I gave it a quick mention in the docs.

Ref. #2216, #2126, #2109

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
