### PR TITLE
Add missing chaining test for "Method return value is never used"

### DIFF
--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -793,7 +793,7 @@ public class NumericAssertionSpecs
             int smallerValue = 1;
 
             // Act / Assert
-            value.Should().BeGreaterThan(smallerValue).And.Be(2);
+            value.Should().BeGreaterThanOrEqualTo(smallerValue).And.Be(2);
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -196,6 +196,16 @@ public class ObjectAssertionSpecs
             // Act / Assert
             value.Should().Be(value).And.NotBeNull();
         }
+
+        [Fact]
+        public void Can_chain_multiple_assertions()
+        {
+            // Arrange
+            var value = new object();
+
+            // Act / Assert
+            value.Should().Be<object>(value, new DumbObjectEqualityComparer()).And.NotBeNull();
+        }
     }
 
     public class NotBe
@@ -334,6 +344,16 @@ public class ObjectAssertionSpecs
 
             // Act / Assert
             value.Should().NotBe(new SomeClass(3)).And.NotBeNull();
+        }
+
+        [Fact]
+        public void Can_chain_multiple_assertions()
+        {
+            // Arrange
+            var value = new object();
+
+            // Act / Assert
+            value.Should().NotBe<object>(new object(), new DumbObjectEqualityComparer()).And.NotBeNull();
         }
     }
 
@@ -537,6 +557,16 @@ public class ObjectAssertionSpecs
 
             // Act / Assert
             value.Should().BeOneOf(value).And.NotBeNull();
+        }
+
+        [Fact]
+        public void Can_chain_multiple_assertions()
+        {
+            // Arrange
+            var value = new object();
+
+            // Act / Assert
+            value.Should().BeOneOf<object>(new[] { value }, new DumbObjectEqualityComparer()).And.NotBeNull();
         }
     }
 
@@ -1509,6 +1539,13 @@ internal class SomeClass
     public int Key { get; }
 
     public override string ToString() => $"SomeClass({Key})";
+}
+
+internal class DumbObjectEqualityComparer : IEqualityComparer<object>
+{
+    public new bool Equals(object x, object y) => x.Equals(y);
+
+    public int GetHashCode(object obj) => obj.GetHashCode();
 }
 
 internal class SomeClassEqualityComparer : IEqualityComparer<SomeClass>

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,7 +1,7 @@
 version: "1.0"
 
 linter: jetbrains/qodana-dotnet:latest
-failThreshold: 57
+failThreshold: 13
 
 dotnet:
   solution: FluentAssertions.sln


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
