### PR TITLE
Turn off RoslynAnalyzers in Qodana WF

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -21,7 +21,7 @@ jobs:
         uses: JetBrains/qodana-action@v2023.2
         with:
           upload-result: ${{ github.ref_name == 'master' || github.ref_name == 'develop' }}
-          args: --baseline,qodana.sarif.json,--ide,QDNET
+          args: --baseline,qodana.sarif.json,--ide,QDNET,--property,idea.log.debug.categories=#org.jetbrains.qodana.publisher
           pr-mode: ${{ github.event_name == 'pull_request_target' }}
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -18,10 +18,10 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2023.2
+        uses: JetBrains/qodana-action@v2023.3
         with:
           upload-result: ${{ github.ref_name == 'master' || github.ref_name == 'develop' }}
-          args: --baseline,qodana.sarif.json,--ide,QDNET,--property,idea.log.debug.categories=#org.jetbrains.qodana.publisher
+          args: --baseline,qodana.sarif.json,--ide,QDNET
           pr-mode: ${{ github.event_name == 'pull_request_target' }}
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/profile.yaml
+++ b/profile.yaml
@@ -1,0 +1,12 @@
+name: "Custom profile"
+
+baseProfile: qodana.starter
+
+groups: # List of configured groups
+  - groupId: InspectionsToExclude
+    groups:
+      - "category:C#/Roslyn Analyzers"
+
+inspections: # Group invocation
+  - group: InspectionsToExclude
+    enabled: false # Enable the InspectionsToInclude group

--- a/profile.yaml
+++ b/profile.yaml
@@ -9,4 +9,4 @@ groups: # List of configured groups
 
 inspections: # Group invocation
   - group: InspectionsToExclude
-    enabled: false # Enable the InspectionsToInclude group
+    enabled: false # Disable the InspectionsToExclude group

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,7 +1,10 @@
 version: "1.0"
 
-linter: jetbrains/qodana-dotnet:latest
+ide: QDNET
 failThreshold: 20
+
+profile:
+  path: profile.yaml
 
 dotnet:
   solution: FluentAssertions.sln


### PR DESCRIPTION
This PR turns off RoslynAnalyzers in Qodana by introducing new profile that is based on qodana.starter. This profile creates group InspectionsToExclude and excludes them from the default sets. 