### PR TITLE
Spike to revisit AssertionScope

### DIFF
--- a/FluentAssertions.sln.DotSettings
+++ b/FluentAssertions.sln.DotSettings
@@ -158,22 +158,22 @@
 	<s:Int64 x:Key="/Default/Environment/UnitTesting/ParallelProcessesCount/@EntryValue">4</s:Int64>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/ShadowCopy/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/@KeyIndexDefined">True</s:Boolean>
-	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Field/=behavior/@KeyIndexDefined">True</s:Boolean>
-	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Field/=behavior/Order/@EntryValue">1</s:Int64>
-	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Field/=scenario/@KeyIndexDefined">True</s:Boolean>
-	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Field/=scenario/Order/@EntryValue">0</s:Int64>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Field/=behavior/@KeyIndexDefined">False</s:Boolean>
+	
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Field/=scenario/@KeyIndexDefined">False</s:Boolean>
+	
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Shortcut/@EntryValue">aaa</s:String>
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Description/@EntryValue">Arrange-Act-Assert</s:String>
-	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Text/@EntryValue">[TestMethod]&#xD;
-public void When_$scenario$_it_should_$behavior$()&#xD;
-{&#xD;
-    // Arrange&#xD;
-    $END$&#xD;
-&#xD;
-    // Act&#xD;
-&#xD;
-&#xD;
-    // Assert&#xD;
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Text/@EntryValue">[Fact]
+public void $END$()
+{
+    // Arrange
+    
+
+    // Act
+
+
+    // Assert
 }</s:String>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Reformat/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/ShortenQualifiedReferences/@EntryValue">True</s:Boolean>

--- a/Src/FluentAssertions/AndConstraint.cs
+++ b/Src/FluentAssertions/AndConstraint.cs
@@ -10,8 +10,8 @@ public class AndConstraint<T>
     /// <summary>
     /// Initializes a new instance of the <see cref="AndConstraint{T}"/> class.
     /// </summary>
-    public AndConstraint(T parentConstraint)
+    public AndConstraint(T assertion)
     {
-        And = parentConstraint;
+        And = assertion;
     }
 }

--- a/Src/FluentAssertions/AndWhichConstraint2.cs
+++ b/Src/FluentAssertions/AndWhichConstraint2.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions.Common;
+using FluentAssertions.Execution;
+using FluentAssertions.Formatting;
+
+namespace FluentAssertions;
+
+/// <summary>
+/// Constraint which can be returned from an assertion which matches a condition and which will allow
+/// further matches to be performed on the matched condition as well as the parent constraint.
+/// </summary>
+/// <typeparam name="TParentConstraint">The type of the original constraint that was matched</typeparam>
+/// <typeparam name="TMatchedElement">The type of the matched object which the parent constraint matched</typeparam>
+public class AndWhichConstraint2<TParentConstraint, TMatchedElement> : AndConstraint<TParentConstraint>
+{
+    private readonly Assertion assertion;
+    private readonly Lazy<TMatchedElement> matchedConstraint;
+
+    public AndWhichConstraint2(TParentConstraint parentConstraint, TMatchedElement matchedConstraint, Assertion assertion)
+        : base(parentConstraint)
+    {
+        this.assertion = assertion;
+
+        this.matchedConstraint =
+            new Lazy<TMatchedElement>(() => matchedConstraint);
+    }
+
+    public AndWhichConstraint2(TParentConstraint assertion, IEnumerable<TMatchedElement> matchedConstraint)
+        : base(assertion)
+    {
+        this.matchedConstraint =
+            new Lazy<TMatchedElement>(
+                () => SingleOrDefault(matchedConstraint));
+    }
+
+    private static TMatchedElement SingleOrDefault(
+        IEnumerable<TMatchedElement> matchedConstraint)
+    {
+        TMatchedElement[] matchedElements = matchedConstraint.ToArray();
+
+        if (matchedElements.Length > 1)
+        {
+            string foundObjects = string.Join(Environment.NewLine,
+                matchedElements.Select(
+                    ele => "\t" + Formatter.ToString(ele)));
+
+            string message = "More than one object found.  FluentAssertions cannot determine which object is meant."
+                + $"  Found objects:{Environment.NewLine}{foundObjects}";
+
+            Services.ThrowException(message);
+        }
+
+        return matchedElements.Single();
+    }
+
+    /// <summary>
+    /// Returns the single result of a prior assertion that is used to select a nested or collection item.
+    /// </summary>
+    public WhichResult<TMatchedElement> Which => new(matchedConstraint.Value, assertion);
+
+    /// <summary>
+    /// Returns the single result of a prior assertion that is used to select a nested or collection item.
+    /// </summary>
+    /// <remarks>
+    /// Just a convenience property that returns the same value as <see cref="Which"/>.
+    /// </remarks>
+    public WhichResult<TMatchedElement> Subject => Which;
+}

--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -11,6 +12,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions.Collections;
 using FluentAssertions.Common;
+using FluentAssertions.Execution;
 using FluentAssertions.Numeric;
 using FluentAssertions.Primitives;
 using FluentAssertions.Reflection;
@@ -287,6 +289,11 @@ public static class AssertionExtensions
         return new ObjectAssertions(actualValue);
     }
 
+    public static ObjectAssertions Should(this WhichResult<object> tuple)
+    {
+        return new ObjectAssertions(tuple.MatchedElement);
+    }
+
     /// <summary>
     /// Returns an <see cref="BooleanAssertions"/> object that can be used to assert the
     /// current <see cref="bool"/>.
@@ -344,7 +351,7 @@ public static class AssertionExtensions
     [Pure]
     public static GenericCollectionAssertions<T> Should<T>(this IEnumerable<T> actualValue)
     {
-        return new GenericCollectionAssertions<T>(actualValue);
+        return new GenericCollectionAssertions<T>(actualValue, new Assertion(AssertionScope.Current, () => AssertionScope.Current.GetIdentifier()));
     }
 
     /// <summary>
@@ -354,7 +361,7 @@ public static class AssertionExtensions
     [Pure]
     public static StringCollectionAssertions Should(this IEnumerable<string> @this)
     {
-        return new StringCollectionAssertions(@this);
+        return new StringCollectionAssertions(@this, new Assertion(AssertionScope.Current, () => AssertionScope.Current.GetIdentifier()));
     }
 
     /// <summary>
@@ -365,7 +372,8 @@ public static class AssertionExtensions
     public static GenericDictionaryAssertions<IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(
         this IDictionary<TKey, TValue> actualValue)
     {
-        return new GenericDictionaryAssertions<IDictionary<TKey, TValue>, TKey, TValue>(actualValue);
+        return new GenericDictionaryAssertions<IDictionary<TKey, TValue>, TKey, TValue>(actualValue, new Assertion(AssertionScope.Current,
+            () => AssertionScope.Current.GetIdentifier()));
     }
 
     /// <summary>
@@ -376,7 +384,8 @@ public static class AssertionExtensions
     public static GenericDictionaryAssertions<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(
         this IEnumerable<KeyValuePair<TKey, TValue>> actualValue)
     {
-        return new GenericDictionaryAssertions<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue>(actualValue);
+        return new GenericDictionaryAssertions<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue>(actualValue, new Assertion(AssertionScope.Current,
+            () => AssertionScope.Current.GetIdentifier()));
     }
 
     /// <summary>
@@ -388,7 +397,8 @@ public static class AssertionExtensions
         this TCollection actualValue)
         where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
     {
-        return new GenericDictionaryAssertions<TCollection, TKey, TValue>(actualValue);
+        return new GenericDictionaryAssertions<TCollection, TKey, TValue>(actualValue, new Assertion(AssertionScope.Current,
+            () => AssertionScope.Current.GetIdentifier()));
     }
 
     /// <summary>
@@ -485,6 +495,16 @@ public static class AssertionExtensions
     }
 
     /// <summary>
+    /// Returns an <see cref="ComparableTypeAssertions{T}"/> object that can be used to assert the
+    /// current <see cref="IComparable{T}"/>.
+    /// </summary>
+    [Pure]
+    public static ComparableTypeAssertions<T> Should<T>(this WhichResult<IComparable<T>> tuple)
+    {
+        return new ComparableTypeAssertions<T>(tuple.MatchedElement);
+    }
+
+    /// <summary>
     /// Returns an <see cref="NumericAssertions{T}"/> object that can be used to assert the
     /// current <see cref="int"/>.
     /// </summary>
@@ -492,6 +512,16 @@ public static class AssertionExtensions
     public static NumericAssertions<int> Should(this int actualValue)
     {
         return new Int32Assertions(actualValue);
+    }
+
+    /// <summary>
+    /// Returns an <see cref="NumericAssertions{T}"/> object that can be used to assert the
+    /// current <see cref="int"/>.
+    /// </summary>
+    [Pure]
+    public static NumericAssertions<int> Should(this WhichResult<int> actualValue)
+    {
+        return new Int32Assertions(actualValue.MatchedElement);
     }
 
     /// <summary>
@@ -711,7 +741,18 @@ public static class AssertionExtensions
     [Pure]
     public static StringAssertions Should(this string actualValue)
     {
-        return new StringAssertions(actualValue);
+        return new StringAssertions(actualValue,
+            new Assertion(AssertionScope.Current, () => AssertionScope.Current.GetIdentifier()));
+    }
+
+    /// <summary>
+    /// Returns an <see cref="StringAssertions"/> object that can be used to assert the
+    /// current <see cref="string"/>.
+    /// </summary>
+    [Pure]
+    public static StringAssertions Should(this (string ActualValue, Assertion CurrentAssertion) values)
+    {
+        return new StringAssertions(values.ActualValue, values.CurrentAssertion);
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -17,8 +17,8 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue>
     : GenericDictionaryAssertions<TCollection, TKey, TValue, GenericDictionaryAssertions<TCollection, TKey, TValue>>
     where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
 {
-    public GenericDictionaryAssertions(TCollection keyValuePairs)
-        : base(keyValuePairs)
+    public GenericDictionaryAssertions(TCollection keyValuePairs, Assertion assertion)
+        : base(keyValuePairs, assertion)
     {
     }
 }
@@ -32,8 +32,8 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
     where TAssertions : GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
 {
-    public GenericDictionaryAssertions(TCollection keyValuePairs)
-        : base(keyValuePairs)
+    public GenericDictionaryAssertions(TCollection keyValuePairs, Assertion assertion)
+        : base(keyValuePairs, assertion)
     {
     }
 

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -12,8 +12,8 @@ public class StringCollectionAssertions : StringCollectionAssertions<IEnumerable
     /// <summary>
     /// Initializes a new instance of the <see cref="StringCollectionAssertions"/> class.
     /// </summary>
-    public StringCollectionAssertions(IEnumerable<string> actualValue)
-        : base(actualValue)
+    public StringCollectionAssertions(IEnumerable<string> actualValue, Assertion assertion)
+        : base(actualValue, assertion)
     {
     }
 }
@@ -25,8 +25,8 @@ public class StringCollectionAssertions<TCollection>
     /// <summary>
     /// Initializes a new instance of the <see cref="StringCollectionAssertions{TCollection}"/> class.
     /// </summary>
-    public StringCollectionAssertions(TCollection actualValue)
-        : base(actualValue)
+    public StringCollectionAssertions(TCollection actualValue, Assertion assertion)
+        : base(actualValue, assertion)
     {
     }
 }
@@ -38,8 +38,8 @@ public class StringCollectionAssertions<TCollection, TAssertions> : GenericColle
     /// <summary>
     /// Initializes a new instance of the <see cref="StringCollectionAssertions{TCollection, TAssertions}"/> class.
     /// </summary>
-    public StringCollectionAssertions(TCollection actualValue)
-        : base(actualValue)
+    public StringCollectionAssertions(TCollection actualValue, Assertion assertion)
+        : base(actualValue, assertion)
     {
     }
 

--- a/Src/FluentAssertions/Collections/SubsequentOrderingAssertions.cs
+++ b/Src/FluentAssertions/Collections/SubsequentOrderingAssertions.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using FluentAssertions.Execution;
 
 namespace FluentAssertions.Collections;
 
@@ -8,8 +9,8 @@ namespace FluentAssertions.Collections;
 public class SubsequentOrderingAssertions<T>
     : SubsequentOrderingGenericCollectionAssertions<IEnumerable<T>, T, SubsequentOrderingAssertions<T>>
 {
-    public SubsequentOrderingAssertions(IEnumerable<T> actualValue, IOrderedEnumerable<T> previousOrderedEnumerable)
-        : base(actualValue, previousOrderedEnumerable)
+    public SubsequentOrderingAssertions(IEnumerable<T> actualValue, IOrderedEnumerable<T> previousOrderedEnumerable, Assertion assertion)
+        : base(actualValue, previousOrderedEnumerable, assertion)
     {
     }
 }

--- a/Src/FluentAssertions/Collections/SubsequentOrderingGenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SubsequentOrderingGenericCollectionAssertions.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
+using FluentAssertions.Execution;
 
 namespace FluentAssertions.Collections;
 
@@ -16,8 +17,8 @@ public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAsse
     private readonly IOrderedEnumerable<T> previousOrderedEnumerable;
     private bool subsequentOrdering;
 
-    public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, IOrderedEnumerable<T> previousOrderedEnumerable)
-        : base(actualValue)
+    public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, IOrderedEnumerable<T> previousOrderedEnumerable, Assertion assertion)
+        : base(actualValue, assertion)
     {
         this.previousOrderedEnumerable = previousOrderedEnumerable;
     }
@@ -167,8 +168,8 @@ public class SubsequentOrderingGenericCollectionAssertions<TCollection, T>
     : SubsequentOrderingGenericCollectionAssertions<TCollection, T, SubsequentOrderingGenericCollectionAssertions<TCollection, T>>
     where TCollection : IEnumerable<T>
 {
-    public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, IOrderedEnumerable<T> previousOrderedEnumerable)
-        : base(actualValue, previousOrderedEnumerable)
+    public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, IOrderedEnumerable<T> previousOrderedEnumerable, Assertion assertion)
+        : base(actualValue, previousOrderedEnumerable, assertion)
     {
     }
 }

--- a/Src/FluentAssertions/Execution/Assertion.cs
+++ b/Src/FluentAssertions/Execution/Assertion.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using FluentAssertions.Common;
+
+namespace FluentAssertions.Execution;
+
+public class Assertion<TAssertion> : IAssertion
+    where TAssertion : Assertion<TAssertion>
+{
+    private const string FallbackIdentifier = "object";
+    private Func<string> getCallerIdentifier;
+    private bool previousAssertionSucceeded;
+    private Func<string> reason;
+    private bool? succeeded;
+    private Func<string> expectation;
+
+    public Assertion(IAssertionScope currentScope, Func<string> getCallerIdentifier, bool previousAssertionSucceeded = true)
+    {
+        this.CurrentScope = currentScope;
+        this.getCallerIdentifier = getCallerIdentifier;
+        this.previousAssertionSucceeded = previousAssertionSucceeded;
+    }
+
+    internal Assertion(IAssertion previousAssertion)
+        : this(previousAssertion.CurrentScope, previousAssertion.GetCallerIdentifier, previousAssertion.Succeeded)
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the context of the current assertion scope, e.g. the path of the object graph
+    /// that is being asserted on. The context is provided by a <see cref="Lazy{String}"/> which
+    /// only gets evaluated when its value is actually needed (in most cases during a failure).
+    /// </summary>
+    public Lazy<string> Context { get; set; }
+
+    /// <summary>
+    /// Adds an explanation of why the assertion is supposed to succeed to the scope.
+    /// </summary>
+    public TAssertion BecauseOf(Reason reason)
+    {
+        return BecauseOf(reason.FormattedMessage, reason.Arguments);
+    }
+
+    /// <inheritdoc cref="IAssertionScope.BecauseOf(string, object[])"/>
+    public TAssertion BecauseOf(string because, params object[] becauseArgs)
+    {
+        if (previousAssertionSucceeded)
+        {
+            reason = () =>
+            {
+                try
+                {
+                    string becauseOrEmpty = because ?? string.Empty;
+
+                    return becauseArgs?.Length > 0
+                        ? string.Format(CultureInfo.InvariantCulture, becauseOrEmpty, becauseArgs)
+                        : becauseOrEmpty;
+                }
+                catch (FormatException formatException)
+                {
+                    return
+                        $"**WARNING** because message '{because}' could not be formatted with string.Format{Environment.NewLine}{formatException.StackTrace}";
+                }
+            };
+        }
+
+        return (TAssertion)this;
+    }
+
+    /// <inheritdoc cref="IAssertionScope.ForCondition(bool)"/>
+    public TAssertion ForCondition(bool condition)
+    {
+        if (previousAssertionSucceeded)
+        {
+            succeeded = condition;
+        }
+
+        return (TAssertion)this;
+    }
+
+    void IAssertion.ForCondition(bool predicate) => ForCondition(predicate);
+
+    void IAssertion.FailWith(string message, object[] args) => FailWith(message, args);
+
+    public TAssertion ForConstraint(OccurrenceConstraint constraint, int actualOccurrences)
+    {
+        if (previousAssertionSucceeded)
+        {
+            constraint.RegisterReportables(CurrentScope);
+            succeeded = constraint.Assert(actualOccurrences);
+        }
+
+        return (TAssertion)this;
+    }
+
+    public TAssertion WithExpectation(string message, params object[] args)
+    {
+        if (previousAssertionSucceeded)
+        {
+            Func<string> localReason = reason;
+
+            expectation = () =>
+            {
+                var messageBuilder = new MessageBuilder(CurrentScope.FormattingOptions);
+                string actualReason = localReason?.Invoke() ?? string.Empty;
+                string identifier = getCallerIdentifier();
+
+                return messageBuilder.Build(
+                    message,
+                    args,
+                    actualReason,
+                    CurrentScope.ContextData,
+                    identifier,
+                    FallbackIdentifier);
+            };
+        }
+
+        return (TAssertion)this;
+    }
+
+    public NewContinuation<ContinuedAssertion> FailWith(string message)
+    {
+        return FailWith(() => new FailReason(message));
+    }
+
+    public NewContinuation<ContinuedAssertion> FailWith(string message, params object[] args)
+    {
+        return FailWith(() => new FailReason(message, args));
+    }
+
+    public NewContinuation<ContinuedAssertion> FailWith(string message, params Func<object>[] argProviders)
+    {
+        return FailWith(
+            () => new FailReason(
+                message,
+                argProviders.Select(a => a()).ToArray()));
+    }
+
+    public NewContinuation<ContinuedAssertion> FailWith(Func<FailReason> failReasonFunc)
+    {
+        return FailWith(
+            () =>
+            {
+                string localReason = reason?.Invoke() ?? string.Empty;
+                var messageBuilder = new MessageBuilder(CurrentScope.FormattingOptions);
+                string identifier = getCallerIdentifier();
+                FailReason failReason = failReasonFunc();
+
+                string result = messageBuilder.Build(
+                    failReason.Message,
+                    failReason.Args,
+                    localReason,
+                    CurrentScope.ContextData,
+                    identifier,
+                    FallbackIdentifier);
+
+                return result;
+            });
+    }
+
+    private NewContinuation<ContinuedAssertion> FailWith(Func<string> failReasonFunc)
+    {
+        if (previousAssertionSucceeded)
+        {
+            previousAssertionSucceeded = succeeded is not null or true;
+            if (!previousAssertionSucceeded)
+            {
+                string result = failReasonFunc();
+
+                if (expectation is not null)
+                {
+                    result = expectation() + result;
+                }
+
+                CurrentScope.AddPreFormattedFailure(result.Capitalize());
+            }
+        }
+
+        // Reset the state for successive assertions on this object
+        succeeded = null;
+
+        return new NewContinuation<ContinuedAssertion>(this);
+    }
+
+    public TAssertion WithCallerPostfix(string postfix)
+    {
+        var originalCallerIdentifier = getCallerIdentifier;
+        getCallerIdentifier = () => originalCallerIdentifier() + postfix;
+        return (TAssertion)this;
+    }
+
+    public IAssertionScope CurrentScope { get; }
+
+    public Func<string> GetCallerIdentifier => getCallerIdentifier;
+
+    public bool Succeeded => previousAssertionSucceeded && (succeeded is null or true);
+
+    public TAssertion UsingLineBreaks
+    {
+        get
+        {
+            CurrentScope.FormattingOptions.UseLineBreaks = true;
+            return (TAssertion)this;
+        }
+    }
+}
+
+public class Assertion : Assertion<Assertion>
+{
+    public Assertion(IAssertionScope currentScope, Func<string> getCallerIdentifier)
+        : base(currentScope, getCallerIdentifier, previousAssertionSucceeded: true)
+    {
+    }
+}

--- a/Src/FluentAssertions/Execution/ContextDataItems.cs
+++ b/Src/FluentAssertions/Execution/ContextDataItems.cs
@@ -7,7 +7,7 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Represents a collection of data items that are associated with an <see cref="AssertionScope"/>.
 /// </summary>
-internal class ContextDataItems
+public class ContextDataItems
 {
     private readonly List<DataItem> items = new();
 
@@ -61,7 +61,7 @@ internal class ContextDataItems
         return (T)(item?.Value ?? default(T));
     }
 
-    internal class DataItem
+    public class DataItem
     {
         public DataItem(string key, object value, bool reportable, bool requiresFormatting)
         {

--- a/Src/FluentAssertions/Execution/ContinuedAssertion.cs
+++ b/Src/FluentAssertions/Execution/ContinuedAssertion.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace FluentAssertions.Execution;
+
+public class ContinuedAssertion : Assertion<ContinuedAssertion>
+{
+    public ContinuedAssertion(IAssertion previousAssertion)
+        : base(previousAssertion)
+    {
+    }
+
+    public NewGivenSelector<T> Given<T>(Func<T> selector)
+    {
+        return new NewGivenSelector<T>(selector, this);
+    }
+}

--- a/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
@@ -1,4 +1,5 @@
 using System;
+using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Execution;
 
@@ -141,11 +142,21 @@ public sealed class ContinuedAssertionScope : IAssertionScope
     /// <inheritdoc/>
     public IAssertionScope UsingLineBreaks => predecessor.UsingLineBreaks;
 
+    public ContextDataItems ContextData { get; }
+
+    public FormattingOptions FormattingOptions { get; }
+
     /// <inheritdoc/>
     public string[] Discard()
     {
         return predecessor.Discard();
     }
+
+    public void AddPreFormattedFailure(string formattedFailureMessage) => throw new NotSupportedException();
+
+    public void AddReportable(string key, Func<string> valueFunc) => throw new NotSupportedException();
+
+    public void AddReportable(string key, string value) => throw new NotSupportedException();
 
     /// <inheritdoc/>
     public void Dispose()

--- a/Src/FluentAssertions/Execution/IAssertion.cs
+++ b/Src/FluentAssertions/Execution/IAssertion.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace FluentAssertions.Execution;
+
+public interface IAssertion
+{
+    IAssertionScope CurrentScope { get; }
+
+    bool Succeeded { get; }
+
+    Func<string> GetCallerIdentifier { get; }
+
+    void ForCondition(bool predicate);
+
+    void FailWith(string message, object[] args);
+}

--- a/Src/FluentAssertions/Execution/IAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/IAssertionScope.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Execution;
 
@@ -178,8 +179,32 @@ public interface IAssertionScope : IDisposable
     /// </remarks>
     IAssertionScope UsingLineBreaks { get; }
 
+    ContextDataItems ContextData { get; }
+
+    /// <summary>
+    /// Exposes the options the scope will use for formatting objects in case an assertion fails.
+    /// </summary>
+    FormattingOptions FormattingOptions { get; }
+
     /// <summary>
     /// Discards and returns the failures that happened up to now.
     /// </summary>
     string[] Discard();
+
+    /// <summary>
+    /// Adds a pre-formatted failure message to the current scope.
+    /// </summary>
+    void AddPreFormattedFailure(string formattedFailureMessage);
+
+    /// <summary>
+    /// Adds some information to the assertion scope that will be included in the message
+    /// that is emitted if an assertion fails. The value is only calculated on failure.
+    /// </summary>
+    void AddReportable(string key, Func<string> valueFunc);
+
+    /// <summary>
+    /// Adds some information to the assertion scope that will be included in the message
+    /// that is emitted if an assertion fails.
+    /// </summary>
+    void AddReportable(string key, string value);
 }

--- a/Src/FluentAssertions/Execution/NewContinuation.cs
+++ b/Src/FluentAssertions/Execution/NewContinuation.cs
@@ -1,0 +1,26 @@
+﻿namespace FluentAssertions.Execution;
+
+/// <summary>
+/// Enables chaining multiple assertions on an <see cref="AssertionScope"/>.
+/// </summary>
+public class NewContinuation<TAssertion>
+    where TAssertion : Assertion<TAssertion>
+{
+    private readonly IAssertion assertion;
+
+    internal NewContinuation(IAssertion assertion)
+    {
+        this.assertion = assertion;
+    }
+
+    /// <summary>
+    /// Continuous the assertion chain if the previous assertion was successful.
+    /// </summary>
+    public ContinuedAssertion Then
+    {
+        get
+        {
+            return new ContinuedAssertion(assertion);
+        }
+    }
+}

--- a/Src/FluentAssertions/Execution/NewContinuationOfGiven.cs
+++ b/Src/FluentAssertions/Execution/NewContinuationOfGiven.cs
@@ -1,0 +1,17 @@
+﻿namespace FluentAssertions.Execution;
+
+/// <summary>
+/// Enables chaining multiple assertions from a <see cref="AssertionScope.Given{T}"/> call.
+/// </summary>
+public class NewContinuationOfGiven<TSubject>
+{
+    internal NewContinuationOfGiven(NewGivenSelector<TSubject> parent)
+    {
+        Then = parent;
+    }
+
+    /// <summary>
+    /// Continuous the assertion chain if the previous assertion was successful.
+    /// </summary>
+    public NewGivenSelector<TSubject> Then { get; }
+}

--- a/Src/FluentAssertions/Execution/NewGivenSelector.cs
+++ b/Src/FluentAssertions/Execution/NewGivenSelector.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions.Common;
+
+namespace FluentAssertions.Execution;
+
+/// <summary>
+/// Represents a chaining object returned from <see cref="AssertionScope.Given{T}"/> to continue the assertion using
+/// an object returned by a selector.
+/// </summary>
+public class NewGivenSelector<T>
+{
+    private readonly IAssertion previousAssertion;
+    private readonly T selector;
+
+    internal NewGivenSelector(Func<T> selector, IAssertion previousAssertion)
+    {
+        this.previousAssertion = previousAssertion;
+
+        this.selector = previousAssertion.Succeeded ? selector() : default;
+    }
+
+    /// <summary>
+    /// Specify the condition that must be satisfied upon the subject selected through a prior selector.
+    /// </summary>
+    /// <param name="predicate">
+    /// If <see langword="true"/> the assertion will be treated as successful and no exceptions will be thrown.
+    /// </param>
+    /// <remarks>
+    /// The condition will not be evaluated if the prior assertion failed,
+    /// nor will <see cref="FailWith(string,System.Func{T,object}[])"/> throw any exceptions.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
+    public NewGivenSelector<T> ForCondition(Func<T, bool> predicate)
+    {
+        Guard.ThrowIfArgumentIsNull(predicate);
+
+        if (previousAssertion.Succeeded)
+        {
+            previousAssertion.ForCondition(predicate(selector));
+        }
+
+        return this;
+    }
+
+    /// <remarks>
+    /// The <paramref name="selector"/> will not be invoked if the prior assertion failed,
+    /// nor will <see cref="FailWith(string,System.Func{T,object}[])"/> throw any exceptions.
+    /// </remarks>
+    /// <inheritdoc cref="IAssertionScope.Given{T}"/>
+    /// <exception cref="ArgumentNullException"><paramref name="selector"/> is <see langword="null"/>.</exception>
+    public NewGivenSelector<TOut> Given<TOut>(Func<T, TOut> selector)
+    {
+        Guard.ThrowIfArgumentIsNull(selector);
+
+        return new NewGivenSelector<TOut>(() => selector(this.selector), previousAssertion);
+    }
+
+    /// <inheritdoc cref="IAssertionScope.FailWith(string)"/>
+    public NewContinuationOfGiven<T> FailWith(string message)
+    {
+        return FailWith(message, Array.Empty<object>());
+    }
+
+    /// <remarks>
+    /// <inheritdoc cref="IAssertionScope.FailWith(string, object[])"/>
+    /// The <paramref name="args"/> will not be invoked if the prior assertion failed,
+    /// nor will <see cref="FailWith(string, Func{T,object}[])"/> throw any exceptions.
+    /// </remarks>
+    /// <inheritdoc cref="IAssertionScope.FailWith(string, object[])"/>
+    public NewContinuationOfGiven<T> FailWith(string message, params Func<T, object>[] args)
+    {
+        if (previousAssertion.Succeeded)
+        {
+            object[] mappedArguments = args.Select(a => a(selector)).ToArray();
+            return FailWith(message, mappedArguments);
+        }
+
+        return new NewContinuationOfGiven<T>(this);
+    }
+
+    /// <remarks>
+    /// <inheritdoc cref="IAssertionScope.FailWith(string, object[])"/>
+    /// The <paramref name="args"/> will not be invoked if the prior assertion failed,
+    /// nor will <see cref="FailWith(string, object[])"/> throw any exceptions.
+    /// </remarks>
+    /// <inheritdoc cref="IAssertionScope.FailWith(string, object[])"/>
+    public NewContinuationOfGiven<T> FailWith(string message, params object[] args)
+    {
+        if (previousAssertion.Succeeded)
+        {
+            previousAssertion.FailWith(message, args);
+            return new NewContinuationOfGiven<T>(this);
+        }
+
+        return new NewContinuationOfGiven<T>(this);
+    }
+}

--- a/Src/FluentAssertions/OccurrenceConstraint.cs
+++ b/Src/FluentAssertions/OccurrenceConstraint.cs
@@ -22,7 +22,7 @@ public abstract class OccurrenceConstraint
 
     internal abstract bool Assert(int actual);
 
-    internal void RegisterReportables(AssertionScope scope)
+    internal void RegisterReportables(IAssertionScope scope)
     {
         scope.AddReportable("expectedOccurrence", $"{Mode} {ExpectedCount.Times()}");
     }

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -19,8 +19,8 @@ public class StringAssertions : StringAssertions<StringAssertions>
     /// <summary>
     /// Initializes a new instance of the <see cref="StringAssertions"/> class.
     /// </summary>
-    public StringAssertions(string value)
-        : base(value)
+    public StringAssertions(string value, Assertion assertion)
+        : base(value, assertion)
     {
     }
 }
@@ -32,12 +32,15 @@ public class StringAssertions : StringAssertions<StringAssertions>
 public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAssertions>
     where TAssertions : StringAssertions<TAssertions>
 {
+    private readonly Assertion assertion;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="StringAssertions{TAssertions}"/> class.
     /// </summary>
-    public StringAssertions(string value)
+    public StringAssertions(string value, Assertion assertion)
         : base(value)
     {
+        this.assertion = assertion;
     }
 
     /// <summary>
@@ -780,19 +783,19 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     {
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare string end with <null>.");
 
-        bool success = Execute.Assertion
+        assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject is not null)
             .FailWith("Expected {context:string} {0} to end with {1}{reason}.", Subject, expected);
 
-        if (success)
+        if (assertion.Succeeded)
         {
-            success = Execute.Assertion
+            assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject.Length >= expected.Length)
                 .FailWith("Expected {context:string} to end with {0}{reason}, but {1} is too short.", expected, Subject);
 
-            if (success)
+            if (assertion.Succeeded)
             {
                 Execute.Assertion
                     .ForCondition(Subject.EndsWith(expected, StringComparison.Ordinal))

--- a/Src/FluentAssertions/WhichResult.cs
+++ b/Src/FluentAssertions/WhichResult.cs
@@ -1,0 +1,16 @@
+﻿using FluentAssertions.Execution;
+
+namespace FluentAssertions;
+
+public class WhichResult<T>
+{
+    public WhichResult(T matchedElement, Assertion assertion)
+    {
+        MatchedElement = matchedElement;
+        Assertion = assertion;
+    }
+
+    public T MatchedElement { get; }
+
+    public Assertion Assertion { get; }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -367,18 +367,18 @@ namespace FluentAssertions.Collections
 {
     public class GenericCollectionAssertions<T> : FluentAssertions.Collections.GenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
-        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class GenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T>>
         where TCollection : System.Collections.Generic.IEnumerable<T>
     {
-        public GenericCollectionAssertions(TCollection actualValue) { }
+        public GenericCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class GenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TCollection, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<T>
         where TAssertions : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
     {
-        public GenericCollectionAssertions(TCollection actualValue) { }
+        public GenericCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, System.Collections.Generic.IEnumerable<TExpectation>> AllBeAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) { }
@@ -483,13 +483,13 @@ namespace FluentAssertions.Collections
     public class GenericDictionaryAssertions<TCollection, TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue>>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
     {
-        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, System.Collections.Generic.KeyValuePair<TKey, TValue>, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
         where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs, FluentAssertions.Execution.Assertion assertion) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
@@ -520,18 +520,18 @@ namespace FluentAssertions.Collections
     }
     public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
-        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class StringCollectionAssertions<TCollection> : FluentAssertions.Collections.StringCollectionAssertions<TCollection, FluentAssertions.Collections.StringCollectionAssertions<TCollection>>
         where TCollection : System.Collections.Generic.IEnumerable<string>
     {
-        public StringCollectionAssertions(TCollection actualValue) { }
+        public StringCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class StringCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, string, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<string>
         where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
     {
-        public StringCollectionAssertions(TCollection actualValue) { }
+        public StringCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
         public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
@@ -544,18 +544,18 @@ namespace FluentAssertions.Collections
     }
     public class SubsequentOrderingAssertions<T> : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.SubsequentOrderingAssertions<T>>
     {
-        public SubsequentOrderingAssertions(System.Collections.Generic.IEnumerable<T> actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public SubsequentOrderingAssertions(System.Collections.Generic.IEnumerable<T> actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class SubsequentOrderingGenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T>>
         where TCollection : System.Collections.Generic.IEnumerable<T>
     {
-        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<T>
         where TAssertions : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions>
     {
-        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable, FluentAssertions.Execution.Assertion assertion) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
@@ -1135,6 +1135,10 @@ namespace FluentAssertions.Events
 }
 namespace FluentAssertions.Execution
 {
+    public class Assertion : FluentAssertions.Execution.Assertion<FluentAssertions.Execution.Assertion>
+    {
+        public Assertion(FluentAssertions.Execution.IAssertionScope currentScope, System.Func<string> getCallerIdentifier) { }
+    }
     [System.Serializable]
     public class AssertionFailedException : System.Exception
     {
@@ -1149,6 +1153,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(string context) { }
         public string CallerIdentity { get; }
         public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Execution.ContextDataItems ContextData { get; }
         public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
@@ -1170,10 +1175,49 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
         public FluentAssertions.Execution.AssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
+        public string GetIdentifier() { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }
         public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
         public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Assertion<TAssertion> : FluentAssertions.Execution.IAssertion
+        where TAssertion : FluentAssertions.Execution.Assertion<TAssertion>
+    {
+        public Assertion(FluentAssertions.Execution.IAssertionScope currentScope, System.Func<string> getCallerIdentifier, bool previousAssertionSucceeded = true) { }
+        public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Execution.IAssertionScope CurrentScope { get; }
+        public System.Func<string> GetCallerIdentifier { get; }
+        public bool Succeeded { get; }
+        public TAssertion UsingLineBreaks { get; }
+        public TAssertion BecauseOf(FluentAssertions.Execution.Reason reason) { }
+        public TAssertion BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(string message) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(string message, params System.Func<object>[] argProviders) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(string message, params object[] args) { }
+        public TAssertion ForCondition(bool condition) { }
+        public TAssertion ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
+        public TAssertion WithCallerPostfix(string postfix) { }
+        public TAssertion WithExpectation(string message, params object[] args) { }
+    }
+    public class ContextDataItems
+    {
+        public ContextDataItems() { }
+        public void Add(FluentAssertions.Execution.ContextDataItems contextDataItems) { }
+        public void Add(FluentAssertions.Execution.ContextDataItems.DataItem item) { }
+        public string AsStringOrDefault(string key) { }
+        public T Get<T>(string key) { }
+        public System.Collections.Generic.IDictionary<string, object> GetReportable() { }
+        public class DataItem
+        {
+            public DataItem(string key, object value, bool reportable, bool requiresFormatting) { }
+            public string Key { get; }
+            public bool Reportable { get; }
+            public bool RequiresFormatting { get; }
+            public object Value { get; }
+            public FluentAssertions.Execution.ContextDataItems.DataItem Clone() { }
+        }
     }
     public class Continuation
     {
@@ -1185,9 +1229,19 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
     }
+    public class ContinuedAssertion : FluentAssertions.Execution.Assertion<FluentAssertions.Execution.ContinuedAssertion>
+    {
+        public ContinuedAssertion(FluentAssertions.Execution.IAssertion previousAssertion) { }
+        public FluentAssertions.Execution.NewGivenSelector<T> Given<T>(System.Func<T> selector) { }
+    }
     public sealed class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
     {
+        public FluentAssertions.Execution.ContextDataItems ContextData { get; }
+        public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, System.Func<string> valueFunc) { }
+        public void AddReportable(string key, string value) { }
         public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }
         public string[] Discard() { }
@@ -1221,9 +1275,22 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
         public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
     }
+    public interface IAssertion
+    {
+        FluentAssertions.Execution.IAssertionScope CurrentScope { get; }
+        System.Func<string> GetCallerIdentifier { get; }
+        bool Succeeded { get; }
+        void FailWith(string message, object[] args);
+        void ForCondition(bool predicate);
+    }
     public interface IAssertionScope : System.IDisposable
     {
+        FluentAssertions.Execution.ContextDataItems ContextData { get; }
+        FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        void AddPreFormattedFailure(string formattedFailureMessage);
+        void AddReportable(string key, System.Func<string> valueFunc);
+        void AddReportable(string key, string value);
         FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
         FluentAssertions.Execution.Continuation ClearExpectation();
         string[] Discard();
@@ -1247,6 +1314,23 @@ namespace FluentAssertions.Execution
     public interface ICloneable2
     {
         object Clone();
+    }
+    public class NewContinuationOfGiven<TSubject>
+    {
+        public FluentAssertions.Execution.NewGivenSelector<TSubject> Then { get; }
+    }
+    public class NewContinuation<TAssertion>
+        where TAssertion : FluentAssertions.Execution.Assertion<TAssertion>
+    {
+        public FluentAssertions.Execution.ContinuedAssertion Then { get; }
+    }
+    public class NewGivenSelector<T>
+    {
+        public FluentAssertions.Execution.NewContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.NewContinuationOfGiven<T> FailWith(string message, params System.Func<T, object>[] args) { }
+        public FluentAssertions.Execution.NewContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.NewGivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.NewGivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
     }
     public class Reason
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -380,18 +380,18 @@ namespace FluentAssertions.Collections
 {
     public class GenericCollectionAssertions<T> : FluentAssertions.Collections.GenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
-        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class GenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T>>
         where TCollection : System.Collections.Generic.IEnumerable<T>
     {
-        public GenericCollectionAssertions(TCollection actualValue) { }
+        public GenericCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class GenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TCollection, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<T>
         where TAssertions : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
     {
-        public GenericCollectionAssertions(TCollection actualValue) { }
+        public GenericCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, System.Collections.Generic.IEnumerable<TExpectation>> AllBeAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) { }
@@ -496,13 +496,13 @@ namespace FluentAssertions.Collections
     public class GenericDictionaryAssertions<TCollection, TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue>>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
     {
-        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, System.Collections.Generic.KeyValuePair<TKey, TValue>, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
         where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs, FluentAssertions.Execution.Assertion assertion) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
@@ -533,18 +533,18 @@ namespace FluentAssertions.Collections
     }
     public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
-        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class StringCollectionAssertions<TCollection> : FluentAssertions.Collections.StringCollectionAssertions<TCollection, FluentAssertions.Collections.StringCollectionAssertions<TCollection>>
         where TCollection : System.Collections.Generic.IEnumerable<string>
     {
-        public StringCollectionAssertions(TCollection actualValue) { }
+        public StringCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class StringCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, string, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<string>
         where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
     {
-        public StringCollectionAssertions(TCollection actualValue) { }
+        public StringCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
         public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
@@ -557,18 +557,18 @@ namespace FluentAssertions.Collections
     }
     public class SubsequentOrderingAssertions<T> : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.SubsequentOrderingAssertions<T>>
     {
-        public SubsequentOrderingAssertions(System.Collections.Generic.IEnumerable<T> actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public SubsequentOrderingAssertions(System.Collections.Generic.IEnumerable<T> actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class SubsequentOrderingGenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T>>
         where TCollection : System.Collections.Generic.IEnumerable<T>
     {
-        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<T>
         where TAssertions : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions>
     {
-        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable, FluentAssertions.Execution.Assertion assertion) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
@@ -1148,6 +1148,10 @@ namespace FluentAssertions.Events
 }
 namespace FluentAssertions.Execution
 {
+    public class Assertion : FluentAssertions.Execution.Assertion<FluentAssertions.Execution.Assertion>
+    {
+        public Assertion(FluentAssertions.Execution.IAssertionScope currentScope, System.Func<string> getCallerIdentifier) { }
+    }
     [System.Serializable]
     public class AssertionFailedException : System.Exception
     {
@@ -1162,6 +1166,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(string context) { }
         public string CallerIdentity { get; }
         public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Execution.ContextDataItems ContextData { get; }
         public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
@@ -1183,10 +1188,49 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
         public FluentAssertions.Execution.AssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
+        public string GetIdentifier() { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }
         public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
         public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Assertion<TAssertion> : FluentAssertions.Execution.IAssertion
+        where TAssertion : FluentAssertions.Execution.Assertion<TAssertion>
+    {
+        public Assertion(FluentAssertions.Execution.IAssertionScope currentScope, System.Func<string> getCallerIdentifier, bool previousAssertionSucceeded = true) { }
+        public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Execution.IAssertionScope CurrentScope { get; }
+        public System.Func<string> GetCallerIdentifier { get; }
+        public bool Succeeded { get; }
+        public TAssertion UsingLineBreaks { get; }
+        public TAssertion BecauseOf(FluentAssertions.Execution.Reason reason) { }
+        public TAssertion BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(string message) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(string message, params System.Func<object>[] argProviders) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(string message, params object[] args) { }
+        public TAssertion ForCondition(bool condition) { }
+        public TAssertion ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
+        public TAssertion WithCallerPostfix(string postfix) { }
+        public TAssertion WithExpectation(string message, params object[] args) { }
+    }
+    public class ContextDataItems
+    {
+        public ContextDataItems() { }
+        public void Add(FluentAssertions.Execution.ContextDataItems contextDataItems) { }
+        public void Add(FluentAssertions.Execution.ContextDataItems.DataItem item) { }
+        public string AsStringOrDefault(string key) { }
+        public T Get<T>(string key) { }
+        public System.Collections.Generic.IDictionary<string, object> GetReportable() { }
+        public class DataItem
+        {
+            public DataItem(string key, object value, bool reportable, bool requiresFormatting) { }
+            public string Key { get; }
+            public bool Reportable { get; }
+            public bool RequiresFormatting { get; }
+            public object Value { get; }
+            public FluentAssertions.Execution.ContextDataItems.DataItem Clone() { }
+        }
     }
     public class Continuation
     {
@@ -1198,9 +1242,19 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
     }
+    public class ContinuedAssertion : FluentAssertions.Execution.Assertion<FluentAssertions.Execution.ContinuedAssertion>
+    {
+        public ContinuedAssertion(FluentAssertions.Execution.IAssertion previousAssertion) { }
+        public FluentAssertions.Execution.NewGivenSelector<T> Given<T>(System.Func<T> selector) { }
+    }
     public sealed class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
     {
+        public FluentAssertions.Execution.ContextDataItems ContextData { get; }
+        public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, System.Func<string> valueFunc) { }
+        public void AddReportable(string key, string value) { }
         public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }
         public string[] Discard() { }
@@ -1234,9 +1288,22 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
         public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
     }
+    public interface IAssertion
+    {
+        FluentAssertions.Execution.IAssertionScope CurrentScope { get; }
+        System.Func<string> GetCallerIdentifier { get; }
+        bool Succeeded { get; }
+        void FailWith(string message, object[] args);
+        void ForCondition(bool predicate);
+    }
     public interface IAssertionScope : System.IDisposable
     {
+        FluentAssertions.Execution.ContextDataItems ContextData { get; }
+        FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        void AddPreFormattedFailure(string formattedFailureMessage);
+        void AddReportable(string key, System.Func<string> valueFunc);
+        void AddReportable(string key, string value);
         FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
         FluentAssertions.Execution.Continuation ClearExpectation();
         string[] Discard();
@@ -1260,6 +1327,23 @@ namespace FluentAssertions.Execution
     public interface ICloneable2
     {
         object Clone();
+    }
+    public class NewContinuationOfGiven<TSubject>
+    {
+        public FluentAssertions.Execution.NewGivenSelector<TSubject> Then { get; }
+    }
+    public class NewContinuation<TAssertion>
+        where TAssertion : FluentAssertions.Execution.Assertion<TAssertion>
+    {
+        public FluentAssertions.Execution.ContinuedAssertion Then { get; }
+    }
+    public class NewGivenSelector<T>
+    {
+        public FluentAssertions.Execution.NewContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.NewContinuationOfGiven<T> FailWith(string message, params System.Func<T, object>[] args) { }
+        public FluentAssertions.Execution.NewContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.NewGivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.NewGivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
     }
     public class Reason
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -360,18 +360,18 @@ namespace FluentAssertions.Collections
 {
     public class GenericCollectionAssertions<T> : FluentAssertions.Collections.GenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
-        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class GenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T>>
         where TCollection : System.Collections.Generic.IEnumerable<T>
     {
-        public GenericCollectionAssertions(TCollection actualValue) { }
+        public GenericCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class GenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TCollection, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<T>
         where TAssertions : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
     {
-        public GenericCollectionAssertions(TCollection actualValue) { }
+        public GenericCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, System.Collections.Generic.IEnumerable<TExpectation>> AllBeAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) { }
@@ -476,13 +476,13 @@ namespace FluentAssertions.Collections
     public class GenericDictionaryAssertions<TCollection, TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue>>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
     {
-        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, System.Collections.Generic.KeyValuePair<TKey, TValue>, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
         where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs, FluentAssertions.Execution.Assertion assertion) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
@@ -513,18 +513,18 @@ namespace FluentAssertions.Collections
     }
     public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
-        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class StringCollectionAssertions<TCollection> : FluentAssertions.Collections.StringCollectionAssertions<TCollection, FluentAssertions.Collections.StringCollectionAssertions<TCollection>>
         where TCollection : System.Collections.Generic.IEnumerable<string>
     {
-        public StringCollectionAssertions(TCollection actualValue) { }
+        public StringCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class StringCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, string, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<string>
         where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
     {
-        public StringCollectionAssertions(TCollection actualValue) { }
+        public StringCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
         public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
@@ -537,18 +537,18 @@ namespace FluentAssertions.Collections
     }
     public class SubsequentOrderingAssertions<T> : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.SubsequentOrderingAssertions<T>>
     {
-        public SubsequentOrderingAssertions(System.Collections.Generic.IEnumerable<T> actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public SubsequentOrderingAssertions(System.Collections.Generic.IEnumerable<T> actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class SubsequentOrderingGenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T>>
         where TCollection : System.Collections.Generic.IEnumerable<T>
     {
-        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<T>
         where TAssertions : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions>
     {
-        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable, FluentAssertions.Execution.Assertion assertion) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
@@ -1086,6 +1086,10 @@ namespace FluentAssertions.Equivalency.Tracing
 }
 namespace FluentAssertions.Execution
 {
+    public class Assertion : FluentAssertions.Execution.Assertion<FluentAssertions.Execution.Assertion>
+    {
+        public Assertion(FluentAssertions.Execution.IAssertionScope currentScope, System.Func<string> getCallerIdentifier) { }
+    }
     [System.Serializable]
     public class AssertionFailedException : System.Exception
     {
@@ -1100,6 +1104,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(string context) { }
         public string CallerIdentity { get; }
         public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Execution.ContextDataItems ContextData { get; }
         public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
@@ -1121,10 +1126,49 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
         public FluentAssertions.Execution.AssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
+        public string GetIdentifier() { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }
         public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
         public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Assertion<TAssertion> : FluentAssertions.Execution.IAssertion
+        where TAssertion : FluentAssertions.Execution.Assertion<TAssertion>
+    {
+        public Assertion(FluentAssertions.Execution.IAssertionScope currentScope, System.Func<string> getCallerIdentifier, bool previousAssertionSucceeded = true) { }
+        public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Execution.IAssertionScope CurrentScope { get; }
+        public System.Func<string> GetCallerIdentifier { get; }
+        public bool Succeeded { get; }
+        public TAssertion UsingLineBreaks { get; }
+        public TAssertion BecauseOf(FluentAssertions.Execution.Reason reason) { }
+        public TAssertion BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(string message) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(string message, params System.Func<object>[] argProviders) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(string message, params object[] args) { }
+        public TAssertion ForCondition(bool condition) { }
+        public TAssertion ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
+        public TAssertion WithCallerPostfix(string postfix) { }
+        public TAssertion WithExpectation(string message, params object[] args) { }
+    }
+    public class ContextDataItems
+    {
+        public ContextDataItems() { }
+        public void Add(FluentAssertions.Execution.ContextDataItems contextDataItems) { }
+        public void Add(FluentAssertions.Execution.ContextDataItems.DataItem item) { }
+        public string AsStringOrDefault(string key) { }
+        public T Get<T>(string key) { }
+        public System.Collections.Generic.IDictionary<string, object> GetReportable() { }
+        public class DataItem
+        {
+            public DataItem(string key, object value, bool reportable, bool requiresFormatting) { }
+            public string Key { get; }
+            public bool Reportable { get; }
+            public bool RequiresFormatting { get; }
+            public object Value { get; }
+            public FluentAssertions.Execution.ContextDataItems.DataItem Clone() { }
+        }
     }
     public class Continuation
     {
@@ -1136,9 +1180,19 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
     }
+    public class ContinuedAssertion : FluentAssertions.Execution.Assertion<FluentAssertions.Execution.ContinuedAssertion>
+    {
+        public ContinuedAssertion(FluentAssertions.Execution.IAssertion previousAssertion) { }
+        public FluentAssertions.Execution.NewGivenSelector<T> Given<T>(System.Func<T> selector) { }
+    }
     public sealed class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
     {
+        public FluentAssertions.Execution.ContextDataItems ContextData { get; }
+        public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, System.Func<string> valueFunc) { }
+        public void AddReportable(string key, string value) { }
         public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }
         public string[] Discard() { }
@@ -1172,9 +1226,22 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
         public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
     }
+    public interface IAssertion
+    {
+        FluentAssertions.Execution.IAssertionScope CurrentScope { get; }
+        System.Func<string> GetCallerIdentifier { get; }
+        bool Succeeded { get; }
+        void FailWith(string message, object[] args);
+        void ForCondition(bool predicate);
+    }
     public interface IAssertionScope : System.IDisposable
     {
+        FluentAssertions.Execution.ContextDataItems ContextData { get; }
+        FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        void AddPreFormattedFailure(string formattedFailureMessage);
+        void AddReportable(string key, System.Func<string> valueFunc);
+        void AddReportable(string key, string value);
         FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
         FluentAssertions.Execution.Continuation ClearExpectation();
         string[] Discard();
@@ -1198,6 +1265,23 @@ namespace FluentAssertions.Execution
     public interface ICloneable2
     {
         object Clone();
+    }
+    public class NewContinuationOfGiven<TSubject>
+    {
+        public FluentAssertions.Execution.NewGivenSelector<TSubject> Then { get; }
+    }
+    public class NewContinuation<TAssertion>
+        where TAssertion : FluentAssertions.Execution.Assertion<TAssertion>
+    {
+        public FluentAssertions.Execution.ContinuedAssertion Then { get; }
+    }
+    public class NewGivenSelector<T>
+    {
+        public FluentAssertions.Execution.NewContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.NewContinuationOfGiven<T> FailWith(string message, params System.Func<T, object>[] args) { }
+        public FluentAssertions.Execution.NewContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.NewGivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.NewGivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
     }
     public class Reason
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -367,18 +367,18 @@ namespace FluentAssertions.Collections
 {
     public class GenericCollectionAssertions<T> : FluentAssertions.Collections.GenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
-        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class GenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T>>
         where TCollection : System.Collections.Generic.IEnumerable<T>
     {
-        public GenericCollectionAssertions(TCollection actualValue) { }
+        public GenericCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class GenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TCollection, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<T>
         where TAssertions : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
     {
-        public GenericCollectionAssertions(TCollection actualValue) { }
+        public GenericCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, System.Collections.Generic.IEnumerable<TExpectation>> AllBeAssignableTo<TExpectation>(string because = "", params object[] becauseArgs) { }
@@ -483,13 +483,13 @@ namespace FluentAssertions.Collections
     public class GenericDictionaryAssertions<TCollection, TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue>>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
     {
-        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, System.Collections.Generic.KeyValuePair<TKey, TValue>, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
         where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs, FluentAssertions.Execution.Assertion assertion) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
@@ -520,18 +520,18 @@ namespace FluentAssertions.Collections
     }
     public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
-        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class StringCollectionAssertions<TCollection> : FluentAssertions.Collections.StringCollectionAssertions<TCollection, FluentAssertions.Collections.StringCollectionAssertions<TCollection>>
         where TCollection : System.Collections.Generic.IEnumerable<string>
     {
-        public StringCollectionAssertions(TCollection actualValue) { }
+        public StringCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class StringCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, string, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<string>
         where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
     {
-        public StringCollectionAssertions(TCollection actualValue) { }
+        public StringCollectionAssertions(TCollection actualValue, FluentAssertions.Execution.Assertion assertion) { }
         public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
@@ -544,18 +544,18 @@ namespace FluentAssertions.Collections
     }
     public class SubsequentOrderingAssertions<T> : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.SubsequentOrderingAssertions<T>>
     {
-        public SubsequentOrderingAssertions(System.Collections.Generic.IEnumerable<T> actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public SubsequentOrderingAssertions(System.Collections.Generic.IEnumerable<T> actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class SubsequentOrderingGenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T>>
         where TCollection : System.Collections.Generic.IEnumerable<T>
     {
-        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable, FluentAssertions.Execution.Assertion assertion) { }
     }
     public class SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<T>
         where TAssertions : FluentAssertions.Collections.SubsequentOrderingGenericCollectionAssertions<TCollection, T, TAssertions>
     {
-        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable) { }
+        public SubsequentOrderingGenericCollectionAssertions(TCollection actualValue, System.Linq.IOrderedEnumerable<T> previousOrderedEnumerable, FluentAssertions.Execution.Assertion assertion) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
@@ -1135,6 +1135,10 @@ namespace FluentAssertions.Events
 }
 namespace FluentAssertions.Execution
 {
+    public class Assertion : FluentAssertions.Execution.Assertion<FluentAssertions.Execution.Assertion>
+    {
+        public Assertion(FluentAssertions.Execution.IAssertionScope currentScope, System.Func<string> getCallerIdentifier) { }
+    }
     [System.Serializable]
     public class AssertionFailedException : System.Exception
     {
@@ -1149,6 +1153,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(string context) { }
         public string CallerIdentity { get; }
         public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Execution.ContextDataItems ContextData { get; }
         public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
@@ -1170,10 +1175,49 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
         public FluentAssertions.Execution.AssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
+        public string GetIdentifier() { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }
         public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
         public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Assertion<TAssertion> : FluentAssertions.Execution.IAssertion
+        where TAssertion : FluentAssertions.Execution.Assertion<TAssertion>
+    {
+        public Assertion(FluentAssertions.Execution.IAssertionScope currentScope, System.Func<string> getCallerIdentifier, bool previousAssertionSucceeded = true) { }
+        public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Execution.IAssertionScope CurrentScope { get; }
+        public System.Func<string> GetCallerIdentifier { get; }
+        public bool Succeeded { get; }
+        public TAssertion UsingLineBreaks { get; }
+        public TAssertion BecauseOf(FluentAssertions.Execution.Reason reason) { }
+        public TAssertion BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(string message) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(string message, params System.Func<object>[] argProviders) { }
+        public FluentAssertions.Execution.NewContinuation<FluentAssertions.Execution.ContinuedAssertion> FailWith(string message, params object[] args) { }
+        public TAssertion ForCondition(bool condition) { }
+        public TAssertion ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
+        public TAssertion WithCallerPostfix(string postfix) { }
+        public TAssertion WithExpectation(string message, params object[] args) { }
+    }
+    public class ContextDataItems
+    {
+        public ContextDataItems() { }
+        public void Add(FluentAssertions.Execution.ContextDataItems contextDataItems) { }
+        public void Add(FluentAssertions.Execution.ContextDataItems.DataItem item) { }
+        public string AsStringOrDefault(string key) { }
+        public T Get<T>(string key) { }
+        public System.Collections.Generic.IDictionary<string, object> GetReportable() { }
+        public class DataItem
+        {
+            public DataItem(string key, object value, bool reportable, bool requiresFormatting) { }
+            public string Key { get; }
+            public bool Reportable { get; }
+            public bool RequiresFormatting { get; }
+            public object Value { get; }
+            public FluentAssertions.Execution.ContextDataItems.DataItem Clone() { }
+        }
     }
     public class Continuation
     {
@@ -1185,9 +1229,19 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
     }
+    public class ContinuedAssertion : FluentAssertions.Execution.Assertion<FluentAssertions.Execution.ContinuedAssertion>
+    {
+        public ContinuedAssertion(FluentAssertions.Execution.IAssertion previousAssertion) { }
+        public FluentAssertions.Execution.NewGivenSelector<T> Given<T>(System.Func<T> selector) { }
+    }
     public sealed class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
     {
+        public FluentAssertions.Execution.ContextDataItems ContextData { get; }
+        public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, System.Func<string> valueFunc) { }
+        public void AddReportable(string key, string value) { }
         public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }
         public string[] Discard() { }
@@ -1221,9 +1275,22 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
         public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
     }
+    public interface IAssertion
+    {
+        FluentAssertions.Execution.IAssertionScope CurrentScope { get; }
+        System.Func<string> GetCallerIdentifier { get; }
+        bool Succeeded { get; }
+        void FailWith(string message, object[] args);
+        void ForCondition(bool predicate);
+    }
     public interface IAssertionScope : System.IDisposable
     {
+        FluentAssertions.Execution.ContextDataItems ContextData { get; }
+        FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        void AddPreFormattedFailure(string formattedFailureMessage);
+        void AddReportable(string key, System.Func<string> valueFunc);
+        void AddReportable(string key, string value);
         FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
         FluentAssertions.Execution.Continuation ClearExpectation();
         string[] Discard();
@@ -1247,6 +1314,23 @@ namespace FluentAssertions.Execution
     public interface ICloneable2
     {
         object Clone();
+    }
+    public class NewContinuationOfGiven<TSubject>
+    {
+        public FluentAssertions.Execution.NewGivenSelector<TSubject> Then { get; }
+    }
+    public class NewContinuation<TAssertion>
+        where TAssertion : FluentAssertions.Execution.Assertion<TAssertion>
+    {
+        public FluentAssertions.Execution.ContinuedAssertion Then { get; }
+    }
+    public class NewGivenSelector<T>
+    {
+        public FluentAssertions.Execution.NewContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.NewContinuationOfGiven<T> FailWith(string message, params System.Func<T, object>[] args) { }
+        public FluentAssertions.Execution.NewContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.NewGivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.NewGivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
     }
     public class Reason
     {

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -12,8 +12,21 @@ namespace FluentAssertions.Specs.Collections;
 /// </summary>
 public partial class CollectionAssertionSpecs
 {
-    public class Chainings
+    public class Chaining
     {
+        [Fact]
+        public void Chaining_something_should_do_something()
+        {
+            // Act
+            var languages = new[] { "C#" };
+
+            var act = () => languages.Should().ContainSingle()
+                .Which.Should().EndWith("script");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected languages[0]*");
+        }
+
         [Fact]
         public void Should_support_chaining_constraints_with_and()
         {


### PR DESCRIPTION
* `AssertionScope` is only used by consumers as they do now _and_ by certain APIs such as `BeEquivalentTo`
* Every `Should` method will create a new object called `Assertion` (but I'm open to a better name) that contains the context of the assertion and a link to the scope. When no ambient `AssertionScope` is available, it will be a new one that is created at that point. This is different from v6 where we create a new scope per call to `Execute.Assertion`. 
* Every `Should` method will also take an extra parameter annotated with `[CallerArgumentExpression]`. If this returns a non-`null` value, we can use that instead of using the `CallerIdentifier`.
* This `Assertion` instance will be explicitly passed to all the assertion classes (like `StringAssertions`). 
* No public APIs will depend on `AssertionScope.Current` anymore
* Most of the APIs that are now part of `AssertionScope` will need to move to `Assertion`.
* This should allow methods like `ContainSingle` to update the `Assertion` instance with extra information to solve #1502 
* This should also allow us to drop `ClearExpectations`
* Also provides a nice split between the responsibility of `AssertionScope` as a way to group related assertions and its responsibilities as the internal assertion API
#2253 

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
