### PR TITLE
Handle comparing an `IDictionary` subject with an `IDictionary<,>` expectation

### DIFF
--- a/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Globalization;
 using System.Linq;
 using FluentAssertions.Equivalency.Tracing;
@@ -1188,4 +1189,142 @@ public class DictionarySpecs
 
         act.Should().Throw<XunitException>().WithMessage("*FOO BAR*");
     }
+
+    [Fact]
+    public void A_non_generic_subject_can_be_compared_with_a_generic_expectation()
+    {
+        var subject = new ListDictionary
+        {
+            ["id"] = 22,
+            ["CustomerId"] = 33
+        };
+
+        var expected = new Dictionary<object, object>
+        {
+            ["id"] = 22,
+            ["CustomerId"] = 33
+        };
+
+        subject.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void A_non_generic_subject_which_is_null_can_be_compared_with_a_generic_expectation()
+    {
+        var subject = (ListDictionary)null;
+
+        var expected = new Dictionary<object, object>
+        {
+            ["id"] = 22,
+            ["CustomerId"] = 33
+        };
+
+        Action act = () => subject.Should().BeEquivalentTo(expected);
+
+        act.Should().Throw<XunitException>().WithMessage("*<null>*");
+    }
+
+    [Fact]
+    public void Excluding_nested_objects_when_dictionary_is_equivalent()
+    {
+        var subject = new Dictionary<object, object>
+        {
+            ["id"] = 22,
+            ["CustomerId"] = 33
+        };
+
+        var expected = new Dictionary<object, object>
+        {
+            ["id"] = 22,
+            ["CustomerId"] = 33
+        };
+
+        subject.Should().BeEquivalentTo(expected, opt => opt.ExcludingNestedObjects());
+    }
+
+    [Fact]
+    public void Custom_types_which_implementing_dictionaries_pass()
+    {
+        var subject = new NonGenericChildDictionary
+        {
+            ["id"] = 22,
+            ["CustomerId"] = 33
+        };
+
+        var expected = new Specs.NonGenericDictionary
+        {
+            ["id"] = 22,
+            ["CustomerId"] = 33
+        };
+
+        subject.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void Custom_types_which_implementing_dictionaries_pass_with_swapped_subject_expectation()
+    {
+        var subject = new Specs.NonGenericDictionary
+        {
+            ["id"] = 22,
+            ["CustomerId"] = 33
+        };
+
+        var expected = new NonGenericChildDictionary
+        {
+            ["id"] = 22,
+            ["CustomerId"] = 33
+        };
+
+        subject.Should().BeEquivalentTo(expected);
+    }
+}
+
+internal class NonGenericChildDictionary : Dictionary<string, int>
+{
+    public new void Add(string key, int value)
+    {
+        base.Add(key, value);
+    }
+}
+
+internal class NonGenericDictionary : IDictionary<string, int>
+{
+    private readonly Dictionary<string, int> innerDictionary = new();
+
+    public int this[string key]
+    {
+        get => innerDictionary[key];
+        set => innerDictionary[key] = value;
+    }
+
+    public ICollection<string> Keys => innerDictionary.Keys;
+
+    public ICollection<int> Values => innerDictionary.Values;
+
+    public int Count => innerDictionary.Count;
+
+    public bool IsReadOnly => false;
+
+    public void Add(string key, int value) => innerDictionary.Add(key, value);
+
+    public void Add(KeyValuePair<string, int> item) => innerDictionary.Add(item.Key, item.Value);
+
+    public void Clear() => innerDictionary.Clear();
+
+    public bool Contains(KeyValuePair<string, int> item) => innerDictionary.Contains(item);
+
+    public bool ContainsKey(string key) => innerDictionary.ContainsKey(key);
+
+    public void CopyTo(KeyValuePair<string, int>[] array, int arrayIndex) =>
+        ((ICollection<KeyValuePair<string, int>>)innerDictionary).CopyTo(array, arrayIndex);
+
+    public IEnumerator<KeyValuePair<string, int>> GetEnumerator() => innerDictionary.GetEnumerator();
+
+    public bool Remove(string key) => innerDictionary.Remove(key);
+
+    public bool Remove(KeyValuePair<string, int> item) => innerDictionary.Remove(item.Key);
+
+    public bool TryGetValue(string key, out int value) => innerDictionary.TryGetValue(key, out value);
+
+    IEnumerator IEnumerable.GetEnumerator() => innerDictionary.GetEnumerator();
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -19,6 +19,7 @@ sidebar:
 `BeWithin(...).Before(...)` - [#2312](https://github.com/fluentassertions/fluentassertions/pull/2312)
 * `BeEquivalentTo` will now find and can map subject properties that are implemented through an explicitly-implemented interface - [#2152](https://github.com/fluentassertions/fluentassertions/pull/2152)
 * Fixed that the `because` and `becauseArgs` were not passed down the equivalency tree - [#2318](https://github.com/fluentassertions/fluentassertions/pull/2318)
+* `BeEquivalentTo` can again compare a non-generic `IDictionary` with a generic one - [#2358](https://github.com/fluentassertions/fluentassertions/pull/23158)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Fixes: #2308 

~~**Note**: The very first two commits are to fix the actual problem. Commit 3-6 are for code quality (and therefore can moved to a separate PR if needed).~~

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
