### PR TITLE
Cleanup

### DIFF
--- a/Build/Configuration.cs
+++ b/Build/Configuration.cs
@@ -4,9 +4,9 @@ using Nuke.Common.Tooling;
 [TypeConverter(typeof(TypeConverter<Configuration>))]
 public class Configuration : Enumeration
 {
-    public static Configuration Debug = new() { Value = nameof(Debug) };
+    public static readonly Configuration Debug = new() { Value = nameof(Debug) };
 
-    public static Configuration CI = new() { Value = nameof(CI) };
+    public static readonly Configuration CI = new() { Value = nameof(CI) };
 
     public static implicit operator string(Configuration configuration)
     {

--- a/Src/FluentAssertions/Common/Services.cs
+++ b/Src/FluentAssertions/Common/Services.cs
@@ -62,7 +62,7 @@ public static class Services
 #if NETFRAMEWORK || NET6_0_OR_GREATER
                 ConfigurationStore = new ConfigurationStoreExceptionInterceptor(new AppSettingsConfigurationStore());
 #else
-                    ConfigurationStore = new NullConfigurationStore();
+                ConfigurationStore = new NullConfigurationStore();
 #endif
                 ThrowException = new TestFrameworkProvider(Configuration).Throw;
 
@@ -107,12 +107,12 @@ public static class Services
 
     private static bool IsFramework(Assembly assembly)
     {
-    #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
         return assembly!.FullName?.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase) == true ||
             assembly.FullName?.StartsWith("System.", StringComparison.OrdinalIgnoreCase) == true;
-    #else
+#else
         return assembly.FullName.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase) ||
             assembly.FullName.StartsWith("System.", StringComparison.OrdinalIgnoreCase);
-    #endif
+#endif
     }
 }


### PR DESCRIPTION
1st commit is auto-formatting in VS
2nd commit fixes analyzer errors when manually running code analysis on the `_build` project.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
