### PR TITLE
Change `AllSatisfy` to succeed on empty collections

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -2965,9 +2965,6 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .ForCondition(subject => subject is not null)
             .FailWith("but collection is <null>.")
             .Then
-            .ForCondition(subject => subject.Any())
-            .FailWith("but collection is empty.")
-            .Then
             .ClearExpectation();
 
         if (success)

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
@@ -50,20 +50,13 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void An_empty_collection_should_throw()
+        public void An_empty_collection_should_succeed()
         {
             // Arrange
             var collection = Enumerable.Empty<int>();
 
-            // Act
-            Action act = () =>
-                collection.Should().AllSatisfy(x => x.Should().Be(1), "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should()
-                .Throw<XunitException>()
-                .WithMessage(
-                    "Expected collection to contain only items satisfying the inspector because we want to test the failure message, but collection is empty.");
+            // Act / Assert
+            collection.Should().AllSatisfy(x => x.Should().Be(1));
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -35,7 +35,7 @@ sidebar:
     * `BeLessOrEqualTo`: Use `BeLessThanOrEqualTo`
 * Removed the `DefaultValueFormatter.SpacesPerIndentionLevel` property which was added during the development of v6, but wasn't removed before the release of v6 - [#2281](https://github.com/fluentassertions/fluentassertions/pull/2281)
 * Dropped direct support for .NET Core 2.x and .NET Core 3.x - [#2302](https://github.com/fluentassertions/fluentassertions/pull/2302)
-* `AllSatisfy` now suceeds when asserting that an empty collection satifies some predicates - [#2321](https://github.com/fluentassertions/fluentassertions/pull/2321)
+* `AllSatisfy` now suceeds when asserting that an empty collection satisfies some predicates - [#2321](https://github.com/fluentassertions/fluentassertions/pull/2321)
 
 ### Breaking Changes (for extensions)
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -35,6 +35,7 @@ sidebar:
     * `BeLessOrEqualTo`: Use `BeLessThanOrEqualTo`
 * Removed the `DefaultValueFormatter.SpacesPerIndentionLevel` property which was added during the development of v6, but wasn't removed before the release of v6 - [#2281](https://github.com/fluentassertions/fluentassertions/pull/2281)
 * Dropped direct support for .NET Core 2.x and .NET Core 3.x - [#2302](https://github.com/fluentassertions/fluentassertions/pull/2302)
+* `AllSatisfy` now suceeds when asserting that an empty collection satifies some predicates - [#2321](https://github.com/fluentassertions/fluentassertions/pull/2321)
 
 ### Breaking Changes (for extensions)
 


### PR DESCRIPTION
This fixes #2169


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
