### PR TITLE
Add EqualityStrategyProvider for `SelfReferenceEquivalencyAssertionOptions`

### DIFF
--- a/Src/FluentAssertions/Equivalency/EqualityStrategyCache.cs
+++ b/Src/FluentAssertions/Equivalency/EqualityStrategyCache.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using FluentAssertions.Common;
+using JetBrains.Annotations;
+
+namespace FluentAssertions.Equivalency;
+
+internal sealed class EqualityStrategyCache
+{
+    private readonly List<Type> referenceTypes = new();
+    private readonly List<Type> valueTypes = new();
+    private readonly ConcurrentDictionary<Type, EqualityStrategy> typeCache = new();
+    [CanBeNull]
+    private readonly Func<Type, EqualityStrategy> defaultStrategy;
+    private bool? compareRecordsByValue;
+
+    public bool? CompareRecordsByValue
+    {
+        get => compareRecordsByValue;
+        set
+        {
+            compareRecordsByValue = value;
+            typeCache.Clear();
+        }
+    }
+
+    public EqualityStrategyCache([CanBeNull] Func<Type, EqualityStrategy> defaultStrategy)
+    {
+        this.defaultStrategy = defaultStrategy;
+    }
+
+    public EqualityStrategy GetEqualityStrategy(Type type)
+    {
+        // As the valueFactory parameter captures instance members,
+        // be aware if the cache must be cleared on mutating the members.
+        return typeCache.GetOrAdd(type, typeKey =>
+        {
+            if (!typeKey.IsPrimitive && referenceTypes.Count > 0 && referenceTypes.Exists(t => typeKey.IsSameOrInherits(t)))
+            {
+                return EqualityStrategy.ForceMembers;
+            }
+            else if (valueTypes.Count > 0 && valueTypes.Exists(t => typeKey.IsSameOrInherits(t)))
+            {
+                return EqualityStrategy.ForceEquals;
+            }
+            else if (!typeKey.IsPrimitive && referenceTypes.Count > 0 &&
+                     referenceTypes.Exists(t => typeKey.IsAssignableToOpenGeneric(t)))
+            {
+                return EqualityStrategy.ForceMembers;
+            }
+            else if (valueTypes.Count > 0 && valueTypes.Exists(t => typeKey.IsAssignableToOpenGeneric(t)))
+            {
+                return EqualityStrategy.ForceEquals;
+            }
+            else if ((compareRecordsByValue.HasValue || defaultStrategy is null) && typeKey.IsRecord())
+            {
+                return compareRecordsByValue is true ? EqualityStrategy.ForceEquals : EqualityStrategy.ForceMembers;
+            }
+            else if (defaultStrategy is not null)
+            {
+                return defaultStrategy(typeKey);
+            }
+
+            return typeKey.HasValueSemantics() ? EqualityStrategy.Equals : EqualityStrategy.Members;
+        });
+    }
+
+    public bool AddReferenceType(Type type)
+    {
+        if (valueTypes.Exists(t => type.IsSameOrInherits(t)))
+        {
+            return false;
+        }
+
+        referenceTypes.Add(type);
+        typeCache.Clear();
+        return true;
+    }
+
+    public bool AddValueType(Type type)
+    {
+        if (referenceTypes.Exists(t => type.IsSameOrInherits(t)))
+        {
+            return false;
+        }
+
+        valueTypes.Add(type);
+        typeCache.Clear();
+        return true;
+    }
+
+    public void AppendToString(StringBuilder builder)
+    {
+        if (compareRecordsByValue is true)
+        {
+            builder.AppendLine("- Compare records by value");
+        }
+        else
+        {
+            builder.AppendLine("- Compare records by their members");
+        }
+
+        foreach (Type valueType in valueTypes)
+        {
+            builder.AppendLine(CultureInfo.InvariantCulture, $"- Compare {valueType} by value");
+        }
+
+        foreach (Type type in referenceTypes)
+        {
+            builder.AppendLine(CultureInfo.InvariantCulture, $"- Compare {type} by its members");
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/EqualityStrategyCache.cs
+++ b/Src/FluentAssertions/Equivalency/EqualityStrategyCache.cs
@@ -13,8 +13,10 @@ internal sealed class EqualityStrategyCache
     private readonly List<Type> referenceTypes = new();
     private readonly List<Type> valueTypes = new();
     private readonly ConcurrentDictionary<Type, EqualityStrategy> typeCache = new();
+
     [CanBeNull]
     private readonly Func<Type, EqualityStrategy> defaultStrategy;
+
     private bool? compareRecordsByValue;
 
     public bool? CompareRecordsByValue
@@ -92,8 +94,10 @@ internal sealed class EqualityStrategyCache
         return true;
     }
 
-    public void AppendToString(StringBuilder builder)
+    public override string ToString()
     {
+        var builder = new StringBuilder();
+
         if (compareRecordsByValue is true)
         {
             builder.AppendLine("- Compare records by value");
@@ -112,5 +116,7 @@ internal sealed class EqualityStrategyCache
         {
             builder.AppendLine(CultureInfo.InvariantCulture, $"- Compare {type} by its members");
         }
+
+        return builder.ToString();
     }
 }

--- a/Src/FluentAssertions/Equivalency/EqualityStrategyProvider.cs
+++ b/Src/FluentAssertions/Equivalency/EqualityStrategyProvider.cs
@@ -8,7 +8,7 @@ using JetBrains.Annotations;
 
 namespace FluentAssertions.Equivalency;
 
-internal sealed class EqualityStrategyCache
+internal sealed class EqualityStrategyProvider
 {
     private readonly List<Type> referenceTypes = new();
     private readonly List<Type> valueTypes = new();
@@ -19,6 +19,15 @@ internal sealed class EqualityStrategyCache
 
     private bool? compareRecordsByValue;
 
+    public EqualityStrategyProvider()
+    {
+    }
+
+    public EqualityStrategyProvider(Func<Type, EqualityStrategy> defaultStrategy)
+    {
+        this.defaultStrategy = defaultStrategy;
+    }
+
     public bool? CompareRecordsByValue
     {
         get => compareRecordsByValue;
@@ -27,11 +36,6 @@ internal sealed class EqualityStrategyCache
             compareRecordsByValue = value;
             typeCache.Clear();
         }
-    }
-
-    public EqualityStrategyCache([CanBeNull] Func<Type, EqualityStrategy> defaultStrategy)
-    {
-        this.defaultStrategy = defaultStrategy;
     }
 
     public EqualityStrategy GetEqualityStrategy(Type type)

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -714,9 +714,8 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
 
         builder
             .AppendLine("- Compare tuples by their properties")
-            .AppendLine("- Compare anonymous types by their properties");
-
-        equalityStrategyCache.AppendToString(builder);
+            .AppendLine("- Compare anonymous types by their properties")
+            .Append(equalityStrategyCache);
 
         if (excludeNonBrowsableOnExpectation)
         {

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -26,12 +25,7 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
 {
     #region Private Definitions
 
-    // REFACTOR: group the next three fields in a dedicated class
-    private readonly List<Type> referenceTypes = new();
-    private readonly List<Type> valueTypes = new();
-    private readonly Func<Type, EqualityStrategy> getDefaultEqualityStrategy;
-
-    private readonly ConcurrentDictionary<Type, EqualityStrategy> equalityStrategyCache = new();
+    private readonly EqualityStrategyCache equalityStrategyCache;
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly List<IMemberSelectionRule> selectionRules = new();
@@ -62,12 +56,12 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
     private bool ignoreNonBrowsableOnSubject;
     private bool excludeNonBrowsableOnExpectation;
 
-    private bool? compareRecordsByValue;
-
     #endregion
 
     private protected SelfReferenceEquivalencyAssertionOptions()
     {
+        equalityStrategyCache = new EqualityStrategyCache(null);
+
         AddMatchingRule(new MustMatchByNameRule());
 
         OrderingRules.Add(new ByteArrayOrderingRule());
@@ -78,6 +72,11 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
     /// </summary>
     protected SelfReferenceEquivalencyAssertionOptions(IEquivalencyAssertionOptions defaults)
     {
+        equalityStrategyCache = new EqualityStrategyCache(defaults.GetEqualityStrategy)
+        {
+            CompareRecordsByValue = defaults.CompareRecordsByValue
+        };
+
         isRecursive = defaults.IsRecursive;
         cyclicReferenceHandling = defaults.CyclicReferenceHandling;
         allowInfiniteRecursion = defaults.AllowInfiniteRecursion;
@@ -87,7 +86,6 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
         includedFields = defaults.IncludedFields;
         ignoreNonBrowsableOnSubject = defaults.IgnoreNonBrowsableOnSubject;
         excludeNonBrowsableOnExpectation = defaults.ExcludeNonBrowsableOnExpectation;
-        compareRecordsByValue = defaults.CompareRecordsByValue;
 
         ConversionSelector = defaults.ConversionSelector.Clone();
 
@@ -96,7 +94,6 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
         matchingRules.AddRange(defaults.MatchingRules);
         OrderingRules = new OrderingRuleCollection(defaults.OrderingRules);
 
-        getDefaultEqualityStrategy = defaults.GetEqualityStrategy;
         TraceWriter = defaults.TraceWriter;
 
         RemoveSelectionRule<AllPropertiesSelectionRule>();
@@ -178,42 +175,10 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
 
     bool IEquivalencyAssertionOptions.ExcludeNonBrowsableOnExpectation => excludeNonBrowsableOnExpectation;
 
-    public bool? CompareRecordsByValue => compareRecordsByValue;
+    public bool? CompareRecordsByValue => equalityStrategyCache.CompareRecordsByValue;
 
     EqualityStrategy IEquivalencyAssertionOptions.GetEqualityStrategy(Type type)
-    {
-        // As the valueFactory parameter captures instance members,
-        // be aware if the cache must be cleared on mutating the members.
-        return equalityStrategyCache.GetOrAdd(type, typeKey =>
-        {
-            if (!typeKey.IsPrimitive && referenceTypes.Count > 0 && referenceTypes.Exists(t => typeKey.IsSameOrInherits(t)))
-            {
-                return EqualityStrategy.ForceMembers;
-            }
-            else if (valueTypes.Count > 0 && valueTypes.Exists(t => typeKey.IsSameOrInherits(t)))
-            {
-                return EqualityStrategy.ForceEquals;
-            }
-            else if (!typeKey.IsPrimitive && referenceTypes.Count > 0 && referenceTypes.Exists(t => typeKey.IsAssignableToOpenGeneric(t)))
-            {
-                return EqualityStrategy.ForceMembers;
-            }
-            else if (valueTypes.Count > 0 && valueTypes.Exists(t => typeKey.IsAssignableToOpenGeneric(t)))
-            {
-                return EqualityStrategy.ForceEquals;
-            }
-            else if ((compareRecordsByValue.HasValue || getDefaultEqualityStrategy is null) && typeKey.IsRecord())
-            {
-                return compareRecordsByValue is true ? EqualityStrategy.ForceEquals : EqualityStrategy.ForceMembers;
-            }
-            else if (getDefaultEqualityStrategy is not null)
-            {
-                return getDefaultEqualityStrategy(typeKey);
-            }
-
-            return typeKey.HasValueSemantics() ? EqualityStrategy.Equals : EqualityStrategy.Members;
-        });
-    }
+        => equalityStrategyCache.GetEqualityStrategy(type);
 
     public ITraceWriter TraceWriter { get; private set; }
 
@@ -603,8 +568,7 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
     /// </summary>
     public TSelf ComparingRecordsByValue()
     {
-        compareRecordsByValue = true;
-        equalityStrategyCache.Clear();
+        equalityStrategyCache.CompareRecordsByValue = true;
         return (TSelf)this;
     }
 
@@ -617,8 +581,7 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
     /// </remarks>
     public TSelf ComparingRecordsByMembers()
     {
-        compareRecordsByValue = false;
-        equalityStrategyCache.Clear();
+        equalityStrategyCache.CompareRecordsByValue = false;
         return (TSelf)this;
     }
 
@@ -642,14 +605,12 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
             throw new InvalidOperationException($"Cannot compare a primitive type such as {type.Name} by its members");
         }
 
-        if (valueTypes.Exists(t => type.IsSameOrInherits(t)))
+        if (!equalityStrategyCache.AddReferenceType(type))
         {
             throw new InvalidOperationException(
                 $"Can't compare {type.Name} by its members if it already setup to be compared by value");
         }
 
-        referenceTypes.Add(type);
-        equalityStrategyCache.Clear();
         return (TSelf)this;
     }
 
@@ -668,14 +629,12 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
     {
         Guard.ThrowIfArgumentIsNull(type);
 
-        if (referenceTypes.Exists(t => type.IsSameOrInherits(t)))
+        if (!equalityStrategyCache.AddValueType(type))
         {
             throw new InvalidOperationException(
                 $"Can't compare {type.Name} by value if it already setup to be compared by its members");
         }
 
-        valueTypes.Add(type);
-        equalityStrategyCache.Clear();
         return (TSelf)this;
     }
 
@@ -757,24 +716,7 @@ public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquival
             .AppendLine("- Compare tuples by their properties")
             .AppendLine("- Compare anonymous types by their properties");
 
-        if (compareRecordsByValue is true)
-        {
-            builder.AppendLine("- Compare records by value");
-        }
-        else
-        {
-            builder.AppendLine("- Compare records by their members");
-        }
-
-        foreach (Type valueType in valueTypes)
-        {
-            builder.AppendLine(CultureInfo.InvariantCulture, $"- Compare {valueType} by value");
-        }
-
-        foreach (Type type in referenceTypes)
-        {
-            builder.AppendLine(CultureInfo.InvariantCulture, $"- Compare {type} by its members");
-        }
+        equalityStrategyCache.AppendToString(builder);
 
         if (excludeNonBrowsableOnExpectation)
         {


### PR DESCRIPTION
Refactor according to [this comment](https://github.com/fluentassertions/fluentassertions/blob/6.12.0/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs#L029) in the `SelfReferenceEquivalencyAssertionOptions`:
Extract the private fields `referenceTypes`, `valueTypes`, `getDefaultEqualityStrategy` and `equalityStrategyCache` to a dedicated class `EqualityStrategyProvider`.


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
