### PR TITLE
Avoid variable in local function that hides variable from outer scope

### DIFF
--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -107,8 +107,9 @@ public static class Formatter
 
             try
             {
-                Format(value, output, context, (path, childValue,
-                    output) => FormatChild(path, childValue, output, context, options, graph));
+                Format(value, output, context,
+                    (path, childValue, childOutput)
+                        => FormatChild(path, childValue, childOutput, context, options, graph));
             }
             catch (MaxLinesExceededException)
             {


### PR DESCRIPTION
Fix ﻿"Variable in local function hides variable from outer scope"
- Src\FluentAssertions\Formatting\Formatter.cs:111 Parameter 'output' hides outer local variable with the same name
- Build\Build.cs:127 Parameter '_' hides outer parameter with the same name
- Build\Build.cs:133 Parameter '_' hides outer parameter with the same name
- Build\Build.cs:179 Parameter '_' hides outer parameter with the same name
- Build\Build.cs:209 Parameter '_' hides outer parameter with the same name
- Build\Build.cs:242 Parameter '_' hides outer parameter with the same name
- Build\Build.cs:245 Parameter '_' hides outer parameter with the same name
- Build\Build.cs:301 Parameter '_' hides outer parameter with the same name
- Build\Build.cs:319 Parameter '_' hides outer parameter with the same name
- Build\Build.cs: Parameter '_' hides outer parameter with the same name


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
