### PR TITLE
Use base class constructor in delegate assertions

### DIFF
--- a/Src/FluentAssertions/Specialized/ActionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ActionAssertions.cs
@@ -12,7 +12,7 @@ namespace FluentAssertions.Specialized;
 public class ActionAssertions : DelegateAssertions<Action, ActionAssertions>
 {
     public ActionAssertions(Action subject, IExtractExceptions extractor)
-        : this(subject, extractor, new Clock())
+        : base(subject, extractor)
     {
     }
 

--- a/Src/FluentAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertions.cs
@@ -12,7 +12,7 @@ namespace FluentAssertions.Specialized;
 public class FunctionAssertions<T> : DelegateAssertions<Func<T>, FunctionAssertions<T>>
 {
     public FunctionAssertions(Func<T> subject, IExtractExceptions extractor)
-        : this(subject, extractor, new Clock())
+        : base(subject, extractor)
     {
     }
 


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
From my understanding this shouldn't make any difference, but increase the code coverage


Alternatively we just could remove the unsed constructor, but this would be a breaking change.
<img width="1157" alt="image" src="https://github.com/fluentassertions/fluentassertions/assets/49762557/cbf0150a-2432-437d-a846-9cfcda873e79">

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
