### PR TITLE
Avoid possible 'null' assignment in `CallerIdentifier`

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -27,9 +27,7 @@ public static class CallerIdentifier
         {
             var stack = new StackTrace(fNeedFileInfo: true);
 
-            var allStackFrames = stack.GetFrames()
-                .Where(frame => frame is not null && !IsCompilerServices(frame))
-                .ToArray();
+            var allStackFrames = GetFrames(stack);
 
             int searchStart = allStackFrames.Length - 1;
 
@@ -83,9 +81,7 @@ public static class CallerIdentifier
         {
             var stack = new StackTrace();
 
-            var allStackFrames = stack.GetFrames()
-                .Where(frame => frame is not null && !IsCompilerServices(frame))
-                .ToArray();
+            var allStackFrames = GetFrames(stack);
 
             int firstUserCodeFrameIndex = 0;
 
@@ -116,9 +112,7 @@ public static class CallerIdentifier
 
     internal static bool OnlyOneFluentAssertionScopeOnCallStack()
     {
-        var allStackFrames = new StackTrace().GetFrames()
-            .Where(frame => frame is not null && !IsCompilerServices(frame))
-            .ToArray();
+        var allStackFrames = GetFrames(new StackTrace());
 
         int firstNonFluentAssertionsStackFrameIndex = Array.FindIndex(
             allStackFrames,
@@ -266,5 +260,12 @@ public static class CallerIdentifier
     private static bool IsBooleanLiteral(string candidate)
     {
         return candidate is "true" or "false";
+    }
+
+    private static StackFrame[] GetFrames(StackTrace stack)
+    {
+        return stack.GetFrames()?
+            .Where(frame => frame is not null && !IsCompilerServices(frame))
+            .ToArray() ?? Array.Empty<StackFrame>();
     }
 }

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -264,8 +264,15 @@ public static class CallerIdentifier
 
     private static StackFrame[] GetFrames(StackTrace stack)
     {
-        return stack.GetFrames()?
-            .Where(frame => frame is not null && !IsCompilerServices(frame))
-            .ToArray() ?? Array.Empty<StackFrame>();
+        var frames = stack.GetFrames();
+#if !NET6_0_OR_GREATER
+        if (frames == null)
+        {
+            return Array.Empty<StackFrame>();
+        }
+#endif
+        return frames
+            .Where(frame => !IsCompilerServices(frame))
+            .ToArray();
     }
 }


### PR DESCRIPTION
Fix issue detected by ReSharper:
- Possible 'null' assignment to non-nullable entity


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
