### PR TITLE
Introduction of interface to improve extensibility

### DIFF
--- a/Src/FluentAssertions/IAssertions.cs
+++ b/Src/FluentAssertions/IAssertions.cs
@@ -1,0 +1,8 @@
+﻿#nullable enable
+
+namespace FluentAssertions;
+
+public interface IAssertions<out TSubject>
+{
+    TSubject? Subject { get; }
+}

--- a/Tests/FluentAssertions.Specs/IAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/IAssertionsSpecs.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Globalization;
+using Xunit;
+
+namespace FluentAssertions.Specs;
+
+internal class IAssertionsSpecs
+{
+    [Fact]
+    public void Test()
+    {
+        var assertions = new FormatableAssertions<int>(42);
+
+        assertions.BeFormatted("0.00", "42.00");
+    }
+}
+
+internal sealed class FormatableAssertions<TSubject> : IAssertions<IFormattable>
+    where TSubject : IFormattable
+{
+    public FormatableAssertions(TSubject subject)
+    {
+        Subject = subject;
+    }
+
+    public TSubject Subject { get; }
+
+    IFormattable IAssertions<IFormattable>.Subject => Subject;
+}
+
+public static class FormatableExtensions
+{
+    public static AndConstraint<TAssertions> BeFormatted<TAssertions>(this TAssertions assertions, string format, string result)
+        where TAssertions : IAssertions<IFormattable>
+    {
+        assertions.Subject.ToString(format, CultureInfo.InvariantCulture).Should().Be(result);
+
+        return new AndConstraint<TAssertions>(assertions);
+    }
+}


### PR DESCRIPTION
What about introducing an interface that can be used to write extensions like this?

``` C#
using System;
using System.Globalization;
using Xunit;

namespace FluentAssertions.Specs;

public class IAssertionsSpecs
{
    [Fact]
    public void Test()
    {
        var assertions = new FormatableAssertions<int>(42);

        assertions.BeFormatted("0.00", "42.00");
    }
}

internal sealed class FormatableAssertions<TSubject> : IAssertions<IFormattable>
    where TSubject : IFormattable
{
    public FormatableAssertions(TSubject subject)
    {
        Subject = subject;
    }

    public TSubject Subject { get; }

    IFormattable IAssertions<IFormattable>.Subject => Subject;
}

public static class FormatableExtensions
{
    public static AndConstraint<TAssertions> BeFormatted<TAssertions>(this TAssertions assertions, string format, string result)
        where TAssertions : IAssertions<IFormattable>
    {
        assertions.Subject.ToString(format, CultureInfo.InvariantCulture).Should().Be(result);

        return new AndConstraint<TAssertions>(assertions);
    }
}
```