### PR TITLE
Optimize `TypeMemberReflector`

### DIFF
--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -29,12 +29,12 @@ internal sealed class TypeMemberReflector
 
     private static PropertyInfo[] LoadProperties(Type typeToReflect, MemberVisibility visibility)
     {
-        IEnumerable<PropertyInfo> query = GetPropertiesFromHierarchy(typeToReflect, visibility);
+        List<PropertyInfo> query = GetPropertiesFromHierarchy(typeToReflect, visibility);
 
         return query.ToArray();
     }
 
-    private static IEnumerable<PropertyInfo> GetPropertiesFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
+    private static List<PropertyInfo> GetPropertiesFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
     {
         bool includeInternal = memberVisibility.HasFlag(MemberVisibility.Internal);
 
@@ -63,12 +63,12 @@ internal sealed class TypeMemberReflector
 
     private static FieldInfo[] LoadFields(Type typeToReflect, MemberVisibility visibility)
     {
-        IEnumerable<FieldInfo> query = GetFieldsFromHierarchy(typeToReflect, visibility);
+        List<FieldInfo> query = GetFieldsFromHierarchy(typeToReflect, visibility);
 
         return query.ToArray();
     }
 
-    private static IEnumerable<FieldInfo> GetFieldsFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
+    private static List<FieldInfo> GetFieldsFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
     {
         bool includeInternal = memberVisibility.HasFlag(MemberVisibility.Internal);
 
@@ -87,7 +87,7 @@ internal sealed class TypeMemberReflector
         return field.IsAssembly || field.IsFamilyOrAssembly;
     }
 
-    private static IEnumerable<TMemberInfo> GetMembersFromHierarchy<TMemberInfo>(
+    private static List<TMemberInfo> GetMembersFromHierarchy<TMemberInfo>(
         Type typeToReflect,
         Func<Type, IEnumerable<TMemberInfo>> getMembers)
         where TMemberInfo : MemberInfo
@@ -100,7 +100,7 @@ internal sealed class TypeMemberReflector
         return GetClassMembers(typeToReflect, getMembers);
     }
 
-    private static IEnumerable<TMemberInfo> GetInterfaceMembers<TMemberInfo>(Type typeToReflect,
+    private static List<TMemberInfo> GetInterfaceMembers<TMemberInfo>(Type typeToReflect,
         Func<Type, IEnumerable<TMemberInfo>> getMembers)
         where TMemberInfo : MemberInfo
     {
@@ -136,7 +136,7 @@ internal sealed class TypeMemberReflector
         return members;
     }
 
-    private static IEnumerable<TMemberInfo> GetClassMembers<TMemberInfo>(Type typeToReflect,
+    private static List<TMemberInfo> GetClassMembers<TMemberInfo>(Type typeToReflect,
         Func<Type, IEnumerable<TMemberInfo>> getMembers)
         where TMemberInfo : MemberInfo
     {

--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -44,8 +44,7 @@ internal sealed class TypeMemberReflector
                 .GetProperties(AllInstanceMembersFlag | BindingFlags.DeclaredOnly)
                 .Where(p => HasGetter(p, memberVisibility) && !p.IsIndexer())
                 .Where(property => includeInternal || !IsInternal(property))
-                .OrderBy(property => IsExplicitImplementation(property))
-                .ToArray();
+                .OrderBy(property => IsExplicitImplementation(property));
         });
     }
 
@@ -77,8 +76,7 @@ internal sealed class TypeMemberReflector
             return type
                 .GetFields(AllInstanceMembersFlag)
                 .Where(field => !field.IsPrivate && !field.IsFamily)
-                .Where(field => includeInternal || !IsInternal(field))
-                .ToArray();
+                .Where(field => includeInternal || !IsInternal(field));
         });
     }
 

--- a/Tests/Benchmarks/TypeMemberReflectorBenchmarks.cs
+++ b/Tests/Benchmarks/TypeMemberReflectorBenchmarks.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using FluentAssertions.Common;
+using FluentAssertions.Equivalency;
+using static FluentAssertions.Equivalency.MemberVisibility;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net60)]
+public class TypeMemberReflectorBenchmarks
+{
+    [Benchmark]
+    public object Publicc() => new TypeMemberReflector(typeof(A), Public);
+
+    [Benchmark]
+    public object Public_Internal() => new TypeMemberReflector(typeof(A), Public | Internal);
+
+    [Benchmark]
+    public object Public_Internal_ExplicitlyImplemented() => new TypeMemberReflector(typeof(A), Public | Internal | ExplicitlyImplemented);
+}
+
+interface I
+{
+    int Interface0 { get; set; }
+    int Interface1 { get; set; }
+    int Interface2 { get; set; }
+    int Interface3 { get; set; }
+    int Interface4 { get; set; }
+    int Interface5 { get; set; }
+    int Interface6 { get; set; }
+    int Interface7 { get; set; }
+    int Interface8 { get; set; }
+    int Interface9 { get; set; }
+}
+
+class A : I
+{
+    public int Public0 { get; set; }
+    public int Public1 { get; set; }
+    public int Public2 { get; set; }
+    public int Public3 { get; set; }
+    public int Public4 { get; set; }
+    public int Public5 { get; set; }
+    public int Public6 { get; set; }
+    public int Public7 { get; set; }
+    public int Public8 { get; set; }
+    public int Public9 { get; set; }
+
+    internal int Internal0 { get; set; }
+    internal int Internal1 { get; set; }
+    internal int Internal2 { get; set; }
+    internal int Internal3 { get; set; }
+    internal int Internal4 { get; set; }
+    internal int Internal5 { get; set; }
+    internal int Internal6 { get; set; }
+    internal int Internal7 { get; set; }
+    internal int Internal8 { get; set; }
+    internal int Internal9 { get; set; }
+
+    int I.Interface0 { get; set; }
+    int I.Interface1 { get; set; }
+    int I.Interface2 { get; set; }
+    int I.Interface3 { get; set; }
+    int I.Interface4 { get; set; }
+    int I.Interface5 { get; set; }
+    int I.Interface6 { get; set; }
+    int I.Interface7 { get; set; }
+    int I.Interface8 { get; set; }
+    int I.Interface9 { get; set; }
+}


### PR DESCRIPTION
Picking some low-hanging fruits in `TypeMemberReflector` to speed it up a bit.

The `_Old` suffix is the version of `TypeMemberReflector` in `develop`.
The "Ratio" column is manually calculated as `new / old`

|                                    Method |     Mean | Ratio |     Error |    StdDev |   Gen0 | Allocated | Ratio |
|------------------------------------------ |---------:|------:|----------:|----------:|-------:|----------:|------:|
|                                   Publicc | 2.759 us |  0.55 | 0.0548 us | 0.0631 us | 0.5646 |   3.46 KB |  0.60 |
|                               Publicc_Old | 5.006 us |       | 0.0433 us | 0.0384 us | 0.9384 |   5.77 KB |       |
|                           Public_Internal | 4.190 us |  0.60 | 0.0386 us | 0.0342 us | 0.8240 |   5.06 KB |  0.70 |
|                       Public_Internal_Old | 6.947 us |       | 0.0212 us | 0.0177 us | 1.1673 |   7.18 KB |       |
|     Public_Internal_ExplicitlyImplemented | 6.302 us |  0.90 | 0.0206 us | 0.0182 us | 1.0071 |   6.20 KB |  0.84 |
| Public_Internal_ExplicitlyImplemented_Old | 7.017 us |       | 0.0212 us | 0.0198 us | 1.1902 |   7.34 KB |       |

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
