### PR TITLE
Add missing `DateTimeOffset` assertions

### DIFF
--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using FluentAssertions.Common;
 using FluentAssertions.Extensions;
 using Xunit;
@@ -2069,6 +2070,17 @@ public class DateTimeOffsetAssertionSpecs
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected the date part of subject to be <2009-12-30>, but it was <2009-12-31>.");
         }
+
+        [Fact]
+        public void Successive_and_call_works()
+        {
+            // Arrange
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
+
+            // Act / Assert
+            subject.Should().BeSameDateAs(expectation).And.Be(subject);
+        }
     }
 
     public class NotBeSameDateAs
@@ -2082,6 +2094,21 @@ public class DateTimeOffsetAssertionSpecs
 
             // Act
             Action act = () => subject.Should().NotBeSameDateAs(expectation);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect the date part of subject to be <2009-12-31>, but it was.");
+        }
+
+        [Fact]
+        public void Successive_and_call_works()
+        {
+            // Arrange
+            DateTimeOffset subject = new(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
+            DateTimeOffset expectation = new(new DateTime(2009, 12, 31), TimeSpan.Zero);
+
+            // Act
+            Action act = () => subject.Should().NotBeSameDateAs(expectation).And.Be(subject);
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -2519,6 +2546,52 @@ public class DateTimeOffsetAssertionSpecs
             // Assert
             action.Should().Throw<XunitException>().WithMessage(
                 "Expected value to be one of {<2017-01-01 +1h>, <2016-12-31 04:00:00 +1h>}, but it was <2016-12-31 +1h>.");
+        }
+
+        [Fact]
+        public void When_a_value_is_one_of_the_specified_param_values_successive_assertions_with_and_works()
+        {
+            // Arrange
+            var value = new DateTimeOffset(31.December(2016), 1.Hours());
+
+            // Act / Assert
+            value.Should().BeOneOf(value, value + 1.Hours())
+                .And.Be(31.December(2016).WithOffset(1.Hours()));
+        }
+
+        [Fact]
+        public void When_a_value_is_one_of_the_specified_nullable_params_values_successive_assertions_with_and_works()
+        {
+            // Arrange
+            var value = new DateTimeOffset(31.December(2016), 1.Hours());
+
+            // Act / Assert
+            value.Should().BeOneOf(null, value, value + 1.Hours())
+                .And.Be(31.December(2016).WithOffset(1.Hours()));
+        }
+
+        [Fact]
+        public void When_a_value_is_one_of_the_specified_enumerable_values_successive_assertions_with_and_works()
+        {
+            // Arrange
+            var value = new DateTimeOffset(31.December(2016), 1.Hours());
+            var expected = new[] { value, value + 1.Hours() }.AsEnumerable();
+
+            // Act / Assert
+            value.Should().BeOneOf(expected)
+                .And.Be(31.December(2016).WithOffset(1.Hours()));
+        }
+
+        [Fact]
+        public void When_a_value_is_one_of_the_specified_nullable_enumerable_values_successive_assertions_with_and_works()
+        {
+            // Arrange
+            var value = new DateTimeOffset(31.December(2016), 1.Hours());
+            var expected = new DateTimeOffset?[] { null, value, value + 1.Hours() }.AsEnumerable();
+
+            // Act / Assert
+            value.Should().BeOneOf(expected)
+                .And.Be(31.December(2016).WithOffset(1.Hours()));
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -2072,7 +2072,7 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void Successive_and_call_works()
+        public void Can_chain_follow_up_assertions()
         {
             // Arrange
             DateTimeOffset subject = new(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
@@ -2101,7 +2101,7 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void Successive_and_call_works()
+        public void Can_chain_follow_up_assertions()
         {
             // Arrange
             DateTimeOffset subject = new(new DateTime(2009, 12, 31, 4, 5, 6), TimeSpan.Zero);
@@ -2549,7 +2549,7 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void When_a_value_is_one_of_the_specified_param_values_successive_assertions_with_and_works()
+        public void When_a_value_is_one_of_the_specified_param_values_follow_up_assertions_works()
         {
             // Arrange
             var value = new DateTimeOffset(31.December(2016), 1.Hours());
@@ -2560,7 +2560,7 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void When_a_value_is_one_of_the_specified_nullable_params_values_successive_assertions_with_and_works()
+        public void When_a_value_is_one_of_the_specified_nullable_params_values_follow_up_assertions_works()
         {
             // Arrange
             var value = new DateTimeOffset(31.December(2016), 1.Hours());
@@ -2571,7 +2571,7 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void When_a_value_is_one_of_the_specified_enumerable_values_successive_assertions_with_and_works()
+        public void When_a_value_is_one_of_the_specified_enumerable_values_follow_up_assertions_works()
         {
             // Arrange
             var value = new DateTimeOffset(31.December(2016), 1.Hours());
@@ -2583,7 +2583,7 @@ public class DateTimeOffsetAssertionSpecs
         }
 
         [Fact]
-        public void When_a_value_is_one_of_the_specified_nullable_enumerable_values_successive_assertions_with_and_works()
+        public void When_a_value_is_one_of_the_specified_nullable_enumerable_follow_up_assertions_works()
         {
             // Arrange
             var value = new DateTimeOffset(31.December(2016), 1.Hours());


### PR DESCRIPTION
This also ref. qodana complaining about 'Method return value is never used'

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
