### PR TITLE
Ignore ` UnusedMember.Global` Qodana scan rule and add missing tests

### DIFF
--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
@@ -69,5 +69,15 @@ public partial class CollectionAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
         }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().HaveCountGreaterThanOrEqualTo(3).And.Contain(1);
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
@@ -69,5 +69,15 @@ public partial class CollectionAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
         }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().HaveCountLessThanOrEqualTo(3).And.Contain(1);
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
@@ -556,6 +556,17 @@ public class ComparableSpecs
             // Assert
             act.Should().NotThrow();
         }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            var subject = new ComparableOfString("World");
+            var other = new ComparableOfString("World");
+
+            // Act / Assert
+            subject.Should().BeLessThanOrEqualTo(other).And.NotBeNull();
+        }
     }
 
     public class BeGreaterThan
@@ -649,6 +660,17 @@ public class ComparableSpecs
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            var subject = new ComparableOfString("def");
+            var other = new ComparableOfString("def");
+
+            // Act / Assert
+            subject.Should().BeGreaterThanOrEqualTo(other).And.NotBeNull();
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -784,6 +784,17 @@ public class NumericAssertionSpecs
                 .Should().Throw<ArgumentException>()
                 .WithMessage("*NaN*");
         }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            int value = 2;
+            int smallerValue = 1;
+
+            // Act / Assert
+            value.Should().BeGreaterThan(smallerValue).And.Be(2);
+        }
     }
 
     public class LessThanOrEqualTo
@@ -1030,6 +1041,17 @@ public class NumericAssertionSpecs
             act
                 .Should().Throw<ArgumentException>()
                 .WithMessage("*NaN*");
+        }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            int value = 1;
+            int greaterValue = 2;
+
+            // Act / Assert
+            value.Should().BeLessThanOrEqualTo(greaterValue).And.Be(1);
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -186,6 +186,16 @@ public class ObjectAssertionSpecs
             // Assert
             act.Should().Throw<ArgumentNullException>().WithParameterName("comparer");
         }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            var value = new SomeClass(3);
+
+            // Act / Assert
+            value.Should().Be(value).And.NotBeNull();
+        }
     }
 
     public class NotBe
@@ -314,6 +324,16 @@ public class ObjectAssertionSpecs
 
             // Assert
             act.Should().Throw<ArgumentNullException>().WithParameterName("comparer");
+        }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            var value = new SomeClass(3);
+
+            // Act / Assert
+            value.Should().NotBe(new SomeClass(3)).And.NotBeNull();
         }
     }
 
@@ -507,6 +527,16 @@ public class ObjectAssertionSpecs
 
             // Assert
             act.Should().Throw<ArgumentNullException>().WithParameterName("comparer");
+        }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            var value = new SomeClass(3);
+
+            // Act / Assert
+            value.Should().BeOneOf(value).And.NotBeNull();
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
@@ -358,6 +358,16 @@ public class SimpleTimeSpanAssertionSpecs
     }
 
     [Fact]
+    public void Chaining_after_one_assertion_1()
+    {
+        // Arrange
+        var twoSeconds = 2.Seconds();
+
+        // Act / Assert
+        twoSeconds.Should().BeGreaterThanOrEqualTo(twoSeconds).And.Be(2.Seconds());
+    }
+
+    [Fact]
     public void When_asserting_value_to_be_greater_than_or_equal_to_greater_value_it_should_fail()
     {
         // Arrange
@@ -462,6 +472,17 @@ public class SimpleTimeSpanAssertionSpecs
 
         // Act / Assert
         actual.Should().BeLessThanOrEqualTo(greater);
+    }
+
+    [Fact]
+    public void Chaining_after_one_assertion_2()
+    {
+        // Arrange
+        TimeSpan actual = 1.Seconds();
+        TimeSpan greater = 2.Seconds();
+
+        // Act / Assert
+        actual.Should().BeLessThanOrEqualTo(greater).And.Be(1.Seconds());
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
@@ -302,6 +302,16 @@ public class AssemblyAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage("Can't check for assembly signing if nullAssembly reference is <null>.");
         }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            var unsignedAssembly = FindAssembly.Stub("");
+
+            // Act & Assert
+            unsignedAssembly.Should().BeUnsigned().And.NotBeNull();
+        }
     }
 
     public class BeSignedWithPublicKey
@@ -361,6 +371,17 @@ public class AssemblyAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Can't check for assembly signing if nullAssembly reference is <null>.");
+        }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            var key = "0123456789ABCEF007";
+            var signedAssembly = FindAssembly.Stub(key);
+
+            // Act & Assert
+            signedAssembly.Should().BeSignedWithPublicKey(key).And.NotBeNull();
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -101,6 +101,18 @@ public class ExecutionTimeAssertionsSpecs
             act.Should().ThrowExactly<XunitException>()
                 .Which.Message.Should().Contain("{}").And.NotContain("{0}");
         }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            var subject = new SleepingClass();
+
+            // Act / Assert
+            subject.ExecutionTimeOf(s => s.Sleep(0))
+                .Should().BeLessThanOrEqualTo(500.Milliseconds())
+                .And.BeCloseTo(0.Seconds(), 500.Milliseconds());
+        }
     }
 
     public class BeLessThan
@@ -309,6 +321,18 @@ public class ExecutionTimeAssertionsSpecs
             // Assert
             act.Should().ThrowExactly<XunitException>()
                 .Which.Message.Should().Contain("{}").And.NotContain("{0}");
+        }
+
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            var subject = new SleepingClass();
+
+            // Act / Assert
+            subject.ExecutionTimeOf(s => s.Sleep(100))
+                .Should().BeGreaterThanOrEqualTo(50.Milliseconds())
+                .And.BeCloseTo(0.Seconds(), 500.Milliseconds());
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -5,7 +5,6 @@ using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
-
 using static FluentAssertions.FluentActions;
 
 namespace FluentAssertions.Specs.Specialized;
@@ -25,6 +24,38 @@ public static class TaskAssertionSpecs
 
             // Assert
             action.Should().NotThrow("the Subject should remain the same");
+        }
+    }
+
+    public class NotThrow
+    {
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            Func<Task<int>> subject = () => Task.FromResult(42);
+
+            // Act
+            Action action = () => subject.Should().Subject.As<object>().Should().BeSameAs(subject);
+
+            // Assert
+            action.Should().NotThrow("the Subject should remain the same").And.NotBeNull();
+        }
+    }
+
+    public class NotThrowAfter
+    {
+        [Fact]
+        public void Chaining_after_one_assertion()
+        {
+            // Arrange
+            Func<Task<int>> subject = () => Task.FromResult(42);
+
+            // Act
+            Action action = () => subject.Should().Subject.As<object>().Should().BeSameAs(subject);
+
+            // Assert
+            action.Should().NotThrowAfter(1.Seconds(), 1.Seconds()).And.NotBeNull();
         }
     }
 
@@ -99,6 +130,7 @@ public static class TaskAssertionSpecs
             // Act
             Func<Task> action = () =>
                 taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+
             timer.Complete();
 
             // Assert
@@ -214,6 +246,7 @@ public static class TaskAssertionSpecs
             Func<Task> testAction = async () =>
             {
                 using var _ = new AssertionScope();
+
                 await action.Should().ThrowAsync<InvalidOperationException>(
                     "because we want to test the failure {0}", "message");
             };
@@ -231,7 +264,7 @@ public static class TaskAssertionSpecs
             {
                 return
                     Awaiting(() => Task.FromException(new InvalidOperationException("foo")))
-                    .Should().ThrowAsync<InvalidOperationException>();
+                        .Should().ThrowAsync<InvalidOperationException>();
             };
 
             // Assert
@@ -246,7 +279,7 @@ public static class TaskAssertionSpecs
             {
                 return
                     Awaiting(() => Task.FromException(new NotSupportedException("foo")))
-                    .Should().ThrowAsync<InvalidOperationException>();
+                        .Should().ThrowAsync<InvalidOperationException>();
             };
 
             // Assert
@@ -263,7 +296,7 @@ public static class TaskAssertionSpecs
             {
                 return
                     Awaiting(() => Task.CompletedTask)
-                    .Should().ThrowAsync<InvalidOperationException>();
+                        .Should().ThrowAsync<InvalidOperationException>();
             };
 
             // Assert
@@ -299,6 +332,7 @@ public static class TaskAssertionSpecs
             Func<Task> testAction = async () =>
             {
                 using var _ = new AssertionScope();
+
                 await action.Should().ThrowWithinAsync<InvalidOperationException>(
                     100.Milliseconds(), "because we want to test the failure {0}", "message");
             };
@@ -368,6 +402,7 @@ public static class TaskAssertionSpecs
                 return Awaiting(() => (Task)taskFactory.Task)
                     .Should(timer).ThrowWithinAsync<InvalidOperationException>(1.Seconds());
             };
+
             _ = action.Invoke();
             taskFactory.SetException(new InvalidOperationException("foo"));
 
@@ -390,6 +425,7 @@ public static class TaskAssertionSpecs
                     .Should(timer).ThrowWithinAsync<InvalidOperationException>(
                         100.Ticks(), "because we want to test the failure {0}", "message");
             };
+
             timer.Delay(101.Ticks());
 
             // Assert
@@ -413,6 +449,7 @@ public static class TaskAssertionSpecs
                     .Awaiting(t => (Task)t.Task)
                     .Should(timer).ThrowWithinAsync<InvalidOperationException>(100.Milliseconds());
             };
+
             taskFactory.SetResult(true);
             timer.Complete();
 
@@ -435,6 +472,7 @@ public static class TaskAssertionSpecs
                     .Awaiting(t => (Task)t.Task)
                     .Should(timer).ThrowWithinAsync<InvalidOperationException>(100.Milliseconds());
             };
+
             taskFactory.SetException(new NotSupportedException("foo"));
 
             // Assert
@@ -456,6 +494,7 @@ public static class TaskAssertionSpecs
                 return Awaiting(() => (Task)taskFactory.Task)
                     .Should(timer).ThrowWithinAsync<InvalidOperationException>(1.Seconds());
             };
+
             _ = action.Invoke();
             taskFactory.SetException(new NotSupportedException("foo"));
 

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -20,3 +20,4 @@ exclude:
       - Tests/AssemblyB
       - Tests/Benchmarks
       - Tests/UWP.Specs
+  - name: UnusedMember.Global


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Qodana is failing due to "The number of problems exceeds the fail threshold".

This was a surprise to me, because no PR was merged which had other than "Qodana alright!"-messages.

As I dug into the logs (and also checked the uploaded results on qodana.cloud) I realized, that sometimes `develop` (with the correct fail threshold) and sometimes `refs/heads/develop` (which has a higher fail rate) is chosen from qodana. I couldn't figure out when this happens.. seems a little random to me.

As a possible solution we could try the hint from YouTrack: https://youtrack.jetbrains.com/issue/QD-7084/Getting-refs-heads-branch-instead-of-just-branch-Qodana-GitHub-Actions#focus=Comments-27-8090586.0-0

Note: 
 - I think the real impact will be seen only after this is merged.
 - The diffenences between this two branch reports are
![image](https://github.com/fluentassertions/fluentassertions/assets/44049228/6df26c59-8c88-4b5e-b9ae-34be81d54a5a)
However I also don't get why qodana reports this 🤔 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
