### PR TITLE
Avoid possible 'System.NullReferenceException' in `PredicateLambdaExpressionValueFormatter`

### DIFF
--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -134,7 +134,7 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
 
         public override Expression Visit(Expression node)
         {
-            if (node?.NodeType == ExpressionType.AndAlso)
+            if (node!.NodeType == ExpressionType.AndAlso)
             {
                 var binaryExpression = (BinaryExpression)node;
                 Visit(binaryExpression.Left);

--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -134,7 +134,7 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
 
         public override Expression Visit(Expression node)
         {
-            if (node.NodeType == ExpressionType.AndAlso)
+            if (node?.NodeType == ExpressionType.AndAlso)
             {
                 var binaryExpression = (BinaryExpression)node;
                 Visit(binaryExpression.Left);


### PR DESCRIPTION
The `ExpressionVisitor.Visit` method can accept `null` as node expression (see [here (.NET core)](https://source.dot.net/#System.Linq.Expressions/System/Linq/Expressions/ExpressionVisitor.cs,f0615a823a9efe36) or [here (.NET Framework 4.8)](https://referencesource.microsoft.com/#System.Core/Microsoft/Scripting/Ast/ExpressionVisitor.cs,f0615a823a9efe36)).

This fixes a `Possible 'System.NullReferenceException'` in #2450 


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
