### PR TITLE
Silence CA1859

### DIFF
--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using FluentAssertions.Types;
@@ -896,8 +897,8 @@ namespace Internal.UnwrapSelectorTestTypes.Test
 
     internal class ClassImplementingMultipleEnumerable : IEnumerable<int>, IEnumerable<string>
     {
-        private readonly IEnumerable<int> integers = new int[0];
-        private readonly IEnumerable<string> strings = new string[0];
+        private readonly IEnumerable<int> integers = Enumerable.Empty<int>();
+        private readonly IEnumerable<string> strings = Enumerable.Empty<string>();
 
         public IEnumerator<int> GetEnumerator() => integers.GetEnumerator();
 


### PR DESCRIPTION
Silence another case of [CA1859](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1859) after updating to .NET 8 RC1.

The alternative of changing the fields to `int[]` and `string[]` would then require casts to `IEnumerable<>` later as the array types only exposes the non-generic `GetEnumerator()` directly.


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
