### PR TITLE
Run the Qodana on Windows so .NET 4.7 scanning works.

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   qodana-scan:
     name: Qodana Scan
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
According to JetBrains, in order for Qodana to properly detect .NET 4.7 usage, we need to run the build on Windows. 

