### PR TITLE
Add missing test for `because` is `null`

### DIFF
--- a/Tests/FluentAssertions.Specs/Execution/AssertionScope.ChainingApiSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScope.ChainingApiSpecs.cs
@@ -114,6 +114,20 @@ public partial class AssertionScopeSpecs
     }
 
     [Fact]
+    public void Passing_a_null_value_as_reason_does_not_fail()
+    {
+        // Act
+        Action act = () => Execute.Assertion
+            .BecauseOf(null, "only because for method disambiguity")
+            .ForCondition(false)
+            .FailWith("First assertion");
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("First assertion");
+    }
+
+    [Fact]
     public void When_a_given_is_used_before_an_assertion_then_the_result_should_be_available_for_evaluation()
     {
         // Act


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->

| Before | After |
|--------|--------|
|  ![image](https://github.com/fluentassertions/fluentassertions/assets/44049228/c97da9fc-794e-4742-ad53-6901cd6d7adc) |  ![image](https://github.com/fluentassertions/fluentassertions/assets/44049228/dc4682d8-e8d5-4d58-a743-2ca1433a37c9)| 

Ref. #1823
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
