### PR TITLE
Move non-generic `NotThrow[After]` to `ActionAssertions`

### DIFF
--- a/Src/FluentAssertions/Specialized/ActionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ActionAssertions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using FluentAssertions.Common;
+using FluentAssertions.Execution;
 
 namespace FluentAssertions.Specialized;
 
@@ -18,6 +19,97 @@ public class ActionAssertions : DelegateAssertions<Action, ActionAssertions>
     public ActionAssertions(Action subject, IExtractExceptions extractor, IClock clock)
         : base(subject, extractor, clock)
     {
+    }
+
+    /// <summary>
+    /// Asserts that the current <see cref="Delegate" /> does not throw any exception.
+    /// </summary>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public AndConstraint<ActionAssertions> NotThrow(string because = "", params object[] becauseArgs)
+    {
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context} not to throw{reason}, but found <null>.");
+
+        if (success)
+        {
+            FailIfSubjectIsAsyncVoid();
+            Exception exception = InvokeSubjectWithInterception();
+            return NotThrowInternal(exception, because, becauseArgs);
+        }
+
+        return new AndConstraint<ActionAssertions>(this);
+    }
+
+    /// <summary>
+    /// Asserts that the current <see cref="Delegate"/> stops throwing any exception
+    /// after a specified amount of time.
+    /// </summary>
+    /// <remarks>
+    /// The delegate is invoked. If it raises an exception,
+    /// the invocation is repeated until it either stops raising any exceptions
+    /// or the specified wait time is exceeded.
+    /// </remarks>
+    /// <param name="waitTime">
+    /// The time after which the delegate should have stopped throwing any exception.
+    /// </param>
+    /// <param name="pollInterval">
+    /// The time between subsequent invocations of the delegate.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="waitTime"/> or <paramref name="pollInterval"/> are negative.</exception>
+    public AndConstraint<ActionAssertions> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "",
+        params object[] becauseArgs)
+    {
+        Guard.ThrowIfArgumentIsNegative(waitTime);
+        Guard.ThrowIfArgumentIsNegative(pollInterval);
+
+        bool success = Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context} not to throw after {0}{reason}, but found <null>.", waitTime);
+
+        if (success)
+        {
+            FailIfSubjectIsAsyncVoid();
+
+            TimeSpan? invocationEndTime = null;
+            Exception exception = null;
+            ITimer timer = Clock.StartTimer();
+
+            while (invocationEndTime is null || invocationEndTime < waitTime)
+            {
+                exception = InvokeSubjectWithInterception();
+
+                if (exception is null)
+                {
+                    break;
+                }
+
+                Clock.Delay(pollInterval);
+                invocationEndTime = timer.Elapsed;
+            }
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(exception is null)
+                .FailWith("Did not expect any exceptions after {0}{reason}, but found {1}.", waitTime, exception);
+        }
+
+        return new AndConstraint<ActionAssertions>(this);
     }
 
     protected override void InvokeSubject()

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -82,33 +82,6 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
     }
 
     /// <summary>
-    /// Asserts that the current <see cref="Delegate" /> does not throw any exception.
-    /// </summary>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-    /// </param>
-    public AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs)
-    {
-        bool success = Execute.Assertion
-            .ForCondition(Subject is not null)
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context} not to throw{reason}, but found <null>.");
-
-        if (success)
-        {
-            FailIfSubjectIsAsyncVoid();
-            Exception exception = InvokeSubjectWithInterception();
-            return NotThrowInternal(exception, because, becauseArgs);
-        }
-
-        return new AndConstraint<TAssertions>((TAssertions)this);
-    }
-
-    /// <summary>
     /// Asserts that the current <see cref="Delegate"/> throws an exception of the exact type <typeparamref name="TException"/> (and not a derived exception type).
     /// </summary>
     /// <typeparam name="TException">
@@ -153,73 +126,9 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
         return new ExceptionAssertions<TException>(Array.Empty<TException>());
     }
 
-    /// <summary>
-    /// Asserts that the current <see cref="Delegate"/> stops throwing any exception
-    /// after a specified amount of time.
-    /// </summary>
-    /// <remarks>
-    /// The delegate is invoked. If it raises an exception,
-    /// the invocation is repeated until it either stops raising any exceptions
-    /// or the specified wait time is exceeded.
-    /// </remarks>
-    /// <param name="waitTime">
-    /// The time after which the delegate should have stopped throwing any exception.
-    /// </param>
-    /// <param name="pollInterval">
-    /// The time between subsequent invocations of the delegate.
-    /// </param>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-    /// </param>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="waitTime"/> or <paramref name="pollInterval"/> are negative.</exception>
-    public AndConstraint<TAssertions> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "",
-        params object[] becauseArgs)
-    {
-        Guard.ThrowIfArgumentIsNegative(waitTime);
-        Guard.ThrowIfArgumentIsNegative(pollInterval);
-
-        bool success = Execute.Assertion
-            .ForCondition(Subject is not null)
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context} not to throw after {0}{reason}, but found <null>.", waitTime);
-
-        if (success)
-        {
-            FailIfSubjectIsAsyncVoid();
-
-            TimeSpan? invocationEndTime = null;
-            Exception exception = null;
-            ITimer timer = Clock.StartTimer();
-
-            while (invocationEndTime is null || invocationEndTime < waitTime)
-            {
-                exception = InvokeSubjectWithInterception();
-
-                if (exception is null)
-                {
-                    break;
-                }
-
-                Clock.Delay(pollInterval);
-                invocationEndTime = timer.Elapsed;
-            }
-
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(exception is null)
-                .FailWith("Did not expect any exceptions after {0}{reason}, but found {1}.", waitTime, exception);
-        }
-
-        return new AndConstraint<TAssertions>((TAssertions)this);
-    }
-
     protected abstract void InvokeSubject();
 
-    private Exception InvokeSubjectWithInterception()
+    private protected Exception InvokeSubjectWithInterception()
     {
         Exception actualException = null;
 
@@ -248,7 +157,7 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
         return actualException;
     }
 
-    private void FailIfSubjectIsAsyncVoid()
+    private protected void FailIfSubjectIsAsyncVoid()
     {
         if (Subject.GetMethodInfo().IsDecoratedWithOrInherit<AsyncStateMachineAttribute>())
         {

--- a/Src/FluentAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertions.cs
@@ -38,7 +38,7 @@ public class FunctionAssertions<T> : DelegateAssertions<Func<T>, FunctionAsserti
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public new AndWhichConstraint<FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs)
+    public AndWhichConstraint<FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs)
     {
         bool success = Execute.Assertion
             .ForCondition(Subject is not null)
@@ -78,7 +78,7 @@ public class FunctionAssertions<T> : DelegateAssertions<Func<T>, FunctionAsserti
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="waitTime"/> or <paramref name="pollInterval"/> are negative.</exception>
-    public new AndWhichConstraint<FunctionAssertions<T>, T> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval,
+    public AndWhichConstraint<FunctionAssertions<T>, T> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval,
         string because = "", params object[] becauseArgs)
     {
         bool success = Execute.Assertion

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2088,6 +2088,8 @@ namespace FluentAssertions.Specialized
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         protected override void InvokeSubject() { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ActionAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ActionAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
     public class AsyncFunctionAssertions<TTask, TAssertions> : FluentAssertions.Specialized.DelegateAssertionsBase<System.Func<TTask>, TAssertions>
         where TTask : System.Threading.Tasks.Task
@@ -2121,10 +2123,8 @@ namespace FluentAssertions.Specialized
     {
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         protected abstract void InvokeSubject();
-        public FluentAssertions.AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public FluentAssertions.AndConstraint<TAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2209,6 +2209,8 @@ namespace FluentAssertions.Specialized
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         protected override void InvokeSubject() { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ActionAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ActionAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
     public class AsyncFunctionAssertions<TTask, TAssertions> : FluentAssertions.Specialized.DelegateAssertionsBase<System.Func<TTask>, TAssertions>
         where TTask : System.Threading.Tasks.Task
@@ -2242,10 +2244,8 @@ namespace FluentAssertions.Specialized
     {
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         protected abstract void InvokeSubject();
-        public FluentAssertions.AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public FluentAssertions.AndConstraint<TAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2039,6 +2039,8 @@ namespace FluentAssertions.Specialized
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         protected override void InvokeSubject() { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ActionAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ActionAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
     public class AsyncFunctionAssertions<TTask, TAssertions> : FluentAssertions.Specialized.DelegateAssertionsBase<System.Func<TTask>, TAssertions>
         where TTask : System.Threading.Tasks.Task
@@ -2072,10 +2074,8 @@ namespace FluentAssertions.Specialized
     {
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         protected abstract void InvokeSubject();
-        public FluentAssertions.AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public FluentAssertions.AndConstraint<TAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2088,6 +2088,8 @@ namespace FluentAssertions.Specialized
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
         protected override void InvokeSubject() { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ActionAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ActionAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
     public class AsyncFunctionAssertions<TTask, TAssertions> : FluentAssertions.Specialized.DelegateAssertionsBase<System.Func<TTask>, TAssertions>
         where TTask : System.Threading.Tasks.Task
@@ -2121,10 +2123,8 @@ namespace FluentAssertions.Specialized
     {
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         protected abstract void InvokeSubject();
-        public FluentAssertions.AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public FluentAssertions.AndConstraint<TAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -48,6 +48,7 @@ sidebar:
   * Its constructor has been made `protected`.
   * Unused constructors have been removed.
   * Methods overwritten in `GenericAsyncFunctionAssertions` has been moved to `NonGenericAsyncFunctionAssertions`.
+* Moved the non-generic `NotThrow` and `NotThrowAfter` from `DelegateAssertions<TDelegate, TAssertions>` to `ActionAssertions` - [#2371](https://github.com/fluentassertions/fluentassertions/pull/2371)
 
 ## 6.12.0
 


### PR DESCRIPTION
Gid rid of more `new` modifiers.
Similar to what we did in #2359

On [grep.app](https://grep.app/search?q=DelegateAssertions&filter[repo][0]=kzrnm/ac-library-csharp) I found a single usage of `DelegateAssertions` and that used the generic `Throw<TException>` which does not change in this PR.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
