### PR TITLE
Do not continue asserting on the concrete exception type when the exception is `null`

### DIFF
--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -91,12 +91,15 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         {
             Exception exception = await InvokeWithInterceptionAsync(Subject);
 
-            Execute.Assertion
+            success = Execute.Assertion
                 .ForCondition(exception is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but no exception was thrown.", expectedType);
 
-            exception.Should().BeOfType(expectedType, because, becauseArgs);
+            if (success)
+            {
+                exception.Should().BeOfType(expectedType, because, becauseArgs);
+            }
 
             return new ExceptionAssertions<TException>(new[] { exception as TException });
         }

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -113,12 +113,15 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
 
             Type expectedType = typeof(TException);
 
-            Execute.Assertion
+            success = Execute.Assertion
                 .ForCondition(exception is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but no exception was thrown.", expectedType);
 
-            exception.Should().BeOfType(expectedType, because, becauseArgs);
+            if (success)
+            {
+                exception.Should().BeOfType(expectedType, because, becauseArgs);
+            }
 
             return new ExceptionAssertions<TException>(new[] { exception as TException });
         }

--- a/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions.Execution;
 using FluentAssertions.Specialized;
 using Xunit;
 
@@ -33,5 +35,23 @@ public class DelegateAssertionSpecs
         // Act
         act.Should().ThrowExactly<ArgumentNullException>()
             .WithParameterName("clock");
+    }
+
+    public class ThrowExactly
+    {
+        [Fact]
+        public void Does_not_continue_assertion_on_exact_exception_type()
+        {
+            // Arrange
+            var a = () => { };
+
+            // Act
+            using var scope = new AssertionScope();
+            a.Should().ThrowExactly<InvalidOperationException>();
+
+            // Assert
+            scope.Discard().Should().ContainSingle()
+                .Which.Should().Match("*InvalidOperationException*no exception*");
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
+using FluentAssertions.Specialized;
 using Xunit;
 using Xunit.Sdk;
 using static FluentAssertions.FluentActions;
@@ -502,6 +503,24 @@ public static class TaskAssertionSpecs
             await action.Should().ThrowAsync<XunitException>().WithMessage(
                 "Expected a <System.InvalidOperationException> to be thrown within 1s,"
                 + " but found <System.NotSupportedException>:*foo*");
+        }
+    }
+
+    public class ThrowExactlyAsync
+    {
+        [Fact]
+        public async Task Does_not_continue_assertion_on_exact_exception_type()
+        {
+            // Arrange
+            var a = () => Task.Delay(1);
+
+            // Act
+            using var scope = new AssertionScope();
+            await a.Should().ThrowExactlyAsync<InvalidOperationException>();
+
+            // Assert
+            scope.Discard().Should().ContainSingle()
+                .Which.Should().Match("*InvalidOperationException*no exception*");
         }
     }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -25,6 +25,8 @@ sidebar:
 * Capitalize `true` and `false` in failure messages and make them formattable to a custom `BooleanFormatter` - [#2390](https://github.com/fluentassertions/fluentassertions/pull/2390), [#2393](https://github.com/fluentassertions/fluentassertions/pull/2393)
 * Improved the failure message for `NotBeOfType` when wrapped in an `AssertionScope` and the subject is null  - [#2399](https://github.com/fluentassertions/fluentassertions/pull/2399)
 * Improved the failure message for `BeWritable`/`BeReadable` when wrapped in an `AssertionScope` and the subject is read-only/write-only - [#2399](https://github.com/fluentassertions/fluentassertions/pull/2399)
+* Improved the failure message for `ThrowExactly[Async]` when wrapped in an `AssertionScope` and no exception is thrown - [#2398](https://github.com/fluentassertions/fluentassertions/pull/2398)
+
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Fixes #2395 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
