### PR TITLE
Rename the unit test steps to match what's done inside the steps

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -84,8 +84,8 @@
               "SpellCheck",
               "TestFrameworks",
               "UnitTests",
-              "UnitTestsNetFramework",
-              "UnitTestsNewerFrameworks"
+              "UnitTestsNet47",
+              "UnitTestsNet6OrGreater"
             ]
           }
         },
@@ -110,8 +110,8 @@
               "SpellCheck",
               "TestFrameworks",
               "UnitTests",
-              "UnitTestsNetFramework",
-              "UnitTestsNewerFrameworks"
+              "UnitTestsNet47",
+              "UnitTestsNet6OrGreater"
             ]
           }
         },

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -169,7 +169,7 @@ class Build : NukeBuild
         Solution.Specs.VB_Specs
     };
 
-    Target UnitTestsNetFramework => _ => _
+    Target UnitTestsNet47 => _ => _
         .Unlisted()
         .DependsOn(Compile)
         .OnlyWhenDynamic(() => EnvironmentInfo.IsWin && (RunAllTargets || HasSourceChanges))
@@ -188,7 +188,7 @@ class Build : NukeBuild
             );
         });
 
-    Target UnitTestsNewerFrameworks => _ => _
+    Target UnitTestsNet6OrGreater => _ => _
         .Unlisted()
         .DependsOn(Compile)
         .OnlyWhenDynamic(() => RunAllTargets || HasSourceChanges)
@@ -222,8 +222,8 @@ class Build : NukeBuild
         });
 
     Target UnitTests => _ => _
-        .DependsOn(UnitTestsNetFramework)
-        .DependsOn(UnitTestsNewerFrameworks);
+        .DependsOn(UnitTestsNet47)
+        .DependsOn(UnitTestsNet6OrGreater);
 
     static string[] Outcomes(AbsolutePath path)
         => XmlTasks.XmlPeek(


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
If I watch the build pipeline I find it sometimes difficult to distinguish between the `UnitTestsNetFramework` and `UnitTestsNewerFrameworks` when the log is quickly passing by :)

So I renamed them to fit more what's actually done.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
