### PR TITLE
Converted AsyncFunctionAssertions into real base class

### DIFF
--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -24,48 +24,6 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     protected override string Identifier => "async function";
 
     /// <summary>
-    /// Asserts that the current <typeparamref name="TTask"/> will complete within the specified time.
-    /// </summary>
-    /// <param name="timeSpan">The allowed time span for the operation.</param>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-    /// </param>
-    public async Task<AndConstraint<TAssertions>> CompleteWithinAsync(
-        TimeSpan timeSpan, string because = "", params object[] becauseArgs)
-    {
-        bool success = Execute.Assertion
-            .ForCondition(Subject is not null)
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:task} to complete within {0}{reason}, but found <null>.", timeSpan);
-
-        if (success)
-        {
-            (TTask task, TimeSpan remainingTime) = InvokeWithTimer(timeSpan);
-
-            success = Execute.Assertion
-                .ForCondition(remainingTime >= TimeSpan.Zero)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
-
-            if (success)
-            {
-                bool completesWithinTimeout = await CompletesWithinTimeoutAsync(task, remainingTime);
-
-                Execute.Assertion
-                    .ForCondition(completesWithinTimeout)
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
-            }
-        }
-
-        return new AndConstraint<TAssertions>((TAssertions)this);
-    }
-
-    /// <summary>
     /// Asserts that the current <typeparamref name="TTask"/> will not complete within the specified time.
     /// </summary>
     /// <param name="timeSpan">The allowed time span for the operation.</param>
@@ -273,38 +231,6 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     }
 
     /// <summary>
-    /// Asserts that the current <see cref="Func{Task}"/> does not throw any exception.
-    /// </summary>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-    /// </param>
-    public async Task<AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs)
-    {
-        bool success = Execute.Assertion
-            .ForCondition(Subject is not null)
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context} not to throw{reason}, but found <null>.");
-
-        if (success)
-        {
-            try
-            {
-                await Subject!.Invoke();
-            }
-            catch (Exception exception)
-            {
-                return NotThrowInternal(exception, because, becauseArgs);
-            }
-        }
-
-        return new AndConstraint<TAssertions>((TAssertions)this);
-    }
-
-    /// <summary>
     /// Asserts that the current <see cref="Func{Task}"/> does not throw an exception of type <typeparamref name="TException"/>.
     /// </summary>
     /// <typeparam name="TException">The type of exception expected to not be thrown.</typeparam>
@@ -336,74 +262,6 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
-    }
-
-    /// <summary>
-    /// Asserts that the current <see cref="Func{T}"/> stops throwing any exception
-    /// after a specified amount of time.
-    /// </summary>
-    /// <remarks>
-    /// The <see cref="Func{T}"/> is invoked. If it raises an exception,
-    /// the invocation is repeated until it either stops raising any exceptions
-    /// or the specified wait time is exceeded.
-    /// </remarks>
-    /// <param name="waitTime">
-    /// The time after which the <see cref="Func{T}"/> should have stopped throwing any exception.
-    /// </param>
-    /// <param name="pollInterval">
-    /// The time between subsequent invocations of the <see cref="Func{T}"/>.
-    /// </param>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-    /// </param>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="waitTime"/> or <paramref name="pollInterval"/> are negative.</exception>
-    public Task<AndConstraint<TAssertions>> NotThrowAfterAsync(TimeSpan waitTime, TimeSpan pollInterval, string because = "",
-        params object[] becauseArgs)
-    {
-        Guard.ThrowIfArgumentIsNegative(waitTime);
-        Guard.ThrowIfArgumentIsNegative(pollInterval);
-
-        bool success = Execute.Assertion
-            .ForCondition(Subject is not null)
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context} not to throw any exceptions after {0}{reason}, but found <null>.", waitTime);
-
-        if (success)
-        {
-            return AssertionTaskAsync();
-
-            async Task<AndConstraint<TAssertions>> AssertionTaskAsync()
-            {
-                TimeSpan? invocationEndTime = null;
-                Exception exception = null;
-                ITimer timer = Clock.StartTimer();
-
-                while (invocationEndTime is null || invocationEndTime < waitTime)
-                {
-                    exception = await InvokeWithInterceptionAsync(Subject);
-
-                    if (exception is null)
-                    {
-                        return new AndConstraint<TAssertions>((TAssertions)this);
-                    }
-
-                    await Clock.DelayAsync(pollInterval, CancellationToken.None);
-                    invocationEndTime = timer.Elapsed;
-                }
-
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Did not expect any exceptions after {0}{reason}, but found {1}.", waitTime, exception);
-
-                return new AndConstraint<TAssertions>((TAssertions)this);
-            }
-        }
-
-        return Task.FromResult(new AndConstraint<TAssertions>((TAssertions)this));
     }
 
     /// <summary>
@@ -445,7 +303,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         return true;
     }
 
-    private static async Task<Exception> InvokeWithInterceptionAsync(Func<Task> action)
+    private protected static async Task<Exception> InvokeWithInterceptionAsync(Func<Task> action)
     {
         try
         {

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -16,14 +16,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     where TTask : Task
     where TAssertions : AsyncFunctionAssertions<TTask, TAssertions>
 {
-    [Obsolete("This class is intended as base class. This ctor is accidentally public and will be removed in Version 7.")]
-    public AsyncFunctionAssertions(Func<TTask> subject, IExtractExceptions extractor)
-        : this(subject, extractor, new Clock())
-    {
-    }
-
-    [Obsolete("This class is intended as base class. This ctor is accidentally public and will be made protected in Version 7.")]
-    public AsyncFunctionAssertions(Func<TTask> subject, IExtractExceptions extractor, IClock clock)
+    protected AsyncFunctionAssertions(Func<TTask> subject, IExtractExceptions extractor, IClock clock)
         : base(subject, extractor, clock)
     {
     }

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -11,6 +11,8 @@ namespace FluentAssertions.Specialized;
 /// <summary>
 /// Contains a number of methods to assert that an asynchronous method yields the expected result.
 /// </summary>
+/// <typeparam name="TTask">The type of <see cref="Task{T}"/> to be handled.</typeparam>
+/// <typeparam name="TAssertions">The type of assertion to be returned.</typeparam>
 [DebuggerNonUserCode]
 public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBase<Func<TTask>, TAssertions>
     where TTask : Task

--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -15,9 +15,7 @@ public class GenericAsyncFunctionAssertions<TResult>
     }
 
     public GenericAsyncFunctionAssertions(Func<Task<TResult>> subject, IExtractExceptions extractor, IClock clock)
-#pragma warning disable CS0618 // is currently obsolete to make it protected in Version 7
         : base(subject, extractor, clock)
-#pragma warning restore CS0618
     {
     }
 

--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -6,14 +6,24 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Specialized;
 
+/// <summary>
+/// Contains a number of methods to assert that an asynchronous method yields the expected result.
+/// </summary>
+/// <typeparam name="TResult">The type returned in the <see cref="Task{T}"/>.</typeparam>
 public class GenericAsyncFunctionAssertions<TResult>
     : AsyncFunctionAssertions<Task<TResult>, GenericAsyncFunctionAssertions<TResult>>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenericAsyncFunctionAssertions{TResult}"/> class.
+    /// </summary>
     public GenericAsyncFunctionAssertions(Func<Task<TResult>> subject, IExtractExceptions extractor)
         : this(subject, extractor, new Clock())
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenericAsyncFunctionAssertions{TResult}"/> class with custom <see cref="IClock"/>.
+    /// </summary>
     public GenericAsyncFunctionAssertions(Func<Task<TResult>> subject, IExtractExceptions extractor, IClock clock)
         : base(subject, extractor, clock)
     {

--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -30,7 +30,7 @@ public class GenericAsyncFunctionAssertions<TResult>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public new async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(
+    public async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(
         TimeSpan timeSpan, string because = "", params object[] becauseArgs)
     {
         bool success = Execute.Assertion
@@ -76,7 +76,7 @@ public class GenericAsyncFunctionAssertions<TResult>
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public new async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(
+    public async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(
         string because = "", params object[] becauseArgs)
     {
         bool success = Execute.Assertion
@@ -123,7 +123,7 @@ public class GenericAsyncFunctionAssertions<TResult>
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="waitTime"/> or <paramref name="pollInterval"/> are negative.</exception>
-    public new Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(
+    public Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(
         TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNegative(waitTime);

--- a/Src/FluentAssertions/Specialized/NonGenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/NonGenericAsyncFunctionAssertions.cs
@@ -12,9 +12,7 @@ public class NonGenericAsyncFunctionAssertions : AsyncFunctionAssertions<Task, N
     }
 
     public NonGenericAsyncFunctionAssertions(Func<Task> subject, IExtractExceptions extractor, IClock clock)
-#pragma warning disable CS0618 // is currently obsolete to make it protected in Version 7
         : base(subject, extractor, clock)
-#pragma warning restore CS0618
     {
     }
 }

--- a/Src/FluentAssertions/Specialized/NonGenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/NonGenericAsyncFunctionAssertions.cs
@@ -6,13 +6,22 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Specialized;
 
+/// <summary>
+/// Contains a number of methods to assert that an asynchronous method yields the expected result.
+/// </summary>
 public class NonGenericAsyncFunctionAssertions : AsyncFunctionAssertions<Task, NonGenericAsyncFunctionAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NonGenericAsyncFunctionAssertions"/> class.
+    /// </summary>
     public NonGenericAsyncFunctionAssertions(Func<Task> subject, IExtractExceptions extractor)
         : this(subject, extractor, new Clock())
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NonGenericAsyncFunctionAssertions"/> class with custom <see cref="IClock"/>.
+    /// </summary>
     public NonGenericAsyncFunctionAssertions(Func<Task> subject, IExtractExceptions extractor, IClock clock)
         : base(subject, extractor, clock)
     {
@@ -92,7 +101,7 @@ public class NonGenericAsyncFunctionAssertions : AsyncFunctionAssertions<Task, N
         return new AndConstraint<NonGenericAsyncFunctionAssertions>(this);
     }
 
-        /// <summary>
+    /// <summary>
     /// Asserts that the current <see cref="Func{T}"/> stops throwing any exception
     /// after a specified amount of time.
     /// </summary>

--- a/Src/FluentAssertions/Specialized/NonGenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/NonGenericAsyncFunctionAssertions.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions.Common;
+using FluentAssertions.Execution;
 
 namespace FluentAssertions.Specialized;
 
@@ -14,5 +16,147 @@ public class NonGenericAsyncFunctionAssertions : AsyncFunctionAssertions<Task, N
     public NonGenericAsyncFunctionAssertions(Func<Task> subject, IExtractExceptions extractor, IClock clock)
         : base(subject, extractor, clock)
     {
+    }
+
+    /// <summary>
+    /// Asserts that the current <see cref="Task"/> will complete within the specified time.
+    /// </summary>
+    /// <param name="timeSpan">The allowed time span for the operation.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public async Task<AndConstraint<NonGenericAsyncFunctionAssertions>> CompleteWithinAsync(
+        TimeSpan timeSpan, string because = "", params object[] becauseArgs)
+    {
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:task} to complete within {0}{reason}, but found <null>.", timeSpan);
+
+        if (success)
+        {
+            (Task task, TimeSpan remainingTime) = InvokeWithTimer(timeSpan);
+
+            success = Execute.Assertion
+                .ForCondition(remainingTime >= TimeSpan.Zero)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
+
+            if (success)
+            {
+                bool completesWithinTimeout = await CompletesWithinTimeoutAsync(task, remainingTime);
+
+                Execute.Assertion
+                    .ForCondition(completesWithinTimeout)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
+            }
+        }
+
+        return new AndConstraint<NonGenericAsyncFunctionAssertions>(this);
+    }
+
+    /// <summary>
+    /// Asserts that the current <see cref="Func{Task}"/> does not throw any exception.
+    /// </summary>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public async Task<AndConstraint<NonGenericAsyncFunctionAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs)
+    {
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context} not to throw{reason}, but found <null>.");
+
+        if (success)
+        {
+            try
+            {
+                await Subject!.Invoke();
+            }
+            catch (Exception exception)
+            {
+                return NotThrowInternal(exception, because, becauseArgs);
+            }
+        }
+
+        return new AndConstraint<NonGenericAsyncFunctionAssertions>(this);
+    }
+
+        /// <summary>
+    /// Asserts that the current <see cref="Func{T}"/> stops throwing any exception
+    /// after a specified amount of time.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="Func{T}"/> is invoked. If it raises an exception,
+    /// the invocation is repeated until it either stops raising any exceptions
+    /// or the specified wait time is exceeded.
+    /// </remarks>
+    /// <param name="waitTime">
+    /// The time after which the <see cref="Func{T}"/> should have stopped throwing any exception.
+    /// </param>
+    /// <param name="pollInterval">
+    /// The time between subsequent invocations of the <see cref="Func{T}"/>.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="waitTime"/> or <paramref name="pollInterval"/> are negative.</exception>
+    public Task<AndConstraint<NonGenericAsyncFunctionAssertions>> NotThrowAfterAsync(TimeSpan waitTime, TimeSpan pollInterval, string because = "",
+        params object[] becauseArgs)
+    {
+        Guard.ThrowIfArgumentIsNegative(waitTime);
+        Guard.ThrowIfArgumentIsNegative(pollInterval);
+
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context} not to throw any exceptions after {0}{reason}, but found <null>.", waitTime);
+
+        if (success)
+        {
+            return AssertionTaskAsync();
+
+            async Task<AndConstraint<NonGenericAsyncFunctionAssertions>> AssertionTaskAsync()
+            {
+                TimeSpan? invocationEndTime = null;
+                Exception exception = null;
+                ITimer timer = Clock.StartTimer();
+
+                while (invocationEndTime is null || invocationEndTime < waitTime)
+                {
+                    exception = await InvokeWithInterceptionAsync(Subject);
+
+                    if (exception is null)
+                    {
+                        return new AndConstraint<NonGenericAsyncFunctionAssertions>(this);
+                    }
+
+                    await Clock.DelayAsync(pollInterval, CancellationToken.None);
+                    invocationEndTime = timer.Elapsed;
+                }
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Did not expect any exceptions after {0}{reason}, but found {1}.", waitTime, exception);
+
+                return new AndConstraint<NonGenericAsyncFunctionAssertions>(this);
+            }
+        }
+
+        return Task.FromResult(new AndConstraint<NonGenericAsyncFunctionAssertions>(this));
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2097,10 +2097,7 @@ namespace FluentAssertions.Specialized
     {
         protected AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
@@ -2198,6 +2195,9 @@ namespace FluentAssertions.Specialized
     {
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
     }
     public class TaskCompletionSourceAssertionsBase
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2095,12 +2095,7 @@ namespace FluentAssertions.Specialized
         where TTask : System.Threading.Tasks.Task
         where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
-        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
-            "e removed in Version 7.")]
-        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
-            "e made protected in Version 7.")]
-        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2218,10 +2218,7 @@ namespace FluentAssertions.Specialized
     {
         protected AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
@@ -2319,6 +2316,9 @@ namespace FluentAssertions.Specialized
     {
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
     }
     public class TaskCompletionSourceAssertions : FluentAssertions.Specialized.TaskCompletionSourceAssertionsBase
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2216,12 +2216,7 @@ namespace FluentAssertions.Specialized
         where TTask : System.Threading.Tasks.Task
         where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
-        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
-            "e removed in Version 7.")]
-        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
-            "e made protected in Version 7.")]
-        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2048,10 +2048,7 @@ namespace FluentAssertions.Specialized
     {
         protected AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
@@ -2149,6 +2146,9 @@ namespace FluentAssertions.Specialized
     {
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
     }
     public class TaskCompletionSourceAssertionsBase
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2046,12 +2046,7 @@ namespace FluentAssertions.Specialized
         where TTask : System.Threading.Tasks.Task
         where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
-        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
-            "e removed in Version 7.")]
-        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
-            "e made protected in Version 7.")]
-        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2097,10 +2097,7 @@ namespace FluentAssertions.Specialized
     {
         protected AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
@@ -2198,6 +2195,9 @@ namespace FluentAssertions.Specialized
     {
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
     }
     public class TaskCompletionSourceAssertionsBase
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2095,12 +2095,7 @@ namespace FluentAssertions.Specialized
         where TTask : System.Threading.Tasks.Task
         where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
-        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
-            "e removed in Version 7.")]
-        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        [System.Obsolete("This class is intended as base class. This ctor is accidentally public and will b" +
-            "e made protected in Version 7.")]
-        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,7 +14,7 @@ sidebar:
 ### Improvements
 
 ### Fixes
-* Fixed formatting error when checking nullable `DateTimeOffset` with 
+* Fixed formatting error when checking nullable `DateTimeOffset` with
 `BeWithin(...).Before(...)` - [#2312](https://github.com/fluentassertions/fluentassertions/pull/2312)
 * `BeEquivalentTo` will now find and can map subject properties that are implemented through an explicitly-implemented interface - [#2152](https://github.com/fluentassertions/fluentassertions/pull/2152)
 * Fixed that the `because` and `becauseArgs` were not passed down the equivalency tree - [#2318](https://github.com/fluentassertions/fluentassertions/pull/2318)
@@ -23,8 +23,8 @@ sidebar:
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)
 * Removed obsolete `...OrEqualTo` methods - [#2269](https://github.com/fluentassertions/fluentassertions/pull/2269)
   * `GenericCollectionAssertions`
-    * `HaveCountGreaterOrEqualTo`: Use `HaveCountGreaterThanOrEqualTo` 
-    * `HaveCountLessOrEqualTo`: Use `HaveCountLessThanOrEqualTo` 
+    * `HaveCountGreaterOrEqualTo`: Use `HaveCountGreaterThanOrEqualTo`
+    * `HaveCountLessOrEqualTo`: Use `HaveCountLessThanOrEqualTo`
   * `ComparableTypeAssertions`
     * `BeGreaterOrEqualTo`: Use `BeGreaterThanOrEqualTo`
     * `BeLessOrEqualTo`: Use `BeLessThanOrEqualTo`
@@ -41,6 +41,10 @@ sidebar:
 
 ### Breaking Changes (for extensions)
 * Add `ForConstraint` to `IAssertionsScope` to support chaining `.ForConstraint()` after `.Then` - [#2324](https://github.com/fluentassertions/fluentassertions/pull/2324)
+* Refactored `AsyncFunctionAssertions` into real base class - [#2359](https://github.com/fluentassertions/fluentassertions/pull/2359)
+  * Its constructor has been made `protected`.
+  * Unused constructors have been removed.
+  * Methods overwritten in `GenericAsyncFunctionAssertions` has been moved to `NonGenericAsyncFunctionAssertions`.
 
 ## 6.12.0
 

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -9,6 +9,7 @@ dotnet:
 exclude:
   - name: ConvertIfStatementToReturnStatement
   - name: ConvertIfStatementToConditionalTernaryExpression
+  - name: InvertIf
   - name: SimilarAnonymousTypeNearby
     paths:
       - Tests


### PR DESCRIPTION
As listed in #1677 and started in #1972, I converted AsyncFunctionAssertions into "real" base class (protected constructor).
Further, I moved some methods from base class into concrete class to prevent from overwriting (using `new` keyword).

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
