### PR TITLE
Exclude `private protected` members from `BeEquivalentTo`

### DIFF
--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -53,7 +53,7 @@ internal sealed class TypeMemberReflector
     }
 
     private static bool IsPublic(MethodBase getMethod) =>
-        !getMethod.IsPrivate && !getMethod.IsFamily;
+        !getMethod.IsPrivate && !getMethod.IsFamily && !getMethod.IsFamilyAndAssembly;
 
     private static bool IsExplicitlyImplemented(MethodBase getMethod) =>
         getMethod.IsPrivate && getMethod.IsFinal;
@@ -83,10 +83,13 @@ internal sealed class TypeMemberReflector
         {
             return type
                 .GetFields(AllInstanceMembersFlag)
-                .Where(field => !field.IsPrivate && !field.IsFamily)
+                .Where(field => IsPublic(field))
                 .Where(field => includeInternal || !IsInternal(field));
         });
     }
+
+    private static bool IsPublic(FieldInfo field) =>
+        !field.IsPrivate && !field.IsFamily && !field.IsFamilyAndAssembly;
 
     private static bool IsInternal(FieldInfo field)
     {

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -1442,6 +1442,54 @@ public class SelectionRulesSpecs
             // Act / Assert
             actual.Should().BeEquivalentTo(expected);
         }
+
+        [Fact]
+        public void Private_protected_properties_are_ignored()
+        {
+            // Arrange
+            var subject = new ClassWithPrivateProtectedProperty("Name", 13);
+            var other = new ClassWithPrivateProtectedProperty("Name", 37);
+
+            // Act/Assert
+            subject.Should().BeEquivalentTo(other);
+        }
+
+        private class ClassWithPrivateProtectedProperty
+        {
+            public ClassWithPrivateProtectedProperty(string name, int value)
+            {
+                Name = name;
+                Value = value;
+            }
+
+            public string Name { get; }
+
+            private protected int Value { get; }
+        }
+
+        [Fact]
+        public void Private_protected_fields_are_ignored()
+        {
+            // Arrange
+            var subject = new ClassWithPrivateProtectedField("Name", 13);
+            var other = new ClassWithPrivateProtectedField("Name", 37);
+
+            // Act/Assert
+            subject.Should().BeEquivalentTo(other);
+        }
+
+        private class ClassWithPrivateProtectedField
+        {
+            public ClassWithPrivateProtectedField(string name, int value)
+            {
+                Name = name;
+                this.value = value;
+            }
+
+            public string Name;
+
+            private protected int value;
+        }
     }
 
     public class MemberHiding

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -905,13 +905,14 @@ public class SelectionRulesSpecs
                 "internal", "protected-internal", "private", "private-protected");
 
             var expected = new ClassWithAllAccessModifiersForMembers("public", "protected",
-                "ignored-internal", "ignored-protected-internal", "private", "ignore-private-protected");
+                "ignored-internal", "ignored-protected-internal", "private", "private-protected");
 
             // Act
-            Action act = () => subject.Should().BeEquivalentTo(expected, config =>
-                config.Excluding(ctx => ctx.WhichGetterHas(CSharpAccessModifier.Internal) ||
-                    ctx.WhichGetterHas(CSharpAccessModifier.ProtectedInternal) ||
-                    ctx.WhichGetterHas(CSharpAccessModifier.PrivateProtected)));
+            Action act = () => subject.Should().BeEquivalentTo(expected, config => config
+                .IncludingInternalFields()
+                .Excluding(ctx =>
+                    ctx.WhichGetterHas(CSharpAccessModifier.Internal) ||
+                    ctx.WhichGetterHas(CSharpAccessModifier.ProtectedInternal)));
 
             // Assert
             act.Should().NotThrow();
@@ -925,14 +926,15 @@ public class SelectionRulesSpecs
                 "internal", "protected-internal", "private", "private-protected");
 
             var expected = new ClassWithAllAccessModifiersForMembers("public", "protected",
-                "ignored-internal", "ignored-protected-internal", "ignored-private", "ignore-private-protected");
+                "ignored-internal", "ignored-protected-internal", "ignored-private", "private-protected");
 
             // Act
-            Action act = () => subject.Should().BeEquivalentTo(expected, config =>
-                config.Excluding(ctx => ctx.WhichSetterHas(CSharpAccessModifier.Internal) ||
+            Action act = () => subject.Should().BeEquivalentTo(expected, config => config
+                .IncludingInternalFields()
+                .Excluding(ctx =>
+                    ctx.WhichSetterHas(CSharpAccessModifier.Internal) ||
                     ctx.WhichSetterHas(CSharpAccessModifier.ProtectedInternal) ||
-                    ctx.WhichSetterHas(CSharpAccessModifier.Private) ||
-                    ctx.WhichSetterHas(CSharpAccessModifier.PrivateProtected)));
+                    ctx.WhichSetterHas(CSharpAccessModifier.Private)));
 
             // Assert
             act.Should().NotThrow();

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -30,6 +30,7 @@ sidebar:
 * Improved the failure message for `ThrowExactly[Async]` when wrapped in an `AssertionScope` and no exception is thrown - [#2398](https://github.com/fluentassertions/fluentassertions/pull/2398)
 * Improved the failure message for `[Not]HaveExplicitProperty` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
 * Improved the failure message for `[Not]HaveExplicitMethod` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
+* Changed `BeEquivalentTo` to exclude `private protected` members from the comparison - [#2417](https://github.com/fluentassertions/fluentassertions/pull/2417)
 
 
 ### Breaking Changes (for users)


### PR DESCRIPTION
This fixes #2409 

I guess this is what I meant with this [comment](https://github.com/fluentassertions/fluentassertions/pull/1575#discussion_r641972449)


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
