### PR TITLE
Use targeted methods instead of LINQ

### DIFF
--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -351,9 +351,7 @@ internal static class TypeExtensions
 
         // check subject's interfaces against definition
         return type.GetInterfaces()
-            .Where(i => i.IsGenericType)
-            .Select(i => i.GetGenericTypeDefinition())
-            .Contains(definition);
+            .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == definition);
     }
 
     public static bool IsDerivedFromOpenGeneric(this Type type, Type definition)

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -462,7 +462,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     {
         Guard.ThrowIfArgumentIsNull(interfaceType);
 
-        bool containsInterface = Subject.GetInterfaces().Contains(interfaceType);
+        bool containsInterface = interfaceType.IsAssignableFrom(Subject) && interfaceType != Subject;
 
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -511,7 +511,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     {
         Guard.ThrowIfArgumentIsNull(interfaceType);
 
-        bool containsInterface = Subject.GetInterfaces().Contains(interfaceType);
+        bool containsInterface = interfaceType.IsAssignableFrom(Subject) && interfaceType != Subject;
 
         Execute.Assertion
             .BecauseOf(because, becauseArgs)

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.Implement.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.Implement.cs
@@ -73,6 +73,20 @@ public partial class TypeAssertionSpecs
             act.Should().ThrowExactly<ArgumentNullException>()
                 .WithParameterName("interfaceType");
         }
+
+        [Fact]
+        public void An_interface_does_not_implement_itself()
+        {
+            // Arrange
+            var type = typeof(IDummyInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().Implement(typeof(IDummyInterface));
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
     }
 
     public class ImplementOfT
@@ -155,6 +169,16 @@ public partial class TypeAssertionSpecs
             // Assert
             act.Should().ThrowExactly<ArgumentNullException>()
                 .WithParameterName("interfaceType");
+        }
+
+        [Fact]
+        public void An_interface_does_not_implement_itself()
+        {
+            // Arrange
+            var type = typeof(IDummyInterface);
+
+            // Act / Assert
+            type.Should().NotImplement(typeof(IDummyInterface));
         }
     }
 


### PR DESCRIPTION
Inspired by https://github.com/fluentassertions/fluentassertions/pull/2358#discussion_r1355137402 I had a look at other places we work with interfaces.

I benchmarked the difference between `GetInterfaces().Contains` and `IsAssignableFrom`

| Method              | Mean     | Error    | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
|-------------------- |---------:|---------:|---------:|------:|-------:|----------:|------------:|
| GetInterfaces       | 24.97 ns | 0.290 ns | 0.257 ns |  1.00 | 0.0051 |      32 B |        1.00 |
| AssignableFrom      | 10.97 ns | 0.037 ns | 0.034 ns |  0.44 |      - |         - |        0.00 |
| GetInterfacesNoLinq | 14.35 ns | 0.261 ns | 0.244 ns |  0.58 | 0.0051 |      32 B |        1.00 |

<details>
<summary>benchmark code</summary>

```cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Jobs;
using BenchmarkDotNet.Running;
using System;
using System.Linq;

BenchmarkRunner.Run<ImplementsBenchmark>();

[SimpleJob(RuntimeMoniker.Net60)]
[ReturnValueValidator]
[MemoryDiagnoser]
public class ImplementsBenchmark
{
    [Params(typeof(Child))]
    public Type Subject { get; set; }

    [Params(typeof(I))]
    public Type Interface { get; set; }

    [Benchmark(Baseline = true)]
    public bool GetInterfaces() => Subject.GetInterfaces().Contains(Interface);

    [Benchmark]
    public bool AssignableFrom() => Interface.IsAssignableFrom(Subject) && Interface != Subject;

    [Benchmark]
    public bool GetInterfacesNoLinq()
    {
        foreach (var i in Subject.GetInterfaces())
        {
            if (i == Interface)
                return true;
        }

        return false;
    }
}

public class Child : Parent { }

public class Parent : I { }

public interface I { }
```

</details>


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
