### PR TITLE
Add `ForConstraint` to `IAssertionScope`

### DIFF
--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -226,16 +226,7 @@ public sealed class AssertionScope : IAssertionScope
         return this;
     }
 
-    /// <summary>
-    /// Makes assertion fail when <paramref name="actualOccurrences"/> does not match <paramref name="constraint"/>.
-    /// <para>
-    /// The occurrence description in natural language could then be inserted in failure message by using
-    /// <em>{expectedOccurrence}</em> placeholder in message parameters of <see cref="FailWith(string, object[])"/> and its
-    /// overloaded versions.
-    /// </para>
-    /// </summary>
-    /// <param name="constraint"><see cref="OccurrenceConstraint"/> defining the number of expected occurrences.</param>
-    /// <param name="actualOccurrences">The number of actual occurrences.</param>
+    /// <inheritdoc cref="IAssertionScope.ForConstraint(OccurrenceConstraint, int)" />
     public AssertionScope ForConstraint(OccurrenceConstraint constraint, int actualOccurrences)
     {
         constraint.RegisterReportables(this);
@@ -454,6 +445,8 @@ public sealed class AssertionScope : IAssertionScope
     #region Explicit Implementation to support the interface
 
     IAssertionScope IAssertionScope.ForCondition(bool condition) => ForCondition(condition);
+
+    IAssertionScope IAssertionScope.ForConstraint(OccurrenceConstraint constraint, int actualOccurrences) => ForConstraint(constraint, actualOccurrences);
 
     IAssertionScope IAssertionScope.BecauseOf(string because, params object[] becauseArgs) => BecauseOf(because, becauseArgs);
 

--- a/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
@@ -42,6 +42,17 @@ public sealed class ContinuedAssertionScope : IAssertionScope
         return this;
     }
 
+    /// <inheritdoc />
+    public IAssertionScope ForConstraint(OccurrenceConstraint constraint, int actualOccurrences)
+    {
+        if (continueAsserting)
+        {
+            return predecessor.ForConstraint(constraint, actualOccurrences);
+        }
+
+        return this;
+    }
+
     /// <inheritdoc/>
     public Continuation FailWith(string message)
     {

--- a/Src/FluentAssertions/Execution/IAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/IAssertionScope.cs
@@ -21,6 +21,18 @@ public interface IAssertionScope : IDisposable
     IAssertionScope ForCondition(bool condition);
 
     /// <summary>
+    /// Makes assertion fail when <paramref name="actualOccurrences"/> does not match <paramref name="constraint"/>.
+    /// <para>
+    /// The occurrence description in natural language could then be inserted in failure message by using
+    /// <em>{expectedOccurrence}</em> placeholder in message parameters of <see cref="FailWith(string, object[])"/> and its
+    /// overloaded versions.
+    /// </para>
+    /// </summary>
+    /// <param name="constraint"><see cref="OccurrenceConstraint"/> defining the number of expected occurrences.</param>
+    /// <param name="actualOccurrences">The number of actual occurrences.</param>
+    IAssertionScope ForConstraint(OccurrenceConstraint constraint, int actualOccurrences);
+
+    /// <summary>
     /// Sets the failure message when the assertion is not met, or completes the failure message set to a prior call to
     /// <see cref="AssertionScope.WithExpectation"/>.
     /// </summary>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1194,6 +1194,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.IAssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
         public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
@@ -1228,6 +1229,7 @@ namespace FluentAssertions.Execution
         FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders);
         FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
         FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.IAssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences);
         FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
         FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
         FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1207,6 +1207,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.IAssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
         public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
@@ -1241,6 +1242,7 @@ namespace FluentAssertions.Execution
         FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders);
         FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
         FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.IAssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences);
         FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
         FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
         FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1145,6 +1145,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.IAssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
         public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
@@ -1179,6 +1180,7 @@ namespace FluentAssertions.Execution
         FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders);
         FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
         FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.IAssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences);
         FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
         FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
         FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1194,6 +1194,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.IAssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
         public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
@@ -1228,6 +1229,7 @@ namespace FluentAssertions.Execution
         FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders);
         FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
         FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.IAssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences);
         FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
         FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
         FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -38,6 +38,7 @@ sidebar:
 * Dropped direct support for .NET Core 2.x and .NET Core 3.x - [#2302](https://github.com/fluentassertions/fluentassertions/pull/2302)
 
 ### Breaking Changes (for extensions)
+* Add `ForConstraint` to `IAssertionsScope` to support chaining `.ForConstraint()` after `.Then` - [#2324](https://github.com/fluentassertions/fluentassertions/pull/2324)
 
 ## 6.12.0
 


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Until 6.12 you are not able to chain `.ForConstraint()` after `.Then`.

The only possibility for was to check `.ForConstraint()` first and then chain all subsequent assertions with `.Then`.

This leads to following issue: you cannot pre-check for e.g. `null` or empty, which leads to multiple sets of `Execute.Assertions...` to check every possible failure first.

This PR introduces this `.ForConstraint()` to the contract `IAssertionScope` to make this before mentioned possible.

Closes #1918 
 
## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
