### PR TITLE
Add missing tests for ActionAssertions and DelegateAssertions

### DIFF
--- a/Tests/FluentAssertions.Specs/Specialized/ActionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ActionAssertionSpecs.cs
@@ -5,6 +5,35 @@ namespace FluentAssertions.Specs.Specialized;
 
 public class ActionAssertionSpecs
 {
+    [Fact]
+    public void Null_clock_throws_exception()
+    {
+        // Arrange
+        Action subject = () => { };
+
+        // Act
+        var act = void () => subject.Should(clock: null).NotThrow();
+
+        // Assert
+        act.Should().ThrowExactly<ArgumentNullException>()
+            .WithParameterName("clock");
+    }
+
+    public class Throw
+    {
+        [Fact]
+        public void Allow_additional_assertions_on_return_value()
+        {
+            // Arrange
+            var exception = new Exception("foo");
+            Action subject = () => throw exception;
+
+            // Act / Assert
+            subject.Should().Throw<Exception>()
+                .Which.Message.Should().Be("foo");
+        }
+    }
+
     public class NotThrow
     {
         [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/ActionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ActionAssertionSpecs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Xunit;
+
+namespace FluentAssertions.Specs.Specialized;
+
+public class ActionAssertionSpecs
+{
+    public class NotThrow
+    {
+        [Fact]
+        public void Allow_additional_assertions_on_return_value()
+        {
+            // Arrange
+            Action subject = () => { };
+
+            // Act / Assert
+            subject.Should().NotThrow()
+                .And.NotBeNull();
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using FluentAssertions.Execution;
-using FluentAssertions.Specialized;
 using Xunit;
 
 namespace FluentAssertions.Specs.Specialized;
@@ -24,35 +23,6 @@ public class DelegateAssertionSpecs
 
     public class ThrowExactly
     {
-        [Fact]
-        public void When_injecting_a_null_extractor_it_should_throw()
-        {
-            // Arrange
-            Action subject = () => { };
-
-            // Act
-            Func<ActionAssertions> act = () => new ActionAssertions(subject, extractor: null);
-
-            // Act
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("extractor");
-        }
-
-        [Fact]
-        public void When_injecting_a_null_clock_it_should_throw()
-        {
-            // Arrange
-            Action subject = () => { };
-            IExtractExceptions extractor = new AggregateExceptionExtractor();
-
-            // Act
-            Func<ActionAssertions> act = () => new ActionAssertions(subject, extractor, clock: null);
-
-            // Act
-            act.Should().ThrowExactly<ArgumentNullException>()
-                .WithParameterName("clock");
-        }
-
         [Fact]
         public void Does_not_continue_assertion_on_exact_exception_type()
         {

--- a/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
@@ -7,37 +7,52 @@ namespace FluentAssertions.Specs.Specialized;
 
 public class DelegateAssertionSpecs
 {
-    [Fact]
-    public void When_injecting_a_null_extractor_it_should_throw()
+    public class Throw
     {
-        // Arrange
-        Action subject = () => { };
+        [Fact]
+        public void Allow_additional_assertions_on_return_value()
+        {
+            // Arrange
+            var exception = new Exception("foo");
+            Action subject = () => throw exception;
 
-        // Act
-        Func<ActionAssertions> act = () => new ActionAssertions(subject, extractor: null);
-
-        // Act
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("extractor");
-    }
-
-    [Fact]
-    public void When_injecting_a_null_clock_it_should_throw()
-    {
-        // Arrange
-        Action subject = () => { };
-        IExtractExceptions extractor = new AggregateExceptionExtractor();
-
-        // Act
-        Func<ActionAssertions> act = () => new ActionAssertions(subject, extractor, clock: null);
-
-        // Act
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("clock");
+            // Act / Assert
+            subject.Should().Throw<Exception>()
+                .Which.Message.Should().Be("foo");
+        }
     }
 
     public class ThrowExactly
     {
+        [Fact]
+        public void When_injecting_a_null_extractor_it_should_throw()
+        {
+            // Arrange
+            Action subject = () => { };
+
+            // Act
+            Func<ActionAssertions> act = () => new ActionAssertions(subject, extractor: null);
+
+            // Act
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("extractor");
+        }
+
+        [Fact]
+        public void When_injecting_a_null_clock_it_should_throw()
+        {
+            // Arrange
+            Action subject = () => { };
+            IExtractExceptions extractor = new AggregateExceptionExtractor();
+
+            // Act
+            Func<ActionAssertions> act = () => new ActionAssertions(subject, extractor, clock: null);
+
+            // Act
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("clock");
+        }
+
         [Fact]
         public void Does_not_continue_assertion_on_exact_exception_type()
         {

--- a/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
@@ -6,6 +6,20 @@ namespace FluentAssertions.Specs.Specialized;
 
 public class DelegateAssertionSpecs
 {
+    [Fact]
+    public void Null_clock_throws_exception()
+    {
+        // Arrange
+        Func<int> subject = () => 1;
+
+        // Act
+        var act = void () => subject.Should(clock: null).NotThrow();
+
+        // Assert
+        act.Should().ThrowExactly<ArgumentNullException>()
+            .WithParameterName("clock");
+    }
+
     public class Throw
     {
         [Fact]


### PR DESCRIPTION
Fixes `Method return value is never used (non-private accessibility)` in #2450 


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
