### PR TITLE
Add [NotNull] attribute on the Should() method for object assertions

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -18,6 +18,7 @@ using FluentAssertions.Streams;
 using FluentAssertions.Types;
 using FluentAssertions.Xml;
 using JetBrains.Annotations;
+using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 #if !NETSTANDARD2_0
 using FluentAssertions.Events;
 #endif
@@ -174,7 +175,7 @@ public static class AssertionExtensions
     /// current <see cref="Assembly"/>.
     /// </summary>
     [Pure]
-    public static AssemblyAssertions Should(this Assembly assembly)
+    public static AssemblyAssertions Should([NotNull] this Assembly assembly)
     {
         return new AssemblyAssertions(assembly);
     }
@@ -184,7 +185,7 @@ public static class AssertionExtensions
     /// current <see cref="XElement"/>.
     /// </summary>
     [Pure]
-    public static XDocumentAssertions Should(this XDocument actualValue)
+    public static XDocumentAssertions Should([NotNull] this XDocument actualValue)
     {
         return new XDocumentAssertions(actualValue);
     }
@@ -194,7 +195,7 @@ public static class AssertionExtensions
     /// current <see cref="XElement"/>.
     /// </summary>
     [Pure]
-    public static XElementAssertions Should(this XElement actualValue)
+    public static XElementAssertions Should([NotNull] this XElement actualValue)
     {
         return new XElementAssertions(actualValue);
     }
@@ -204,7 +205,7 @@ public static class AssertionExtensions
     /// current <see cref="XAttribute"/>.
     /// </summary>
     [Pure]
-    public static XAttributeAssertions Should(this XAttribute actualValue)
+    public static XAttributeAssertions Should([NotNull] this XAttribute actualValue)
     {
         return new XAttributeAssertions(actualValue);
     }
@@ -214,7 +215,7 @@ public static class AssertionExtensions
     /// current <see cref="Stream"/>.
     /// </summary>
     [Pure]
-    public static StreamAssertions Should(this Stream actualValue)
+    public static StreamAssertions Should([NotNull] this Stream actualValue)
     {
         return new StreamAssertions(actualValue);
     }
@@ -224,7 +225,7 @@ public static class AssertionExtensions
     /// current <see cref="BufferedStream"/>.
     /// </summary>
     [Pure]
-    public static BufferedStreamAssertions Should(this BufferedStream actualValue)
+    public static BufferedStreamAssertions Should([NotNull] this BufferedStream actualValue)
     {
         return new BufferedStreamAssertions(actualValue);
     }
@@ -281,7 +282,7 @@ public static class AssertionExtensions
     /// current <see cref="object"/>.
     /// </summary>
     [Pure]
-    public static ObjectAssertions Should(this object actualValue)
+    public static ObjectAssertions Should([NotNull] this object actualValue)
     {
         return new ObjectAssertions(actualValue);
     }
@@ -311,7 +312,7 @@ public static class AssertionExtensions
     /// current <see cref="HttpResponseMessage"/>.
     /// </summary>
     [Pure]
-    public static HttpResponseMessageAssertions Should(this HttpResponseMessage actualValue)
+    public static HttpResponseMessageAssertions Should([NotNull] this HttpResponseMessage actualValue)
     {
         return new HttpResponseMessageAssertions(actualValue);
     }
@@ -341,7 +342,7 @@ public static class AssertionExtensions
     /// current <see cref="IEnumerable{T}"/>.
     /// </summary>
     [Pure]
-    public static GenericCollectionAssertions<T> Should<T>(this IEnumerable<T> actualValue)
+    public static GenericCollectionAssertions<T> Should<T>([NotNull] this IEnumerable<T> actualValue)
     {
         return new GenericCollectionAssertions<T>(actualValue);
     }
@@ -351,7 +352,7 @@ public static class AssertionExtensions
     /// current <see cref="IEnumerable{T}"/>.
     /// </summary>
     [Pure]
-    public static StringCollectionAssertions Should(this IEnumerable<string> @this)
+    public static StringCollectionAssertions Should([NotNull] this IEnumerable<string> @this)
     {
         return new StringCollectionAssertions(@this);
     }
@@ -362,7 +363,7 @@ public static class AssertionExtensions
     /// </summary>
     [Pure]
     public static GenericDictionaryAssertions<IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(
-        this IDictionary<TKey, TValue> actualValue)
+        [NotNull] this IDictionary<TKey, TValue> actualValue)
     {
         return new GenericDictionaryAssertions<IDictionary<TKey, TValue>, TKey, TValue>(actualValue);
     }
@@ -373,7 +374,7 @@ public static class AssertionExtensions
     /// </summary>
     [Pure]
     public static GenericDictionaryAssertions<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(
-        this IEnumerable<KeyValuePair<TKey, TValue>> actualValue)
+        [NotNull] this IEnumerable<KeyValuePair<TKey, TValue>> actualValue)
     {
         return new GenericDictionaryAssertions<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue>(actualValue);
     }
@@ -384,7 +385,7 @@ public static class AssertionExtensions
     /// </summary>
     [Pure]
     public static GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(
-        this TCollection actualValue)
+        [NotNull] this TCollection actualValue)
         where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
     {
         return new GenericDictionaryAssertions<TCollection, TKey, TValue>(actualValue);
@@ -478,7 +479,7 @@ public static class AssertionExtensions
     /// current <see cref="IComparable{T}"/>.
     /// </summary>
     [Pure]
-    public static ComparableTypeAssertions<T> Should<T>(this IComparable<T> comparableValue)
+    public static ComparableTypeAssertions<T> Should<T>([NotNull] this IComparable<T> comparableValue)
     {
         return new ComparableTypeAssertions<T>(comparableValue);
     }
@@ -708,7 +709,7 @@ public static class AssertionExtensions
     /// current <see cref="string"/>.
     /// </summary>
     [Pure]
-    public static StringAssertions Should(this string actualValue)
+    public static StringAssertions Should([NotNull] this string actualValue)
     {
         return new StringAssertions(actualValue);
     }
@@ -738,7 +739,7 @@ public static class AssertionExtensions
     /// current <see cref="System.Type"/>.
     /// </summary>
     [Pure]
-    public static TypeAssertions Should(this Type subject)
+    public static TypeAssertions Should([NotNull] this Type subject)
     {
         return new TypeAssertions(subject);
     }
@@ -762,7 +763,7 @@ public static class AssertionExtensions
     /// </summary>
     /// <seealso cref="TypeAssertions"/>
     [Pure]
-    public static ConstructorInfoAssertions Should(this ConstructorInfo constructorInfo)
+    public static ConstructorInfoAssertions Should([NotNull] this ConstructorInfo constructorInfo)
     {
         return new ConstructorInfoAssertions(constructorInfo);
     }
@@ -772,7 +773,7 @@ public static class AssertionExtensions
     /// </summary>
     /// <seealso cref="TypeAssertions"/>
     [Pure]
-    public static MethodInfoAssertions Should(this MethodInfo methodInfo)
+    public static MethodInfoAssertions Should([NotNull] this MethodInfo methodInfo)
     {
         return new MethodInfoAssertions(methodInfo);
     }
@@ -797,7 +798,7 @@ public static class AssertionExtensions
     /// </summary>
     /// <seealso cref="TypeAssertions"/>
     [Pure]
-    public static PropertyInfoAssertions Should(this PropertyInfo propertyInfo)
+    public static PropertyInfoAssertions Should([NotNull] this PropertyInfo propertyInfo)
     {
         return new PropertyInfoAssertions(propertyInfo);
     }
@@ -821,7 +822,7 @@ public static class AssertionExtensions
     /// current <see cref="System.Action"/>.
     /// </summary>
     [Pure]
-    public static ActionAssertions Should(this Action action)
+    public static ActionAssertions Should([NotNull] this Action action)
     {
         return new ActionAssertions(action, Extractor);
     }
@@ -831,7 +832,7 @@ public static class AssertionExtensions
     /// current <see cref="System.Func{Task}"/>.
     /// </summary>
     [Pure]
-    public static NonGenericAsyncFunctionAssertions Should(this Func<Task> action)
+    public static NonGenericAsyncFunctionAssertions Should([NotNull] this Func<Task> action)
     {
         return new NonGenericAsyncFunctionAssertions(action, Extractor);
     }
@@ -841,7 +842,7 @@ public static class AssertionExtensions
     /// current <see><cref>System.Func{Task{T}}</cref></see>.
     /// </summary>
     [Pure]
-    public static GenericAsyncFunctionAssertions<T> Should<T>(this Func<Task<T>> action)
+    public static GenericAsyncFunctionAssertions<T> Should<T>([NotNull] this Func<Task<T>> action)
     {
         return new GenericAsyncFunctionAssertions<T>(action, Extractor);
     }
@@ -851,7 +852,7 @@ public static class AssertionExtensions
     /// current <see cref="System.Func{T}"/>.
     /// </summary>
     [Pure]
-    public static FunctionAssertions<T> Should<T>(this Func<T> func)
+    public static FunctionAssertions<T> Should<T>([NotNull] this Func<T> func)
     {
         return new FunctionAssertions<T>(func, Extractor);
     }

--- a/Src/FluentAssertions/XmlAssertionExtensions.cs
+++ b/Src/FluentAssertions/XmlAssertionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Xml;
 using FluentAssertions.Xml;
 
@@ -7,12 +8,12 @@ namespace FluentAssertions;
 [DebuggerNonUserCode]
 public static class XmlAssertionExtensions
 {
-    public static XmlNodeAssertions Should(this XmlNode actualValue)
+    public static XmlNodeAssertions Should([NotNull] this XmlNode actualValue)
     {
         return new XmlNodeAssertions(actualValue);
     }
 
-    public static XmlElementAssertions Should(this XmlElement actualValue)
+    public static XmlElementAssertions Should([NotNull] this XmlElement actualValue)
     {
         return new XmlElementAssertions(actualValue);
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -57,28 +57,28 @@ namespace FluentAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this FluentAssertions.Types.TypeSelectorAssertions _) { }
-        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
-        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<string> @this) { }
         public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
-        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
-        public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
-        public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
-        public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should(this System.Net.Http.HttpResponseMessage actualValue) { }
-        public static FluentAssertions.Types.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
-        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
-        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
-        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
+        public static FluentAssertions.Streams.StreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.Stream actualValue) { }
+        public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Net.Http.HttpResponseMessage actualValue) { }
+        public static FluentAssertions.Types.AssemblyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
         public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
         public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
-        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
-        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
-        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
-        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XElement actualValue) { }
         public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
         public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
@@ -93,12 +93,12 @@ namespace FluentAssertions
         public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
-        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this object actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
-        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this string actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
@@ -133,10 +133,10 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
-        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
-        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
-        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
@@ -152,9 +152,9 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TSubject, TAssertions>(this FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(this TCollection actualValue)
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this TCollection actualValue)
             where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
     }
     public static class AssertionOptions
@@ -359,8 +359,8 @@ namespace FluentAssertions
     }
     public static class XmlAssertionExtensions
     {
-        public static FluentAssertions.Xml.XmlElementAssertions Should(this System.Xml.XmlElement actualValue) { }
-        public static FluentAssertions.Xml.XmlNodeAssertions Should(this System.Xml.XmlNode actualValue) { }
+        public static FluentAssertions.Xml.XmlElementAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.XmlElement actualValue) { }
+        public static FluentAssertions.Xml.XmlNodeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.XmlNode actualValue) { }
     }
 }
 namespace FluentAssertions.Collections

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -57,33 +57,33 @@ namespace FluentAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this FluentAssertions.Types.TypeSelectorAssertions _) { }
-        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
-        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<string> @this) { }
         public static FluentAssertions.Primitives.DateOnlyAssertions Should(this System.DateOnly actualValue) { }
         public static FluentAssertions.Primitives.NullableDateOnlyAssertions Should(this System.DateOnly? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
-        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
-        public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
-        public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
-        public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should(this System.Net.Http.HttpResponseMessage actualValue) { }
-        public static FluentAssertions.Types.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
-        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
-        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
-        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
+        public static FluentAssertions.Streams.StreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.Stream actualValue) { }
+        public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Net.Http.HttpResponseMessage actualValue) { }
+        public static FluentAssertions.Types.AssemblyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions Should(this System.Threading.Tasks.TaskCompletionSource tcs) { }
         public static FluentAssertions.Primitives.TimeOnlyAssertions Should(this System.TimeOnly actualValue) { }
         public static FluentAssertions.Primitives.NullableTimeOnlyAssertions Should(this System.TimeOnly? actualValue) { }
         public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
         public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
-        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
-        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
-        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
-        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XElement actualValue) { }
         public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
         public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
@@ -98,12 +98,12 @@ namespace FluentAssertions
         public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
-        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this object actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
-        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this string actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
@@ -146,10 +146,10 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions> { }
-        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
-        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
-        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
@@ -165,9 +165,9 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TSubject, TAssertions>(this FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(this TCollection actualValue)
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this TCollection actualValue)
             where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
     }
     public static class AssertionOptions
@@ -372,8 +372,8 @@ namespace FluentAssertions
     }
     public static class XmlAssertionExtensions
     {
-        public static FluentAssertions.Xml.XmlElementAssertions Should(this System.Xml.XmlElement actualValue) { }
-        public static FluentAssertions.Xml.XmlNodeAssertions Should(this System.Xml.XmlNode actualValue) { }
+        public static FluentAssertions.Xml.XmlElementAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.XmlElement actualValue) { }
+        public static FluentAssertions.Xml.XmlNodeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.XmlNode actualValue) { }
     }
 }
 namespace FluentAssertions.Collections

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -56,28 +56,28 @@ namespace FluentAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this FluentAssertions.Types.TypeSelectorAssertions _) { }
-        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
-        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<string> @this) { }
         public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
-        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
-        public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
-        public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
-        public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should(this System.Net.Http.HttpResponseMessage actualValue) { }
-        public static FluentAssertions.Types.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
-        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
-        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
-        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
+        public static FluentAssertions.Streams.StreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.Stream actualValue) { }
+        public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Net.Http.HttpResponseMessage actualValue) { }
+        public static FluentAssertions.Types.AssemblyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
         public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
         public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
-        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
-        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
-        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
-        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XElement actualValue) { }
         public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
         public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
@@ -92,12 +92,12 @@ namespace FluentAssertions
         public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
-        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this object actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
-        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this string actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
@@ -132,10 +132,10 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
-        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
-        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
-        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
@@ -151,9 +151,9 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TSubject, TAssertions>(this FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(this TCollection actualValue)
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this TCollection actualValue)
             where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
     }
     public static class AssertionOptions
@@ -352,8 +352,8 @@ namespace FluentAssertions
     }
     public static class XmlAssertionExtensions
     {
-        public static FluentAssertions.Xml.XmlElementAssertions Should(this System.Xml.XmlElement actualValue) { }
-        public static FluentAssertions.Xml.XmlNodeAssertions Should(this System.Xml.XmlNode actualValue) { }
+        public static FluentAssertions.Xml.XmlElementAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.XmlElement actualValue) { }
+        public static FluentAssertions.Xml.XmlNodeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.XmlNode actualValue) { }
     }
 }
 namespace FluentAssertions.Collections

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -57,28 +57,28 @@ namespace FluentAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this FluentAssertions.Types.TypeSelectorAssertions _) { }
-        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
-        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<string> @this) { }
         public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
-        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
-        public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
-        public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
-        public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should(this System.Net.Http.HttpResponseMessage actualValue) { }
-        public static FluentAssertions.Types.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
-        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
-        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
-        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
+        public static FluentAssertions.Streams.StreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.Stream actualValue) { }
+        public static FluentAssertions.Primitives.HttpResponseMessageAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Net.Http.HttpResponseMessage actualValue) { }
+        public static FluentAssertions.Types.AssemblyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
         public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
         public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
-        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
-        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
-        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
-        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XElement actualValue) { }
         public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
         public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
@@ -93,12 +93,12 @@ namespace FluentAssertions
         public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
-        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this object actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
-        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this string actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
         public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
         public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
@@ -133,10 +133,10 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
-        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
-        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
-        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
@@ -152,9 +152,9 @@ namespace FluentAssertions
             "ly following \'And\'", true)]
         public static void Should<TSubject, TAssertions>(this FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> _)
             where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(this TCollection actualValue)
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this TCollection actualValue)
             where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
     }
     public static class AssertionOptions
@@ -359,8 +359,8 @@ namespace FluentAssertions
     }
     public static class XmlAssertionExtensions
     {
-        public static FluentAssertions.Xml.XmlElementAssertions Should(this System.Xml.XmlElement actualValue) { }
-        public static FluentAssertions.Xml.XmlNodeAssertions Should(this System.Xml.XmlNode actualValue) { }
+        public static FluentAssertions.Xml.XmlElementAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.XmlElement actualValue) { }
+        public static FluentAssertions.Xml.XmlNodeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.XmlNode actualValue) { }
     }
 }
 namespace FluentAssertions.Collections

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -20,6 +20,7 @@ sidebar:
 * Improve failure message for string assertions when checking for equality - [#2307](https://github.com/fluentassertions/fluentassertions/pull/2307)
 * You can mark all assertions in an assembly as custom assertions using the `[CustomAssertionsAssembly]` attribute - [#2389](https://github.com/fluentassertions/fluentassertions/pull/2389)
 * Improve `BeEmpty()` and `BeNullOrEmpty()` performance for `IEnumerable<T>`, by materializing only the first item - [#2530](https://github.com/fluentassertions/fluentassertions/pull/2530)
+* All `Should()` methods on reference types are now annotated with the `[NotNull]` attribute for a better Fluent Assertions experience when nullable reference types are enabled - [#2380](https://github.com/fluentassertions/fluentassertions/pull/2380)
 
 ### Fixes
 * Fixed formatting error when checking nullable `DateTimeOffset` with


### PR DESCRIPTION
Compelling example:

```csharp
[Theory]
[InlineData(true)]
[InlineData(false)]
public void Test1(bool currentUser)
{
    IPrincipal principal = currentUser ? new WindowsPrincipal(WindowsIdentity.GetCurrent()) : new ClaimsPrincipal();
    IIdentity? identity = principal.Identity;
    
    identity.Should().NotBeOfType<GenericIdentity>();
    identity.IsAuthenticated.Should().BeFalse();
}
```

Fixes #1115