### PR TITLE
Allow anonymous object for selecting fields/properties at `Exclude` and `Include`

### DIFF
--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -31,21 +31,22 @@ internal static class ExpressionExtensions
         (((expression.Body as UnaryExpression)?.Operand ?? expression.Body) as MemberExpression)?.Member;
 
     /// <summary>
-    /// Gets a dotted path of property names representing the property expression, including the declaring type.
+    /// Gets one or more dotted paths of property names representing the property expression, including the declaring type.
     /// </summary>
     /// <example>
-    /// E.g. Parent.Child.Sibling.Name.
+    /// E.g. ["Parent.Child.Sibling.Name"] or ["A.Dotted.Path1", "A.Dotted.Path2"].
     /// </example>
     /// <exception cref="ArgumentNullException"><paramref name="expression"/> is <see langword="null"/>.</exception>
 #pragma warning disable MA0051
-    public static MemberPath GetMemberPath<TDeclaringType, TPropertyType>(
+    public static IEnumerable<MemberPath> GetMemberPaths<TDeclaringType, TPropertyType>(
         this Expression<Func<TDeclaringType, TPropertyType>> expression)
 #pragma warning restore MA0051
     {
         Guard.ThrowIfArgumentIsNull(expression, nameof(expression), "Expected an expression, but found <null>.");
 
-        var segments = new List<string>();
-        var declaringTypes = new List<Type>();
+        string singlePath = null;
+        List<string> selectors = [];
+        List<Type> declaringTypes = [];
         Expression node = expression;
 
         while (node is not null)
@@ -68,7 +69,7 @@ internal static class ExpressionExtensions
                     var memberExpression = (MemberExpression)node;
                     node = memberExpression.Expression;
 
-                    segments.Add(memberExpression.Member.Name);
+                    singlePath = $"{memberExpression.Member.Name}.{singlePath}";
                     declaringTypes.Add(memberExpression.Member.DeclaringType);
                     break;
 
@@ -77,7 +78,7 @@ internal static class ExpressionExtensions
                     var indexExpression = (ConstantExpression)binaryExpression.Right;
                     node = binaryExpression.Left;
 
-                    segments.Add($"[{indexExpression.Value}]");
+                    singlePath = $"[{indexExpression.Value}].{singlePath}";
                     break;
 
                 case ExpressionType.Parameter:
@@ -87,13 +88,26 @@ internal static class ExpressionExtensions
                 case ExpressionType.Call:
                     var methodCallExpression = (MethodCallExpression)node;
 
-                    if (methodCallExpression is not { Method.Name: "get_Item", Arguments: [ConstantExpression argumentExpression] })
+                    if (methodCallExpression is not
+                        { Method.Name: "get_Item", Arguments: [ConstantExpression argumentExpression] })
                     {
                         throw new ArgumentException(GetUnsupportedExpressionMessage(expression.Body), nameof(expression));
                     }
 
                     node = methodCallExpression.Object;
-                    segments.Add($"[{argumentExpression.Value}]");
+                    singlePath = $"[{argumentExpression.Value}].{singlePath}";
+                    break;
+                case ExpressionType.New:
+                    var newExpression = (NewExpression)node;
+
+                    foreach (Expression member in newExpression.Arguments)
+                    {
+                        var expr = member.ToString();
+                        selectors.Add(expr[expr.IndexOf('.', StringComparison.Ordinal)..]);
+                        declaringTypes.Add(((MemberExpression)member).Member.DeclaringType);
+                    }
+
+                    node = null;
                     break;
 
                 default:
@@ -101,14 +115,36 @@ internal static class ExpressionExtensions
             }
         }
 
-        // If any members were accessed in the expression, the first one found is the last member.
         Type declaringType = declaringTypes.FirstOrDefault() ?? typeof(TDeclaringType);
 
-        IEnumerable<string> reversedSegments = segments.AsEnumerable().Reverse();
-        string segmentPath = string.Join(".", reversedSegments);
+        if (singlePath is null)
+        {
+#if NET47 || NETSTANDARD2_0
+            return selectors.Select(selector =>
+                GetNewInstance<TDeclaringType>(declaringType, selector)).ToList();
+#else
+            return selectors.ConvertAll(selector =>
+                GetNewInstance<TDeclaringType>(declaringType, selector));
+#endif
+        }
 
-        return new MemberPath(typeof(TDeclaringType), declaringType, segmentPath.Replace(".[", "[", StringComparison.Ordinal));
+        return [GetNewInstance<TDeclaringType>(declaringType, singlePath)];
     }
+
+    private static MemberPath GetNewInstance<TReflectedType>(Type declaringType, string dottedPath) =>
+        new(typeof(TReflectedType), declaringType, dottedPath.Trim('.').Replace(".[", "[", StringComparison.Ordinal));
+
+    /// <summary>
+    /// Gets the first dotted path of property names collected by <see cref="GetMemberPaths{TDeclaringType,TPropertyType}"/>
+    /// from a given property expression, including the declaring type.
+    /// </summary>
+    /// <example>
+    /// E.g. Parent.Child.Sibling.Name.
+    /// </example>
+    /// <exception cref="ArgumentNullException"><paramref name="expression"/> is <see langword="null"/>.</exception>
+    public static MemberPath GetMemberPath<TDeclaringType, TPropertyType>(
+        this Expression<Func<TDeclaringType, TPropertyType>> expression) =>
+        expression.GetMemberPaths().First();
 
     /// <summary>
     /// Validates that the expression can be used to construct a <see cref="MemberPath"/>.

--- a/Src/FluentAssertions/Equivalency/EquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyOptions.cs
@@ -29,7 +29,11 @@ public class EquivalencyOptions<TExpectation>
     /// </summary>
     public EquivalencyOptions<TExpectation> Excluding(Expression<Func<TExpectation, object>> expression)
     {
-        AddSelectionRule(new ExcludeMemberByPathSelectionRule(expression.GetMemberPath()));
+        foreach (var memberPath in expression.GetMemberPaths())
+        {
+            AddSelectionRule(new ExcludeMemberByPathSelectionRule(memberPath));
+        }
+
         return this;
     }
 
@@ -40,9 +44,8 @@ public class EquivalencyOptions<TExpectation>
     public NestedExclusionOptionBuilder<TExpectation, TNext> For<TNext>(
         Expression<Func<TExpectation, IEnumerable<TNext>>> expression)
     {
-        var selectionRule = new ExcludeMemberByPathSelectionRule(expression.GetMemberPath());
-        AddSelectionRule(selectionRule);
-        return new NestedExclusionOptionBuilder<TExpectation, TNext>(this, selectionRule);
+        return new NestedExclusionOptionBuilder<TExpectation, TNext>(
+            this, new ExcludeMemberByPathSelectionRule(expression.GetMemberPath()));
     }
 
     /// <summary>
@@ -53,7 +56,11 @@ public class EquivalencyOptions<TExpectation>
     /// </remarks>
     public EquivalencyOptions<TExpectation> Including(Expression<Func<TExpectation, object>> expression)
     {
-        AddSelectionRule(new IncludeMemberByPathSelectionRule(expression.GetMemberPath()));
+        foreach (var memberPath in expression.GetMemberPaths())
+        {
+            AddSelectionRule(new IncludeMemberByPathSelectionRule(memberPath));
+        }
+
         return this;
     }
 
@@ -77,10 +84,12 @@ public class EquivalencyOptions<TExpectation>
         Expression<Func<TExpectation, object>> expression)
     {
         string expressionMemberPath = expression.GetMemberPath().ToString();
+
         OrderingRules.Add(new PathBasedOrderingRule(expressionMemberPath)
         {
             Invert = true
         });
+
         return this;
     }
 

--- a/Src/FluentAssertions/Equivalency/NestedExclusionOptionBuilder.cs
+++ b/Src/FluentAssertions/Equivalency/NestedExclusionOptionBuilder.cs
@@ -27,8 +27,14 @@ public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
     /// </summary>
     public EquivalencyOptions<TExpectation> Exclude(Expression<Func<TCurrent, object>> expression)
     {
-        var nextPath = expression.GetMemberPath();
-        currentPathSelectionRule.AppendPath(nextPath);
+        var currentSelectionPath = currentPathSelectionRule.CurrentPath;
+
+        foreach (var path in expression.GetMemberPaths())
+        {
+            var newPath = currentSelectionPath.AsParentCollectionOf(path);
+            capturedOptions.AddSelectionRule(new ExcludeMemberByPathSelectionRule(newPath));
+        }
+
         return capturedOptions;
     }
 

--- a/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByPathSelectionRule.cs
@@ -27,6 +27,8 @@ internal class ExcludeMemberByPathSelectionRule : SelectMemberByPathSelectionRul
         memberToExclude = memberToExclude.AsParentCollectionOf(nextPath);
     }
 
+    public MemberPath CurrentPath => memberToExclude;
+
     public override string ToString()
     {
         return "Exclude member " + memberToExclude;

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -879,7 +879,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
         selectionRules.RemoveAll(selectionRule => selectionRule is T);
     }
 
-    protected TSelf AddSelectionRule(IMemberSelectionRule selectionRule)
+    protected internal TSelf AddSelectionRule(IMemberSelectionRule selectionRule)
     {
         selectionRules.Add(selectionRule);
         return (TSelf)this;

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Excluding.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Excluding.cs
@@ -745,5 +745,416 @@ public partial class SelectionRulesSpecs
             int DefaultProperty => NormalProperty.Length;
         }
 #endif
+
+        [Fact]
+        public void An_anonymous_object_with_multiple_fields_excludes_correctly()
+        {
+            // Arrange
+            var subject = new
+            {
+                FirstName = "John",
+                MiddleName = "X",
+                LastName = "Doe",
+                Age = 34
+            };
+
+            var expectation = new
+            {
+                FirstName = "John",
+                MiddleName = "W.",
+                LastName = "Smith",
+                Age = 29
+            };
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opts => opts
+                .Excluding(p => new { p.MiddleName, p.LastName, p.Age }));
+        }
+
+        [Fact]
+        public void An_empty_anonymous_object_excludes_nothing()
+        {
+            // Arrange
+            var subject = new
+            {
+                FirstName = "John",
+                MiddleName = "X",
+                LastName = "Doe",
+                Age = 34
+            };
+
+            var expectation = new
+            {
+                FirstName = "John",
+                MiddleName = "W.",
+                LastName = "Smith",
+                Age = 29
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opts => opts
+                .Excluding(p => new { }));
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void An_anonymous_object_can_exclude_collections()
+        {
+            // Arrange
+            var subject = new
+            {
+                Names = new[]
+                {
+                    "John",
+                    "X.",
+                    "Doe"
+                },
+                Age = 34
+            };
+
+            var expectation = new
+            {
+                Names = new[]
+                {
+                    "John",
+                    "W.",
+                    "Smith"
+                },
+                Age = 34
+            };
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opts => opts
+                .Excluding(p => new { p.Names }));
+        }
+
+        [Fact]
+        public void An_anonymous_object_can_exclude_nested_objects()
+        {
+            // Arrange
+            var subject = new
+            {
+                Names = new
+                {
+                    FirstName = "John",
+                    MiddleName = "X",
+                    LastName = "Doe",
+                },
+                Age = 34
+            };
+
+            var expectation = new
+            {
+                Names = new
+                {
+                    FirstName = "John",
+                    MiddleName = "W.",
+                    LastName = "Smith",
+                },
+                Age = 34
+            };
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opts => opts
+                .Excluding(p => new { p.Names.MiddleName, p.Names.LastName }));
+        }
+
+        [Fact]
+        public void An_anonymous_object_can_exclude_nested_objects_inside_collections()
+        {
+            // Arrange
+            var subject = new
+            {
+                Names = new
+                {
+                    FirstName = "John",
+                    MiddleName = "X",
+                    LastName = "Doe",
+                },
+                Pets = new[]
+                {
+                    new
+                    {
+                        Name = "Dog",
+                        Age = 1,
+                        Color = "Black"
+                    },
+                    new
+                    {
+                        Name = "Cat",
+                        Age = 1,
+                        Color = "Black"
+                    },
+                    new
+                    {
+                        Name = "Bird",
+                        Age = 1,
+                        Color = "Black"
+                    },
+                }
+            };
+
+            var expectation = new
+            {
+                Names = new
+                {
+                    FirstName = "John",
+                    MiddleName = "W.",
+                    LastName = "Smith",
+                },
+                Pets = new[]
+                {
+                    new
+                    {
+                        Name = "Dog",
+                        Age = 1,
+                        Color = "Black"
+                    },
+                    new
+                    {
+                        Name = "Dog",
+                        Age = 2,
+                        Color = "Gray"
+                    },
+                    new
+                    {
+                        Name = "Bird",
+                        Age = 3,
+                        Color = "Black"
+                    },
+                }
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opts => opts
+                .Excluding(p => new { p.Names.MiddleName, p.Names.LastName })
+                .For(p => p.Pets)
+                .Exclude(p => new { p.Age, p.Name }));
+
+            // Assert
+            act.Should().Throw<XunitException>().Which.Message.Should()
+                .NotMatch("*Pets[1].Age*").And
+                .NotMatch("*Pets[1].Name*").And
+                .Match("*Pets[1].Color*");
+        }
+
+        [Fact]
+        public void An_anonymous_object_can_exclude_nested_objects_inside_nested_collections()
+        {
+            // Arrange
+            var subject = new
+            {
+                Names = new
+                {
+                    FirstName = "John",
+                    MiddleName = "W.",
+                    LastName = "Smith",
+                },
+                Pets = new[]
+                {
+                    new
+                    {
+                        Name = "Dog",
+                        Fleas = new[]
+                        {
+                            new
+                            {
+                                Name = "Flea 1",
+                                Age = 1,
+                            },
+                            new
+                            {
+                                Name = "Flea 2",
+                                Age = 2,
+                            },
+                        },
+                    },
+                    new
+                    {
+                        Name = "Dog",
+                        Fleas = new[]
+                        {
+                            new
+                            {
+                                Name = "Flea 10",
+                                Age = 1,
+                            },
+                            new
+                            {
+                                Name = "Flea 21",
+                                Age = 3,
+                            },
+                        },
+                    },
+                    new
+                    {
+                        Name = "Dog",
+                        Fleas = new[]
+                        {
+                            new
+                            {
+                                Name = "Flea 1",
+                                Age = 1,
+                            },
+                            new
+                            {
+                                Name = "Flea 2",
+                                Age = 2,
+                            },
+                        },
+                    },
+                },
+            };
+
+            var expectation = new
+            {
+                Names = new
+                {
+                    FirstName = "John",
+                    MiddleName = "W.",
+                    LastName = "Smith",
+                },
+                Pets = new[]
+                {
+                    new
+                    {
+                        Name = "Dog",
+                        Fleas = new[]
+                        {
+                            new
+                            {
+                                Name = "Flea 1",
+                                Age = 1,
+                            },
+                            new
+                            {
+                                Name = "Flea 2",
+                                Age = 2,
+                            },
+                        },
+                    },
+                    new
+                    {
+                        Name = "Dog",
+                        Fleas = new[]
+                        {
+                            new
+                            {
+                                Name = "Flea 1",
+                                Age = 1,
+                            },
+                            new
+                            {
+                                Name = "Flea 2",
+                                Age = 1,
+                            },
+                        },
+                    },
+                    new
+                    {
+                        Name = "Bird",
+                        Fleas = new[]
+                        {
+                            new
+                            {
+                                Name = "Flea 1",
+                                Age = 1,
+                            },
+                            new
+                            {
+                                Name = "Flea 2",
+                                Age = 2,
+                            },
+                        },
+                    },
+                },
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opts => opts
+                .Excluding(p => new { p.Names.MiddleName, p.Names.LastName })
+                .For(person => person.Pets)
+                .For(pet => pet.Fleas)
+                .Exclude(flea => new { flea.Name, flea.Age }));
+
+            // Assert
+            act.Should().Throw<XunitException>().Which.Message.Should()
+                .NotMatch("*Pets[*].Fleas[*].Age*").And
+                .NotMatch("*Pets[*].Fleas[*].Name*").And
+                .Match("*- Exclude*Pets[]Fleas[]Age*").And
+                .Match("*- Exclude*Pets[]Fleas[]Name*");
+        }
+
+        [Fact]
+        public void An_empty_anonymous_object_excludes_nothing_inside_collections()
+        {
+            // Arrange
+            var subject = new
+            {
+                Names = new
+                {
+                    FirstName = "John",
+                    MiddleName = "X",
+                    LastName = "Doe",
+                },
+                Pets = new[]
+                {
+                    new
+                    {
+                        Name = "Dog",
+                        Age = 1
+                    },
+                    new
+                    {
+                        Name = "Cat",
+                        Age = 1
+                    },
+                    new
+                    {
+                        Name = "Bird",
+                        Age = 1
+                    },
+                }
+            };
+
+            var expectation = new
+            {
+                Names = new
+                {
+                    FirstName = "John",
+                    MiddleName = "W.",
+                    LastName = "Smith",
+                },
+                Pets = new[]
+                {
+                    new
+                    {
+                        Name = "Dog",
+                        Age = 1
+                    },
+                    new
+                    {
+                        Name = "Dog",
+                        Age = 2
+                    },
+                    new
+                    {
+                        Name = "Bird",
+                        Age = 1
+                    },
+                }
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opts => opts
+                .Excluding(p => new { p.Names.MiddleName, p.Names.LastName })
+                .For(p => p.Pets)
+                .Exclude(p => new { }));
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*Pets[1].Name*Pets[1].Age*");
+        }
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Including.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Including.cs
@@ -408,5 +408,103 @@ public partial class SelectionRulesSpecs
             int DefaultProperty => NormalProperty.Length;
         }
 #endif
+
+        [Fact]
+        public void An_anonymous_object_selects_correctly()
+        {
+            // Arrange
+            var subject = new ClassWithSomeFieldsAndProperties
+            {
+                Field1 = "Lorem",
+                Field2 = "ipsum",
+                Field3 = "dolor",
+                Property1 = "sit",
+                Property2 = "amet",
+                Property3 = "consectetur"
+            };
+
+            var expectation = new ClassWithSomeFieldsAndProperties
+            {
+                Field1 = "Lorem",
+                Field2 = "ipsum"
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation,
+                        opts => opts.Including(o => new { o.Field1, o.Field2, o.Field3 }));
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected field subject.Field3*");
+        }
+
+        [Fact]
+        public void An_anonymous_object_selects_nested_fields_correctly()
+        {
+            // Arrange
+            var subject = new
+            {
+                Field = "Lorem",
+                NestedField = new
+                {
+                    FieldB = "ipsum"
+                }
+            };
+
+            var expectation = new
+            {
+                FieldA = "Lorem",
+                NestedField = new
+                {
+                    FieldB = "no ipsum"
+                }
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation,
+                        opts => opts.Including(o => new { o.NestedField.FieldB }));
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected*subject.NestedField.FieldB*");
+        }
+
+        [Fact]
+        public void An_anonymous_object_in_combination_with_exclude_selects_nested_fields_correctly()
+        {
+            // Arrange
+            var subject = new
+            {
+                FieldA = "Lorem",
+                NestedField = new
+                {
+                    FieldB = "ipsum",
+                    FieldC = "ipsum2",
+                    FieldD = "ipsum3",
+                    FieldE = "ipsum4",
+                }
+            };
+
+            var expectation = new
+            {
+                FieldA = "Lorem",
+                NestedField = new
+                {
+                    FieldB = "no ipsum",
+                    FieldC = "no ipsum2",
+                    FieldD = "no ipsum3",
+                    FieldE = "no ipsum4",
+                }
+            };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opts => opts
+                .Excluding(o => new { o.NestedField })
+                .Including(o => new { o.NestedField.FieldB }));
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .Which.Message.Should()
+                .Match("*Expected*subject.NestedField.FieldB*").And
+                .NotMatch("*Expected*FieldC*FieldD*FieldE*");
+        }
     }
 }

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -147,6 +147,22 @@ orderDto.Should().BeEquivalentTo(order, options =>
            .Exclude(o => o.Name));
 ```
 
+You can also use an anonymous object to exclude members. This can be useful if you want to exclude multiple (maybe nested) fields and avoid writing 
+`Excluding().Excuding().Excluding()...`.
+
+```csharp
+orderDto.Should().BeEquivalentTo(order, options => 
+    options.Excluding(o => new { o.Customer.Name, o.Customer.LastName, o.Vat }));
+```
+
+This is also possible after `.For()` like
+
+```csharp
+orderDto.Should().BeEquivalentTo(order, options =>
+    options.For(o => o.Products)
+           .Exclude(o => new { o.Name, o.Price }));
+```
+
 Of course, `Excluding()` and `ExcludingMissingMembers()` can be combined.
 
 You can also take a different approach and explicitly tell Fluent Assertions which members to include. You can directly specify a property expression or use a predicate that acts on the provided `ISubjectInfo`.
@@ -190,6 +206,8 @@ orderDto.Should().BeEquivalentTo(order, options => options
 ```
 
 This configuration affects the initial inclusion of members and happens before any `Exclude`s or other `IMemberSelectionRule`s. This configuration also affects matching. For example, that if properties are excluded, properties will not be inspected when looking for a match on the expected object.
+
+The behavior with anonymous objects for selection also applies to `Include` as it does to `Exclude`.
 
 ### Comparing members with different names
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -39,6 +39,7 @@ sidebar:
 * All `Should()` methods on reference types are now annotated with the `[NotNull]` attribute for a better Fluent Assertions experience when nullable reference types are enabled - [#2380](https://github.com/fluentassertions/fluentassertions/pull/2380)
 * All assertions that support chaining using the `.Which` construct will now amend the caller identifier - [2539](https://github.com/fluentassertions/pull/2539)
 * Introduced a `MethodInfoFormatter` and improved the `PropertyInfoFormatter` - [2539](https://github.com/fluentassertions/pull/2539)
+* `Excluding()` / `For().Exclude()` and `Including()` on `BeEquivalentTo()` now also accepts an anonymous object to include/exclude multiple members at once - [#2488](https://github.com/fluentassertions/fluentassertions/pull/2488)
 
 ### Fixes
 * Fixed formatting error when checking nullable `DateTimeOffset` with


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->


This refers to `Excluding()` / `.For().Exclude()` and `Including()`.

This closes #2479 

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
