### PR TITLE
Prepare for .NET8 analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -154,6 +154,8 @@ dotnet_diagnostic.CA1819.severity = none
 dotnet_diagnostic.CA1851.severity = suggestion
 # CA1860: Avoid using 'Enumerable.Any()' extension method
 dotnet_diagnostic.CA1860.severity = warning
+# CA1861: Avoid constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = none
 # CA2007: Do not directly await a Task
 dotnet_diagnostic.CA2007.severity = none
 # CA2225: Operator overloads have named alternates

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -250,7 +250,7 @@ class Build : NukeBuild
         .Executes(() =>
         {
             ReportGenerator(s => s
-                .SetProcessToolPath(NuGetToolPathResolver .GetPackageExecutable("ReportGenerator", "ReportGenerator.dll", framework: "net6.0"))
+                .SetProcessToolPath(NuGetToolPathResolver.GetPackageExecutable("ReportGenerator", "ReportGenerator.dll", framework: "net6.0"))
                 .SetTargetDirectory(TestResultsDirectory / "reports")
                 .AddReports(TestResultsDirectory / "**/coverage.cobertura.xml")
                 .AddReportTypes(
@@ -301,7 +301,7 @@ class Build : NukeBuild
 
             if (EnvironmentInfo.IsWin)
             {
-                NSpec3( $"{Solution.TestFrameworks.NSpec3_Net47_Specs.Directory / "bin" / "Debug" / "net47" / "NSpec3.Specs.dll"}");
+                NSpec3($"{Solution.TestFrameworks.NSpec3_Net47_Specs.Directory / "bin" / "Debug" / "net47" / "NSpec3.Specs.dll"}");
             }
 
             ReportTestOutcome(projects.Select(p => $"*{p.Name}*.trx").ToArray());

--- a/Src/FluentAssertions/Formatting/FormattedObjectGraph.cs
+++ b/Src/FluentAssertions/Formatting/FormattedObjectGraph.cs
@@ -168,7 +168,7 @@ public class FormattedObjectGraph
     {
         private readonly FormattedObjectGraph parentGraph;
         private readonly int startingLineBuilderIndex;
-        private int startingLineCount;
+        private readonly int startingLineCount;
 
         public PossibleMultilineFragment(FormattedObjectGraph parentGraph)
         {

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -63,6 +63,8 @@ dotnet_diagnostic.CA1822.severity = none
 dotnet_diagnostic.CA1825.severity = none
 # CA1852: A type that's not accessible outside its assembly and has no subtypes within its containing assembly is not marked sealed
 dotnet_diagnostic.CA1852.severity = none
+# CA1861: Avoid constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = none
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none
 # CA2201: Exception type System.Exception is not sufficiently specific

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -53,7 +53,9 @@ public class AssertionOptionsSpecs
         {
             When(() =>
             {
+#pragma warning disable CA1859 // https://github.com/dotnet/roslyn-analyzers/issues/6704
                 IEquivalencyAssertionOptions equivalencyAssertionOptions = new EquivalencyAssertionOptions();
+#pragma warning restore CA1859
 
                 return () => Parallel.For(0, 10_000, new ParallelOptions { MaxDegreeOfParallelism = 8 },
                     _ => equivalencyAssertionOptions.GetEqualityStrategy(typeof(IEnumerable))

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -307,9 +307,9 @@ namespace FluentAssertions.Specs.Execution
     }
 }
 
-#pragma warning disable RCS1110, CA1050 // Declare type inside namespace.
+#pragma warning disable RCS1110, CA1050, S3903 // Declare type inside namespace.
 public class AssertionScopeSpecsWithoutNamespace
-#pragma warning restore RCS1110, CA1050 // Declare type inside namespace.
+#pragma warning restore RCS1110, CA1050, S3903 // Declare type inside namespace.
 {
     [Fact]
     public void This_class_should_not_be_inside_a_namespace()


### PR DESCRIPTION
I installed the latest .NET8 preview to see what analyzers we would trigger.

These three lines trigger [CA1861: Avoid constant arrays as arguments](https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1861)
https://github.com/fluentassertions/fluentassertions/blob/343e80ff81a0598f58d241ba7a4f1588e3fff35d/Src/FluentAssertions/Common/MemberPath.cs#L119
https://github.com/fluentassertions/fluentassertions/blob/343e80ff81a0598f58d241ba7a4f1588e3fff35d/Src/FluentAssertions/Common/StringExtensions.cs#L121
https://github.com/fluentassertions/fluentassertions/blob/343e80ff81a0598f58d241ba7a4f1588e3fff35d/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs#L42

As I see it, we have three options here:
* Follow the analyzer and extract the constant arrays to static readonly fields. 
  * Downside: Reduced locality of the values
* Suppress CA1861 locally with `#pragma`s.
  * Downside: Added preprocessor noise.
* Suppress CA1861 for the entire project like I did for tests.
  * Downside: no warnings anywhere

I'm probably fine with either, but lean mostly towards either of the first two.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
