### PR TITLE
Update qodana.yaml to limit target frameworks

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -8,6 +8,7 @@ profile:
 
 dotnet:
   solution: FluentAssertions.sln
+  frameworks: "!netstandard2.0;!netstandard2.1"
 
 exclude:
   - name: ConvertIfStatementToReturnStatement


### PR DESCRIPTION
Using `frameworks:` property one could limit analysed TFMs.