### PR TITLE
Improve failure message for `NotBeOfType` and `BeReadable`/`BeWritable`

### DIFF
--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -440,12 +440,15 @@ public class NumericAssertions<T, TAssertions>
     {
         Guard.ThrowIfArgumentIsNull(unexpectedType);
 
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject.HasValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected type not to be " + unexpectedType + "{reason}, but found <null>.");
 
-        Subject.GetType().Should().NotBe(unexpectedType, because, becauseArgs);
+        if (success)
+        {
+            Subject.GetType().Should().NotBe(unexpectedType, because, becauseArgs);
+        }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
@@ -130,9 +130,17 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
 
         if (success)
         {
-            Subject.Should().BeWritable(because, becauseArgs);
+            success = Execute.Assertion
+                .ForCondition(Subject!.CanWrite)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected {context:property} {0} to have a setter{reason}.",
+                    Subject);
 
-            Subject!.GetSetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            if (success)
+            {
+                Subject!.GetSetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            }
         }
 
         return new AndConstraint<PropertyInfoAssertions>(this);
@@ -221,9 +229,14 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
 
         if (success)
         {
-            Subject.Should().BeReadable(because, becauseArgs);
+            success = Execute.Assertion.ForCondition(Subject!.CanRead)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected property " + Subject.Name + " to have a getter{reason}, but it does not.");
 
-            Subject!.GetGetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            if (success)
+            {
+                Subject!.GetGetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            }
         }
 
         return new AndConstraint<PropertyInfoAssertions>(this);

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -875,7 +875,10 @@ public class ObjectAssertionSpecs
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 valueTypeObject.Should().NotBeOfType(typeof(int), "because we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
@@ -2,6 +2,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using FluentAssertions.Common;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -557,6 +558,24 @@ public class PropertyInfoAssertionSpecs
         }
 
         [Fact]
+        public void Do_not_the_check_access_modifier_when_the_property_is_not_readable()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WriteOnlyProperty");
+
+            // Act
+            Action action = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().BeReadable(CSharpAccessModifier.Private);
+            };
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected property WriteOnlyProperty to have a getter, but it does not.");
+        }
+
+        [Fact]
         public void When_subject_is_null_be_readable_with_accessmodifier_should_fail()
         {
             // Arrange
@@ -616,6 +635,24 @@ public class PropertyInfoAssertionSpecs
             action.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method set_ReadPrivateWriteProperty to be Public because we want to test the error message, but it is Private.");
+        }
+
+        [Fact]
+        public void Do_not_the_check_access_modifier_when_the_property_is_not_writable()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadOnlyProperty");
+
+            // Act
+            Action action = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().BeWritable(CSharpAccessModifier.Private);
+            };
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected propertyInfo ReadOnlyProperty to have a setter.");
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -23,7 +23,8 @@ sidebar:
 * `BeEquivalentTo` can again compare a non-generic `IDictionary` with a generic one - [#2358](https://github.com/fluentassertions/fluentassertions/pull/2358)
 * Fixed that the `FormattingOptions` were not respected in inner `AssertionScope` - [#2329](https://github.com/fluentassertions/fluentassertions/pull/2329)
 * Capitalize `true` and `false` in failure messages and make them formattable to a custom `BooleanFormatter` - [#2390](https://github.com/fluentassertions/fluentassertions/pull/2390), [#2393](https://github.com/fluentassertions/fluentassertions/pull/2393)
-
+* Improved the failure message for `NotBeOfType` when wrapped in an `AssertionScope` and the subject is null  - [#2399](https://github.com/fluentassertions/fluentassertions/pull/2399)
+* Improved the failure message for `BeWritable`/`BeReadable` when wrapped in an `AssertionScope` and the subject is read-only/write-only - [#2399](https://github.com/fluentassertions/fluentassertions/pull/2399)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION
Inspired by #2398 I searched for more places where we don't guard continued assertions.


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
