### PR TITLE
Pass down the reason to inner `AssertionScope`

### DIFF
--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -148,10 +148,7 @@ public sealed class AssertionScope : IAssertionScope
     /// </summary>
     public FormattingOptions FormattingOptions { get; } = AssertionOptions.FormattingOptions.Clone();
 
-    internal bool Succeeded
-    {
-        get => succeeded == true;
-    }
+    internal bool Succeeded => succeeded == true;
 
     /// <summary>
     /// Adds an explanation of why the assertion is supposed to succeed to the scope.

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -107,6 +107,7 @@ public sealed class AssertionScope : IAssertionScope
         {
             contextData.Add(parent.contextData);
             Context = parent.Context;
+            reason = parent.reason;
             callerIdentityProvider = parent.callerIdentityProvider;
         }
     }

--- a/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
@@ -1184,8 +1184,8 @@ public class DictionarySpecs
             ["a"] = new List<int> { 42 }
         };
 
-        Action act = () => subject.Should().BeEquivalentTo(expected, "FOO");
+        Action act = () => subject.Should().BeEquivalentTo(expected, "FOO {0}", "BAR");
 
-        act.Should().Throw<XunitException>().WithMessage("*FOO*");
+        act.Should().Throw<XunitException>().WithMessage("*FOO BAR*");
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
@@ -1170,4 +1170,22 @@ public class DictionarySpecs
             .WhenTypeIs<double>()
         );
     }
+
+    [Fact]
+    public void Passing_the_reason_to_the_inner_equivalency_assertion_works()
+    {
+        var subject = new Dictionary<string, object>
+        {
+            ["a"] = new List<int>()
+        };
+
+        var expected = new Dictionary<string, object>
+        {
+            ["a"] = new List<int> { 42 }
+        };
+
+        Action act = () => subject.Should().BeEquivalentTo(expected, "FOO");
+
+        act.Should().Throw<XunitException>().WithMessage("*FOO*");
+    }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,6 +17,7 @@ sidebar:
 * Fixed formatting error when checking nullable `DateTimeOffset` with 
 `BeWithin(...).Before(...)` - [#2312](https://github.com/fluentassertions/fluentassertions/pull/2312)
 * `BeEquivalentTo` will now find and can map subject properties that are implemented through an explicitly-implemented interface - [#2152](https://github.com/fluentassertions/fluentassertions/pull/2152)
+* Fixed that the `because` and `becauseArgs` were not passed down the equivalency tree - [#2318](https://github.com/fluentassertions/fluentassertions/pull/2318)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
This fixes #2293 

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
