### PR TITLE
Fix auto conversion to enums

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
@@ -58,10 +58,10 @@ public class AutoConversionStep : IEquivalencyStep
         {
             if (expectationType.IsEnum)
             {
-                if (Enum.IsDefined(expectationType, subject))
+                if (subject is sbyte or byte or short or ushort or int or uint or long or ulong)
                 {
                     conversionResult = Enum.ToObject(expectationType, subject);
-                    return true;
+                    return Enum.IsDefined(expectationType, conversionResult);
                 }
 
                 return false;

--- a/Tests/FluentAssertions.Equivalency.Specs/MemberConversionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/MemberConversionSpecs.cs
@@ -56,10 +56,34 @@ public class MemberConversionSpecs
     {
         // Arrange
         var expectation = new { Property = EnumFour.Three };
-        var subject = new { Property = 3 };
+        var subject = new { Property = 3UL };
 
         // Act / Assert
         subject.Should().BeEquivalentTo(expectation, options => options.WithAutoConversion());
+    }
+
+    [Fact]
+    public void Enums_are_not_converted_to_enums_of_different_type()
+    {
+        // Arrange
+        var expectation = new { Property = EnumTwo.Two };
+        var subject = new { Property = EnumThree.Two };
+
+        // Act / Assert
+        subject.Should().BeEquivalentTo(expectation, options => options.WithAutoConversion());
+    }
+
+    [Fact]
+    public void Strings_are_not_converted_to_enums()
+    {
+        // Arrange
+        var expectation = new { Property = EnumTwo.Two };
+        var subject = new { Property = "Two" };
+
+        // Act / Assert
+        var act = () => subject.Should().BeEquivalentTo(expectation, options => options.WithAutoConversion());
+
+        act.Should().Throw<XunitException>();
     }
 
     [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -15,6 +15,8 @@ sidebar:
 ### Fixes
 * `because` and `becauseArgs` were not included in the error message when collections of enums were not equivalent - [#2214](https://github.com/fluentassertions/fluentassertions/pull/2214)
 * Improve caller identification for tests written in Visual Basic - [#2254](https://github.com/fluentassertions/fluentassertions/pull/2254)
+* Improved auto conversion to enums for objects of different integral type - [#2261](https://github.com/fluentassertions/fluentassertions/pull/2261)
+* Fixed exceptions when trying to auto convert strings or enums of different type to enums- [#2261](https://github.com/fluentassertions/fluentassertions/pull/2261)
 
 ## 6.11.0
 


### PR DESCRIPTION
`Enum.IsDefined` throws an `ArgumentException` if the value is of different enum type or different underlying integral type.
`Enum.IsDefined` allows strings, but `Enum.ToObject` does _not_ and throws an `ArgumentException`.

This fixes #2259

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
