### PR TITLE
Added `Be`, `NotBe` and `BeOneOf` for object comparisons with custom comparer

### DIFF
--- a/Src/FluentAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ObjectAssertions.cs
@@ -16,6 +16,97 @@ public class ObjectAssertions : ObjectAssertions<object, ObjectAssertions>
         : base(value)
     {
     }
+
+    /// <summary>
+    /// Asserts that a value equals <paramref name="expected"/> using the provided <paramref name="comparer"/>.
+    /// </summary>
+    /// <param name="expected">The expected value</param>
+    /// <param name="comparer">
+    /// An equality comparer to compare values.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
+    public AndConstraint<ObjectAssertions> Be<TExpectation>(TExpectation expected, IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs)
+    {
+        Guard.ThrowIfArgumentIsNull(comparer);
+
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject is TExpectation subject && comparer.Equals(subject, expected))
+            .WithDefaultIdentifier(Identifier)
+            .FailWith("Expected {context} to be {0}{reason}, but found {1}.", expected,
+                Subject);
+
+        return new AndConstraint<ObjectAssertions>(this);
+    }
+
+    /// <summary>
+    /// Asserts that a value does not equal <paramref name="unexpected"/> using the provided <paramref name="comparer"/>.
+    /// </summary>
+    /// <param name="unexpected">The unexpected value</param>
+    /// <param name="comparer">
+    /// An equality comparer to compare values.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
+    public AndConstraint<ObjectAssertions> NotBe<TExpectation>(TExpectation unexpected, IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs)
+    {
+        Guard.ThrowIfArgumentIsNull(comparer);
+
+        Execute.Assertion
+            .ForCondition(Subject is not TExpectation subject || !comparer.Equals(subject, unexpected))
+            .BecauseOf(because, becauseArgs)
+            .WithDefaultIdentifier(Identifier)
+            .FailWith("Did not expect {context} to be equal to {0}{reason}.", unexpected);
+
+        return new AndConstraint<ObjectAssertions>(this);
+    }
+
+    /// <summary>
+    /// Asserts that a value is one of the specified <paramref name="validValues"/> using the provided <paramref name="comparer"/>.
+    /// </summary>
+    /// <param name="validValues">
+    /// The values that are valid.
+    /// </param>
+    /// <param name="comparer">
+    /// An equality comparer to compare values.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="validValues"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
+    public AndConstraint<ObjectAssertions> BeOneOf<TExpectation>(IEnumerable<TExpectation> validValues,
+        IEqualityComparer<TExpectation> comparer,
+        string because = "",
+        params object[] becauseArgs)
+    {
+        Guard.ThrowIfArgumentIsNull(validValues);
+        Guard.ThrowIfArgumentIsNull(comparer);
+
+        Execute.Assertion
+            .ForCondition(Subject is TExpectation subject && validValues.Contains(subject, comparer))
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:object} to be one of {0}{reason}, but found {1}.", validValues, Subject);
+
+        return new AndConstraint<ObjectAssertions>(this);
+    }
 }
 
 #pragma warning disable CS0659, S1206 // Ignore not overriding Object.GetHashCode()
@@ -32,7 +123,7 @@ public class ObjectAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
     }
 
     /// <summary>
-    /// Asserts that a <typeparamref name="TSubject"/> equals another <typeparamref name="TSubject"/> using its <see cref="object.Equals(object)" /> implementation.
+    /// Asserts that a value equals <paramref name="expected"/> using its <see cref="object.Equals(object)" /> implementation.
     /// </summary>
     /// <param name="expected">The expected value</param>
     /// <param name="because">
@@ -55,7 +146,36 @@ public class ObjectAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
     }
 
     /// <summary>
-    /// Asserts that a <typeparamref name="TSubject"/> does not equal another <typeparamref name="TSubject"/> using its <see cref="object.Equals(object)" /> method.
+    /// Asserts that a value equals <paramref name="expected"/> using the provided <paramref name="comparer"/>.
+    /// </summary>
+    /// <param name="expected">The expected value</param>
+    /// <param name="comparer">
+    /// An equality comparer to compare values.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
+    public AndConstraint<TAssertions> Be(TSubject expected, IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs)
+    {
+        Guard.ThrowIfArgumentIsNull(comparer);
+
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(comparer.Equals(Subject, expected))
+            .WithDefaultIdentifier(Identifier)
+            .FailWith("Expected {context} to be {0}{reason}, but found {1}.", expected,
+                Subject);
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
+    /// Asserts that a value does not equal <paramref name="unexpected"/> using its <see cref="object.Equals(object)" /> method.
     /// </summary>
     /// <param name="unexpected">The unexpected value</param>
     /// <param name="because">
@@ -69,6 +189,34 @@ public class ObjectAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
     {
         Execute.Assertion
             .ForCondition(!ObjectExtensions.GetComparer<TSubject>()(Subject, unexpected))
+            .BecauseOf(because, becauseArgs)
+            .WithDefaultIdentifier(Identifier)
+            .FailWith("Did not expect {context} to be equal to {0}{reason}.", unexpected);
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
+    /// Asserts that a value does not equal <paramref name="unexpected"/> using the provided <paramref name="comparer"/>.
+    /// </summary>
+    /// <param name="unexpected">The unexpected value</param>
+    /// <param name="comparer">
+    /// An equality comparer to compare values.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
+    public AndConstraint<TAssertions> NotBe(TSubject unexpected, IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs)
+    {
+        Guard.ThrowIfArgumentIsNull(comparer);
+
+        Execute.Assertion
+            .ForCondition(!comparer.Equals(Subject, unexpected))
             .BecauseOf(because, becauseArgs)
             .WithDefaultIdentifier(Identifier)
             .FailWith("Did not expect {context} to be equal to {0}{reason}.", unexpected);
@@ -255,6 +403,40 @@ public class ObjectAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
     {
         Execute.Assertion
             .ForCondition(validValues.Contains(Subject))
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:object} to be one of {0}{reason}, but found {1}.", validValues, Subject);
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
+    /// Asserts that a value is one of the specified <paramref name="validValues"/>.
+    /// </summary>
+    /// <param name="validValues">
+    /// The values that are valid.
+    /// </param>
+    /// <param name="comparer">
+    /// An equality comparer to compare values.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="validValues"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <see langword="null"/>.</exception>
+    public AndConstraint<TAssertions> BeOneOf(IEnumerable<TSubject> validValues,
+        IEqualityComparer<TSubject> comparer,
+        string because = "",
+        params object[] becauseArgs)
+    {
+        Guard.ThrowIfArgumentIsNull(validValues);
+        Guard.ThrowIfArgumentIsNull(comparer);
+
+        Execute.Assertion
+            .ForCondition(validValues.Contains(Subject, comparer))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:object} to be one of {0}{reason}, but found {1}.", validValues, Subject);
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2102,6 +2102,9 @@ namespace FluentAssertions.Primitives
     public class ObjectAssertions : FluentAssertions.Primitives.ObjectAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
         public ObjectAssertions(object value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be<TExpectation>(TExpectation expected, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeOneOf<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> validValues, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe<TExpectation>(TExpectation unexpected, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
     }
     public class ObjectAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ObjectAssertions<TSubject, TAssertions>
@@ -2109,12 +2112,15 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(TSubject value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params TSubject[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2186,6 +2186,9 @@ namespace FluentAssertions.Primitives
     public class ObjectAssertions : FluentAssertions.Primitives.ObjectAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
         public ObjectAssertions(object value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be<TExpectation>(TExpectation expected, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeOneOf<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> validValues, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe<TExpectation>(TExpectation unexpected, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
     }
     public class ObjectAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ObjectAssertions<TSubject, TAssertions>
@@ -2193,12 +2196,15 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(TSubject value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params TSubject[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -2102,6 +2102,9 @@ namespace FluentAssertions.Primitives
     public class ObjectAssertions : FluentAssertions.Primitives.ObjectAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
         public ObjectAssertions(object value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be<TExpectation>(TExpectation expected, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeOneOf<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> validValues, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe<TExpectation>(TExpectation unexpected, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
     }
     public class ObjectAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ObjectAssertions<TSubject, TAssertions>
@@ -2109,12 +2112,15 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(TSubject value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params TSubject[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -2102,6 +2102,9 @@ namespace FluentAssertions.Primitives
     public class ObjectAssertions : FluentAssertions.Primitives.ObjectAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
         public ObjectAssertions(object value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be<TExpectation>(TExpectation expected, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeOneOf<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> validValues, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe<TExpectation>(TExpectation unexpected, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
     }
     public class ObjectAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ObjectAssertions<TSubject, TAssertions>
@@ -2109,12 +2112,15 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(TSubject value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params TSubject[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2053,6 +2053,9 @@ namespace FluentAssertions.Primitives
     public class ObjectAssertions : FluentAssertions.Primitives.ObjectAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
         public ObjectAssertions(object value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be<TExpectation>(TExpectation expected, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeOneOf<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> validValues, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe<TExpectation>(TExpectation unexpected, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
     }
     public class ObjectAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ObjectAssertions<TSubject, TAssertions>
@@ -2060,12 +2063,15 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(TSubject value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params TSubject[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2102,6 +2102,9 @@ namespace FluentAssertions.Primitives
     public class ObjectAssertions : FluentAssertions.Primitives.ObjectAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
         public ObjectAssertions(object value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be<TExpectation>(TExpectation expected, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeOneOf<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> validValues, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe<TExpectation>(TExpectation unexpected, System.Collections.Generic.IEqualityComparer<TExpectation> comparer, string because = "", params object[] becauseArgs) { }
     }
     public class ObjectAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ObjectAssertions<TSubject, TAssertions>
@@ -2109,12 +2112,15 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(TSubject value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params TSubject[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public override bool Equals(object obj) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TSubject unexpected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
     }

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -9,6 +9,7 @@ using AssemblyA;
 using AssemblyB;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
+using FluentAssertions.Primitives;
 using Xunit;
 using Xunit.Sdk;
 
@@ -99,6 +100,92 @@ public class ObjectAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>();
         }
+
+        [Fact]
+        public void An_untyped_value_is_equal_to_another_according_to_a_comparer()
+        {
+            // Arrange
+            object value = new SomeClass(5);
+
+            // Act / Assert
+            value.Should().Be(new SomeClass(5), new SomeClassEqualityComparer());
+        }
+
+        [Fact]
+        public void A_typed_value_is_equal_to_another_according_to_a_comparer()
+        {
+            // Arrange
+            var value = new SomeClass(5);
+
+            // Act / Assert
+            value.Should().Be(new SomeClass(5), new SomeClassEqualityComparer());
+        }
+
+        [Fact]
+        public void An_untyped_value_is_not_equal_to_another_according_to_a_comparer()
+        {
+            // Arrange
+            object value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().Be(new SomeClass(4), new SomeClassEqualityComparer(), "I said so");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected value to be SomeClass(4)*I said so*found SomeClass(3).");
+        }
+
+        [Fact]
+        public void A_typed_value_is_not_equal_to_another_according_to_a_comparer()
+        {
+            // Arrange
+            var value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().Be(new SomeClass(4), new SomeClassEqualityComparer(), "I said so");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected value to be SomeClass(4)*I said so*found SomeClass(3).");
+        }
+
+        [Fact]
+        public void A_typed_value_is_not_of_the_same_type()
+        {
+            // Arrange
+            var value = new ClassWithCustomEqualMethod(3);
+
+            // Act
+            Action act = () => value.Should().Be(new SomeClass(3), new SomeClassEqualityComparer(), "I said so");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected value to be SomeClass(3)*I said so*found ClassWithCustomEqualMethod(3).");
+        }
+
+        [Fact]
+        public void A_untyped_value_requires_a_comparer()
+        {
+            // Arrange
+            object value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().Be(new SomeClass(3), comparer: null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("comparer");
+        }
+
+        [Fact]
+        public void A_typed_value_requires_a_comparer()
+        {
+            // Arrange
+            var value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().Be(new SomeClass(3), comparer: null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("comparer");
+        }
     }
 
     public class NotBe
@@ -145,6 +232,88 @@ public class ObjectAssertionSpecs
             act.Should().Throw<XunitException>().WithMessage(
                 "Did not expect someObject to be equal to ClassWithCustomEqualMethod(1) " +
                 "because we want to test the failure message.");
+        }
+
+        [Fact]
+        public void An_untyped_value_is_not_equal_to_another_according_to_a_comparer()
+        {
+            // Arrange
+            object value = new SomeClass(5);
+
+            // Act / Assert
+            value.Should().NotBe(new SomeClass(4), new SomeClassEqualityComparer());
+        }
+
+        [Fact]
+        public void A_typed_value_is_not_equal_to_another_according_to_a_comparer()
+        {
+            // Arrange
+            var value = new SomeClass(5);
+
+            // Act / Assert
+            value.Should().NotBe(new SomeClass(4), new SomeClassEqualityComparer());
+        }
+
+        [Fact]
+        public void An_untyped_value_is_equal_to_another_according_to_a_comparer()
+        {
+            // Arrange
+            object value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().NotBe(new SomeClass(3), new SomeClassEqualityComparer(), "I said so");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Did not expect value to be equal to SomeClass(3)*I said so*");
+        }
+
+        [Fact]
+        public void A_typed_value_is_equal_to_another_according_to_a_comparer()
+        {
+            // Arrange
+            var value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().NotBe(new SomeClass(3), new SomeClassEqualityComparer(), "I said so");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Did not expect value to be equal to SomeClass(3)*I said so*");
+        }
+
+        [Fact]
+        public void A_typed_value_is_not_of_the_same_type()
+        {
+            // Arrange
+            var value = new ClassWithCustomEqualMethod(3);
+
+            // Act / Assert
+            value.Should().NotBe(new SomeClass(3), new SomeClassEqualityComparer(), "I said so");
+        }
+
+        [Fact]
+        public void An_untyped_value_requires_a_comparer()
+        {
+            // Arrange
+            object value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().NotBe(new SomeClass(3), comparer: null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("comparer");
+        }
+
+        [Fact]
+        public void A_typed_value_requires_a_comparer()
+        {
+            // Arrange
+            var value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().NotBe(new SomeClass(3), comparer: null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("comparer");
         }
     }
 
@@ -195,6 +364,149 @@ public class ObjectAssertionSpecs
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void An_untyped_value_is_one_of_the_specified_values()
+        {
+            // Arrange
+            object value = new SomeClass(5);
+
+            // Act / Assert
+            value.Should().BeOneOf(new[] { new SomeClass(4), new SomeClass(5) }, new SomeClassEqualityComparer());
+        }
+
+        [Fact]
+        public void A_typed_value_is_one_of_the_specified_values()
+        {
+            // Arrange
+            var value = new SomeClass(5);
+
+            // Act / Assert
+            value.Should().BeOneOf(new[] { new SomeClass(4), new SomeClass(5) }, new SomeClassEqualityComparer());
+        }
+
+        [Fact]
+        public void An_untyped_value_is_not_one_of_the_specified_values()
+        {
+            // Arrange
+            object value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().BeOneOf(new[] { new SomeClass(4), new SomeClass(5) },
+                new SomeClassEqualityComparer(), "I said so");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+               .WithMessage("Expected value to be one of {SomeClass(4), SomeClass(5)}*I said so*SomeClass(3).");
+        }
+
+        [Fact]
+        public void An_untyped_value_is_not_one_of_no_values()
+        {
+            // Arrange
+            object value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().BeOneOf(Array.Empty<SomeClass>(), new SomeClassEqualityComparer());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void A_typed_value_is_not_one_of_the_specified_values()
+        {
+            // Arrange
+            var value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().BeOneOf(new[] { new SomeClass(4), new SomeClass(5) },
+                new SomeClassEqualityComparer(), "I said so");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+               .WithMessage("Expected value to be one of {SomeClass(4), SomeClass(5)}*I said so*SomeClass(3).");
+        }
+
+        [Fact]
+        public void A_typed_value_is_not_one_of_no_values()
+        {
+            // Arrange
+            var value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().BeOneOf(Array.Empty<SomeClass>(), new SomeClassEqualityComparer());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void A_typed_value_is_not_the_same_type_as_the_specified_values()
+        {
+            // Arrange
+            var value = new ClassWithCustomEqualMethod(3);
+
+            // Act
+            Action act = () => value.Should().BeOneOf(new[] { new SomeClass(4), new SomeClass(5) },
+                new SomeClassEqualityComparer(), "I said so");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+               .WithMessage("Expected value to be one of {SomeClass(4), SomeClass(5)}*I said so*ClassWithCustomEqualMethod(3).");
+        }
+
+        [Fact]
+        public void An_untyped_value_requires_an_expectation()
+        {
+            // Arrange
+            object value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().BeOneOf(null, new SomeClassEqualityComparer());
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("validValues");
+        }
+
+        [Fact]
+        public void A_typed_value_requires_an_expectation()
+        {
+            // Arrange
+            var value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().BeOneOf(null, new SomeClassEqualityComparer());
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("validValues");
+        }
+
+        [Fact]
+        public void An_untyped_value_requires_a_comparer()
+        {
+            // Arrange
+            object value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().BeOneOf(Array.Empty<SomeClass>(), comparer: null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("comparer");
+        }
+
+        [Fact]
+        public void A_typed_value_requires_a_comparer()
+        {
+            // Arrange
+            var value = new SomeClass(3);
+
+            // Act
+            Action act = () => value.Should().BeOneOf(Array.Empty<SomeClass>(), comparer: null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("comparer");
         }
     }
 
@@ -1337,4 +1649,36 @@ internal sealed class DummyImplementingClass : DummyBaseClass, IDisposable
     {
         // Ignore
     }
+}
+
+internal class SomeClass
+{
+    public SomeClass(int key)
+    {
+        Key = key;
+    }
+
+    public int Key { get; }
+
+    public override string ToString() => $"SomeClass({Key})";
+}
+
+internal class SomeClassEqualityComparer : IEqualityComparer<SomeClass>
+{
+    public bool Equals(SomeClass x, SomeClass y) => x.Key == y.Key;
+
+    public int GetHashCode(SomeClass obj) => obj.Key;
+}
+
+internal class SomeClassAssertions : ObjectAssertions<SomeClass, SomeClassAssertions>
+{
+    public SomeClassAssertions(SomeClass value)
+        : base(value)
+    {
+    }
+}
+
+internal static class AssertionExtensions
+{
+    public static SomeClassAssertions Should(this SomeClass value) => new(value);
 }

--- a/docs/_pages/basicassertions.md
+++ b/docs/_pages/basicassertions.md
@@ -41,6 +41,14 @@ To assert that an object is equal to one of the provided objects, you can use
 theObject.Should().BeOneOf(obj1, obj2, obj3);
 ```
 
+To assert object equality using a custom equality comparer, you can use
+
+```csharp
+theObject.Should().Be(otherObject, new ObjEqualityComparer());
+theObject.Should().NotBe(otherObject, new ObjEqualityComparer());
+theObject.Should().BeOneOf(new[] { obj1, obj2, obj3 }, new ObjEqualityComparer());
+```
+
 If you want to make sure two objects are not just functionally equal but refer to the exact same object in memory, use the following two methods.
 
 ```csharp

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -9,6 +9,9 @@ sidebar:
 
 ## Unreleased
 
+### What's new
+* Added `Be`, `NotBe` and `BeOneOf` for object comparisons with custom comparer - [#2111](https://github.com/fluentassertions/fluentassertions/pull/2111)
+
 ### Fixes
 * `because` and `becauseArgs` were not included in the error message when collections of enums were not equivalent - [#2214](https://github.com/fluentassertions/fluentassertions/pull/2214)
 


### PR DESCRIPTION
I messed up updating #2111 

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
