### PR TITLE
Pass `FormattingOptions` to inner `AssertionScope`

### DIFF
--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -109,6 +109,7 @@ public sealed class AssertionScope : IAssertionScope
             Context = parent.Context;
             reason = parent.reason;
             callerIdentityProvider = parent.callerIdentityProvider;
+            FormattingOptions = parent.FormattingOptions.Clone();
         }
     }
 

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -6,6 +6,7 @@ using Chill;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Equivalency.Steps;
 using FluentAssertions.Execution;
+using FluentAssertions.Extensions;
 using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -252,6 +252,129 @@ namespace FluentAssertions.Specs.Execution
             outerScope.Get<string>("innerReportable").Should().Be("bar");
         }
 
+        [Fact]
+        public void Scope_formatting_options_passed_to_inner_scope()
+        {
+            var a = new[]
+            {
+                new Container
+                {
+                    Id = Guid.NewGuid(),
+                    Children = new[]
+                    {
+                        new Container.Child1
+                        {
+                            Id = Guid.NewGuid(),
+                            Children = new[]
+                            {
+                                new Container.Child2
+                                {
+                                    StringProperty = "A",
+                                    IntProperty = 1,
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var b = new[]
+            {
+                new Container
+                {
+                    Id = Guid.NewGuid(),
+                    Children = new[]
+                    {
+                        new Container.Child1
+                        {
+                            Id = Guid.NewGuid(),
+                            Children = new[]
+                            {
+                                new Container.Child2
+                                {
+                                    StringProperty = "B",
+                                    IntProperty = 1,
+                                }
+                            }
+                        }
+                    }
+                },
+                new Container
+                {
+                    Id = Guid.NewGuid(),
+                    Children = new[]
+                    {
+                        new Container.Child1
+                        {
+                            Id = Guid.NewGuid(),
+                            Children = new[]
+                            {
+                                new Container.Child2
+                                {
+                                    StringProperty = "B",
+                                    IntProperty = 1,
+                                }
+                            }
+                        }
+                    }
+                },
+            };
+
+            var messageWithoutMaxDepthRespected = "";
+
+            try
+            {
+                using (var scope = new AssertionScope())
+                {
+                    scope.FormattingOptions.MaxDepth = 1;
+                    a.Should().BeEquivalentTo(b);
+                }
+            }
+            catch (Exception ex)
+            {
+                messageWithoutMaxDepthRespected = ex.Message;
+            }
+
+            AssertionOptions.FormattingOptions.MaxDepth = 1;
+            var messageWithMaxDepthCorrectlyRespected = "";
+
+            try
+            {
+                a.Should().BeEquivalentTo(b);
+            }
+            catch (Exception ex)
+            {
+                messageWithMaxDepthCorrectlyRespected = ex.Message;
+            }
+            finally
+            {
+                AssertionOptions.FormattingOptions.MaxDepth = 5;
+            }
+
+            messageWithMaxDepthCorrectlyRespected.Should().Be(messageWithoutMaxDepthRespected);
+        }
+
+        private class Container
+        {
+            public Guid Id { get; set; }
+
+            public Child1[] Children { get; set; }
+
+            public class Child1
+            {
+                public Guid Id { get; set; }
+
+                public Child2[] Children { get; set; }
+            }
+
+            public class Child2
+            {
+                public string StringProperty { get; set; }
+
+                public int IntProperty { get; set; }
+            }
+        }
+
         public class CustomAssertionStrategy : IAssertionStrategy
         {
             private readonly List<string> failureMessages = new();

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -253,126 +253,37 @@ namespace FluentAssertions.Specs.Execution
         }
 
         [Fact]
-        public void Scope_formatting_options_passed_to_inner_scope()
+        public void Formatting_options_passed_to_inner_assertion_scopes()
         {
-            var a = new[]
+            // Arrange
+            var subject = new[]
             {
-                new Container
+                new
                 {
-                    Id = Guid.NewGuid(),
-                    Children = new[]
-                    {
-                        new Container.Child1
-                        {
-                            Id = Guid.NewGuid(),
-                            Children = new[]
-                            {
-                                new Container.Child2
-                                {
-                                    StringProperty = "A",
-                                    IntProperty = 1,
-                                }
-                            }
-                        }
-                    }
+                    Value = 42
                 }
             };
 
-            var b = new[]
+            var expected = new[]
             {
-                new Container
+                new
                 {
-                    Id = Guid.NewGuid(),
-                    Children = new[]
-                    {
-                        new Container.Child1
-                        {
-                            Id = Guid.NewGuid(),
-                            Children = new[]
-                            {
-                                new Container.Child2
-                                {
-                                    StringProperty = "B",
-                                    IntProperty = 1,
-                                }
-                            }
-                        }
-                    }
+                    Value = 42
                 },
-                new Container
+                new
                 {
-                    Id = Guid.NewGuid(),
-                    Children = new[]
-                    {
-                        new Container.Child1
-                        {
-                            Id = Guid.NewGuid(),
-                            Children = new[]
-                            {
-                                new Container.Child2
-                                {
-                                    StringProperty = "B",
-                                    IntProperty = 1,
-                                }
-                            }
-                        }
-                    }
-                },
+                    Value = 42
+                }
             };
 
-            var messageWithoutMaxDepthRespected = "";
+            // Act
+            using var scope = new AssertionScope();
+            scope.FormattingOptions.MaxDepth = 1;
+            subject.Should().BeEquivalentTo(expected);
 
-            try
-            {
-                using (var scope = new AssertionScope())
-                {
-                    scope.FormattingOptions.MaxDepth = 1;
-                    a.Should().BeEquivalentTo(b);
-                }
-            }
-            catch (Exception ex)
-            {
-                messageWithoutMaxDepthRespected = ex.Message;
-            }
-
-            AssertionOptions.FormattingOptions.MaxDepth = 1;
-            var messageWithMaxDepthCorrectlyRespected = "";
-
-            try
-            {
-                a.Should().BeEquivalentTo(b);
-            }
-            catch (Exception ex)
-            {
-                messageWithMaxDepthCorrectlyRespected = ex.Message;
-            }
-            finally
-            {
-                AssertionOptions.FormattingOptions.MaxDepth = 5;
-            }
-
-            messageWithMaxDepthCorrectlyRespected.Should().Be(messageWithoutMaxDepthRespected);
-        }
-
-        private class Container
-        {
-            public Guid Id { get; set; }
-
-            public Child1[] Children { get; set; }
-
-            public class Child1
-            {
-                public Guid Id { get; set; }
-
-                public Child2[] Children { get; set; }
-            }
-
-            public class Child2
-            {
-                public string StringProperty { get; set; }
-
-                public int IntProperty { get; set; }
-            }
+            // Assert
+            scope.Discard().Should().ContainSingle()
+                .Which.Should().Contain("Maximum recursion depth of 1 was reached");
         }
 
         public class CustomAssertionStrategy : IAssertionStrategy

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -20,6 +20,8 @@ sidebar:
 * `BeEquivalentTo` will now find and can map subject properties that are implemented through an explicitly-implemented interface - [#2152](https://github.com/fluentassertions/fluentassertions/pull/2152)
 * Fixed that the `because` and `becauseArgs` were not passed down the equivalency tree - [#2318](https://github.com/fluentassertions/fluentassertions/pull/2318)
 * `BeEquivalentTo` can again compare a non-generic `IDictionary` with a generic one - [#2358](https://github.com/fluentassertions/fluentassertions/pull/23158)
+* Fixed that the `FormattingOptions` were not respected in inner `AssertionScope` - [#2328](https://github.com/fluentassertions/fluentassertions/pull/2328)
+
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Fixes #2170


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
