### PR TITLE
Analyzer cleanups

### DIFF
--- a/Src/FluentAssertions/CallerIdentification/CallerStatementBuilder.cs
+++ b/Src/FluentAssertions/CallerIdentification/CallerStatementBuilder.cs
@@ -33,7 +33,7 @@ internal class CallerStatementBuilder
         while (symbolEnumerator.MoveNext() && parsingState != ParsingState.Done)
         {
             var hasParsingStrategyWaitingForEndContext = priorityOrderedParsingStrategies
-                .Any(s => s.IsWaitingForContextEnd());
+                .Exists(s => s.IsWaitingForContextEnd());
 
             parsingState = ParsingState.InProgress;
 

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -122,10 +122,10 @@ internal static class TypeExtensions
         return GetCustomAttributes<TAttribute>(type, inherit).Where(isMatchingAttribute);
     }
 
-    private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(this Type type, bool inherit = false)
+    private static TAttribute[] GetCustomAttributes<TAttribute>(this Type type, bool inherit = false)
         where TAttribute : Attribute
     {
-        return (IEnumerable<TAttribute>)type.GetCustomAttributes(typeof(TAttribute), inherit);
+        return (TAttribute[])type.GetCustomAttributes(typeof(TAttribute), inherit);
     }
 
     private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(Type type,

--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -136,7 +136,7 @@ internal sealed class TypeMemberReflector
         {
             foreach (var memberInfo in getMembers(typeToReflect))
             {
-                if (members.All(mi => mi.Name != memberInfo.Name))
+                if (members.TrueForAll(mi => mi.Name != memberInfo.Name))
                 {
                     members.Add(memberInfo);
                 }

--- a/Src/FluentAssertions/Equivalency/ConversionSelector.cs
+++ b/Src/FluentAssertions/Equivalency/ConversionSelector.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 using FluentAssertions.Common;
@@ -83,7 +82,7 @@ public class ConversionSelector
 
         var objectInfo = new ObjectInfo(comparands, currentNode);
 
-        return inclusions.Any(p => p.Predicate(objectInfo)) && !exclusions.Any(p => p.Predicate(objectInfo));
+        return inclusions.Exists(p => p.Predicate(objectInfo)) && !exclusions.Exists(p => p.Predicate(objectInfo));
     }
 
     public override string ToString()

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPredicateSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPredicateSelectionRule.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using FluentAssertions.Common;
@@ -33,7 +32,7 @@ internal class IncludeMemberByPredicateSelectionRule : IMemberSelectionRule
         {
             IMember member = MemberFactory.Create(memberInfo, currentNode);
 
-            if (predicate(new MemberToMemberInfoAdapter(member)) && !members.Any(p => p.IsEquivalentTo(member)))
+            if (predicate(new MemberToMemberInfoAdapter(member)) && !members.Exists(p => p.IsEquivalentTo(member)))
             {
                 members.Add(member);
             }

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -5,7 +5,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 using FluentAssertions.Common;
@@ -111,7 +110,7 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
     {
         get
         {
-            bool hasConflictingRules = selectionRules.Any(rule => rule.IncludesMembers);
+            bool hasConflictingRules = selectionRules.Exists(rule => rule.IncludesMembers);
 
             if (includedProperties.HasFlag(MemberVisibility.Public) && !hasConflictingRules)
             {
@@ -187,19 +186,19 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
         // be aware if the cache must be cleared on mutating the members.
         return equalityStrategyCache.GetOrAdd(type, typeKey =>
         {
-            if (!typeKey.IsPrimitive && referenceTypes.Count > 0 && referenceTypes.Any(t => typeKey.IsSameOrInherits(t)))
+            if (!typeKey.IsPrimitive && referenceTypes.Count > 0 && referenceTypes.Exists(t => typeKey.IsSameOrInherits(t)))
             {
                 return EqualityStrategy.ForceMembers;
             }
-            else if (valueTypes.Count > 0 && valueTypes.Any(t => typeKey.IsSameOrInherits(t)))
+            else if (valueTypes.Count > 0 && valueTypes.Exists(t => typeKey.IsSameOrInherits(t)))
             {
                 return EqualityStrategy.ForceEquals;
             }
-            else if (!typeKey.IsPrimitive && referenceTypes.Count > 0 && referenceTypes.Any(t => typeKey.IsAssignableToOpenGeneric(t)))
+            else if (!typeKey.IsPrimitive && referenceTypes.Count > 0 && referenceTypes.Exists(t => typeKey.IsAssignableToOpenGeneric(t)))
             {
                 return EqualityStrategy.ForceMembers;
             }
-            else if (valueTypes.Count > 0 && valueTypes.Any(t => typeKey.IsAssignableToOpenGeneric(t)))
+            else if (valueTypes.Count > 0 && valueTypes.Exists(t => typeKey.IsAssignableToOpenGeneric(t)))
             {
                 return EqualityStrategy.ForceEquals;
             }
@@ -643,7 +642,7 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
             throw new InvalidOperationException($"Cannot compare a primitive type such as {type.Name} by its members");
         }
 
-        if (valueTypes.Any(t => type.IsSameOrInherits(t)))
+        if (valueTypes.Exists(t => type.IsSameOrInherits(t)))
         {
             throw new InvalidOperationException(
                 $"Can't compare {type.Name} by its members if it already setup to be compared by value");
@@ -669,7 +668,7 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
     {
         Guard.ThrowIfArgumentIsNull(type);
 
-        if (referenceTypes.Any(t => type.IsSameOrInherits(t)))
+        if (referenceTypes.Exists(t => type.IsSameOrInherits(t)))
         {
             throw new InvalidOperationException(
                 $"Can't compare {type.Name} by value if it already setup to be compared by its members");

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -199,7 +199,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
         return this;
     }
 
-    private IEnumerable<Exception> AssertInnerExceptionExactly(Type innerException, string because = "",
+    private Exception[] AssertInnerExceptionExactly(Type innerException, string because = "",
         params object[] becauseArgs)
     {
         Execute.Assertion
@@ -219,7 +219,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
         return expectedExceptions;
     }
 
-    private IEnumerable<Exception> AssertInnerExceptions(Type innerException, string because = "",
+    private Exception[] AssertInnerExceptions(Type innerException, string because = "",
         params object[] becauseArgs)
     {
         Execute.Assertion

--- a/Src/FluentAssertions/StringBuilderExtensions.cs
+++ b/Src/FluentAssertions/StringBuilderExtensions.cs
@@ -15,6 +15,6 @@ internal static class StringBuilderExtensions
 
 #if NET47 || NETSTANDARD2_0
     public static StringBuilder AppendJoin<T>(this StringBuilder stringBuilder, string separator, IEnumerable<T> values) =>
-        stringBuilder.Append(string.Join(Environment.NewLine, values));
+        stringBuilder.Append(string.Join(separator, values));
 #endif
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -354,7 +354,7 @@ internal sealed class TrackingEnumerator : IEnumerator<int>
 
 internal class OneTimeEnumerable<T> : IEnumerable<T>
 {
-    private readonly IEnumerable<T> items;
+    private readonly T[] items;
     private int enumerations;
 
     public OneTimeEnumerable(params T[] items) => this.items = items;
@@ -368,7 +368,7 @@ internal class OneTimeEnumerable<T> : IEnumerable<T>
             throw new InvalidOperationException("OneTimeEnumerable can be enumerated one time only");
         }
 
-        return items.GetEnumerator();
+        return items.AsEnumerable().GetEnumerator();
     }
 }
 


### PR DESCRIPTION
I installed the latest .NET 8 preview 7 and the updated analyzers pointed out some new stuff.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
