### PR TITLE
Test that collection assertions supports vacuous truths

### DIFF
--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeAssignableTo.cs
@@ -28,6 +28,16 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
+        public void All_items_in_an_empty_collection_are_assignable_to_a_generic_type()
+        {
+            // Arrange
+            var collection = Array.Empty<int>();
+
+            // Act / Assert
+            collection.Should().AllBeAssignableTo<int>();
+        }
+
+        [Fact]
         public void When_collection_is_null_then_all_be_assignable_to_should_fail()
         {
             // Arrange
@@ -43,6 +53,16 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
+        }
+
+        [Fact]
+        public void All_items_in_an_empty_collection_are_assignable_to_a_type()
+        {
+            // Arrange
+            var collection = Array.Empty<int>();
+
+            // Act / Assert
+            collection.Should().AllBeAssignableTo(typeof(int));
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeOfType.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeOfType.cs
@@ -28,6 +28,26 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
+        public void All_items_in_an_empty_collection_are_of_a_generic_type()
+        {
+            // Arrange
+            var collection = Array.Empty<int>();
+
+            // Act / Assert
+            collection.Should().AllBeOfType<int>();
+        }
+
+        [Fact]
+        public void All_items_in_an_empty_collection_are_of_a_type()
+        {
+            // Arrange
+            var collection = Array.Empty<int>();
+
+            // Act / Assert
+            collection.Should().AllBeOfType(typeof(int));
+        }
+
+        [Fact]
         public void When_collection_is_null_then_all_be_of_type_should_fail()
         {
             // Arrange


### PR DESCRIPTION
While working on #2321 I noticed that some other assertions on `GenericCollectionAssertions` did support vacuous truths, but no tests verified that.


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
