### PR TITLE
Remove `SpacesPerIndentionLevel`

### DIFF
--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -9,12 +9,6 @@ namespace FluentAssertions.Formatting;
 public class DefaultValueFormatter : IValueFormatter
 {
     /// <summary>
-    /// The number of spaces to indent the members of this object by.
-    /// </summary>
-    /// <remarks>The default value is 3.</remarks>
-    protected virtual int SpacesPerIndentionLevel => 3;
-
-    /// <summary>
     /// Determines whether this instance can handle the specified value.
     /// </summary>
     /// <param name="value">The value.</param>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1359,7 +1359,6 @@ namespace FluentAssertions.Formatting
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
-        protected virtual int SpacesPerIndentionLevel { get; }
         public virtual bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1378,7 +1378,6 @@ namespace FluentAssertions.Formatting
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
-        protected virtual int SpacesPerIndentionLevel { get; }
         public virtual bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1359,7 +1359,6 @@ namespace FluentAssertions.Formatting
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
-        protected virtual int SpacesPerIndentionLevel { get; }
         public virtual bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1359,7 +1359,6 @@ namespace FluentAssertions.Formatting
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
-        protected virtual int SpacesPerIndentionLevel { get; }
         public virtual bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1310,7 +1310,6 @@ namespace FluentAssertions.Formatting
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
-        protected virtual int SpacesPerIndentionLevel { get; }
         public virtual bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1359,7 +1359,6 @@ namespace FluentAssertions.Formatting
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
-        protected virtual int SpacesPerIndentionLevel { get; }
         public virtual bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -1169,8 +1169,6 @@ public class FormatterSpecs
 
     private class CustomClassValueFormatter : DefaultValueFormatter
     {
-        protected override int SpacesPerIndentionLevel => 8;
-
         public override bool CanHandle(object value) => value is CustomClass;
 
         protected override MemberInfo[] GetMembers(Type type)

--- a/docs/_pages/extensibility.md
+++ b/docs/_pages/extensibility.md
@@ -139,7 +139,6 @@ public class DirectoryInfoValueFormatter : IValueFormatter
 
 Say you want to customize the formatting of your `CustomClass` type to:
 
-* Increase the indentation from the default 3 to 8,
 * Exclude all `string` members and
 * Exclude the namespace of the type.
 
@@ -148,8 +147,6 @@ An easy way to achieve this is by extending the `DefaultValueFormatter`.
 ```csharp
 class CustomClassFormatter : DefaultValueFormatter
 {
-    protected override int SpacesPerIndentionLevel => 8;
-
     public override bool CanHandle(object value) => value is CustomClass;
 
     protected override MemberInfo[] GetMembers(Type type) =>

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -30,6 +30,7 @@ sidebar:
   * `ExecutionTimeAssertions`
     * `BeGreaterOrEqualTo`: Use `BeGreaterThanOrEqualTo`
     * `BeLessOrEqualTo`: Use `BeLessThanOrEqualTo`
+* Removed the `DefaultValueFormatter.SpacesPerIndentionLevel` property which was added during the development of v6, but wasn't removed before the release of v6 - [#2281](https://github.com/fluentassertions/fluentassertions/pull/2281)
 
 ### Breaking Changes (for extensions)
 


### PR DESCRIPTION
`SpacesPerIndentionLevel` was added in #1295 but #1469 stopped using it.
Both these PRs where while making v6, so `SpacesPerIndentionLevel` has never worked in any released version of Fluent Assertions.

Not sure what to put in the release notes (if anything) 🤔 

This fixes #2197


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
