### PR TITLE
Remove unused using directives

### DIFF
--- a/Src/FluentAssertions/Common/MemberPathSegmentEqualityComparer.cs
+++ b/Src/FluentAssertions/Common/MemberPathSegmentEqualityComparer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if NET6_0_OR_GREATER || NETSTANDARD2_1
+using System;
+#endif
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 

--- a/Src/FluentAssertions/Formatting/DateOnlyValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateOnlyValueFormatter.cs
@@ -1,7 +1,8 @@
+#if NET6_0_OR_GREATER
+
 using System;
 using System.Globalization;
 
-#if NET6_0_OR_GREATER
 namespace FluentAssertions.Formatting;
 
 public class DateOnlyValueFormatter : IValueFormatter

--- a/Src/FluentAssertions/Formatting/TimeOnlyValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TimeOnlyValueFormatter.cs
@@ -1,7 +1,8 @@
+#if NET6_0_OR_GREATER
+
 using System;
 using System.Globalization;
 
-#if NET6_0_OR_GREATER
 namespace FluentAssertions.Formatting;
 
 public class TimeOnlyValueFormatter : IValueFormatter

--- a/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿#if NET6_0_OR_GREATER
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Execution;
 
-#if NET6_0_OR_GREATER
 namespace FluentAssertions.Primitives;
 
 /// <summary>

--- a/Src/FluentAssertions/Primitives/NullableDateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateOnlyAssertions.cs
@@ -1,8 +1,9 @@
+#if NET6_0_OR_GREATER
+
 using System;
 using System.Diagnostics;
 using FluentAssertions.Execution;
 
-#if NET6_0_OR_GREATER
 namespace FluentAssertions.Primitives;
 
 /// <summary>

--- a/Src/FluentAssertions/Primitives/NullableTimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableTimeOnlyAssertions.cs
@@ -1,8 +1,9 @@
+#if NET6_0_OR_GREATER
+
 using System;
 using System.Diagnostics;
 using FluentAssertions.Execution;
 
-#if NET6_0_OR_GREATER
 namespace FluentAssertions.Primitives;
 
 /// <summary>

--- a/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
@@ -1,11 +1,12 @@
-﻿using System;
+﻿#if NET6_0_OR_GREATER
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
-#if NET6_0_OR_GREATER
 namespace FluentAssertions.Primitives;
 
 /// <summary>

--- a/Tests/Benchmarks/TypeMemberReflectorBenchmarks.cs
+++ b/Tests/Benchmarks/TypeMemberReflectorBenchmarks.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using FluentAssertions.Common;
-using FluentAssertions.Equivalency;
 using static FluentAssertions.Equivalency.MemberVisibility;
 
 namespace Benchmarks;

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -6,7 +6,6 @@ using Chill;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Equivalency.Steps;
 using FluentAssertions.Execution;
-using FluentAssertions.Extensions;
 using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountGreaterThan.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountGreaterThan.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountLessThan.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountLessThan.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountLessThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountLessThanOrEqualTo.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 #if NET47

--- a/Tests/FluentAssertions.Specs/Exceptions/NotThrowSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/NotThrowSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using FluentAssertions.Execution;
 #if NET47
 using FluentAssertions.Specs.Common;

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -7,7 +7,6 @@ using FluentAssertions;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
-using FluentAssertions.Primitives;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/Primitives/DateOnlyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateOnlyAssertionSpecs.cs
@@ -1,4 +1,5 @@
 #if NET6_0_OR_GREATER
+
 using System;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeLessThan.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeLessThan.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Linq;
-using FluentAssertions.Common;
 using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Specialized;
 using Xunit;

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
-using FluentAssertions.Specialized;
 using Xunit;
 using Xunit.Sdk;
 using static FluentAssertions.FluentActions;


### PR DESCRIPTION
Remove unused using directives which also result in warnings from ReSharper or Qodana.


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
