### PR TITLE
added closing parenthesis in docs (collections.md)

### DIFF
--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -162,9 +162,9 @@ Consider for instance two collections that contain some kind of domain entity pe
 Since the actual object instance is different, if you want to make sure a particular property was properly persisted, you usually do something like this:
 
 ```csharp
-persistedCustomers.Select(c => c.Name).Should().Equal(customers.Select(c => c.Name);
-persistedCustomers.Select(c => c.Name).Should().StartWith(customers.Select(c => c.Name);
-persistedCustomers.Select(c => c.Name).Should().EndWith(customers.Select(c => c.Name);
+persistedCustomers.Select(c => c.Name).Should().Equal(customers.Select(c => c.Name));
+persistedCustomers.Select(c => c.Name).Should().StartWith(customers.Select(c => c.Name));
+persistedCustomers.Select(c => c.Name).Should().EndWith(customers.Select(c => c.Name));
 ```
 
 With these new overloads, you can rewrite them into:


### PR DESCRIPTION
Closing parenthesis was added to the code block in the "special overloads" section of the `collections.md` file.
![image](https://github.com/fluentassertions/fluentassertions/assets/84538722/29dfaa91-0058-4355-8325-1269b28a97eb)


I ran the `spellcheck` command with success, though a warning did occur; not sure if it's important, but I've included the results below.
![image](https://github.com/fluentassertions/fluentassertions/assets/84538722/1c853a24-b792-41a2-ab62-579fb33de1c3)

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
