### PR TITLE
Draft for Json comparison function using Utf8JsonReader

### DIFF
--- a/Src/FluentAssertions/Json/JsonComparatorOptions.cs
+++ b/Src/FluentAssertions/Json/JsonComparatorOptions.cs
@@ -1,0 +1,54 @@
+#if NET6_0_OR_GREATER
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace FluentAssertions.Json;
+
+[StructLayout(LayoutKind.Auto)]
+public readonly struct JsonComparatorOptions : IEquatable<JsonComparatorOptions>
+{
+    public JsonComparatorOptions()
+    {
+    }
+
+    public JsonCommentHandling CommentHandling { get; init; } = JsonCommentHandling.Skip;
+
+    public bool AllowTrailingCommas { get; init; } = true;
+
+    public int MaxDepth { get; init; } = 64;
+
+    public bool LooseObjectOrderComparison { get; init; }
+
+    public static implicit operator JsonReaderOptions(JsonComparatorOptions options) => new JsonReaderOptions()
+    {
+        CommentHandling = options.CommentHandling,
+        AllowTrailingCommas = options.AllowTrailingCommas,
+        MaxDepth = options.MaxDepth,
+    };
+
+// Analyzers require all structs to implement equality.
+    public override bool Equals(object? obj)
+    {
+        return obj is JsonComparatorOptions other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine((int)CommentHandling, AllowTrailingCommas, MaxDepth, LooseObjectOrderComparison);
+    }
+
+    public static bool operator ==(JsonComparatorOptions left, JsonComparatorOptions right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(JsonComparatorOptions left, JsonComparatorOptions right)
+    {
+        return !(left == right);
+    }
+
+    public bool Equals(JsonComparatorOptions other) => CommentHandling == other.CommentHandling && AllowTrailingCommas == other.AllowTrailingCommas && MaxDepth == other.MaxDepth && LooseObjectOrderComparison == other.LooseObjectOrderComparison;
+}
+#endif

--- a/Src/FluentAssertions/Json/JsonTokenStreamCompare.cs
+++ b/Src/FluentAssertions/Json/JsonTokenStreamCompare.cs
@@ -1,0 +1,128 @@
+#if NET6_0_OR_GREATER
+#nullable enable
+
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace FluentAssertions.Json;
+
+internal static class JsonTokenStreamCompare
+{
+    private const int CharCountBeforeError = 14;
+    private const int CharCountAfterError = 150;
+    private static readonly JsonComparatorOptions DefaultOptions = new();
+
+    internal static string? IsJsonTokenEquivalent(string actual, string expected, JsonComparatorOptions? options = null)
+    {
+        var actualBytes = System.Text.Encoding.UTF8.GetBytes(actual);
+        var expectedBytes = System.Text.Encoding.UTF8.GetBytes(expected);
+        return IsJsonTokenEquivalent(actualBytes, expectedBytes, options);
+    }
+
+    internal static string? IsJsonTokenEquivalent(byte[] actualBytes, byte[] expectedBytes, JsonComparatorOptions? options = null)
+    {
+        options ??= DefaultOptions;
+        var actual = new Utf8JsonReader(actualBytes, options.Value);
+        var expected = new Utf8JsonReader(expectedBytes, options.Value);
+        var comparisonResult = CompareReaders(ref actual, actualBytes, ref expected, expectedBytes);
+        return comparisonResult;
+    }
+
+    private static string? CompareReaders(ref Utf8JsonReader actual, byte[] actualBytes,
+        ref Utf8JsonReader expected, byte[] expectedBytes)
+    {
+        while (actual.Read() && expected.Read())
+        {
+            if (actual.TokenType != expected.TokenType)
+            {
+                return CreateErrorMessage("JsonTokenType mismatch", ref actual, actualBytes, ref expected, expectedBytes);
+            }
+
+            switch (actual.TokenType)
+            {
+                // Ignore tokens without value
+                case JsonTokenType.StartObject:
+                case JsonTokenType.EndObject:
+                case JsonTokenType.None:
+                case JsonTokenType.StartArray:
+                case JsonTokenType.EndArray:
+                case JsonTokenType.True:
+                case JsonTokenType.False:
+                case JsonTokenType.Null:
+                    break;
+
+                // compare the value of tokens with value
+                case JsonTokenType.PropertyName:
+                    if (!actual.ValueTextEquals(expected.ValueSpan))
+                    {
+                        return CreateErrorMessage("PropertyName mismatch (validate strict order)", ref actual, actualBytes, ref expected,
+                            expectedBytes);
+                    }
+
+                    break;
+                case JsonTokenType.String:
+                    if (!actual.ValueTextEquals(expected.ValueSpan))
+                    {
+                        return CreateErrorMessage("string mismatch", ref actual, actualBytes, ref expected, expectedBytes);
+                    }
+
+                    break;
+                case JsonTokenType.Comment: // compare comments if they are not ignored
+                    if (actual.GetComment() != expected.GetComment())
+                    {
+                        return CreateErrorMessage("comment mismatch", ref actual, actualBytes, ref expected, expectedBytes);
+                    }
+
+                    break;
+                case JsonTokenType.Number:
+                    if (actual.GetDecimal() != expected.GetDecimal())
+                    {
+                        return CreateErrorMessage("number mismatch", ref actual, actualBytes, ref expected, expectedBytes);
+                    }
+
+                    break;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? CreateErrorMessage(string message, ref Utf8JsonReader actual, ReadOnlySpan<byte> actualBytes,
+        ref Utf8JsonReader expected, ReadOnlySpan<byte> expectedBytes)
+    {
+        var actualCharacterPositionError = Encoding.UTF8.GetCharCount(actualBytes.Slice(0, (int)actual.TokenStartIndex)); // might be less than pos if there are multi byte characters
+        var expectedCharacterPositionError = Encoding.UTF8.GetCharCount(expectedBytes.Slice(0, (int)expected.TokenStartIndex)); // might be less than pos if there are multi byte characters
+
+        return $"""
+
+                {message}
+                {GetRelevantErrorPart((int)actual.TokenStartIndex, actualBytes)} (diff at index {actualCharacterPositionError})
+                {GetRelevantErrorPart((int)expected.TokenStartIndex, expectedBytes)} (diff at index {expectedCharacterPositionError})
+                {"^".PadLeft(CharCountBeforeError + 1)}
+
+                """;
+    }
+
+    private static readonly Regex RemoveNewlinesAndIndetionRegex = new Regex(@"\r?\n\s*", RegexOptions.Compiled);
+
+    private static string GetRelevantErrorPart(int pos, ReadOnlySpan<byte> bytes)
+    {
+        var startBeforePos = Math.Max(0, pos - (CharCountBeforeError * 3)); // take 3 times as many utf8 bytes than characters (might be multi byte characters, and we remove newlines and indentation)
+        var lengthAfterPos = Math.Min(CharCountAfterError * 3, bytes.Length - pos); // take 3 times as many utf8 bytes than characters
+
+        var beforeErrorString = Encoding.UTF8.GetString(bytes.Slice(startBeforePos, pos - startBeforePos));
+        beforeErrorString = RemoveNewlinesAndIndetionRegex.Replace(beforeErrorString, " ")
+            .PadLeft(CharCountBeforeError);
+        beforeErrorString = beforeErrorString.Substring(beforeErrorString.Length - CharCountBeforeError);
+
+        var afterErrorString = Encoding.UTF8.GetString(bytes.Slice(pos, lengthAfterPos));
+        afterErrorString = RemoveNewlinesAndIndetionRegex.Replace(afterErrorString, " ");
+        afterErrorString = afterErrorString.Substring(0, Math.Min(afterErrorString.Length, CharCountAfterError));
+
+        return beforeErrorString + afterErrorString;
+    }
+}
+
+#endif

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -6,6 +6,9 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
+#if NET6_0_OR_GREATER
+using FluentAssertions.Json;
+#endif
 using JetBrains.Annotations;
 
 namespace FluentAssertions.Primitives;
@@ -1514,6 +1517,32 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             throw new ArgumentException("Cannot assert string containment of values in empty collection", nameof(values));
         }
     }
+
+#if NET6_0_OR_GREATER
+    public AndConstraint<TAssertions> BeJsonEquivalentTo(string expected, JsonComparatorOptions? options = null)
+    {
+        Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot assert string containment against <null>.");
+        Guard.ThrowIfArgumentIsEmpty(expected, nameof(expected), "Cannot assert string containment against an empty string.");
+
+        string result;
+        if (options?.LooseObjectOrderComparison != true)
+        {
+            result = JsonTokenStreamCompare.IsJsonTokenEquivalent(this.Subject, expected, options);
+        }
+        else
+        {
+            throw new NotSupportedException(); // Not implemented yet
+        }
+
+        if (result is not null)
+        {
+            Execute.Assertion
+                .FailWith(() => new FailReason("Expected {context:string} to match expected json, but found diff\n{0}", result));
+        }
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+#endif
 
     /// <summary>
     /// Returns the type of the subject the assertion applies on.

--- a/Tests/FluentAssertions.Specs/Json/JsonAssertionSpecs.BeEquivalentJson.cs
+++ b/Tests/FluentAssertions.Specs/Json/JsonAssertionSpecs.BeEquivalentJson.cs
@@ -1,0 +1,68 @@
+#if NET6_0_OR_GREATER
+#nullable enable
+using System;
+using Xunit;
+
+namespace FluentAssertions.Specs.Json;
+
+public class JsonAssertionSpecs
+{
+    public class BeEquivalentJsonTo
+    {
+        [Fact]
+        public void When_json_is_the_the_same_string_it_should_validate()
+        {
+            // Arrange
+            string actual = """
+            {
+                "a": 1,
+                "b": 2
+            }
+            """;
+            actual.Should().BeJsonEquivalentTo(actual);
+        }
+
+        [Fact]
+        public void When_json_has_different_indentation_it_should_validate()
+        {
+            // Arrange
+            string actual = """
+            {
+                "a": 1,
+                "b": 2
+            }
+            """;
+            string expected = """{"a":1,"b":2}""";
+            actual.Should().BeJsonEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void When_property_order_is_different_it_should_throw()
+        {
+            // Arrange
+            string actual = """
+            {
+                "a": 1,
+                "b": 2,
+            }
+            """;
+            string expected = """
+            {
+                "b": 2,
+                "a": 1
+            }
+            """;
+            var action = () => actual.Should().BeJsonEquivalentTo(expected);
+            action.Should().Throw<Exception>().Which.Message.Should().Be("""
+                 Expected actual to match expected json, but found diff
+                 "
+                 PropertyName mismatch (validate strict order)
+                             { "a": 1, "b": 2, } (diff at index 6)
+                             { "b": 2, "a": 1 } (diff at index 6)
+                               ^
+                 "
+                 """);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
System.Text.Json provides a neat api for parsing Json in a forward only way with `Utf8JsonReader` that just returns tokens, ignoring whitespace and decoding escape sequences in strings.

This would make a lot of sense in tests that produce json to check that it still matches the expected content, while ignoring whitespace and other artefacts that are ignored by a json deserialiser. Currently the only options are `Should().Be()` and `string.Should().BeEquivalentTo()`.

There are previous issues related to Json and the use of `System.Text.Json` in newer dotnet versions. https://github.com/fluentassertions/fluentassertions/issues/2205.

I just wanted to add my suggestion for how this might be done. I hope it is OK to suggest in PR form, instead of opening an issue to discuss this somewhat different approach.

```c#
string actualJson = ...
actualJson.Should().BeJsonEquivalentTo("""
{
    "a": 1,
    "b": 2
}
""", new JsonComparatorOptions()
{
    CommentHandling = JsonCommentHandling.Skip,
    AllowTrailingCommas = false,
    MaxDepth = 64,
});
```
I have added a new `JsonComparatorOptions` struct extending `System.Text.Json.JsonReaderOptions` with more comparison relevant options. It is optional to provide, but I think the api needs a way to specify `CommentHandeling`, `AllowTrailingCommas` and `MaxDepth`, and I also have some ideas for more of these Mode options for how to compare structures.

### Future ideas for possible options (currently not implemented)
*  **LooseObjectOrderComparison**: Ignore the order of properties in json objects so that `{"a": 1, "b": 2}` and `{"b": 2, "a": 1}` can be considered equal, even though the order is different.
* **IgnoreExtraProperites**: Ignore if objects in the actual json text has properties that are missing from the actual json text. This is nice if you have a big structure, and just want to assert that your requirements is present.
* **CaseInsensitiveProperties**: Compare property names in a case insensitive way. 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
