### PR TITLE
Add a pre-check if a user can help with a PR

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -101,3 +101,13 @@ body:
       placeholder: Other information
     validations:
       required: false
+  - type: dropdown
+    id: pull-request
+    attributes:
+      label: Could you help with a pull-request?
+      description: Make sure you have read the sections about [contributing changes](https://github.com/fluentassertions/fluentassertions/blob/develop/CONTRIBUTING.md#contributing-changes) and [dos and don'ts](https://github.com/fluentassertions/fluentassertions/blob/develop/CONTRIBUTING.md#dos-and-donts).
+      options:
+        - "No"
+        - "Yes"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02_api_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/02_api_proposal.yml
@@ -67,3 +67,13 @@ body:
       placeholder: Risks
     validations:
       required: false
+  - type: dropdown
+    id: pull-request
+    attributes:
+      label: Could you help with a proof-of-concept (as PR in that or a separate repo) first and as pull-request later on?
+      description: This is mainly to help demonstrate your suggestion. Please also make sure you have read the sections about [contributing changes](https://github.com/fluentassertions/fluentassertions/blob/develop/CONTRIBUTING.md#contributing-changes) and [dos and don'ts](https://github.com/fluentassertions/fluentassertions/blob/develop/CONTRIBUTING.md#dos-and-donts).
+      options:
+        - "No"
+        - "Yes"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/03_general_feature.yml
+++ b/.github/ISSUE_TEMPLATE/03_general_feature.yml
@@ -24,3 +24,13 @@ body:
       placeholder: Alternative designs
     validations:
       required: false
+  - type: dropdown
+    id: pull-request
+    attributes:
+      label: Could you help with a pull-request?
+      description: Make sure you have read the sections about [contributing changes](https://github.com/fluentassertions/fluentassertions/blob/develop/CONTRIBUTING.md#contributing-changes) and [dos and don'ts](https://github.com/fluentassertions/fluentassertions/blob/develop/CONTRIBUTING.md#dos-and-donts).
+      options:
+        - "No"
+        - "Yes"
+    validations:
+      required: true


### PR DESCRIPTION
Inspired from the issue templates of NUKE
<!-- Please provide a description of your changes above the IMPORTANT checklist -->

<img width="570" alt="image" src="https://github.com/fluentassertions/fluentassertions/assets/49762557/994baf2c-745c-4b41-899f-1f36b0f2fff7">

Main reason for this change is: If  one can help with a PR he should have the possibility of "first blood" on his issue. 


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
