### PR TITLE
Grammatical changes of "which" to "whose"

### DIFF
--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -32,7 +32,7 @@ public class BooleanAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public bool? Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
@@ -34,7 +34,7 @@ public class DateOnlyAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public DateOnly? Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -42,7 +42,7 @@ public class DateTimeAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public DateTime? Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -43,7 +43,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public DateTimeOffset? Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -31,7 +31,7 @@ public class GuidAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public Guid? Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -21,7 +21,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public TSubject Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -32,7 +32,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public TimeSpan? Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
@@ -35,7 +35,7 @@ public class TimeOnlyAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public TimeOnly? Subject { get; }
 

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -30,7 +30,7 @@ public class MethodInfoSelectorAssertions
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public IEnumerable<MethodInfo> SubjectMethods { get; }
 

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Types;
 public class PropertyInfoSelectorAssertions
 {
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public IEnumerable<PropertyInfo> SubjectProperties { get; }
 

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -30,7 +30,7 @@ public class TypeSelectorAssertions
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public IEnumerable<Type> Subject { get; }
 


### PR DESCRIPTION
Update grammar for lines "Gets the object _which_ value is being asserted" to "Gets the object _whose_ value is being asserted". No changes to API or updates to functionality. For issue #2353 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
