### PR TITLE
Add a note to XML-docs that explains the `(Not)ContainEquivalentOf` problem

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -810,13 +810,18 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that a collection of objects contains at least one object equivalent to another object.
+    /// Asserts that at least one element in the collection is equivalent to <paramref name="expectation"/>.
     /// </summary>
     /// <remarks>
-    /// Objects within the collection are equivalent to the expected object when both object graphs have equally named properties with the same
-    /// value, irrespective of the type of those objects. Two properties are also equal if one type can be converted to another
-    /// and the result is equal.
+    /// <para>
+    /// <b>Important:</b> You cannot use this method to assert whether a subset of the collection is equivalent to the <paramref name="expectation"/>.
+    /// This usually means that the expectation is meant to be a <i>single</i> item.
+    /// </para>
+    /// <para>
+    /// By default, objects within the collection are seen as equivalent to the expected object when both object graphs have equally named properties with the same
+    /// value, irrespective of the type of those objects.
     /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
+    /// </para>
     /// </remarks>
     /// <param name="expectation">The expected element.</param>
     /// <param name="because">
@@ -833,13 +838,18 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that a collection of objects contains at least one object equivalent to another object.
+    /// Asserts that at least one element in the collection is equivalent to <paramref name="expectation"/>.
     /// </summary>
     /// <remarks>
-    /// Objects within the collection are equivalent to the expected object when both object graphs have equally named properties with the same
-    /// value, irrespective of the type of those objects. Two properties are also equal if one type can be converted to another
-    /// and the result is equal.
+    /// <para>
+    /// <b>Important:</b> You cannot use this method to assert whether a subset of the collection is equivalent to the <paramref name="expectation"/>.
+    /// This usually means that the expectation is meant to be a <i>single</i> item.
+    /// </para>
+    /// <para>
+    /// By default, objects within the collection are seen as equivalent to the expected object when both object graphs have equally named properties with the same
+    /// value, irrespective of the type of those objects.
     /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
+    /// </para>
     /// </remarks>
     /// <param name="expectation">The expected element.</param>
     /// <param name="config">
@@ -2283,13 +2293,18 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that a collection of objects does not contain any object equivalent to another object.
+    /// Asserts that no element in the collection is equivalent to <paramref name="unexpected"/>.
     /// </summary>
     /// <remarks>
-    /// Objects within the collection are equivalent to the expected object when both object graphs have equally named properties with the same
-    /// value, irrespective of the type of those objects. Two properties are also equal if one type can be converted to another
-    /// and the result is equal.
+    /// <para>
+    /// <b>Important:</b> You cannot use this method to assert whether a subset of the collection is not equivalent to the <paramref name="unexpected"/>.
+    /// This usually means that the expectation is meant to be a <i>single</i> item.
+    /// </para>
+    /// <para>
+    /// By default, objects within the collection are seen as not equivalent to the expected object when both object graphs have unequally named properties with the same
+    /// value, irrespective of the type of those objects.
     /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
+    /// </para>
     /// </remarks>
     /// <param name="unexpected">The unexpected element.</param>
     /// <param name="because">
@@ -2306,13 +2321,18 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that a collection of objects does not contain any object equivalent to another object.
+    /// Asserts that no element in the collection is equivalent to <paramref name="unexpected"/>.
     /// </summary>
     /// <remarks>
-    /// Objects within the collection are equivalent to the expected object when both object graphs have equally named properties with the same
-    /// value, irrespective of the type of those objects. Two properties are also equal if one type can be converted to another
-    /// and the result is equal.
+    /// <para>
+    /// <b>Important:</b> You cannot use this method to assert whether a subset of the collection is not equivalent to the <paramref name="unexpected"/>.
+    /// This usually means that the expectation is meant to be a <i>single</i> item.
+    /// </para>
+    /// <para>
+    /// By default, objects within the collection are seen as not equivalent to the expected object when both object graphs have unequally named properties with the same
+    /// value, irrespective of the type of those objects.
     /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
+    /// </para>
     /// </remarks>
     /// <param name="unexpected">The unexpected element.</param>
     /// <param name="config">


### PR DESCRIPTION
This ref. and hopefully closes #2352 

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
