### PR TITLE
Improve failure message for string assertions when checking for equality

### DIFF
--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -178,7 +178,7 @@ internal static class StringExtensions
         }
 
         var visibleText = subject.Substring(trimStart, firstIndexOfMismatch - trimStart);
-        whiteSpaceCount += visibleText.Count(c => c == '\r' || c == '\n');
+        whiteSpaceCount += visibleText.Count(c => c is '\r' or '\n');
 
         var sb = new StringBuilder();
 
@@ -192,7 +192,7 @@ internal static class StringExtensions
 
     private static StringBuilder AppendVisibleText(this StringBuilder sb, string subject, int trimStart)
     {
-        var subjectLength = CalculateSegmentLength(subject.Substring(trimStart));
+        var subjectLength = CalculateSegmentLength(subject[trimStart..]);
 
         if (trimStart > 0)
         {
@@ -242,7 +242,7 @@ internal static class StringExtensions
     /// </summary>
     private static int CalculateSegmentLength(string value)
     {
-        var word = value.Substring(0, Math.Min(24, value.Length))
+        var word = value[..Math.Min(24, value.Length)]
             .LastIndexOf(' ');
 
         if (word > 16)

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using FluentAssertions.Formatting;
 
@@ -159,97 +158,5 @@ internal static class StringExtensions
     {
         const int humanReadableLength = 8;
         return value.Length > humanReadableLength || value.Contains(Environment.NewLine, StringComparison.Ordinal);
-    }
-
-    /// <summary>
-    /// Get the mismatch segment between <paramref name="expected"/> and <paramref name="subject"/> for long strings,
-    /// when they differ at index <paramref name="firstIndexOfMismatch"/>.
-    /// </summary>
-    public static string GetMismatchSegmentForLongStrings(this string subject, string expected, int firstIndexOfMismatch)
-    {
-        int trimStart = CalculateSegmentStart(subject, firstIndexOfMismatch);
-
-        int whiteSpaceCount = (firstIndexOfMismatch - trimStart) + 3;
-        const string prefix = "  ";
-
-        if (trimStart > 0)
-        {
-            whiteSpaceCount++;
-        }
-
-        var visibleText = subject.Substring(trimStart, firstIndexOfMismatch - trimStart);
-        whiteSpaceCount += visibleText.Count(c => c is '\r' or '\n');
-
-        var sb = new StringBuilder();
-
-        sb.Append(' ', whiteSpaceCount).AppendLine("\u2193 (actual)")
-            .Append(prefix).Append('\"').AppendVisibleText(subject, trimStart).Append('\"').AppendLine()
-            .Append(prefix).Append('\"').AppendVisibleText(expected, trimStart).Append('\"').AppendLine()
-            .Append(' ', whiteSpaceCount).Append("\u2191 (expected)");
-
-        return sb.ToString();
-    }
-
-    private static StringBuilder AppendVisibleText(this StringBuilder sb, string subject, int trimStart)
-    {
-        var subjectLength = CalculateSegmentLength(subject[trimStart..]);
-
-        if (trimStart > 0)
-        {
-            sb.Append('\u2026');
-        }
-
-        sb.Append(subject
-            .Substring(trimStart, subjectLength)
-            .Replace("\r", "\\r", StringComparison.OrdinalIgnoreCase)
-            .Replace("\n", "\\n", StringComparison.OrdinalIgnoreCase));
-
-        if (subject.Length > (trimStart + subjectLength))
-        {
-            sb.Append('\u2026');
-        }
-
-        return sb;
-    }
-
-    /// <summary>
-    /// Calculates the start index of the visible segment from <paramref name="value"/> when highlighting the difference at <paramref name="index"/>.<br />
-    /// Either keep the last 10 characters before <paramref name="index"/> or a word begin (separated by whitespace) between 15 and 5 characters before <paramref name="index"/>.
-    /// </summary>
-    private static int CalculateSegmentStart(string value, int index)
-    {
-        if (index <= 10)
-        {
-            return 0;
-        }
-
-        var wordSearchBegin = Math.Max(index - 16, 0);
-
-        var wordIndex = value.Substring(wordSearchBegin, 8)
-            .IndexOf(' ', StringComparison.OrdinalIgnoreCase);
-
-        if (wordIndex > 0)
-        {
-            return wordSearchBegin + wordIndex + 1;
-        }
-
-        return index - 10;
-    }
-
-    /// <summary>
-    /// Calculates how many characters to keep in <paramref name="value"/>.<br />
-    /// If a word end is found between 15 and 25 characters, use this word end, otherwise keep 20 characters.
-    /// </summary>
-    private static int CalculateSegmentLength(string value)
-    {
-        var word = value[..Math.Min(24, value.Length)]
-            .LastIndexOf(' ');
-
-        if (word > 16)
-        {
-            return word;
-        }
-
-        return Math.Min(20, value.Length);
     }
 }

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using FluentAssertions.Formatting;
 
@@ -149,5 +150,106 @@ internal static class StringExtensions
         }
 
         return count;
+    }
+
+    /// <summary>
+    /// Determines if the <paramref name="value"/> is longer than 8 characters or contains an <see cref="Environment.NewLine"/>.
+    /// </summary>
+    public static bool IsLongOrMultiline(this string value)
+    {
+        const int humanReadableLength = 8;
+        return value.Length > humanReadableLength || value.Contains(Environment.NewLine, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Get the mismatch segment between <paramref name="expected"/> and <paramref name="subject"/> for long strings,
+    /// when they differ at index <paramref name="firstIndexOfMismatch"/>.
+    /// </summary>
+    public static string GetMismatchSegmentForLongStrings(this string subject, string expected, int firstIndexOfMismatch)
+    {
+        int trimStart = CalculateSegmentStart(subject, firstIndexOfMismatch);
+
+        int whiteSpaceCount = (firstIndexOfMismatch - trimStart) + 3;
+        const string prefix = "  ";
+
+        if (trimStart > 0)
+        {
+            whiteSpaceCount++;
+        }
+
+        var visibleText = subject.Substring(trimStart, firstIndexOfMismatch - trimStart);
+        whiteSpaceCount += visibleText.Count(c => c == '\r' || c == '\n');
+
+        var sb = new StringBuilder();
+
+        sb.Append(' ', whiteSpaceCount).AppendLine("\u2193 (actual)")
+            .Append(prefix).Append('\"').AppendVisibleText(subject, trimStart).Append('\"').AppendLine()
+            .Append(prefix).Append('\"').AppendVisibleText(expected, trimStart).Append('\"').AppendLine()
+            .Append(' ', whiteSpaceCount).Append("\u2191 (expected)");
+
+        return sb.ToString();
+    }
+
+    private static StringBuilder AppendVisibleText(this StringBuilder sb, string subject, int trimStart)
+    {
+        var subjectLength = CalculateSegmentLength(subject.Substring(trimStart));
+
+        if (trimStart > 0)
+        {
+            sb.Append('\u2026');
+        }
+
+        sb.Append(subject
+            .Substring(trimStart, subjectLength)
+            .Replace("\r", "\\r", StringComparison.OrdinalIgnoreCase)
+            .Replace("\n", "\\n", StringComparison.OrdinalIgnoreCase));
+
+        if (subject.Length > (trimStart + subjectLength))
+        {
+            sb.Append('\u2026');
+        }
+
+        return sb;
+    }
+
+    /// <summary>
+    /// Calculates the start index of the visible segment from <paramref name="value"/> when highlighting the difference at <paramref name="index"/>.<br />
+    /// Either keep the last 10 characters before <paramref name="index"/> or a word begin (separated by whitespace) between 15 and 5 characters before <paramref name="index"/>.
+    /// </summary>
+    private static int CalculateSegmentStart(string value, int index)
+    {
+        if (index <= 10)
+        {
+            return 0;
+        }
+
+        var wordSearchBegin = Math.Max(index - 16, 0);
+
+        var wordIndex = value.Substring(wordSearchBegin, 8)
+            .IndexOf(' ', StringComparison.OrdinalIgnoreCase);
+
+        if (wordIndex > 0)
+        {
+            return wordSearchBegin + wordIndex + 1;
+        }
+
+        return index - 10;
+    }
+
+    /// <summary>
+    /// Calculates how many characters to keep in <paramref name="value"/>.<br />
+    /// If a word end is found between 15 and 25 characters, use this word end, otherwise keep 20 characters.
+    /// </summary>
+    private static int CalculateSegmentLength(string value)
+    {
+        var word = value.Substring(0, Math.Min(24, value.Length))
+            .LastIndexOf(' ');
+
+        if (word > 16)
+        {
+            return word;
+        }
+
+        return Math.Min(20, value.Length);
     }
 }

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
@@ -68,10 +69,20 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
 
             if (indexOfMismatch != -1)
             {
+                string lineInfo = $"at index {indexOfMismatch}";
+                var matchingString = subject.Substring(0, indexOfMismatch);
+                int lineNumber = matchingString.Count(c => c == '\n');
+
+                if (lineNumber > 0)
+                {
+                    var lastLineIndex = matchingString.LastIndexOf('\n');
+                    var column = matchingString.Length - lastLineIndex;
+                    lineInfo = $"on line {lineNumber + 1} and column {column} (index {indexOfMismatch})";
+                }
+
                 assertion.FailWith(
-                    ExpectationDescription + "the same string{reason}, but they differ at index {0}:" + Environment.NewLine
-                    + subject.GetMismatchSegmentForLongStrings(expected, indexOfMismatch) + ".",
-                    indexOfMismatch);
+                    ExpectationDescription + "the same string{reason}, but they differ " + lineInfo + ":" + Environment.NewLine
+                    + subject.GetMismatchSegmentForLongStrings(expected, indexOfMismatch) + ".");
             }
         }
         else if (ValidateAgainstLengthDifferences(assertion, subject, expected))

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -15,54 +15,9 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
         this.comparisonMode = comparisonMode;
     }
 
-    private bool ValidateAgainstSuperfluousWhitespace(IAssertionScope assertion, string subject, string expected)
-    {
-        return assertion
-            .ForCondition(!(expected.Length > subject.Length && expected.TrimEnd().Equals(subject, comparisonMode)))
-            .FailWith(ExpectationDescription + "{0}{reason}, but it misses some extra whitespace at the end.", expected)
-            .Then
-            .ForCondition(!(subject.Length > expected.Length && subject.TrimEnd().Equals(expected, comparisonMode)))
-            .FailWith(ExpectationDescription + "{0}{reason}, but it has unexpected whitespace at the end.", expected);
-    }
-
-    private bool ValidateAgainstLengthDifferences(IAssertionScope assertion, string subject, string expected)
-    {
-        return assertion
-            .ForCondition(subject.Length == expected.Length)
-            .FailWith(() =>
-            {
-                string mismatchSegment = GetMismatchSegmentForStringsOfDifferentLengths(subject, expected);
-
-                string message = ExpectationDescription +
-                    "{0} with a length of {1}{reason}, but {2} has a length of {3}, differs near " + mismatchSegment + ".";
-
-                return new FailReason(message, expected, expected.Length, subject, subject.Length);
-            });
-    }
-
-    private string GetMismatchSegmentForStringsOfDifferentLengths(string subject, string expected)
-    {
-        int indexOfMismatch = subject.IndexOfFirstMismatch(expected, comparisonMode);
-
-        // If there is no difference it means that expected starts with subject and subject is shorter than expected
-        if (indexOfMismatch == -1)
-        {
-            // Subject is shorter so we point at its last character.
-            // We would like to point at next character as it is the real
-            // index of first mismatch, but we need to point at character existing in
-            // subject, so the next best thing is the last subject character.
-            indexOfMismatch = Math.Max(0, subject.Length - 1);
-        }
-
-        return subject.IndexedSegmentAt(indexOfMismatch);
-    }
-
     public void ValidateAgainstMismatch(IAssertionScope assertion, string subject, string expected)
     {
-        if (!ValidateAgainstSuperfluousWhitespace(assertion, subject, expected))
-        {
-            return;
-        }
+        ValidateAgainstSuperfluousWhitespace(assertion, subject, expected);
 
         if (expected.IsLongOrMultiline() || subject.IsLongOrMultiline())
         {
@@ -115,6 +70,48 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
 
     private bool IgnoreCase
         => comparisonMode == StringComparison.OrdinalIgnoreCase;
+
+    private void ValidateAgainstSuperfluousWhitespace(IAssertionScope assertion, string subject, string expected)
+    {
+        assertion
+            .ForCondition(!(expected.Length > subject.Length && expected.TrimEnd().Equals(subject, comparisonMode)))
+            .FailWith(ExpectationDescription + "{0}{reason}, but it misses some extra whitespace at the end.", expected)
+            .Then
+            .ForCondition(!(subject.Length > expected.Length && subject.TrimEnd().Equals(expected, comparisonMode)))
+            .FailWith(ExpectationDescription + "{0}{reason}, but it has unexpected whitespace at the end.", expected);
+    }
+
+    private bool ValidateAgainstLengthDifferences(IAssertionScope assertion, string subject, string expected)
+    {
+        return assertion
+            .ForCondition(subject.Length == expected.Length)
+            .FailWith(() =>
+            {
+                string mismatchSegment = GetMismatchSegmentForStringsOfDifferentLengths(subject, expected);
+
+                string message = ExpectationDescription +
+                    "{0} with a length of {1}{reason}, but {2} has a length of {3}, differs near " + mismatchSegment + ".";
+
+                return new FailReason(message, expected, expected.Length, subject, subject.Length);
+            });
+    }
+
+    private string GetMismatchSegmentForStringsOfDifferentLengths(string subject, string expected)
+    {
+        int indexOfMismatch = subject.IndexOfFirstMismatch(expected, comparisonMode);
+
+        // If there is no difference it means that expected starts with subject and subject is shorter than expected
+        if (indexOfMismatch == -1)
+        {
+            // Subject is shorter so we point at its last character.
+            // We would like to point at next character as it is the real
+            // index of first mismatch, but we need to point at character existing in
+            // subject, so the next best thing is the last subject character.
+            indexOfMismatch = Math.Max(0, subject.Length - 1);
+        }
+
+        return subject.IndexedSegmentAt(indexOfMismatch);
+    }
 
     /// <summary>
     /// Get the mismatch segment between <paramref name="expected"/> and <paramref name="subject"/> for long strings,
@@ -200,7 +197,8 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
         var indexToStartSearchingForWordBoundary = Math.Max(indexOfFirstMismatch - (maxCharactersToKeep + lengthOfWhitespace), 0);
 
         var indexOfWordBoundary = value
-                .IndexOf(' ', indexToStartSearchingForWordBoundary, phraseLengthToCheckForWordBoundary) - indexToStartSearchingForWordBoundary;
+                .IndexOf(' ', indexToStartSearchingForWordBoundary, phraseLengthToCheckForWordBoundary) -
+            indexToStartSearchingForWordBoundary;
 
         if (indexOfWordBoundary >= 0)
         {

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
@@ -86,7 +87,7 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
 
             assertion.FailWith(
                 ExpectationDescription + "the same string{reason}, but they differ " + lineInfo + ":" + Environment.NewLine
-                + subject.GetMismatchSegmentForLongStrings(expected, indexOfMismatch) + ".");
+                + GetMismatchSegmentForLongStrings(subject, expected, indexOfMismatch) + ".");
         }
         else if (ValidateAgainstLengthDifferences(assertion, subject, expected))
         {
@@ -113,4 +114,100 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
 
     private bool IgnoreCase
         => comparisonMode == StringComparison.OrdinalIgnoreCase;
+
+    /// <summary>
+    /// Get the mismatch segment between <paramref name="expected"/> and <paramref name="subject"/> for long strings,
+    /// when they differ at index <paramref name="firstIndexOfMismatch"/>.
+    /// </summary>
+    private static string GetMismatchSegmentForLongStrings(string subject, string expected, int firstIndexOfMismatch)
+    {
+        int trimStart = CalculateSegmentStart(subject, firstIndexOfMismatch);
+
+        int whiteSpaceCount = (firstIndexOfMismatch - trimStart) + 3;
+        const string prefix = "  ";
+
+        if (trimStart > 0)
+        {
+            whiteSpaceCount++;
+        }
+
+        var visibleText = subject.Substring(trimStart, firstIndexOfMismatch - trimStart);
+        whiteSpaceCount += visibleText.Count(c => c is '\r' or '\n');
+
+        var sb = new StringBuilder();
+
+        sb.Append(' ', whiteSpaceCount).AppendLine("\u2193 (actual)")
+            .Append(prefix).Append('\"');
+
+        AppendVisibleText(sb, subject, trimStart).Append('\"').AppendLine()
+            .Append(prefix).Append('\"');
+
+        AppendVisibleText(sb, expected, trimStart).Append('\"').AppendLine()
+            .Append(' ', whiteSpaceCount).Append("\u2191 (expected)");
+
+        return sb.ToString();
+    }
+
+    private static StringBuilder AppendVisibleText(StringBuilder sb, string subject, int trimStart)
+    {
+        var subjectLength = CalculateSegmentLength(subject[trimStart..]);
+
+        if (trimStart > 0)
+        {
+            sb.Append('\u2026');
+        }
+
+        sb.Append(subject
+            .Substring(trimStart, subjectLength)
+            .Replace("\r", "\\r", StringComparison.OrdinalIgnoreCase)
+            .Replace("\n", "\\n", StringComparison.OrdinalIgnoreCase));
+
+        if (subject.Length > (trimStart + subjectLength))
+        {
+            sb.Append('\u2026');
+        }
+
+        return sb;
+    }
+
+    /// <summary>
+    /// Calculates the start index of the visible segment from <paramref name="value"/> when highlighting the difference at <paramref name="index"/>.<br />
+    /// Either keep the last 10 characters before <paramref name="index"/> or a word begin (separated by whitespace) between 15 and 5 characters before <paramref name="index"/>.
+    /// </summary>
+    private static int CalculateSegmentStart(string value, int index)
+    {
+        if (index <= 10)
+        {
+            return 0;
+        }
+
+        var wordSearchBegin = Math.Max(index - 16, 0);
+
+        var wordIndex = value.Substring(wordSearchBegin, 8)
+            .IndexOf(' ', StringComparison.OrdinalIgnoreCase);
+
+        if (wordIndex > 0)
+        {
+            return wordSearchBegin + wordIndex + 1;
+        }
+
+        return index - 10;
+    }
+
+    /// <summary>
+    /// Calculates how many characters to keep in <paramref name="value"/>.<br />
+    /// If a word end is found between 15 and 25 characters, use this word end, otherwise keep 20 characters.
+    /// </summary>
+    private static int CalculateSegmentLength(string value)
+    {
+        var word = value[..Math.Min(24, value.Length)]
+            .LastIndexOf(' ');
+
+        if (word > 16)
+        {
+            return word;
+        }
+
+        return Math.Min(20, value.Length);
+    }
 }

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -69,6 +69,7 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
 
             if (indexOfMismatch == -1)
             {
+                ValidateAgainstLengthDifferences(assertion, subject, expected);
                 return;
             }
 

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -135,7 +135,7 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
             whiteSpaceCountBeforeArrow++;
         }
 
-        var visibleText = subject.Substring(trimStart, firstIndexOfMismatch - trimStart);
+        var visibleText = subject[trimStart..firstIndexOfMismatch];
         whiteSpaceCountBeforeArrow += visibleText.Count(c => c is '\r' or '\n');
 
         var sb = new StringBuilder();
@@ -190,6 +190,7 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
         const int minCharactersToKeep = 5;
         const int maxCharactersToKeep = 15;
         const int lengthOfWhitespace = 1;
+        const int phraseLengthToCheckForWordBoundary = (maxCharactersToKeep - minCharactersToKeep) + lengthOfWhitespace;
 
         if (indexOfFirstMismatch <= defaultCharactersToKeep)
         {
@@ -199,8 +200,7 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
         var indexToStartSearchingForWordBoundary = Math.Max(indexOfFirstMismatch - (maxCharactersToKeep + lengthOfWhitespace), 0);
 
         var indexOfWordBoundary = value
-            .Substring(indexToStartSearchingForWordBoundary, (maxCharactersToKeep - minCharactersToKeep) + lengthOfWhitespace)
-            .IndexOf(' ', StringComparison.OrdinalIgnoreCase);
+                .IndexOf(' ', indexToStartSearchingForWordBoundary, phraseLengthToCheckForWordBoundary) - indexToStartSearchingForWordBoundary;
 
         if (indexOfWordBoundary >= 0)
         {
@@ -223,8 +223,8 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
         const int maxLength = 25;
         const int lengthOfWhitespace = 1;
 
-        var indexOfWordBoundary = value[..Math.Min(maxLength + lengthOfWhitespace, value.Length)]
-            .LastIndexOf(' ');
+        var indexOfWordBoundary = value
+            .LastIndexOf(' ', Math.Min(maxLength + lengthOfWhitespace, value.Length) - 1);
 
         if (indexOfWordBoundary >= minLength)
         {

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -57,19 +57,34 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
 
     public void ValidateAgainstMismatch(IAssertionScope assertion, string subject, string expected)
     {
-        if (!ValidateAgainstSuperfluousWhitespace(assertion, subject, expected) ||
-            !ValidateAgainstLengthDifferences(assertion, subject, expected))
+        if (!ValidateAgainstSuperfluousWhitespace(assertion, subject, expected))
         {
             return;
         }
 
-        int indexOfMismatch = subject.IndexOfFirstMismatch(expected, comparisonMode);
-
-        if (indexOfMismatch != -1)
+        if (expected.IsLongOrMultiline() || subject.IsLongOrMultiline())
         {
-            assertion.FailWith(
-                ExpectationDescription + "{0}{reason}, but {1} differs near " + subject.IndexedSegmentAt(indexOfMismatch) + ".",
-                expected, subject);
+            int indexOfMismatch = subject.IndexOfFirstMismatch(expected, comparisonMode);
+
+            if (indexOfMismatch != -1)
+            {
+                assertion.FailWith(
+                    ExpectationDescription + "the same string{reason}, but they differ at index {0}:" + Environment.NewLine
+                    + subject.GetMismatchSegmentForLongStrings(expected, indexOfMismatch) + ".",
+                    indexOfMismatch);
+            }
+        }
+        else if (ValidateAgainstLengthDifferences(assertion, subject, expected))
+        {
+            int indexOfMismatch = subject.IndexOfFirstMismatch(expected, comparisonMode);
+
+            if (indexOfMismatch != -1)
+            {
+                assertion.FailWith(
+                    ExpectationDescription + "{0}{reason}, but {1} differs near " + subject.IndexedSegmentAt(indexOfMismatch) +
+                    ".",
+                    expected, subject);
+            }
         }
     }
 

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -67,23 +67,25 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
         {
             int indexOfMismatch = subject.IndexOfFirstMismatch(expected, comparisonMode);
 
-            if (indexOfMismatch != -1)
+            if (indexOfMismatch == -1)
             {
-                string lineInfo = $"at index {indexOfMismatch}";
-                var matchingString = subject.Substring(0, indexOfMismatch);
-                int lineNumber = matchingString.Count(c => c == '\n');
-
-                if (lineNumber > 0)
-                {
-                    var lastLineIndex = matchingString.LastIndexOf('\n');
-                    var column = matchingString.Length - lastLineIndex;
-                    lineInfo = $"on line {lineNumber + 1} and column {column} (index {indexOfMismatch})";
-                }
-
-                assertion.FailWith(
-                    ExpectationDescription + "the same string{reason}, but they differ " + lineInfo + ":" + Environment.NewLine
-                    + subject.GetMismatchSegmentForLongStrings(expected, indexOfMismatch) + ".");
+                return;
             }
+
+            string lineInfo = $"at index {indexOfMismatch}";
+            var matchingString = subject[..indexOfMismatch];
+            int lineNumber = matchingString.Count(c => c == '\n');
+
+            if (lineNumber > 0)
+            {
+                var lastLineIndex = matchingString.LastIndexOf('\n');
+                var column = matchingString.Length - lastLineIndex;
+                lineInfo = $"on line {lineNumber + 1} and column {column} (index {indexOfMismatch})";
+            }
+
+            assertion.FailWith(
+                ExpectationDescription + "the same string{reason}, but they differ " + lineInfo + ":" + Environment.NewLine
+                + subject.GetMismatchSegmentForLongStrings(expected, indexOfMismatch) + ".");
         }
         else if (ValidateAgainstLengthDifferences(assertion, subject, expected))
         {

--- a/Src/FluentAssertions/Primitives/StringValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringValidator.cs
@@ -1,12 +1,10 @@
-using System;
+using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
 internal class StringValidator
 {
-    private const int HumanReadableLength = 8;
-
     private readonly IStringComparisonStrategy comparisonStrategy;
     private IAssertionScope assertion;
 
@@ -28,7 +26,7 @@ internal class StringValidator
             return;
         }
 
-        if (IsLongOrMultiline(expected) || IsLongOrMultiline(subject))
+        if (expected.IsLongOrMultiline() || subject.IsLongOrMultiline())
         {
             assertion = assertion.UsingLineBreaks;
         }
@@ -45,10 +43,5 @@ internal class StringValidator
 
         assertion.FailWith(comparisonStrategy.ExpectationDescription + "{0}{reason}, but found {1}.", expected, subject);
         return false;
-    }
-
-    private static bool IsLongOrMultiline(string value)
-    {
-        return value.Length > HumanReadableLength || value.Contains(Environment.NewLine, StringComparison.Ordinal);
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -221,7 +221,7 @@ public class BasicSpecs
             options => options.ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>());
 
         // Assert
-        act.Should().Throw<XunitException>().WithMessage("*NestedProperty*OtherValue*SomeValue*");
+        act.Should().Throw<XunitException>().WithMessage("*NestedProperty*SomeValue*OtherValue*");
     }
 
     [Fact]
@@ -237,7 +237,7 @@ public class BasicSpecs
             options => options.ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>());
 
         // Assert
-        act.Should().Throw<XunitException>().WithMessage("*NestedProperty*OtherValue*SomeValue*");
+        act.Should().Throw<XunitException>().WithMessage("*NestedProperty*SomeValue*OtherValue*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
@@ -340,7 +340,7 @@ public class CyclicReferencesSpecs
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("*subject.Next.Title*Second*SecondDifferent*")
+            .WithMessage("*subject.Next.Title*SecondDifferent*Second*")
             .Which.Message.Should().NotContain("maximum recursion depth was reached");
     }
 

--- a/Tests/FluentAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
@@ -270,7 +270,7 @@ public class NestedPropertiesSpecs
         act
             .Should().Throw<XunitException>()
             .WithMessage(
-                "Expected*Level.Level.Text*to be *A wrong text value*but*\"Level2\"*length*");
+                "Expected*Level.Level.Text*to be *\"Level2\"*A wrong text value*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -1295,7 +1295,7 @@ public class SelectionRulesSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*InternalProperty*also internal*internal*ProtectedInternalProperty*");
+                .WithMessage("*InternalProperty*internal*also internal*ProtectedInternalProperty*");
         }
 
         private class ClassWithInternalProperty
@@ -1351,7 +1351,7 @@ public class SelectionRulesSpecs
             Action act = () => actual.Should().BeEquivalentTo(expected, options => options.IncludingInternalFields());
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*InternalField*also internal*internal*ProtectedInternalField*");
+            act.Should().Throw<XunitException>().WithMessage("*InternalField*internal*also internal*ProtectedInternalField*");
         }
 
         private class ClassWithInternalField

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net47;net6.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
@@ -7,7 +7,6 @@
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn),IDE0052,1573,1591,1712,CS8002</NoWarn>
     <DebugType>full</DebugType>
-    <langVersion>latest</langVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' ">

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -7,6 +7,7 @@
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn),IDE0052,1573,1591,1712,CS8002</NoWarn>
     <DebugType>full</DebugType>
+    <langVersion>latest</langVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' ">

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -74,7 +74,7 @@ public class FormatterSpecs
         Action act = () => result.Should().Be(expectedJson);
 
         // Assert
-        act.Should().Throw<XunitException>().WithMessage("*near*index 37*");
+        act.Should().Throw<XunitException>().WithMessage("*at*index 37*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -695,7 +695,7 @@ public class ObjectAssertionSpecs
             Action act = () => someObject.Should().BeOfType<Exception>().Which.Message.Should().Be("Other Message");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*Expected*Other*Actual*");
+            act.Should().Throw<XunitException>().WithMessage("*Expected*Actual*Other*");
         }
 
         [Fact]
@@ -906,7 +906,7 @@ public class ObjectAssertionSpecs
             Action act = () => someObject.Should().BeAssignableTo<Exception>().Which.Message.Should().Be("Other Message");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*Expected*Other*Actual*");
+            act.Should().Throw<XunitException>().WithMessage("*Expected*Actual*Other*");
         }
 
         [Fact]
@@ -1117,7 +1117,7 @@ public class ObjectAssertionSpecs
                 .Which.Message.Should().Be("Other Message");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*Expected*Other*Actual*");
+            act.Should().Throw<XunitException>().WithMessage("*Expected*Actual*Other*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -253,7 +253,7 @@ public partial class StringAssertionSpecs
             Alice -> Bob : Authentication Request
             Bob --> Alice : Authentication Response
 
-            Bob -> Alice : Another authentication Request
+            Alice -> Bob : Invalid authentication Request
             Alice <-- Bob : Another authentication Response
             @enduml
             """;
@@ -263,12 +263,12 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be the same string, but they differ on line 5 and column 1 (index 93):" +
+                "Expected subject to be the same string, but they differ on line 5 and column 16 (index 108):" +
                 Environment.NewLine
-                + "                    ↓ (actual)" + Environment.NewLine
-                + "  \"…Response\\r\\n\\r\\nAlice ->…\"" + Environment.NewLine
-                + "  \"…Response\\r\\n\\r\\nBob ->…\"" + Environment.NewLine
-                + "                    ↑ (expected).");
+                + "             ↓ (actual)" + Environment.NewLine
+                + "  \"…-> Bob : Another aut…\"" + Environment.NewLine
+                + "  \"…-> Bob : Invalid aut…\"" + Environment.NewLine
+                + "             ↑ (expected).");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -239,6 +239,8 @@ public partial class StringAssertionSpecs
         [Fact]
         public void When_text_has_many_lines_failure_message_should_look_informative()
         {
+            var expectedIndex = 100 + 4 * (Environment.NewLine.Length);
+
             var subject = """
             @startuml
             Alice -> Bob : Authentication Request
@@ -263,7 +265,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be the same string, but they differ on line 5 and column 16 (index 108):" +
+                $"Expected subject to be the same string, but they differ on line 5 and column 16 (index {expectedIndex}):" +
                 Environment.NewLine
                 + "             ↓ (actual)" + Environment.NewLine
                 + "  \"…-> Bob : Another aut…\"" + Environment.NewLine

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -239,7 +239,7 @@ public partial class StringAssertionSpecs
         [Fact]
         public void When_text_has_many_lines_failure_message_should_look_informative()
         {
-            var expectedIndex = 100 + 4 * (Environment.NewLine.Length);
+            var expectedIndex = 100 + (4 * Environment.NewLine.Length);
 
             var subject = """
             @startuml
@@ -250,6 +250,7 @@ public partial class StringAssertionSpecs
             Alice <-- Bob : Another authentication Response
             @enduml
             """;
+
             var expected = """
             @startuml
             Alice -> Bob : Authentication Request

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -190,7 +190,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().Which.Message.Should().Be(
-                "Expected string to be the same string, but they differ at index 3:" +
+                "Expected string to be the same string, but they differ on line 2 and column 1 (index 3):" +
                 Environment.NewLine
                 + "        ↓ (actual)" + Environment.NewLine
                 + "  \"A\\r\\nB\"" + Environment.NewLine
@@ -201,8 +201,8 @@ public partial class StringAssertionSpecs
         [Fact]
         public void When_text_is_longer_than_8_characters_use_failure_message_with_arrows()
         {
-            var subject = "this is a long text that differs in between";
-            var expected = "this is a long text which differs in between";
+            const string subject = "this is a long text that differs in between two words";
+            const string expected = "this is a long text which differs in between two words";
 
             // Act
             Action act = () => subject.Should().Be(expected, "because we use arrows now");
@@ -220,8 +220,8 @@ public partial class StringAssertionSpecs
         [Fact]
         public void When_text_is_longer_than_8_characters_only_add_ellipsis_where_applicable()
         {
-            var subject = "this is a long text that differs in between";
-            var expected = "this was too short";
+            const string subject = "this is a long text that differs";
+            const string expected = "this was too short";
 
             // Act
             Action act = () => subject.Should().Be(expected, "because we use arrows now");
@@ -234,6 +234,41 @@ public partial class StringAssertionSpecs
                 + "  \"this is a long text…\"" + Environment.NewLine
                 + "  \"this was too short\"" + Environment.NewLine
                 + "        ↑ (expected).");
+        }
+
+        [Fact]
+        public void When_text_has_many_lines_failure_message_should_look_informative()
+        {
+            var subject = """
+            @startuml
+            Alice -> Bob : Authentication Request
+            Bob --> Alice : Authentication Response
+
+            Alice -> Bob : Another authentication Request
+            Alice <-- Bob : Another authentication Response
+            @enduml
+            """;
+            var expected = """
+            @startuml
+            Alice -> Bob : Authentication Request
+            Bob --> Alice : Authentication Response
+
+            Bob -> Alice : Another authentication Request
+            Alice <-- Bob : Another authentication Response
+            @enduml
+            """;
+
+            // Act
+            Action act = () => subject.Should().Be(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected subject to be the same string, but they differ on line 5 and column 1 (index 93):" +
+                Environment.NewLine
+                + "                    ↓ (actual)" + Environment.NewLine
+                + "  \"…Response\\r\\n\\r\\nAlice ->…\"" + Environment.NewLine
+                + "  \"…Response\\r\\n\\r\\nBob ->…\"" + Environment.NewLine
+                + "                    ↑ (expected).");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -231,9 +231,69 @@ public partial class StringAssertionSpecs
                 "Expected subject to be the same string because we use arrows now, but they differ at index 5:" +
                 Environment.NewLine
                 + "        ↓ (actual)" + Environment.NewLine
-                + "  \"this is a long text…\"" + Environment.NewLine
+                + "  \"this is a long text that…\"" + Environment.NewLine
                 + "  \"this was too short\"" + Environment.NewLine
                 + "        ↑ (expected).");
+        }
+
+        [Theory]
+        [InlineData("ThisIsUsedTo Check a difference after 5 characters")]
+        [InlineData("ThisIsUsedTo CheckADifferenc e after 15 characters")]
+        public void When_long_text_differs_should_use_word_boundary_between_5_and_15_characters_before(string expected)
+        {
+            const string subject = "ThisIsUsedTo CheckADifferenceInThe WordBoundaryAlgorithm";
+
+            // Act
+            Action act = () => subject.Should().Be(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*\"…CheckADifferenceInThe*");
+        }
+
+        [Theory]
+        [InlineData("ThisIsUsedTo Chec k a difference after 4 characters", "\"…sedTo CheckADifferen")]
+        [InlineData("ThisIsUsedTo CheckADifference after 16 characters", "\"…Difference")]
+        public void
+            When_long_text_differs_should_use_use_10_characters_when_no_word_boundary_exists_between_5_and_15_characters_before(
+                string expected, string expectedMessagePart)
+        {
+            const string subject = "ThisIsUsedTo CheckADifferenceInThe WordBoundaryAlgorithm";
+
+            // Act
+            Action act = () => subject.Should().Be(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage($"*{expectedMessagePart}*");
+        }
+
+        [Theory]
+        [InlineData("ThisLongTextIsUsedToCheckADifferenceAtTheEnd after 10 + 5 characters")]
+        [InlineData("ThisLongTextIsUsedToCheckADifferen after 10 + 15 characters")]
+        public void When_long_text_differs_should_use_word_boundary_between_15_and_25_characters_after(string expected)
+        {
+            const string subject = "ThisLongTextIsUsedToCheckADifferenceAtTheEndOfThe WordBoundaryAlgorithm";
+
+            // Act
+            Action act = () => subject.Should().Be(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*AtTheEndOfThe…\"*");
+        }
+
+        [Theory]
+        [InlineData("ThisLongTextIsUsedToCheckADifferenceAtTheEndO after 10 + 4 characters", "eAtTheEndOfThe WordB…\"")]
+        [InlineData("ThisLongTextIsUsedToCheckADiffere after 10 + 16 characters", "ckADifferenceAtTheEn…\"")]
+        public void
+            When_long_text_differs_should_use_use_20_characters_when_no_word_boundary_exists_between_15_and_25_characters_after(
+                string expected, string expectedMessagePart)
+        {
+            const string subject = "ThisLongTextIsUsedToCheckADifferenceAtTheEndOfThe WordBoundaryAlgorithm";
+
+            // Act
+            Action act = () => subject.Should().Be(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage($"*{expectedMessagePart}*");
         }
 
         [Fact]
@@ -269,8 +329,8 @@ public partial class StringAssertionSpecs
                 $"Expected subject to be the same string, but they differ on line 5 and column 16 (index {expectedIndex}):" +
                 Environment.NewLine
                 + "             ↓ (actual)" + Environment.NewLine
-                + "  \"…-> Bob : Another aut…\"" + Environment.NewLine
-                + "  \"…-> Bob : Invalid aut…\"" + Environment.NewLine
+                + "  \"…-> Bob : Another…\"" + Environment.NewLine
+                + "  \"…-> Bob : Invalid…\"" + Environment.NewLine
                 + "             ↑ (expected).");
         }
     }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -199,7 +199,7 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_text_is_longer_than_8_characters_use_failure_message_with_arrows()
+        public void Use_arrows_for_text_longer_than_8_characters()
         {
             const string subject = "this is a long text that differs in between two words";
             const string expected = "this is a long text which differs in between two words";
@@ -218,7 +218,7 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_text_is_longer_than_8_characters_only_add_ellipsis_where_applicable()
+        public void Only_add_ellipsis_for_long_text()
         {
             const string subject = "this is a long text that differs";
             const string expected = "this was too short";
@@ -239,7 +239,7 @@ public partial class StringAssertionSpecs
         [Theory]
         [InlineData("ThisIsUsedTo Check a difference after 5 characters")]
         [InlineData("ThisIsUsedTo CheckADifferenc e after 15 characters")]
-        public void When_long_text_differs_should_use_word_boundary_between_5_and_15_characters_before(string expected)
+        public void Will_look_for_a_word_boundary_between_5_and_15_characters_before_the_mismatching_index_to_highlight_the_mismatch(string expected)
         {
             const string subject = "ThisIsUsedTo CheckADifferenceInThe WordBoundaryAlgorithm";
 
@@ -253,8 +253,7 @@ public partial class StringAssertionSpecs
         [Theory]
         [InlineData("ThisIsUsedTo Chec k a difference after 4 characters", "\"…sedTo CheckADifferen")]
         [InlineData("ThisIsUsedTo CheckADifference after 16 characters", "\"…Difference")]
-        public void
-            When_long_text_differs_should_use_use_10_characters_when_no_word_boundary_exists_between_5_and_15_characters_before(
+        public void Will_fallback_to_10_characters_if_no_word_boundary_can_be_found_before_the_mismatching_index(
                 string expected, string expectedMessagePart)
         {
             const string subject = "ThisIsUsedTo CheckADifferenceInThe WordBoundaryAlgorithm";
@@ -269,7 +268,7 @@ public partial class StringAssertionSpecs
         [Theory]
         [InlineData("ThisLongTextIsUsedToCheckADifferenceAtTheEnd after 10 + 5 characters")]
         [InlineData("ThisLongTextIsUsedToCheckADifferen after 10 + 15 characters")]
-        public void When_long_text_differs_should_use_word_boundary_between_15_and_25_characters_after(string expected)
+        public void Will_look_for_a_word_boundary_between_15_and_25_characters_after_the_mismatching_index_to_highlight_the_mismatch(string expected)
         {
             const string subject = "ThisLongTextIsUsedToCheckADifferenceAtTheEndOfThe WordBoundaryAlgorithm";
 
@@ -281,7 +280,7 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_empty_string_is_compared_with_long_text_should_differ_in_length()
+        public void An_empty_string_is_always_shorter_than_a_long_text()
         {
             // Act
             Action act = () => "".Should().Be("ThisIsALongText");
@@ -291,7 +290,7 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_long_text_has_first_mismatch_in_first_10_characters_should_include_whole_start_of_the_text()
+        public void A_mismatch_below_index_11_includes_all_text_preceding_the_index_in_the_failure()
         {
             // Act
             Action act = () => "This is a long text".Should().Be("This is a text that differs at index 10");
@@ -303,8 +302,7 @@ public partial class StringAssertionSpecs
         [Theory]
         [InlineData("ThisLongTextIsUsedToCheckADifferenceAtTheEndO after 10 + 4 characters", "eAtTheEndOfThe WordB…\"")]
         [InlineData("ThisLongTextIsUsedToCheckADiffere after 10 + 16 characters", "ckADifferenceAtTheEn…\"")]
-        public void
-            When_long_text_differs_should_use_use_20_characters_when_no_word_boundary_exists_between_15_and_25_characters_after(
+        public void Will_fallback_to_20_characters_if_no_word_boundary_can_be_found_after_the_mismatching_index(
                 string expected, string expectedMessagePart)
         {
             const string subject = "ThisLongTextIsUsedToCheckADifferenceAtTheEndOfThe WordBoundaryAlgorithm";
@@ -317,7 +315,7 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_text_has_many_lines_failure_message_should_look_informative()
+        public void Mismatches_in_multiline_text_includes_the_line_number()
         {
             var expectedIndex = 100 + (4 * Environment.NewLine.Length);
 

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -173,13 +173,13 @@ public partial class StringAssertionSpecs
             Action act = () => "1234567890".Should().Be("0987654321");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected string to be the same string, but they differ at index 0:" +
-                Environment.NewLine
-                + "   ↓ (actual)" + Environment.NewLine
-                + "  \"1234567890\"" + Environment.NewLine
-                + "  \"0987654321\"" + Environment.NewLine
-                + "   ↑ (expected).");
+            act.Should().Throw<XunitException>().WithMessage("""
+                Expected string to be the same string, but they differ at index 0:
+                   ↓ (actual)
+                  "1234567890"
+                  "0987654321"
+                   ↑ (expected).
+                """);
         }
 
         [Fact]
@@ -189,13 +189,13 @@ public partial class StringAssertionSpecs
             Action act = () => "A\r\nB".Should().Be("A\r\nC");
 
             // Assert
-            act.Should().Throw<XunitException>().Which.Message.Should().Be(
-                "Expected string to be the same string, but they differ on line 2 and column 1 (index 3):" +
-                Environment.NewLine
-                + "        ↓ (actual)" + Environment.NewLine
-                + "  \"A\\r\\nB\"" + Environment.NewLine
-                + "  \"A\\r\\nC\"" + Environment.NewLine
-                + "        ↑ (expected).");
+            act.Should().Throw<XunitException>().Which.Message.Should().Be("""
+                Expected string to be the same string, but they differ on line 2 and column 1 (index 3):
+                        ↓ (actual)
+                  "A\r\nB"
+                  "A\r\nC"
+                        ↑ (expected).
+                """);
         }
 
         [Fact]
@@ -208,13 +208,13 @@ public partial class StringAssertionSpecs
             Action act = () => subject.Should().Be(expected, "because we use arrows now");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be the same string because we use arrows now, but they differ at index 20:" +
-                Environment.NewLine
-                + "              ↓ (actual)" + Environment.NewLine
-                + "  \"…long text that differs…\"" + Environment.NewLine
-                + "  \"…long text which differs…\"" + Environment.NewLine
-                + "              ↑ (expected).");
+            act.Should().Throw<XunitException>().WithMessage("""
+                Expected subject to be the same string because we use arrows now, but they differ at index 20:
+                                   ↓ (actual)
+                  "…is a long text that…"
+                  "…is a long text which…"
+                                   ↑ (expected).
+                """);
         }
 
         [Fact]
@@ -227,13 +227,13 @@ public partial class StringAssertionSpecs
             Action act = () => subject.Should().Be(expected, "because we use arrows now");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be the same string because we use arrows now, but they differ at index 5:" +
-                Environment.NewLine
-                + "        ↓ (actual)" + Environment.NewLine
-                + "  \"this is a long text that…\"" + Environment.NewLine
-                + "  \"this was too short\"" + Environment.NewLine
-                + "        ↑ (expected).");
+            act.Should().Throw<XunitException>().WithMessage("""
+                Expected subject to be the same string because we use arrows now, but they differ at index 5:
+                        ↓ (actual)
+                  "this is a long text that…"
+                  "this was too short"
+                        ↑ (expected).
+                """);
         }
 
         [Theory]
@@ -325,13 +325,13 @@ public partial class StringAssertionSpecs
             Action act = () => subject.Should().Be(expected);
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                $"Expected subject to be the same string, but they differ on line 5 and column 16 (index {expectedIndex}):" +
-                Environment.NewLine
-                + "             ↓ (actual)" + Environment.NewLine
-                + "  \"…-> Bob : Another…\"" + Environment.NewLine
-                + "  \"…-> Bob : Invalid…\"" + Environment.NewLine
-                + "             ↑ (expected).");
+            act.Should().Throw<XunitException>().WithMessage($"""
+                Expected subject to be the same string, but they differ on line 5 and column 16 (index {expectedIndex}):
+                             ↓ (actual)
+                  "…-> Bob : Another…"
+                  "…-> Bob : Invalid…"
+                             ↑ (expected).
+                """);
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -280,6 +280,26 @@ public partial class StringAssertionSpecs
             act.Should().Throw<XunitException>().WithMessage("*AtTheEndOfThe…\"*");
         }
 
+        [Fact]
+        public void When_empty_string_is_compared_with_long_text_should_differ_in_length()
+        {
+            // Act
+            Action act = () => "".Should().Be("ThisIsALongText");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*length*15*differs*");
+        }
+
+        [Fact]
+        public void When_long_text_has_first_mismatch_in_first_10_characters_should_include_whole_start_of_the_text()
+        {
+            // Act
+            Action act = () => "This is a long text".Should().Be("This is a text that differs at index 10");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*\"This is a long*");
+        }
+
         [Theory]
         [InlineData("ThisLongTextIsUsedToCheckADifferenceAtTheEndO after 10 + 4 characters", "eAtTheEndOfThe WordB…\"")]
         [InlineData("ThisLongTextIsUsedToCheckADiffere after 10 + 16 characters", "ckADifferenceAtTheEn…\"")]

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -174,7 +174,12 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected string to be*\"0987654321\", but*\"1234567890\" differs near \"123\" (index 0).");
+                "Expected string to be the same string, but they differ at index 0:" +
+                Environment.NewLine
+                + "   ↓ (actual)" + Environment.NewLine
+                + "  \"1234567890\"" + Environment.NewLine
+                + "  \"0987654321\"" + Environment.NewLine
+                + "   ↑ (expected).");
         }
 
         [Fact]
@@ -184,8 +189,51 @@ public partial class StringAssertionSpecs
             Action act = () => "A\r\nB".Should().Be("A\r\nC");
 
             // Assert
+            act.Should().Throw<XunitException>().Which.Message.Should().Be(
+                "Expected string to be the same string, but they differ at index 3:" +
+                Environment.NewLine
+                + "        ↓ (actual)" + Environment.NewLine
+                + "  \"A\\r\\nB\"" + Environment.NewLine
+                + "  \"A\\r\\nC\"" + Environment.NewLine
+                + "        ↑ (expected).");
+        }
+
+        [Fact]
+        public void When_text_is_longer_than_8_characters_use_failure_message_with_arrows()
+        {
+            var subject = "this is a long text that differs in between";
+            var expected = "this is a long text which differs in between";
+
+            // Act
+            Action act = () => subject.Should().Be(expected, "because we use arrows now");
+
+            // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected string to be \r\n\"A\\r\\nC\", but \r\n\"A\\r\\nB\" differs near \"B\" (index 3).");
+                "Expected subject to be the same string because we use arrows now, but they differ at index 20:" +
+                Environment.NewLine
+                + "              ↓ (actual)" + Environment.NewLine
+                + "  \"…long text that differs…\"" + Environment.NewLine
+                + "  \"…long text which differs…\"" + Environment.NewLine
+                + "              ↑ (expected).");
+        }
+
+        [Fact]
+        public void When_text_is_longer_than_8_characters_only_add_ellipsis_where_applicable()
+        {
+            var subject = "this is a long text that differs in between";
+            var expected = "this was too short";
+
+            // Act
+            Action act = () => subject.Should().Be(expected, "because we use arrows now");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected subject to be the same string because we use arrows now, but they differ at index 5:" +
+                Environment.NewLine
+                + "        ↓ (actual)" + Environment.NewLine
+                + "  \"this is a long text…\"" + Environment.NewLine
+                + "  \"this was too short\"" + Environment.NewLine
+                + "        ↑ (expected).");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
@@ -140,7 +140,7 @@ public class PropertyInfoAssertionSpecs
                 propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>().Which.Value.Should().Be("OtherValue");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*OtherValue*Value*");
+            act.Should().Throw<XunitException>().WithMessage("Expected*Value*OtherValue*");
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's new
 
 ### Improvements
+* Improve failure message for string assertions when checking for equality - [#2307](https://github.com/fluentassertions/fluentassertions/pull/2307)
 
 ### Fixes
 


### PR DESCRIPTION
When asserting that two strings are equal, and one of the strings is longer than 8 characters or contains a NewLine, instead of simply stating at which index the first difference occurs, this difference is made visible using arrows, e.g.
```csharp
var subject = "this is a long text that differs in between";
var expected = "this was too short";
subject.Should().Be(expected, "because we use arrows now");
```
throws with message
```
Expected subject to be the same string because we use arrows now, but they differ at index 5:
        ↓ (actual)
  "this is a long text…"
  "this was too short"
        ↑ (expected)."
```

For multi-line strings, instead of only providing information about the index, the failure message also contains the line and column information, e.g. `…but they differ on line 5 and column 1 (index 93):`

For short single-line strings the behaviour remains unchanged!

This closes #2050.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
