### PR TITLE
Simplify the ApiApproval test

### DIFF
--- a/Tests/Approval.Tests/ApiApproval.cs
+++ b/Tests/Approval.Tests/ApiApproval.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -23,19 +23,9 @@ public class ApiApproval
     [ClassData(typeof(TargetFrameworksTheoryData))]
     public Task ApproveApi(string frameworkVersion)
     {
-        string codeBase = Assembly.GetExecutingAssembly().Location;
-        var uri = new UriBuilder(new Uri(codeBase));
-        string assemblyPath = Uri.UnescapeDataString(uri.Path);
-        var containingDirectory = Path.GetDirectoryName(assemblyPath);
-        var configurationName = new DirectoryInfo(containingDirectory).Parent.Name;
-
-        var assemblyFile = Path.GetFullPath(
-            Path.Combine(
-                GetSourceDirectory(),
-                Path.Combine("..", "..", "Src", "FluentAssertions", "bin", configurationName, frameworkVersion,
-                    "FluentAssertions.dll")));
-
-        var assembly = Assembly.LoadFile(Path.GetFullPath(assemblyFile));
+        var configuration = typeof(ApiApproval).Assembly.GetCustomAttribute<AssemblyConfigurationAttribute>()!.Configuration;
+        var assemblyFile = GetPath("Src", "FluentAssertions", "bin", configuration, frameworkVersion, "FluentAssertions.dll");
+        var assembly = Assembly.LoadFile(assemblyFile);
         var publicApi = assembly.GeneratePublicApi(options: null);
 
         return Verifier
@@ -47,7 +37,9 @@ public class ApiApproval
             .DisableDiff();
     }
 
-    private static string GetSourceDirectory([CallerFilePath] string path = "") => Path.GetDirectoryName(path);
+    private static string GetSolutionDirectory([CallerFilePath] string path = "") => Path.Combine(Path.GetDirectoryName(path)!, "..", "..");
+
+    private static string GetPath(params string[] paths) => Path.GetFullPath(Path.Combine(paths.Prepend(GetSolutionDirectory()).ToArray()));
 
     // Copied from https://github.com/VerifyTests/Verify.DiffPlex/blob/master/src/Verify.DiffPlex/VerifyDiffPlex.cs
     public static Task<CompareResult> OnlyIncludeChanges(string received, string verified, IReadOnlyDictionary<string, object> _)
@@ -82,9 +74,7 @@ public class ApiApproval
     {
         public TargetFrameworksTheoryData()
         {
-            var csproj = Path.Combine(GetSourceDirectory(),
-                Path.Combine("..", "..", "Src", "FluentAssertions", "FluentAssertions.csproj"));
-
+            var csproj = GetPath("Src", "FluentAssertions", "FluentAssertions.csproj");
             var project = XDocument.Load(csproj);
             var targetFrameworks = project.XPathSelectElement("/Project/PropertyGroup/TargetFrameworks");
 

--- a/Tests/Approval.Tests/ApiApproval.cs
+++ b/Tests/Approval.Tests/ApiApproval.cs
@@ -16,7 +16,7 @@ namespace Approval.Tests;
 [UsesVerify]
 public class ApiApproval
 {
-    static ApiApproval() => VerifyDiffPlex.Initialize(OutputType.Compact);
+    static ApiApproval() => VerifyDiffPlex.Initialize(OutputType.Minimal);
 
     [Theory]
     [ClassData(typeof(TargetFrameworksTheoryData))]

--- a/Tests/Approval.Tests/Approval.Tests.csproj
+++ b/Tests/Approval.Tests/Approval.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
-    <PackageReference Include="Verify.DiffPlex" Version="2.2.1" />
+    <PackageReference Include="Verify.DiffPlex" Version="2.3.0" />
     <PackageReference Include="Verify.Xunit" Version="22.1.4" />
   </ItemGroup>
 


### PR DESCRIPTION
* Simplify how paths relative to the solution directory are accessed.
* Actually use the Verify.DiffPlex integration instead of using DiffPlex directly.
