### PR TITLE
Guard methods against assertion scope `[Not]HaveExplicit(Property|Method)`

### DIFF
--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1124,14 +1124,17 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
         {
             success = AssertSubjectImplements(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType}.{name}", parameterTypes);
+            if (success)
+            {
+                var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType}.{name}", parameterTypes);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(explicitlyImplementsMethod)
-                .FailWith(
-                    $"Expected {Subject} to explicitly implement {interfaceType}.{name}" +
-                    $"({GetParameterString(parameterTypes)}){{reason}}, but it does not.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(explicitlyImplementsMethod)
+                    .FailWith(
+                        $"Expected {Subject} to explicitly implement {interfaceType}.{name}" +
+                        $"({GetParameterString(parameterTypes)}){{reason}}, but it does not.");
+            }
         }
 
         return new AndConstraint<TypeAssertions>(this);
@@ -1197,14 +1200,17 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
         {
             success = AssertSubjectImplements(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType}.{name}", parameterTypes);
+            if (success)
+            {
+                var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType}.{name}", parameterTypes);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(!explicitlyImplementsMethod)
-                .FailWith(
-                    $"Expected {Subject} to not explicitly implement {interfaceType}.{name}" +
-                    $"({GetParameterString(parameterTypes)}){{reason}}, but it does.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!explicitlyImplementsMethod)
+                    .FailWith(
+                        $"Expected {Subject} to not explicitly implement {interfaceType}.{name}" +
+                        $"({GetParameterString(parameterTypes)}){{reason}}, but it does.");
+            }
         }
 
         return new AndConstraint<TypeAssertions>(this);

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -462,20 +462,25 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     {
         Guard.ThrowIfArgumentIsNull(interfaceType);
 
-        bool containsInterface = interfaceType.IsAssignableFrom(Subject) && interfaceType != Subject;
-
-        Execute.Assertion
-            .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected type {0} to implement interface {1}{reason}", Subject, interfaceType)
-            .ForCondition(interfaceType.IsInterface)
-            .FailWith(", but {0} is not an interface.", interfaceType)
-            .Then
-            .ForCondition(containsInterface)
-            .FailWith(", but it does not.")
-            .Then
-            .ClearExpectation();
+        AssertSubjectImplements(interfaceType, because, becauseArgs);
 
         return new AndConstraint<TypeAssertions>(this);
+    }
+
+    private bool AssertSubjectImplements(Type interfaceType, string because = "", params object[] becauseArgs)
+    {
+        bool containsInterface = interfaceType.IsAssignableFrom(Subject) && interfaceType != Subject;
+
+        return Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected type {0} to implement interface {1}{reason}", Subject, interfaceType)
+                .ForCondition(interfaceType.IsInterface)
+                .FailWith(", but {0} is not an interface.", interfaceType)
+                .Then
+                .ForCondition(containsInterface)
+                .FailWith(", but it does not.")
+                .Then
+                .ClearExpectation();
     }
 
     /// <summary>
@@ -973,15 +978,18 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
 
         if (success)
         {
-            Subject.Should().Implement(interfaceType, because, becauseArgs);
+            success = AssertSubjectImplements(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
+            if (success)
+            {
+                var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(explicitlyImplementsProperty)
-                .FailWith(
-                    $"Expected {Subject} to explicitly implement {interfaceType}.{name}{{reason}}, but it does not.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(explicitlyImplementsProperty)
+                    .FailWith(
+                        $"Expected {Subject} to explicitly implement {interfaceType}.{name}{{reason}}, but it does not.");
+            }
         }
 
         return new AndConstraint<TypeAssertions>(this);
@@ -1040,16 +1048,19 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
 
         if (success)
         {
-            Subject.Should().Implement(interfaceType, because, becauseArgs);
+            success = AssertSubjectImplements(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
+            if (success)
+            {
+                var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(!explicitlyImplementsProperty)
-                .FailWith(
-                    $"Expected {Subject} to not explicitly implement {interfaceType}.{name}{{reason}}" +
-                    ", but it does.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!explicitlyImplementsProperty)
+                    .FailWith(
+                        $"Expected {Subject} to not explicitly implement {interfaceType}.{name}{{reason}}" +
+                        ", but it does.");
+            }
         }
 
         return new AndConstraint<TypeAssertions>(this);
@@ -1111,7 +1122,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
 
         if (success)
         {
-            Subject.Should().Implement(interfaceType, because, becauseArgs);
+            success = AssertSubjectImplements(interfaceType, because, becauseArgs);
 
             var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType}.{name}", parameterTypes);
 
@@ -1184,7 +1195,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
 
         if (success)
         {
-            Subject.Should().Implement(interfaceType, because, becauseArgs);
+            success = AssertSubjectImplements(interfaceType, because, becauseArgs);
 
             var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType}.{name}", parameterTypes);
 

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitMethod.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitMethod.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -182,6 +183,19 @@ public partial class TypeAssertionSpecs
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
                 .WithParameterName("name");
+        }
+
+        [Fact]
+        public void Does_not_continue_assertion_on_explicit_interface_implementation_if_not_implemented_at_all()
+        {
+            var act = () =>
+            {
+                using var _ = new AssertionScope();
+                typeof(ClassWithMembers).Should().HaveExplicitMethod(typeof(IExplicitInterface), "Foo", new Type[0]);
+            };
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type *ClassWithMembers* to*implement *IExplicitInterface, but it does not.");
         }
     }
 
@@ -439,6 +453,21 @@ public partial class TypeAssertionSpecs
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
                 .WithParameterName("name");
+        }
+
+        [Fact]
+        public void Does_not_continue_assertion_on_explicit_interface_implementation_if_implemented()
+        {
+            var act = () =>
+            {
+                using var _ = new AssertionScope();
+                typeof(ClassExplicitlyImplementingInterface)
+                    .Should().NotHaveExplicitMethod(typeof(IExplicitInterface), "ExplicitMethod", new Type[0]);
+            };
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected *ClassExplicitlyImplementingInterface* to not*implement " +
+                    "*IExplicitInterface.ExplicitMethod(), but it does.");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitProperty.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitProperty.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -167,6 +168,19 @@ public partial class TypeAssertionSpecs
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
                 .WithParameterName("name");
+        }
+
+        [Fact]
+        public void Does_not_continue_assertion_on_explicit_interface_implementation_if_not_implemented_at_all()
+        {
+            var act = () =>
+            {
+                using var _ = new AssertionScope();
+                typeof(int).Should().HaveExplicitProperty(typeof(IExplicitInterface), "Foo");
+            };
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type System.Int32 to*implement *IExplicitInterface, but it does not.");
         }
     }
 
@@ -394,6 +408,21 @@ public partial class TypeAssertionSpecs
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
                 .WithParameterName("name");
+        }
+
+        [Fact]
+        public void Does_not_continue_assertion_on_explicit_interface_implementation_if_implemented()
+        {
+            var act = () =>
+            {
+                using var _ = new AssertionScope();
+                typeof(ClassExplicitlyImplementingInterface)
+                    .Should().NotHaveExplicitProperty(typeof(IExplicitInterface), "ExplicitStringProperty");
+            };
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected *ClassExplicitlyImplementingInterface* to*implement " +
+                    "*IExplicitInterface.ExplicitStringProperty, but it does.");
         }
     }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -26,6 +26,8 @@ sidebar:
 * Improved the failure message for `NotBeOfType` when wrapped in an `AssertionScope` and the subject is null  - [#2399](https://github.com/fluentassertions/fluentassertions/pull/2399)
 * Improved the failure message for `BeWritable`/`BeReadable` when wrapped in an `AssertionScope` and the subject is read-only/write-only - [#2399](https://github.com/fluentassertions/fluentassertions/pull/2399)
 * Improved the failure message for `ThrowExactly[Async]` when wrapped in an `AssertionScope` and no exception is thrown - [#2398](https://github.com/fluentassertions/fluentassertions/pull/2398)
+* Improved the failure message for `[Not]HaveExplicitProperty` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
+* Improved the failure message for `[Not]HaveExplicitMethod` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
 
 
 ### Breaking Changes (for users)


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Fixes #2400 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
