### PR TITLE
Capitalize true and false in failure messages

### DIFF
--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -51,7 +51,7 @@ public class BooleanAssertions<TAssertions>
         Execute.Assertion
             .ForCondition(Subject == false)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:boolean} to be false{reason}, but found {0}.", Subject);
+            .FailWith("Expected {context:boolean} to be False{reason}, but found {0}.", Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -71,7 +71,7 @@ public class BooleanAssertions<TAssertions>
         Execute.Assertion
             .ForCondition(Subject == true)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:boolean} to be true{reason}, but found {0}.", Subject);
+            .FailWith("Expected {context:boolean} to be True{reason}, but found {0}.", Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -41,7 +41,7 @@ public class BooleanAssertionSpecs
             // Assert
             action
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected boolean to be true because we want to test the failure message, but found False.");
+                .WithMessage("Expected boolean to be True because we want to test the failure message, but found False.");
         }
     }
 
@@ -78,7 +78,7 @@ public class BooleanAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected boolean to be false because we want to test the failure message, but found True.");
+                .WithMessage("Expected boolean to be False because we want to test the failure message, but found True.");
         }
     }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -21,7 +21,7 @@ sidebar:
 * Fixed that the `because` and `becauseArgs` were not passed down the equivalency tree - [#2318](https://github.com/fluentassertions/fluentassertions/pull/2318)
 * `BeEquivalentTo` can again compare a non-generic `IDictionary` with a generic one - [#2358](https://github.com/fluentassertions/fluentassertions/pull/23158)
 * Fixed that the `FormattingOptions` were not respected in inner `AssertionScope` - [#2328](https://github.com/fluentassertions/fluentassertions/pull/2328)
-
+* Capitalize `true` and `false` in failure messages - [#2390](https://github.com/fluentassertions/fluentassertions/pull/2390)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION
Display `true` and `false` as capitalized rather than in lowercase so that both expected value and actual value uses the same casing. 

**Before**: `Expected boolean to be false, but found True.`
**After**:   `Expected boolean to be False, but found True.`

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [X] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [X] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
