### PR TITLE
Fix issue when an empty ArraySegment is a member of a class.

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Linq;
 using FluentAssertions.Execution;
+using JetBrains.Annotations;
 
 namespace FluentAssertions.Equivalency.Steps;
 
@@ -70,8 +71,8 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
 
     private static bool IsIgnorableArrayLikeType(object value)
     {
-        return value.GetType() is Type type &&
-                    (type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
-                     (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>)));
+        var type = value.GetType();
+        return  (type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
+                (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>)));
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -61,10 +61,15 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
         {
             return ((IEnumerable)value).Cast<object>().ToArray();
         }
-        catch (InvalidOperationException) when (value.GetType().Name.Equals("ImmutableArray`1", StringComparison.Ordinal))
+        catch (InvalidOperationException) when (IsIgnorableArrayLikeType(value))
         {
-            // This is probably a default ImmutableArray<T>
+            // This is probably a default ImmutableArray<T> or an empty ArraySegment.
             return Array.Empty<object>();
         }
+
+        bool IsIgnorableArrayLikeType(object value)
+            => value.GetType() is Type type &&
+                (type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
+                 (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>)));
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -66,10 +66,12 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
             // This is probably a default ImmutableArray<T> or an empty ArraySegment.
             return Array.Empty<object>();
         }
+    }
 
-        bool IsIgnorableArrayLikeType(object value)
-            => value.GetType() is Type type &&
-                (type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
-                 (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>)));
+    private static bool IsIgnorableArrayLikeType(object value)
+    {
+        return value.GetType() is Type type &&
+                    (type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
+                     (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>)));
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Linq;
 using FluentAssertions.Execution;
-using JetBrains.Annotations;
 
 namespace FluentAssertions.Equivalency.Steps;
 
@@ -71,8 +70,8 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
 
     private static bool IsIgnorableArrayLikeType(object value)
     {
-        var type = value.GetType();
-        return  (type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
-                (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>)));
+        return value.GetType() is { } type &&
+                    (type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
+                     (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>)));
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -659,4 +659,9 @@ public class BasicSpecs
         // Assert
         act.Should().NotThrow();
     }
+
+    private class ClassWithArraySegment
+    {
+        public ArraySegment<byte> Segment { get; set; }
+    }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -645,4 +645,18 @@ public class BasicSpecs
         // Assert
         act.Should().Throw<XunitException>().WithMessage("Expected property actual[0].Id*to be *-*, but found *-*");
     }
+
+    [Fact]
+    public void When_a_class_contains_an_empty_array_segment()
+    {
+        // Arrange
+        var actual = new ClassWithArraySegment();
+        var expected = new ClassWithArraySegment();
+
+        // Act
+        Action act = () => actual.Should().BeEquivalentTo(expected);
+
+        // Assert
+        act.Should().NotThrow();
+    }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
@@ -410,6 +410,11 @@ public class Derived : Base
     public virtual string NonExcludedDerivedProperty => "Foo";
 }
 
+public class ClassWithArraySegment
+{
+    public ArraySegment<byte> Segment { get; set; }
+}
+
 #endregion
 
 #region Nested classes for comparison

--- a/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
@@ -410,11 +410,6 @@ public class Derived : Base
     public virtual string NonExcludedDerivedProperty => "Foo";
 }
 
-public class ClassWithArraySegment
-{
-    public ArraySegment<byte> Segment { get; set; }
-}
-
 #endregion
 
 #region Nested classes for comparison


### PR DESCRIPTION
With latest, it crashes when trying to access the array members of an empty ArraySegment.

How do I change the release notes? Where do I add the bug fix?

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
