### PR TITLE
Change `OnlyContain` to succeed on empty collections

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -2822,11 +2822,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .ForCondition(subject => subject is not null)
             .FailWith("but the collection is <null>.")
             .Then
-            .Given(subject => subject.ConvertOrCastToCollection())
-            .ForCondition(collection => collection.Count > 0)
-            .FailWith("but the collection is empty.")
-            .Then
-            .Given(collection => collection.Where(item => !compiledPredicate(item)))
+            .Given(subject => subject.ConvertOrCastToCollection().Where(item => !compiledPredicate(item)))
             .ForCondition(mismatchingItems => !mismatchingItems.Any())
             .FailWith("but {0} do(es) not match.", mismatchingItems => mismatchingItems)
             .Then

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyContain.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyContain.cs
@@ -62,12 +62,8 @@ public partial class CollectionAssertionSpecs
             // Arrange
             IEnumerable<string> strings = Enumerable.Empty<string>();
 
-            // Act
-            Action act = () => strings.Should().OnlyContain(e => e.Length > 0);
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected strings to contain only items matching (e.Length > 0), but the collection is empty.");
+            // Act / Assert
+            strings.Should().OnlyContain(e => e.Length > 0);
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -37,6 +37,7 @@ sidebar:
 * Removed the `DefaultValueFormatter.SpacesPerIndentionLevel` property which was added during the development of v6, but wasn't removed before the release of v6 - [#2281](https://github.com/fluentassertions/fluentassertions/pull/2281)
 * Dropped direct support for .NET Core 2.x and .NET Core 3.x - [#2302](https://github.com/fluentassertions/fluentassertions/pull/2302)
 * `AllSatisfy` now suceeds when asserting that an empty collection satisfies some predicates - [#2321](https://github.com/fluentassertions/fluentassertions/pull/2321)
+* `OnlyContain` now succeeds when asserting that an empty collection matches some predicates - [#2350](https://github.com/fluentassertions/fluentassertions/pull/2350)
 
 ### Breaking Changes (for extensions)
 


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
This ref: https://github.com/fluentassertions/fluentassertions/pull/2321#issuecomment-1737853301

And: https://github.com/fluentassertions/fluentassertions/issues/1492

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
