### PR TITLE
Avoid redundancies in code

### DIFF
--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -295,11 +295,9 @@ public class CollectionSpecs
     public void When_collection_of_same_count_does_not_match_it_should_include_at_most_10_items_in_message()
     {
         // Arrange
-        const int commonLength = 11;
-
         // Subjects contains different values, because we want to distinguish them in the assertion message
         var subject = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-        var expectation = Enumerable.Repeat(20, commonLength).ToArray();
+        var expectation = Enumerable.Repeat(20, subject.Length).ToArray();
 
         // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation);

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -298,7 +298,7 @@ public class CollectionSpecs
         const int commonLength = 11;
 
         // Subjects contains different values, because we want to distinguish them in the assertion message
-        var subject = new int[commonLength] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        var subject = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         var expectation = Enumerable.Repeat(20, commonLength).ToArray();
 
         // Act

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -295,12 +295,9 @@ internal class CountingGenericCollection<TElement> : ICollection<TElement>
 
 internal sealed class TrackingTestEnumerable : IEnumerable<int>
 {
-    private readonly int[] values;
-
     public TrackingTestEnumerable(params int[] values)
     {
-        this.values = values;
-        Enumerator = new TrackingEnumerator(this.values);
+        Enumerator = new TrackingEnumerator(values);
     }
 
     public TrackingEnumerator Enumerator { get; }

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -11,7 +11,7 @@ using Xunit;
 using Xunit.Sdk;
 
 #pragma warning disable RCS1192, RCS1214, S4144 // verbatim string literals and interpolated strings
-
+// ReSharper disable RedundantStringInterpolation
 namespace FluentAssertions.Specs.Execution
 {
     public class CallerIdentifierSpecs
@@ -259,10 +259,7 @@ namespace FluentAssertions.Specs.Execution
             var foo = new Foo();
 
             // Act
-            // ReSharper disable RedundantStringInterpolation
             Action act = () => foo.BarMethod(@"test", argument2: $@"test2", argument3: @$"test3").Should().BeNull();
-
-            // ReSharper restore RedundantStringInterpolation
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -294,7 +291,6 @@ namespace FluentAssertions.Specs.Execution
             var foo = new Foo();
 
             // Act
-            // ReSharper disable once RedundantStringInterpolation
             Action act = () => foo.BarMethod(@$"test"";").Should().BeNull();
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -259,7 +259,10 @@ namespace FluentAssertions.Specs.Execution
             var foo = new Foo();
 
             // Act
+            // ReSharper disable RedundantStringInterpolation
             Action act = () => foo.BarMethod(@"test", argument2: $@"test2", argument3: @$"test3").Should().BeNull();
+
+            // ReSharper restore RedundantStringInterpolation
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -291,6 +294,7 @@ namespace FluentAssertions.Specs.Execution
             var foo = new Foo();
 
             // Act
+            // ReSharper disable once RedundantStringInterpolation
             Action act = () => foo.BarMethod(@$"test"";").Should().BeNull();
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -15,6 +15,7 @@ public class BooleanAssertionSpecs
             bool boolean = true;
 
             // Act / Assert
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
             boolean.Should().BeTrue();
         }
 
@@ -25,6 +26,7 @@ public class BooleanAssertionSpecs
             bool boolean = false;
 
             // Act
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
             Action action = () => boolean.Should().BeTrue();
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -4,6 +4,7 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.Primitives;
 
+// ReSharper disable ConditionIsAlwaysTrueOrFalse
 public class BooleanAssertionSpecs
 {
     public class BeTrue
@@ -15,7 +16,6 @@ public class BooleanAssertionSpecs
             bool boolean = true;
 
             // Act / Assert
-            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
             boolean.Should().BeTrue();
         }
 
@@ -26,7 +26,6 @@ public class BooleanAssertionSpecs
             bool boolean = false;
 
             // Act
-            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
             Action action = () => boolean.Should().BeTrue();
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Primitives/DateOnlyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateOnlyAssertionSpecs.cs
@@ -2,7 +2,6 @@
 
 using System;
 using Xunit;
-using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.Primitives;
 

--- a/Tests/FluentAssertions.Specs/Primitives/NullableBooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/NullableBooleanAssertionSpecs.cs
@@ -4,6 +4,7 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.Primitives;
 
+// ReSharper disable ConditionIsAlwaysTrueOrFalse
 public class NullableBooleanAssertionSpecs
 {
     [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.Be.cs
@@ -193,7 +193,7 @@ public partial class ObjectAssertionSpecs
             var value = new object();
 
             // Act / Assert
-            value.Should().Be<object>(value, new DumbObjectEqualityComparer()).And.NotBeNull();
+            value.Should().Be(value, new DumbObjectEqualityComparer()).And.NotBeNull();
         }
     }
 
@@ -342,7 +342,7 @@ public partial class ObjectAssertionSpecs
             var value = new object();
 
             // Act / Assert
-            value.Should().NotBe<object>(new object(), new DumbObjectEqualityComparer()).And.NotBeNull();
+            value.Should().NotBe(new object(), new DumbObjectEqualityComparer()).And.NotBeNull();
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeOneOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeOneOf.cs
@@ -215,7 +215,7 @@ public partial class ObjectAssertionSpecs
             var value = new object();
 
             // Act / Assert
-            value.Should().BeOneOf<object>([value], new DumbObjectEqualityComparer()).And.NotBeNull();
+            value.Should().BeOneOf([value], new DumbObjectEqualityComparer()).And.NotBeNull();
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -880,7 +880,7 @@ namespace Internal.ValueTypesAndNotValueTypes.Test
 
     internal class InternalClassNotValueType;
 
-    internal record class InternalRecordClass;
+    internal record InternalRecordClass;
 
     internal enum InternalEnumValueType
     {


### PR DESCRIPTION
Fix "redundancies in code" issues detected by ReSharper:
- Using directive is not required by the code and can be safely removed
- Redundant explicit array size specification
- Redundant 'class' keyword in record declaration
- Type argument specification is redundant
- Redundant string interpolation
- Expression is always true/false
- The field is always assigned before being used and can be converted into a local variable


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
