### PR TITLE
Pass Boolean literals as becauseArguments

### DIFF
--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -51,7 +51,7 @@ public class BooleanAssertions<TAssertions>
         Execute.Assertion
             .ForCondition(Subject == false)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:boolean} to be False{reason}, but found {0}.", Subject);
+            .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", false, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -71,7 +71,7 @@ public class BooleanAssertions<TAssertions>
         Execute.Assertion
             .ForCondition(Subject == true)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:boolean} to be True{reason}, but found {0}.", Subject);
+            .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", true, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }


### PR DESCRIPTION
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
