### PR TITLE
Switch back to the release version of Qodana (to officially support .NET 8)

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -21,7 +21,7 @@ jobs:
         uses: JetBrains/qodana-action@v2023.2
         with:
           upload-result: ${{ github.ref_name == 'master' || github.ref_name == 'develop' }}
-          args: --baseline,qodana.sarif.json,--ide,QDNET-EAP
+          args: --baseline,qodana.sarif.json,--ide,QDNET
           pr-mode: ${{ github.event_name == 'pull_request_target' }}
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}


### PR DESCRIPTION
As was recommended by my contact at JetBrains, they've released a new version and we had to switch back.

