### PR TITLE
Restore `DateTime` tips

### DIFF
--- a/docs/_data/tips/datetimes.yml
+++ b/docs/_data/tips/datetimes.yml
@@ -1,0 +1,23 @@
+- old: |
+    actual.Date.Should().Be(expected.Date);
+
+  new: |
+    actual.Should().BeSameDateAs(expected);
+
+  old-message: |
+    Expected date and time to be <2017-01-01>, but found <2017-01-02>.
+
+  new-message: |
+    Expected a date and time with date <2017-01-01>, but found <2017-01-02 21:00:00>.
+
+- old: |
+    actual.Date.Should().NotBe(unexpected.Date);
+
+  new: |
+    actual.Should().NotBeSameDateAs(unexpected);
+
+  old-message: |
+    Expected date and time not to be <2017-01-01>, but it is.
+
+  new-message: |
+    Expected a date and time that does not have date <2017-01-01>, but found it does.


### PR DESCRIPTION
The tips got lost in #813.
#843 restored all but one.

before:
![image](https://github.com/fluentassertions/fluentassertions/assets/919634/543ffd3e-4e84-4365-a634-c2990a70cd8f)

after:
![image](https://github.com/fluentassertions/fluentassertions/assets/919634/56de9156-1a63-4907-be40-8d8ab38d7147)



## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
