### PR TITLE
Fix issue when an empty ArraySegment is a member of a class

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -70,8 +70,8 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
 
     private static bool IsIgnorableArrayLikeType(object value)
     {
-        return value.GetType() is { } type &&
-                    (type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
-                     (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>)));
+        var type = value.GetType();
+        return type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
+            (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>));
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -70,7 +70,7 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
 
     private static bool IsIgnorableArrayLikeType(object value)
     {
-        return value.GetType() is Type type &&
+        return value.GetType() is { } type &&
                     (type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
                      (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>)));
     }

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -61,10 +61,15 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
         {
             return ((IEnumerable)value).Cast<object>().ToArray();
         }
-        catch (InvalidOperationException) when (value.GetType().Name.Equals("ImmutableArray`1", StringComparison.Ordinal))
+        catch (InvalidOperationException) when (IsIgnorableArrayLikeType(value))
         {
-            // This is probably a default ImmutableArray<T>
+            // This is probably a default ImmutableArray<T> or an empty ArraySegment.
             return Array.Empty<object>();
         }
+
+        bool IsIgnorableArrayLikeType(object value)
+            => value.GetType() is Type type &&
+                (type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
+                 (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>)));
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -66,10 +66,12 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
             // This is probably a default ImmutableArray<T> or an empty ArraySegment.
             return Array.Empty<object>();
         }
+    }
 
-        bool IsIgnorableArrayLikeType(object value)
-            => value.GetType() is Type type &&
-                (type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
-                 (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>)));
+    private static bool IsIgnorableArrayLikeType(object value)
+    {
+        return value.GetType() is Type type &&
+                    (type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
+                     (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>)));
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -647,17 +647,14 @@ public class BasicSpecs
     }
 
     [Fact]
-    public void When_a_class_contains_an_empty_array_segment()
+    public void Empty_array_segments_can_be_compared_for_equivalency()
     {
         // Arrange
         var actual = new ClassWithArraySegment();
         var expected = new ClassWithArraySegment();
 
-        // Act
-        Action act = () => actual.Should().BeEquivalentTo(expected);
-
-        // Assert
-        act.Should().NotThrow();
+        // Act / Assert
+        actual.Should().BeEquivalentTo(expected);
     }
 
     private class ClassWithArraySegment

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -659,4 +659,9 @@ public class BasicSpecs
         // Assert
         act.Should().NotThrow();
     }
+
+    private class ClassWithArraySegment
+    {
+        public ArraySegment<byte> Segment { get; set; }
+    }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -645,4 +645,18 @@ public class BasicSpecs
         // Assert
         act.Should().Throw<XunitException>().WithMessage("Expected property actual[0].Id*to be *-*, but found *-*");
     }
+
+    [Fact]
+    public void When_a_class_contains_an_empty_array_segment()
+    {
+        // Arrange
+        var actual = new ClassWithArraySegment();
+        var expected = new ClassWithArraySegment();
+
+        // Act
+        Action act = () => actual.Should().BeEquivalentTo(expected);
+
+        // Assert
+        act.Should().NotThrow();
+    }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
@@ -410,6 +410,11 @@ public class Derived : Base
     public virtual string NonExcludedDerivedProperty => "Foo";
 }
 
+public class ClassWithArraySegment
+{
+    public ArraySegment<byte> Segment { get; set; }
+}
+
 #endregion
 
 #region Nested classes for comparison

--- a/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
@@ -410,11 +410,6 @@ public class Derived : Base
     public virtual string NonExcludedDerivedProperty => "Foo";
 }
 
-public class ClassWithArraySegment
-{
-    public ArraySegment<byte> Segment { get; set; }
-}
-
 #endregion
 
 #region Nested classes for comparison

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -33,7 +33,7 @@ sidebar:
 * Improved the failure message for `[Not]HaveExplicitProperty` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
 * Improved the failure message for `[Not]HaveExplicitMethod` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
 * Changed `BeEquivalentTo` to exclude `private protected` members from the comparison - [#2417](https://github.com/fluentassertions/fluentassertions/pull/2417)
-
+* When formatting messages, ignoring ArraySegment<> values (they crash the message generation issue) - [#2445](https://github.com/fluentassertions/fluentassertions/pull/2445), [#2511](https://github.com/fluentassertions/fluentassertions/pull/2511)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -33,7 +33,7 @@ sidebar:
 * Improved the failure message for `[Not]HaveExplicitProperty` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
 * Improved the failure message for `[Not]HaveExplicitMethod` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
 * Changed `BeEquivalentTo` to exclude `private protected` members from the comparison - [#2417](https://github.com/fluentassertions/fluentassertions/pull/2417)
-* When formatting messages, ignoring ArraySegment<> values (they crash the message generation issue) - [#2445](https://github.com/fluentassertions/fluentassertions/pull/2445), [#2511](https://github.com/fluentassertions/fluentassertions/pull/2511)
+* Fixed using `BeEquivalentTo` on an empty `ArraySegment` - [#2445](https://github.com/fluentassertions/fluentassertions/pull/2445), [#2511](https://github.com/fluentassertions/fluentassertions/pull/2511)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -14,6 +14,7 @@ exclude:
   - name: ConvertIfStatementToConditionalTernaryExpression
   - name: InvertIf
   - name: SimilarAnonymousTypeNearby
+  - name: UnusedMember.Local
     paths:
       - Tests
   - name: All


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
This finishes #2445 

Al the credit goes to @ShaharPrishMSFT

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
