### PR TITLE
Add `NotContainItemsAssignableTo`

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1079,7 +1079,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that the current collection does not contain any element that is assignable to the type <typeparamref name="TExpectation" />.
+    /// Asserts that the current collection does not contain any elements that are assignable to the type <typeparamref name="TExpectation" />.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -1092,7 +1092,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         NotContainItemsAssignableTo(typeof(TExpectation), because, becauseArgs);
 
     /// <summary>
-    /// Asserts that the current collection does not contain any element that is assignable to the given type.
+    /// Asserts that the current collection does not contain any elements that are assignable to the given type.
     /// </summary>
     /// <param name="type">
     /// Object type that should not be in collection

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1079,7 +1079,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that the current collection does not contain any elements that are assignable to the type <typeparamref name="TExpectation" />.
+    /// Asserts that the current collection does not contain any elements that are assignable to the type <typeparamref name="TUnexpected" />.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -1088,8 +1088,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TAssertions> NotContainItemsAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) =>
-        NotContainItemsAssignableTo(typeof(TExpectation), because, becauseArgs);
+    public AndConstraint<TAssertions> NotContainItemsAssignableTo<TUnexpected>(string because = "", params object[] becauseArgs) =>
+        NotContainItemsAssignableTo(typeof(TUnexpected), because, becauseArgs);
 
     /// <summary>
     /// Asserts that the current collection does not contain any elements that are assignable to the given type.

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1079,7 +1079,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that the current collection does not contain any elements that are assignable to the type <typeparamref name="TUnexpected" />.
+    /// Asserts that the current collection does not contain any elements that are assignable to the type <typeparamref name="TExpectation" />.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -1088,8 +1088,8 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<TAssertions> NotContainItemsAssignableTo<TUnexpected>(string because = "", params object[] becauseArgs) =>
-        NotContainItemsAssignableTo(typeof(TUnexpected), because, becauseArgs);
+    public AndConstraint<TAssertions> NotContainItemsAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) =>
+        NotContainItemsAssignableTo(typeof(TExpectation), because, becauseArgs);
 
     /// <summary>
     /// Asserts that the current collection does not contain any elements that are assignable to the given type.

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1079,6 +1079,52 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
+    /// Asserts that the current collection does not contain any element that is assignable to the type <typeparamref name="TExpectation" />.
+    /// </summary>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public AndConstraint<TAssertions> NotContainItemsAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) =>
+        NotContainItemsAssignableTo(typeof(TExpectation), because, becauseArgs);
+
+    /// <summary>
+    /// Asserts that the current collection does not contain any element that is assignable to the given type.
+    /// </summary>
+    /// <param name="type">
+    /// Object type that should not be in collection
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public AndConstraint<TAssertions> NotContainItemsAssignableTo(Type type, string because = "", params object[] becauseArgs)
+    {
+        Guard.ThrowIfArgumentIsNull(type);
+
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .WithExpectation("Expected {context:collection} to not contain any elements assignable to type {0}{reason}, ",
+                type.FullName)
+            .ForCondition(Subject is not null)
+            .FailWith("but found <null>.")
+            .Then
+            .Given(() => Subject.ConvertOrCastToCollection())
+            .ForCondition(subject => subject.All(x => !type.IsAssignableFrom(GetType(x))))
+            .FailWith("but found {0}.", subject => subject.Select(x => GetType(x)))
+            .Then
+            .ClearExpectation();
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
     /// Expects the current collection to contain only a single item.
     /// </summary>
     /// <param name="because">

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -500,6 +500,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainInConsecutiveOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params T[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainItemsAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainItemsAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
             where TKey :  class { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -513,6 +513,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainInConsecutiveOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params T[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainItemsAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainItemsAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
             where TKey :  class { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -500,6 +500,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainInConsecutiveOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params T[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainItemsAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainItemsAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
             where TKey :  class { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -500,6 +500,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainInConsecutiveOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params T[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainItemsAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainItemsAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
             where TKey :  class { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -493,6 +493,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainInConsecutiveOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params T[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainItemsAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainItemsAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
             where TKey :  class { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -500,6 +500,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainInConsecutiveOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params T[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainItemsAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainItemsAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
             where TKey :  class { }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainItemsAssignableTo.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Collections;
+
+public partial class CollectionAssertionSpecs
+{
+    public class NotContainItemsAssignableTo
+    {
+        [Fact]
+        public void Should_succeed_when_asserting_collection_not_contains_items_assignable_to_type()
+        {
+            // Arrange
+            var collection = new[] { "1", "2", "3" };
+
+            // Act / Assert
+            collection.Should().NotContainItemsAssignableTo<int>();
+        }
+
+        [Fact]
+        public void Should_throw_when_asserting_collection_contains_item_assignable_to_type()
+        {
+            // Arrange
+            var collection = new object[] { 1, "2", "3" };
+
+            // Act
+            var act = () => collection.Should().NotContainItemsAssignableTo<int>();
+
+            // Assert
+            act.Should()
+                .Throw<XunitException>()
+                .WithMessage(
+                    "Expected collection to not contain any elements assignable to type \"System.Int32\", but found {System.Int32, System.String, System.String}.");
+        }
+
+        [Fact]
+        public void Should_throw_when_passed_type_argument_is_null()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            var act = () => collection.Should().NotContainItemsAssignableTo(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Should_throw_when_collection_is_null()
+        {
+            // Arrange
+            int[] collection = null;
+
+            // Act
+            var act = () => collection.Should().NotContainItemsAssignableTo<int>();
+
+            // Assert
+            act.Should()
+                .Throw<XunitException>()
+                .WithMessage(
+                    "Expected collection to not contain any elements assignable to type \"System.Int32\", but found <null>.");
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainItemsAssignableTo.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using FluentAssertions.Collections;
-using FluentAssertions.Specs.Collections.Data;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainItemsAssignableTo.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using FluentAssertions.Collections;
+using FluentAssertions.Specs.Collections.Data;
 using Xunit;
 using Xunit.Sdk;
 
@@ -9,7 +11,7 @@ public partial class CollectionAssertionSpecs
     public class NotContainItemsAssignableTo
     {
         [Fact]
-        public void Should_succeed_when_asserting_collection_not_contains_items_assignable_to_type()
+        public void Succeeds_when_the_collection_does_not_contain_items_of_the_unexpected_type()
         {
             // Arrange
             var collection = new[] { "1", "2", "3" };
@@ -19,23 +21,38 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void Should_throw_when_asserting_collection_contains_item_assignable_to_type()
+        public void Throws_when_the_collection_contains_an_item_of_the_unexpected_type()
         {
             // Arrange
             var collection = new object[] { 1, "2", "3" };
 
             // Act
-            var act = () => collection.Should().NotContainItemsAssignableTo<int>();
+            var act = () => collection
+                .Should()
+                .NotContainItemsAssignableTo<int>(
+                    "because we want test that collection does not contain object of {0} type", typeof(int).FullName);
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to not contain any elements assignable to type \"System.Int32\", but found {System.Int32, System.String, System.String}.");
+                    "Expected collection to not contain any elements assignable to type \"System.Int32\" " +
+                    "because we want test that collection does not contain object of System.Int32 type, " +
+                    "but found {System.Int32, System.String, System.String}.");
         }
 
         [Fact]
-        public void Should_throw_when_passed_type_argument_is_null()
+        public void Succeeds_when_collection_is_empty()
+        {
+            // Arrange
+            var collection = Array.Empty<int>();
+
+            // Act / Assert
+            collection.Should().NotContainItemsAssignableTo<int>();
+        }
+
+        [Fact]
+        public void Throws_when_the_passed_type_argument_is_null()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
@@ -48,7 +65,7 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void Should_throw_when_collection_is_null()
+        public void Throws_when_the_collection_is_null()
         {
             // Arrange
             int[] collection = null;

--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -53,6 +53,7 @@ collection.Should().Contain(collection, "", 5, 6); // It should contain the orig
 
 collection.Should().OnlyContain(x => x < 10);
 collection.Should().ContainItemsAssignableTo<int>();
+collection.Should().NotContainItemsAssignableTo<string>()
 
 collection.Should().ContainInOrder(new[] { 1, 5, 8 });
 collection.Should().NotContainInOrder(new[] { 5, 1, 2 });

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's new
 * Added `Be`, `NotBe` and `BeOneOf` for object comparisons with custom comparer - [#2111](https://github.com/fluentassertions/fluentassertions/pull/2111)
 * Added `BeSignedWithPublicKey()` and `BeUnsigned()` for assertions on `Assembly` - [#2207](https://github.com/fluentassertions/fluentassertions/pull/2207)
+* Added `NotContainItemsAssignableTo` for asserting that collection does not contain any item assignable to specific type [#2266](https://github.com/fluentassertions/fluentassertions/pull/2266)
 
 ### Fixes
 * `because` and `becauseArgs` were not included in the error message when collections of enums were not equivalent - [#2214](https://github.com/fluentassertions/fluentassertions/pull/2214)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,7 +12,7 @@ sidebar:
 ### What's new
 * Added `Be`, `NotBe` and `BeOneOf` for object comparisons with custom comparer - [#2111](https://github.com/fluentassertions/fluentassertions/pull/2111)
 * Added `BeSignedWithPublicKey()` and `BeUnsigned()` for assertions on `Assembly` - [#2207](https://github.com/fluentassertions/fluentassertions/pull/2207)
-* Added `NotContainItemsAssignableTo` for asserting that a collection does not contain any items assignable to specific type - [#2266](https://github.com/fluentassertions/fluentassertions/pull/2266)
+* Added `NotContainItemsAssignableTo` for asserting that a collection does not contain any items assignable to a specific type - [#2266](https://github.com/fluentassertions/fluentassertions/pull/2266)
 
 ### Fixes
 * `because` and `becauseArgs` were not included in the error message when collections of enums were not equivalent - [#2214](https://github.com/fluentassertions/fluentassertions/pull/2214)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,7 +12,7 @@ sidebar:
 ### What's new
 * Added `Be`, `NotBe` and `BeOneOf` for object comparisons with custom comparer - [#2111](https://github.com/fluentassertions/fluentassertions/pull/2111)
 * Added `BeSignedWithPublicKey()` and `BeUnsigned()` for assertions on `Assembly` - [#2207](https://github.com/fluentassertions/fluentassertions/pull/2207)
-* Added `NotContainItemsAssignableTo` for asserting that collection does not contain any item assignable to specific type - [#2266](https://github.com/fluentassertions/fluentassertions/pull/2266)
+* Added `NotContainItemsAssignableTo` for asserting that a collection does not contain any items assignable to specific type - [#2266](https://github.com/fluentassertions/fluentassertions/pull/2266)
 
 ### Fixes
 * `because` and `becauseArgs` were not included in the error message when collections of enums were not equivalent - [#2214](https://github.com/fluentassertions/fluentassertions/pull/2214)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,7 +12,7 @@ sidebar:
 ### What's new
 * Added `Be`, `NotBe` and `BeOneOf` for object comparisons with custom comparer - [#2111](https://github.com/fluentassertions/fluentassertions/pull/2111)
 * Added `BeSignedWithPublicKey()` and `BeUnsigned()` for assertions on `Assembly` - [#2207](https://github.com/fluentassertions/fluentassertions/pull/2207)
-* Added `NotContainItemsAssignableTo` for asserting that collection does not contain any item assignable to specific type [#2266](https://github.com/fluentassertions/fluentassertions/pull/2266)
+* Added `NotContainItemsAssignableTo` for asserting that collection does not contain any item assignable to specific type - [#2266](https://github.com/fluentassertions/fluentassertions/pull/2266)
 
 ### Fixes
 * `because` and `becauseArgs` were not included in the error message when collections of enums were not equivalent - [#2214](https://github.com/fluentassertions/fluentassertions/pull/2214)


### PR DESCRIPTION
New API method for checking that collection does not contain any element assignable to given type
Issue: https://github.com/fluentassertions/fluentassertions/issues/2249

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
