### PR TITLE
Qodana fixes

### DIFF
--- a/Src/FluentAssertions/CallerIdentification/AddNonEmptySymbolParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/AddNonEmptySymbolParsingStrategy.cs
@@ -16,7 +16,7 @@ internal class AddNonEmptySymbolParsingStrategy : IParsingStrategy
         }
         else if (mode is Mode.RemoveSuperfluousWhitespace)
         {
-            if (precedingSymbol is char value && !char.IsWhiteSpace(value))
+            if (precedingSymbol is { } value && !char.IsWhiteSpace(value))
             {
                 statement.Append(symbol);
             }

--- a/Src/FluentAssertions/Common/Configuration.cs
+++ b/Src/FluentAssertions/Common/Configuration.cs
@@ -40,12 +40,7 @@ public class Configuration
         {
             lock (propertiesAccessLock)
             {
-                if (!valueFormatterDetectionMode.HasValue)
-                {
-                    valueFormatterDetectionMode = DetermineFormatterDetectionMode();
-                }
-
-                return valueFormatterDetectionMode.Value;
+                return valueFormatterDetectionMode ??= DetermineFormatterDetectionMode();
             }
         }
 

--- a/Src/FluentAssertions/Common/Guard.cs
+++ b/Src/FluentAssertions/Common/Guard.cs
@@ -2,12 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
 
 namespace FluentAssertions.Common;
 
 internal static class Guard
 {
-    public static void ThrowIfArgumentIsNull<T>([ValidatedNotNull] T obj,
+    public static void ThrowIfArgumentIsNull<T>([ValidatedNotNull][NoEnumeration] T obj,
         [CallerArgumentExpression(nameof(obj))]
         string paramName = "")
     {
@@ -17,7 +18,7 @@ internal static class Guard
         }
     }
 
-    public static void ThrowIfArgumentIsNull<T>([ValidatedNotNull] T obj, string paramName, string message)
+    public static void ThrowIfArgumentIsNull<T>([ValidatedNotNull][NoEnumeration] T obj, string paramName, string message)
     {
         if (obj is null)
         {

--- a/Src/FluentAssertions/Data/DataTableAssertions.cs
+++ b/Src/FluentAssertions/Data/DataTableAssertions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Linq;
-using System.Xml.Schema;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;

--- a/Src/FluentAssertions/Equivalency/MemberFactory.cs
+++ b/Src/FluentAssertions/Equivalency/MemberFactory.cs
@@ -8,17 +8,12 @@ public static class MemberFactory
 {
     public static IMember Create(MemberInfo memberInfo, INode parent)
     {
-        if (memberInfo.MemberType == MemberTypes.Field)
+        return memberInfo.MemberType switch
         {
-            return new Field((FieldInfo)memberInfo, parent);
-        }
-
-        if (memberInfo.MemberType == MemberTypes.Property)
-        {
-            return new Property((PropertyInfo)memberInfo, parent);
-        }
-
-        throw new NotSupportedException($"Don't know how to deal with a {memberInfo.MemberType}");
+            MemberTypes.Field => new Field((FieldInfo)memberInfo, parent),
+            MemberTypes.Property => new Property((PropertyInfo)memberInfo, parent),
+            _ => throw new NotSupportedException($"Don't know how to deal with a {memberInfo.MemberType}")
+        };
     }
 
     internal static IMember Find(object target, string memberName, INode parent)

--- a/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
+++ b/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions.Equivalency.Ordering;
 
 namespace FluentAssertions.Equivalency;

--- a/Src/FluentAssertions/Equivalency/Steps/DataColumnEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataColumnEquivalencyStep.cs
@@ -106,26 +106,25 @@ public class DataColumnEquivalencyStep : EquivalencyStep<DataColumn>
     // NOTE: This list of candidate members is duplicated in the XML documentation for the
     // DataColumn.BeEquivalentTo extension method in DataColumnAssertions.cs. If this ever
     // needs to change, keep them in sync.
-    private static readonly HashSet<string> CandidateMembers =
-        new HashSet<string>
-        {
-            nameof(DataColumn.AllowDBNull),
-            nameof(DataColumn.AutoIncrement),
-            nameof(DataColumn.AutoIncrementSeed),
-            nameof(DataColumn.AutoIncrementStep),
-            nameof(DataColumn.Caption),
-            nameof(DataColumn.ColumnName),
-            nameof(DataColumn.DataType),
-            nameof(DataColumn.DateTimeMode),
-            nameof(DataColumn.DefaultValue),
-            nameof(DataColumn.Expression),
-            nameof(DataColumn.ExtendedProperties),
-            nameof(DataColumn.MaxLength),
-            nameof(DataColumn.Namespace),
-            nameof(DataColumn.Prefix),
-            nameof(DataColumn.ReadOnly),
-            nameof(DataColumn.Unique),
-        };
+    private static readonly HashSet<string> CandidateMembers = new()
+    {
+        nameof(DataColumn.AllowDBNull),
+        nameof(DataColumn.AutoIncrement),
+        nameof(DataColumn.AutoIncrementSeed),
+        nameof(DataColumn.AutoIncrementStep),
+        nameof(DataColumn.Caption),
+        nameof(DataColumn.ColumnName),
+        nameof(DataColumn.DataType),
+        nameof(DataColumn.DateTimeMode),
+        nameof(DataColumn.DefaultValue),
+        nameof(DataColumn.Expression),
+        nameof(DataColumn.ExtendedProperties),
+        nameof(DataColumn.MaxLength),
+        nameof(DataColumn.Namespace),
+        nameof(DataColumn.Prefix),
+        nameof(DataColumn.ReadOnly),
+        nameof(DataColumn.Unique),
+    };
 
     private static IEnumerable<IMember> GetMembersFromExpectation(INode currentNode, Comparands comparands,
         IEquivalencyAssertionOptions config)

--- a/Src/FluentAssertions/Equivalency/Steps/DataRowCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRowCollectionEquivalencyStep.cs
@@ -19,16 +19,12 @@ public class DataRowCollectionEquivalencyStep : EquivalencyStep<DataRowCollectio
         }
         else
         {
-            RowMatchMode rowMatchMode = RowMatchMode.Index;
-
-            if (context.Options is DataEquivalencyAssertionOptions<DataSet> dataSetConfig)
+            RowMatchMode rowMatchMode = context.Options switch
             {
-                rowMatchMode = dataSetConfig.RowMatchMode;
-            }
-            else if (context.Options is DataEquivalencyAssertionOptions<DataTable> dataTableConfig)
-            {
-                rowMatchMode = dataTableConfig.RowMatchMode;
-            }
+                DataEquivalencyAssertionOptions<DataSet> dataSetConfig => dataSetConfig.RowMatchMode,
+                DataEquivalencyAssertionOptions<DataTable> dataTableConfig => dataTableConfig.RowMatchMode,
+                _ => RowMatchMode.Index
+            };
 
             var subject = (DataRowCollection)comparands.Subject;
             var expectation = (DataRowCollection)comparands.Expectation;

--- a/Src/FluentAssertions/Equivalency/Steps/DataRowCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataRowCollectionEquivalencyStep.cs
@@ -205,15 +205,7 @@ public class DataRowCollectionEquivalencyStep : EquivalencyStep<DataRowCollectio
                 return false;
             }
 
-            for (int i = 0; i < values.Length; i++)
-            {
-                if (!values[i].Equals(other.values[i]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return values.SequenceEqual(other.values);
         }
 
         public override bool Equals(object obj) => Equals(obj as CompoundKey);
@@ -222,9 +214,9 @@ public class DataRowCollectionEquivalencyStep : EquivalencyStep<DataRowCollectio
         {
             int hash = 0;
 
-            for (int i = 0; i < values.Length; i++)
+            foreach (var value in values)
             {
-                hash = hash * 389 ^ values[i].GetHashCode();
+                hash = hash * 389 ^ value.GetHashCode();
             }
 
             return hash;

--- a/Src/FluentAssertions/Equivalency/Steps/DataSetEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataSetEquivalencyStep.cs
@@ -96,7 +96,7 @@ public class DataSetEquivalencyStep : EquivalencyStep<DataSet>
         if (selectedMembers.ContainsKey(nameof(expectation.Locale)))
         {
             AssertionScope.Current
-                .ForCondition(subject.Locale == expectation.Locale)
+                .ForCondition(Equals(subject.Locale, expectation.Locale))
                 .FailWith("Expected {context:DataSet} to have Locale value of {0}{reason}, but found {1} instead",
                     expectation.Locale, subject.Locale);
         }

--- a/Src/FluentAssertions/Equivalency/Steps/DataTableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DataTableEquivalencyStep.cs
@@ -101,7 +101,7 @@ public class DataTableEquivalencyStep : EquivalencyStep<DataTable>
         if (selectedMembers.ContainsKey(nameof(expectation.Locale)))
         {
             AssertionScope.Current
-                .ForCondition(subject.Locale == expectation.Locale)
+                .ForCondition(Equals(subject.Locale, expectation.Locale))
                 .FailWith("Expected {context:DataTable} to have Locale value of {0}{reason}, but found {1} instead",
                     expectation.Locale, subject.Locale);
         }

--- a/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 
 namespace FluentAssertions.Execution;

--- a/Src/FluentAssertions/Execution/NSpecFramework.cs
+++ b/Src/FluentAssertions/Execution/NSpecFramework.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 
 namespace FluentAssertions.Execution;

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -80,7 +80,7 @@ public class NumericAssertions<T, TAssertions>
     public AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(expected is T value ? Subject?.CompareTo(value) == 0 : !Subject.HasValue)
+            .ForCondition(expected is { } value ? Subject?.CompareTo(value) == 0 : !Subject.HasValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected), expected,
                 Subject);
@@ -123,7 +123,7 @@ public class NumericAssertions<T, TAssertions>
     public AndConstraint<TAssertions> NotBe(T? unexpected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(unexpected is T value ? Subject?.CompareTo(value) != 0 : Subject.HasValue)
+            .ForCondition(unexpected is { } value ? Subject?.CompareTo(value) != 0 : Subject.HasValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:value} to be {0}{reason}.", unexpected);
 
@@ -163,7 +163,7 @@ public class NumericAssertions<T, TAssertions>
     public AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject is T value && !IsNaN(value) && value.CompareTo(default) < 0)
+            .ForCondition(Subject is { } value && !IsNaN(value) && value.CompareTo(default) < 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be negative{reason}, but found {0}.", Subject);
 
@@ -189,7 +189,7 @@ public class NumericAssertions<T, TAssertions>
         }
 
         Execute.Assertion
-            .ForCondition(Subject is T value && !IsNaN(value) && value.CompareTo(expected) < 0)
+            .ForCondition(Subject is { } value && !IsNaN(value) && value.CompareTo(expected) < 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be less than {0}{reason}, but found {1}" + GenerateDifferenceMessage(expected),
                 expected, Subject);
@@ -217,7 +217,7 @@ public class NumericAssertions<T, TAssertions>
         }
 
         Execute.Assertion
-            .ForCondition(Subject is T value && !IsNaN(value) && value.CompareTo(expected) <= 0)
+            .ForCondition(Subject is { } value && !IsNaN(value) && value.CompareTo(expected) <= 0)
             .BecauseOf(because, becauseArgs)
             .FailWith(
                 "Expected {context:value} to be less than or equal to {0}{reason}, but found {1}" +
@@ -320,7 +320,7 @@ public class NumericAssertions<T, TAssertions>
         }
 
         Execute.Assertion
-            .ForCondition(Subject is T value && value.CompareTo(minimumValue) >= 0 && value.CompareTo(maximumValue) <= 0)
+            .ForCondition(Subject is { } value && value.CompareTo(minimumValue) >= 0 && value.CompareTo(maximumValue) <= 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be between {0} and {1}{reason}, but found {2}.",
                 minimumValue, maximumValue, Subject);
@@ -356,7 +356,7 @@ public class NumericAssertions<T, TAssertions>
         }
 
         Execute.Assertion
-            .ForCondition(Subject is T value && !(value.CompareTo(minimumValue) >= 0 && value.CompareTo(maximumValue) <= 0))
+            .ForCondition(Subject is { } value && !(value.CompareTo(minimumValue) >= 0 && value.CompareTo(maximumValue) <= 0))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to not be between {0} and {1}{reason}, but found {2}.",
                 minimumValue, maximumValue, Subject);
@@ -392,7 +392,7 @@ public class NumericAssertions<T, TAssertions>
         params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject is T value && validValues.Contains(value))
+            .ForCondition(Subject is { } value && validValues.Contains(value))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:value} to be one of {0}{reason}, but found {1}.", validValues, Subject);
 
@@ -508,7 +508,7 @@ public class NumericAssertions<T, TAssertions>
     {
         const string noDifferenceMessage = ".";
 
-        if (Subject is not T subject || expected is not T expectedValue)
+        if (Subject is not { } subject || expected is not T expectedValue)
         {
             return noDifferenceMessage;
         }

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -421,7 +421,7 @@ public class NumericAssertions<T, TAssertions>
 
         if (expectedType.IsGenericTypeDefinition && subjectType?.IsGenericType == true)
         {
-            (subjectType?.GetGenericTypeDefinition()).Should().Be(expectedType, because, becauseArgs);
+            subjectType.GetGenericTypeDefinition().Should().Be(expectedType, because, becauseArgs);
         }
         else
         {

--- a/Src/FluentAssertions/Primitives/EnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/EnumAssertions.cs
@@ -195,7 +195,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> HaveValue(decimal expected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject is TEnum value && GetValue(value) == expected)
+            .ForCondition(Subject is { } value && GetValue(value) == expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to have value {0}{reason}, but found {1}.",
                 expected, Subject);
@@ -217,7 +217,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> NotHaveValue(decimal unexpected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(!(Subject is TEnum value && GetValue(value) == unexpected))
+            .ForCondition(!(Subject is { } value && GetValue(value) == unexpected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to not have value {0}{reason}, but found {1}.",
                 unexpected, Subject);
@@ -240,7 +240,7 @@ public class EnumAssertions<TEnum, TAssertions>
         where T : struct, Enum
     {
         Execute.Assertion
-            .ForCondition(Subject is TEnum value && GetValue(value) == GetValue(expected))
+            .ForCondition(Subject is { } value && GetValue(value) == GetValue(expected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to have same value as {0}{reason}, but found {1}.",
                 expected, Subject);
@@ -263,7 +263,7 @@ public class EnumAssertions<TEnum, TAssertions>
         where T : struct, Enum
     {
         Execute.Assertion
-            .ForCondition(!(Subject is TEnum value && GetValue(value) == GetValue(unexpected)))
+            .ForCondition(!(Subject is { } value && GetValue(value) == GetValue(unexpected)))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to not have same value as {0}{reason}, but found {1}.",
                 unexpected, Subject);
@@ -286,7 +286,7 @@ public class EnumAssertions<TEnum, TAssertions>
         where T : struct, Enum
     {
         Execute.Assertion
-            .ForCondition(Subject is TEnum value && GetName(value) == GetName(expected))
+            .ForCondition(Subject is { } value && GetName(value) == GetName(expected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to have same name as {0}{reason}, but found {1}.",
                 expected, Subject);
@@ -309,7 +309,7 @@ public class EnumAssertions<TEnum, TAssertions>
         where T : struct, Enum
     {
         Execute.Assertion
-            .ForCondition(!(Subject is TEnum value && GetName(value) == GetName(unexpected)))
+            .ForCondition(!(Subject is { } value && GetName(value) == GetName(unexpected)))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to not have same name as {0}{reason}, but found {1}.",
                 unexpected, Subject);

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -70,7 +70,7 @@ public class GuidAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .ForCondition(Subject is Guid value && value != Guid.Empty)
+            .ForCondition(Subject is { } value && value != Guid.Empty)
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:Guid} to be empty{reason}.");
 

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.Types;
 /// </summary>
 public class MethodInfoSelector : IEnumerable<MethodInfo>
 {
-    private IEnumerable<MethodInfo> selectedMethods = new List<MethodInfo>();
+    private IEnumerable<MethodInfo> selectedMethods;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MethodInfoSelector"/> class.

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -12,7 +12,7 @@ namespace FluentAssertions.Types;
 /// </summary>
 public class PropertyInfoSelector : IEnumerable<PropertyInfo>
 {
-    private IEnumerable<PropertyInfo> selectedProperties = new List<PropertyInfo>();
+    private IEnumerable<PropertyInfo> selectedProperties;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PropertyInfoSelector"/> class.

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -293,14 +293,13 @@ public class TypeSelector : IEnumerable<Type>
     {
         types = types.ConvertAll(type =>
         {
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Task<>))
+            if (type.IsGenericType)
             {
-                return type.GetGenericArguments().Single();
-            }
-
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ValueTask<>))
-            {
-                return type.GetGenericArguments().Single();
+                Type genericTypeDefinition = type.GetGenericTypeDefinition();
+                if (genericTypeDefinition == typeof(Task<>) || genericTypeDefinition == typeof(ValueTask<>))
+                {
+                    return type.GetGenericArguments().Single();
+                }
             }
 
             return type == typeof(Task) || type == typeof(ValueTask) ? typeof(void) : type;

--- a/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
@@ -74,8 +74,6 @@ internal class XmlReaderValidator
                     currentNode.GetXPath());
             }
 
-            failure = null;
-
 #pragma warning disable IDE0010 // The default case handles the many missing cases
             switch (expectationIterator.NodeType)
 #pragma warning restore IDE0010

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -5,3 +5,7 @@ failThreshold: 0
 
 dotnet:
   solution: FluentAssertions.sln
+
+exclude:
+  - name: ConvertIfStatementToReturnStatement
+  - name: ConvertIfStatementToConditionalTernaryExpression


### PR DESCRIPTION
Went through the Qodana report and here are fixes to some that should be non-controversial.
This is in addition to be fixed in #2221.

There are a lot of warnings about unused methods/return values of public methods.
To silence them, it seems the idiomatic way is to annotate them with [`[PublicAPI]`](https://www.jetbrains.com/help/resharper/Reference__Code_Annotation_Attributes.html#PublicAPIAttribute)

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
