### PR TITLE
Prevent pipline failing when failing to obtain the source branch name

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -384,9 +384,16 @@ class Build : NukeBuild
 
     Tree TargetBranch => Repository.Branches[PullRequestBase].Tip.Tree;
 
-    Tree SourceBranch => Repository.Branches[Repository.Head.FriendlyName].Tip.Tree;
+    Tree SourceBranch => Repository.Branches[BranchName].Tip.Tree;
 
-    bool RunAllTargets => string.IsNullOrWhiteSpace(PullRequestBase) || Changes.Any(x => x.StartsWith("Build"));
+    string SourceBranchName => Repository?.Head?.FriendlyName;
+    string BranchName => SourceBranchName ?? PullRequestBase;
+    bool FailedToObtainSourceBranch => SourceBranchName is null;
+
+    bool RunAllTargets => 
+        FailedToObtainSourceBranch || 
+        string.IsNullOrWhiteSpace(PullRequestBase) || 
+        Changes.Any(x => x.StartsWith("Build"));
 
     bool IsTag => BranchSpec != null && BranchSpec.Contains("refs/tags", StringComparison.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Ref. https://github.com/fluentassertions/fluentassertions/actions/runs/6169114546/job/16805839918?pr=2296

For some reason this pipline has failed, because `Libgit2Sharp` failed to obtain the source branch name.
I tried to make this a bit more robust, and running the _complete_ pipeline in such case. (Meaning spell check + "normal" pipeline)

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
