### PR TITLE
Add missing tests for `Configuration`

### DIFF
--- a/Tests/FluentAssertions.Specs/Common/ConfigurationSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Common/ConfigurationSpecs.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions.Common;
+using Xunit;
+
+namespace FluentAssertions.Specs.Common;
+
+public class ConfigurationSpecs
+{
+    [Fact]
+    public void Value_formatter_detection_mode_is_disabled_with_empty_store()
+    {
+        // Arrange
+        var store = new DummyConfigurationStore(new Dictionary<string, string>());
+        var sut = new Configuration(store);
+
+        // Act / Assert
+        sut.ValueFormatterDetectionMode.Should().Be(ValueFormatterDetectionMode.Disabled);
+    }
+
+    [Fact]
+    public void Value_formatter_detection_mode_is_specific_with_given_value_formatters_assembly()
+    {
+        // Arrange
+        var store = new DummyConfigurationStore(new Dictionary<string, string>
+        {
+            { "valueFormattersAssembly", "foo" }
+        });
+
+        var sut = new Configuration(store);
+
+        // Act / Assert
+        sut.ValueFormatterDetectionMode.Should().Be(ValueFormatterDetectionMode.Specific);
+    }
+
+    [Fact]
+    public void Value_formatter_detection_mode_can_be_specified_in_configuration_store()
+    {
+        // Arrange
+        var store = new DummyConfigurationStore(new Dictionary<string, string>
+        {
+            { "valueFormatters", nameof(ValueFormatterDetectionMode.Scan) }
+        });
+
+        var sut = new Configuration(store);
+
+        // Act / Assert
+        sut.ValueFormatterDetectionMode.Should().Be(ValueFormatterDetectionMode.Scan);
+    }
+
+    [Fact]
+    public void Value_formatter_detection_mode_throws_when_configured_incorrectly()
+    {
+        // Arrange
+        var store = new DummyConfigurationStore(new Dictionary<string, string>
+        {
+            { "valueFormatters", "foo" }
+        });
+
+        var sut = new Configuration(store);
+
+        // Act
+        var act = () => sut.ValueFormatterDetectionMode;
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    private class DummyConfigurationStore : IConfigurationStore
+    {
+        private readonly Dictionary<string, string> settings;
+
+        public DummyConfigurationStore(Dictionary<string, string> settings)
+        {
+            this.settings = settings;
+        }
+
+        public string GetSetting(string name)
+            => settings.TryGetValue(name, out var value) ? value : null;
+    }
+}


### PR DESCRIPTION
Add missing tests for [`Configuration.cs`](https://github.com/fluentassertions/fluentassertions/blob/develop/Src/FluentAssertions/Common/Configuration.cs).

See #1823 


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
