### PR TITLE
Feature: Add collections methods BeProperSubsetOf / BeProperSupersetOf / BeSupersetOf

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -667,6 +667,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     public AndConstraint<TAssertions> BeSubsetOf(IEnumerable<T> expectedSuperset, string because = "",
         params object[] becauseArgs)
     {
+        Guard.ThrowIfArgumentIsNull(expectedSuperset, nameof(expectedSuperset), "Cannot verify a subset against a <null> collection.");
         AssertBeSubsetOf(expectedSuperset.ConvertOrCastToSet(), "subset", because, becauseArgs);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -711,6 +712,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     public AndConstraint<TAssertions> BeProperSubsetOf(IEnumerable<T> expectedProperSuperset, string because = "",
         params object[] becauseArgs)
     {
+        Guard.ThrowIfArgumentIsNull(expectedProperSuperset, nameof(expectedProperSuperset), "Cannot verify a proper subset against a <null> collection.");
         ISet<T> expectedItems = expectedProperSuperset.ConvertOrCastToSet();
         AssertBeSubsetOf(expectedItems, "proper subset", because, becauseArgs);
 
@@ -3524,9 +3526,6 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     private void AssertBeSubsetOf(ISet<T> expectedSuperset, string subsetType, string because = "",
         params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(expectedSuperset, nameof(expectedSuperset),
-    "Cannot verify a " + subsetType + " against a <null> collection.");
-
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:collection} to be a " + subsetType + " of {0}{reason}, ", expectedSuperset)

--- a/Src/FluentAssertions/Common/EnumerableExtensions.cs
+++ b/Src/FluentAssertions/Common/EnumerableExtensions.cs
@@ -16,6 +16,11 @@ internal static class EnumerableExtensions
         return source as IList<T> ?? source.ToList();
     }
 
+    public static ISet<T> ConvertOrCastToSet<T>(this IEnumerable<T> source)
+    {
+        return source as ISet<T> ?? new HashSet<T>(source);
+    }
+
     /// <summary>
     /// Searches for the first different element in two sequences using specified <paramref name="equalityComparison" />
     /// </summary>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -413,7 +413,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSubsetOf(System.Collections.Generic.IEnumerable<T> expectedProperSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSupersetOf(System.Collections.Generic.IEnumerable<T> expectedProperSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.Generic.IEnumerable<T> expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSupersetOf(System.Collections.Generic.IEnumerable<T> expectedSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -426,7 +426,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSubsetOf(System.Collections.Generic.IEnumerable<T> expectedProperSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSupersetOf(System.Collections.Generic.IEnumerable<T> expectedProperSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.Generic.IEnumerable<T> expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSupersetOf(System.Collections.Generic.IEnumerable<T> expectedSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -405,7 +405,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSubsetOf(System.Collections.Generic.IEnumerable<T> expectedProperSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSupersetOf(System.Collections.Generic.IEnumerable<T> expectedProperSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.Generic.IEnumerable<T> expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSupersetOf(System.Collections.Generic.IEnumerable<T> expectedSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -413,7 +413,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSubsetOf(System.Collections.Generic.IEnumerable<T> expectedProperSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSupersetOf(System.Collections.Generic.IEnumerable<T> expectedProperSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.Generic.IEnumerable<T> expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSupersetOf(System.Collections.Generic.IEnumerable<T> expectedSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeProperSubsetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeProperSubsetOf.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using FluentAssertions.Execution;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Collections;
+
+/// <content>
+/// The BeProperSubsetOf specs.
+/// </content>
+public partial class CollectionAssertionSpecs
+{
+    public class BeProperSubsetOf
+    {
+        [Fact]
+        public void A_collection_with_only_items_of_a_superset_but_misses_some_is_a_proper_subset()
+        {
+            // Arrange
+            var subset = new[] { 1, 2 };
+            var superset = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            subset.Should().BeProperSubsetOf(superset);
+        }
+
+        [Fact]
+        public void A_collection_with_duplicates_and_only_items_of_a_superset_with_duplicates_but_misses_some_is_a_proper_subset()
+        {
+            // Arrange
+            var subset = new[] { 1, 1, 1, 2, 2, 3, 3 };
+            var superset = new[] { 1, 2, 3, 3, 3, 4 };
+
+            // Act / Assert
+            subset.Should().BeProperSubsetOf(superset);
+        }
+
+        [Fact]
+        public void A_collection_with_all_items_of_a_superset_but_has_extra_items_is_not_a_proper_subset()
+        {
+            // Arrange
+            var subset = new[] { 1, 2, 3, 4 };
+            var superset = new[] { 4, 3, 2, 1 };
+
+            // Act
+            Action act = () => subset.Should().BeProperSubsetOf(superset, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected subset to be a proper subset of {4, 3, 2, 1} because we want to test the failure message, " +
+                "but items {1, 2, 3, 4} are equivalent to the superset {4, 3, 2, 1}");
+        }
+
+        [Fact]
+        public void A_collection_with_all_items_and_duplicates_of_a_superset_but_has_extra_items_is_not_a_proper_subset()
+        {
+            // Arrange
+            var subset = new[] { 1, 1, 1, 2, 2, 3, 3, 4 };
+            var superset = new[] { 4, 3, 2, 1 };
+
+            // Act
+            Action act = () => subset.Should().BeProperSubsetOf(superset, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected subset to be a proper subset of {4, 3, 2, 1} because we want to test the failure message, " +
+                "but items {1, 1, 1, 2, 2, 3, 3, 4} are equivalent to the superset {4, 3, 2, 1}");
+        }
+
+        [Fact]
+        public void A_collection_with_duplicates_is_not_a_proper_subset_of_a_superset_with_duplicates()
+        {
+            // Arrange
+            var subset = new[] { 1, 1, 1, 2, 2, 3, 3, 4 };
+            var superset = new[] { 4, 4, 4, 3, 3, 2, 1, 1 };
+
+            // Act
+            Action act = () => subset.Should().BeProperSubsetOf(superset, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected subset to be a proper subset of {4, 3, 2, 1} because we want to test the failure message, " +
+                "but items {1, 1, 1, 2, 2, 3, 3, 4} are equivalent to the superset {4, 4, 4, 3, 3, 2, 1, 1}");
+        }
+
+        [Fact]
+        public void A_collection_that_is_not_a_proper_subset_of_other_collection_with_assertion_scope()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().BeProperSubsetOf(new[] { 4 }).And.BeProperSubsetOf(new[] { 5, 6 });
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*to be a proper subset of {4}*to be a proper subset of {5, 6}*");
+        }
+
+        [Fact]
+        public void A_empty_collection_tested_against_a_proper_superset()
+        {
+            // Arrange
+            var subset = new int[0];
+            var superset = new[] { 1, 2, 4, 5 };
+
+            // Act
+            Action act = () => subset.Should().BeProperSubsetOf(superset);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void A_non_empty_subset_tested_against_a_null_superset()
+        {
+            // Arrange
+            var subset = new[] { 1, 2, 3 };
+            int[] superset = null;
+
+            // Act
+            Action act = () => subset.Should().BeProperSubsetOf(superset);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithMessage(
+                "Cannot verify a proper subset against a <null> collection.*");
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeProperSupersetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeProperSupersetOf.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using FluentAssertions.Execution;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Collections;
+
+/// <content>
+/// The BeProperSupersetOf specs.
+/// </content>
+public partial class CollectionAssertionSpecs
+{
+    public class BeProperSupersetOf
+    {
+        [Fact]
+        public void A_collection_contains_multiple_items_from_the_collection_in_any_order()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().BeProperSupersetOf(new[] { 2, 1 });
+        }
+
+        [Fact]
+        public void A_collection_contains_multiple_items_with_duplicates_from_the_collection_in_any_order()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().BeProperSupersetOf(new[] { 2, 1, 1, 1, 2 });
+        }
+
+        [Fact]
+        public void A_collection_is_not_a_proper_superset_of_a_subset()
+        {
+            // Arrange
+            var superset = new[] { 1, 2, 3, 4 };
+            var subset = new[] { 4, 3, 2, 1 };
+
+            // Act
+            Action act = () => superset.Should().BeProperSupersetOf(subset, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected superset to be a proper superset of {1, 2, 3, 4} because we want to test the failure message, " +
+                "but items {4, 3, 2, 1} are equivalent to the superset");
+        }
+
+        [Fact]
+        public void A_collection_is_not_a_proper_subset_of_another_with_duplicates()
+        {
+            // Arrange
+            var subset = new[] { 1, 1, 1, 2, 2, 3, 3, 4 };
+            var superset = new[] { 4, 3, 2, 1 };
+
+            // Act
+            Action act = () => superset.Should().BeProperSupersetOf(subset, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected superset to be a proper superset of {4, 3, 2, 1} because we want to test the failure message, " +
+                "but items {1, 1, 1, 2, 2, 3, 3, 4} are equivalent to the superset");
+        }
+
+        [Fact]
+        public void A_collection_with_duplicates_is_not_a_proper_subset_of_another_with_duplicates()
+        {
+            // Arrange
+            var subset = new[] { 1, 1, 1, 2, 2, 3, 3, 4 };
+            var superset = new[] { 4, 4, 4, 3, 3, 2, 1, 1 };
+
+            // Act
+            Action act = () => superset.Should().BeProperSupersetOf(subset, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected superset to be a proper superset of {4, 3, 2, 1} because we want to test the failure message, " +
+                "but items {1, 1, 1, 2, 2, 3, 3, 4} are equivalent to the superset");
+        }
+
+        [Fact]
+        public void A_collection_does_not_contain_another_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeProperSupersetOf(new[] { 3, 4, 5 }, "because {0}", "we do");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3} to be a proper superset of {3, 4, 5} because we do, but could not find {4, 5}.");
+        }
+
+        [Fact]
+        public void A_collection_does_not_contain_a_single_element_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeProperSupersetOf(new[] { 4 }, "because {0}", "we do");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3} to be a proper superset of 4 because we do.");
+        }
+
+        [Fact]
+        public void A_collection_does_not_contain_other_collection_with_assertion_scope()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().BeProperSupersetOf(new[] { 4 }).And.BeProperSupersetOf(new[] { 5, 6 });
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*to be a proper superset of 4*to be a proper superset of {5, 6}*");
+        }
+
+        [Fact]
+        public void A_collection_is_not_a_proper_superset_of_an_empty_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeProperSupersetOf(new int[0]);
+
+            // Assert
+            act.Should().Throw<ArgumentException>().WithMessage(
+                "Cannot verify containment against an empty collection*");
+        }
+
+        [Fact]
+        public void A_null_collection_is_not_a_proper_superset_of_a_collection()
+        {
+            // Arrange
+            int[] collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().BeProperSupersetOf(new[] { 1, 2 }, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection to be a proper superset of {1, 2} *failure message*, but found <null>.");
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeSupersetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeSupersetOf.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using FluentAssertions.Execution;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Collections;
+
+/// <content>
+/// The BeSupersetOf specs.
+/// </content>
+public partial class CollectionAssertionSpecs
+{
+    public class BeSupersetOf
+    {
+        [Fact]
+        public void A_collection_contains_multiple_items_from_the_collection_in_any_order()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().BeSupersetOf(new[] { 2, 1 });
+        }
+
+        [Fact]
+        public void A_collection_does_not_contain_another_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeSupersetOf(new[] { 3, 4, 5 }, "because {0}", "we do");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3} to be a superset of {3, 4, 5} because we do, but could not find {4, 5}.");
+        }
+
+        [Fact]
+        public void A_collection_does_not_contain_a_single_element_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeSupersetOf(new[] { 4 }, "because {0}", "we do");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3} to be a superset of 4 because we do.");
+        }
+
+        [Fact]
+        public void A_collection_does_not_contain_other_collection_with_assertion_scope()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().BeSupersetOf(new[] { 4 }).And.BeSupersetOf(new[] { 5, 6 });
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*to be a superset of 4*to be a superset of {5, 6}*");
+        }
+
+        [Fact]
+        public void A_collection_is_not_a_superset_of_an_empty_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeSupersetOf(new int[0]);
+
+            // Assert
+            act.Should().Throw<ArgumentException>().WithMessage(
+                "Cannot verify containment against an empty collection*");
+        }
+
+        [Fact]
+        public void A_null_collection_is_not_a_superset_of_a_collection()
+        {
+            // Arrange
+            int[] collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().BeSupersetOf(new[] { 1, 2 }, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection to be a superset of {1, 2} *failure message*, but found <null>.");
+        }
+    }
+}

--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -40,7 +40,17 @@ collection.Should().StartWith(new[] { 1, 2 });
 collection.Should().EndWith(8);
 collection.Should().EndWith(new[] { 5, 8 });
 
+// Should be contained or equivalent to the superset. In mathematical notation, A ⊆ B.
 collection.Should().BeSubsetOf(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, });
+
+// Should be contained but not equivalent to the superset. In mathematical notation, A ⊂ B.
+collection.Should().BeProperSubsetOf(new[] { 1, 2, 5, 6, 7, 8 }); 
+
+// Should contain or be equivalent to the subset. In mathematical notation, A ⊇ B.
+collection.Should().BeSupersetOf(new[] { 1, 2, 5, 8 });
+
+// Should contain but not be equivalent to the subset. In mathematical notation, A ⊃ B.
+collection.Should().BeProperSupersetOf(new[] { 1, 5, 2 });
 
 collection.Should().ContainSingle();
 collection.Should().ContainSingle(x => x > 3);

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's new
 
 * Introduced a new assembly-level attribute that you can use to initialize Fluent Assertions before the first assertion - [#2292](https://github.com/fluentassertions/fluentassertions/pull/2292)
+* Introduced new collection assertions methods `BeProperSubsetOf`, `BeProperSupersetOf` and `BeSupersetOf` - [#2432](https://github.com/fluentassertions/fluentassertions/pull/2432)
 * Ensure compatibility with .NET 8 - [#2466](https://github.com/fluentassertions/fluentassertions/pull/2466)
 * Add support for NUnit 4 - [#2483](https://github.com/fluentassertions/fluentassertions/pull/2483)
 * Added `NotBeIn` to check if a `DateTime` is not in a given `DateTimeKind` - [#2536](https://github.com/fluentassertions/fluentassertions/pull/2536)


### PR DESCRIPTION
resolves #2363

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
