### PR TITLE
Allow specifying the build configuration.

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -6,6 +6,14 @@
     "build": {
       "type": "object",
       "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "The solution configuration to build. Default is 'Debug' (local) or 'CI' (server)",
+          "enum": [
+            "CI",
+            "Debug"
+          ]
+        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -40,6 +40,9 @@ class Build : NukeBuild
 
     string PullRequestBase => GitHubActions?.BaseRef;
 
+    [Parameter("The solution configuration to build. Default is 'Debug' (local) or 'CI' (server).")]
+    readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.CI;
+
     [Parameter("Use this parameter if you encounter build problems in any way, " +
         "to generate a .binlog file which holds some useful information.")]
     readonly bool? GenerateBinLog;
@@ -126,7 +129,7 @@ class Build : NukeBuild
 
             DotNetBuild(s => s
                 .SetProjectFile(Solution)
-                .SetConfiguration(Configuration.CI)
+                .SetConfiguration(Configuration)
                 .When(GenerateBinLog is true, _ => _
                     .SetBinaryLog(ArtifactsDirectory / $"{Solution.Core.FluentAssertions.Name}.binlog")
                 )
@@ -145,7 +148,7 @@ class Build : NukeBuild
             Project project = Solution.Specs.Approval_Tests;
 
             DotNetTest(s => s
-                .SetConfiguration(Configuration.Release)
+                .SetConfiguration(Configuration == Configuration.Debug ? "Debug" : "Release")
                 .SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
                 .EnableNoBuild()
                 .SetResultsDirectory(TestResultsDirectory)
@@ -318,7 +321,7 @@ class Build : NukeBuild
             DotNetPack(s => s
                 .SetProject(Solution.Core.FluentAssertions)
                 .SetOutputDirectory(ArtifactsDirectory)
-                .SetConfiguration(Configuration.Release)
+                .SetConfiguration(Configuration == Configuration.Debug ? "Debug" : "Release")
                 .EnableNoLogo()
                 .EnableNoRestore()
                 .EnableContinuousIntegrationBuild() // Necessary for deterministic builds

--- a/Build/Configuration.cs
+++ b/Build/Configuration.cs
@@ -4,11 +4,9 @@ using Nuke.Common.Tooling;
 [TypeConverter(typeof(TypeConverter<Configuration>))]
 public class Configuration : Enumeration
 {
-    public static Configuration Debug { get; } = new() { Value = nameof(Debug) };
+    public static Configuration Debug = new() { Value = nameof(Debug) };
 
-    public static Configuration Release { get; } = new() { Value = nameof(Release) };
-
-    public static Configuration CI { get; } = new() { Value = nameof(CI) };
+    public static Configuration CI = new() { Value = nameof(CI) };
 
     public static implicit operator string(Configuration configuration)
     {


### PR DESCRIPTION
1. Made the solution build configuration a build parameter
2. Use the `Debug` configuration for a local build
3. Use the `CI` configuration on a server

Needed this to get a local package for testing #2002 
