### PR TITLE
Upgrade to C# 12 and .NET 8 SDK analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -152,6 +152,8 @@ dotnet_diagnostic.CA1724.severity = none
 dotnet_diagnostic.CA1819.severity = none
 # CA1851: Possible multiple enumerations of IEnumerable collection. Related to GH-issue #2000
 dotnet_diagnostic.CA1851.severity = suggestion
+# CA1859: Use concrete types when possible for improved performance
+dotnet_diagnostic.CA1859.severity = suggestion
 # CA1860: Avoid using 'Enumerable.Any()' extension method
 dotnet_diagnostic.CA1860.severity = warning
 # CA1861: Avoid constant arrays as arguments

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -99,7 +99,7 @@ class Build : NukeBuild
                     "Branch spec {branchspec} is a pull request. Adding build number {buildnumber}",
                     BranchSpec, BuildNumber);
 
-                SemVer = string.Join('.', GitVersion.SemVer.Split('.').Take(3).Union(new[] { BuildNumber }));
+                SemVer = string.Join('.', GitVersion.SemVer.Split('.').Take(3).Union([BuildNumber]));
             }
 
             Information("SemVer = {semver}", SemVer);
@@ -159,14 +159,14 @@ class Build : NukeBuild
             ReportTestOutcome(globFilters: $"*{project.Name}.trx");
         });
 
-    Project[] Projects => new[]
-    {
+    Project[] Projects =>
+    [
         Solution.Specs.FluentAssertions_Specs,
         Solution.Specs.FluentAssertions_Equivalency_Specs,
         Solution.Specs.FluentAssertions_Extensibility_Specs,
         Solution.Specs.FSharp_Specs,
         Solution.Specs.VB_Specs
-    };
+    ];
 
     Target UnitTestsNet47 => _ => _
         .Unlisted()
@@ -209,7 +209,7 @@ class Build : NukeBuild
                         (settings, project) => settings
                             .SetProjectFile(project)
                             .CombineWith(
-                                project.GetTargetFrameworks().Except(new[] { net47 }),
+                                project.GetTargetFrameworks().Except([net47]),
                                 (frameworkSettings, framework) => frameworkSettings
                                     .SetFramework(framework)
                                     .AddLoggers($"trx;LogFileName={project.Name}_{framework}.trx")
@@ -284,7 +284,7 @@ class Build : NukeBuild
             var testCombinations =
                 from project in projects
                 let frameworks = project.GetTargetFrameworks()
-                let supportedFrameworks = EnvironmentInfo.IsWin ? frameworks : frameworks.Except(new[] { "net47" })
+                let supportedFrameworks = EnvironmentInfo.IsWin ? frameworks : frameworks.Except(["net47"])
                 from framework in supportedFrameworks
                 select new { project, framework };
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisLevel>7.0</AnalysisLevel>
+    <AnalysisLevel>8.0</AnalysisLevel>
     <AnalysisMode>All</AnalysisMode>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>

--- a/Src/FluentAssertions/AggregateExceptionExtractor.cs
+++ b/Src/FluentAssertions/AggregateExceptionExtractor.cs
@@ -13,7 +13,7 @@ public class AggregateExceptionExtractor : IExtractExceptions
     {
         if (typeof(T).IsSameOrInherits(typeof(AggregateException)))
         {
-            return actualException is T exception ? new[] { exception } : Enumerable.Empty<T>();
+            return actualException is T exception ? [exception] : [];
         }
 
         return GetExtractedExceptions<T>(actualException);

--- a/Src/FluentAssertions/CallerIdentification/CallerStatementBuilder.cs
+++ b/Src/FluentAssertions/CallerIdentification/CallerStatementBuilder.cs
@@ -14,8 +14,8 @@ internal class CallerStatementBuilder
     {
         statement = new StringBuilder();
 
-        priorityOrderedParsingStrategies = new List<IParsingStrategy>
-        {
+        priorityOrderedParsingStrategies =
+        [
             new QuotesParsingStrategy(),
             new MultiLineCommentParsingStrategy(),
             new SingleLineCommentParsingStrategy(),
@@ -23,7 +23,7 @@ internal class CallerStatementBuilder
             new ShouldCallParsingStrategy(),
             new AwaitParsingStrategy(),
             new AddNonEmptySymbolParsingStrategy()
-        };
+        ];
     }
 
     internal void Append(string symbols)

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -268,7 +268,7 @@ public static class CallerIdentifier
 #if !NET6_0_OR_GREATER
         if (frames == null)
         {
-            return Array.Empty<StackFrame>();
+            return [];
         }
 #endif
         return frames

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -71,7 +71,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .FailWith("Expected type to be {0}{reason}, but found {context:the collection} is <null>.",
                 typeof(TExpectation).FullName);
 
-        IEnumerable<TExpectation> matches = Enumerable.Empty<TExpectation>();
+        IEnumerable<TExpectation> matches = [];
 
         if (success)
         {
@@ -218,7 +218,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .FailWith("Expected type to be {0}{reason}, but found {context:collection} is <null>.",
                 typeof(TExpectation).FullName);
 
-        IEnumerable<TExpectation> matches = Enumerable.Empty<TExpectation>();
+        IEnumerable<TExpectation> matches = [];
 
         if (success)
         {
@@ -701,7 +701,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .ForCondition(Subject is not null)
             .FailWith("Expected {context:collection} to contain {0}{reason}, but found <null>.", expected);
 
-        IEnumerable<T> matches = Enumerable.Empty<T>();
+        IEnumerable<T> matches = [];
 
         if (success)
         {
@@ -740,7 +740,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .ForCondition(Subject is not null)
             .FailWith("Expected {context:collection} to contain {0}{reason}, but found <null>.", predicate.Body);
 
-        IEnumerable<T> matches = Enumerable.Empty<T>();
+        IEnumerable<T> matches = [];
 
         if (success)
         {
@@ -1204,7 +1204,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .ForCondition(Subject is not null)
             .FailWith(expectationPrefix + "but found <null>.", predicate);
 
-        T[] matches = Array.Empty<T>();
+        T[] matches = [];
 
         if (success)
         {
@@ -1304,7 +1304,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// </param>
     public AndConstraint<TAssertions> EndWith(T element, string because = "", params object[] becauseArgs)
     {
-        return EndWith(new[] { element }, ObjectExtensions.GetComparer<T>(), because, becauseArgs);
+        return EndWith([element], ObjectExtensions.GetComparer<T>(), because, becauseArgs);
     }
 
     /// <summary>
@@ -2182,7 +2182,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .ForCondition(Subject is not null)
             .FailWith("Expected {context:collection} to not contain {0}{reason}, but found <null>.", unexpected);
 
-        IEnumerable<T> matched = Enumerable.Empty<T>();
+        IEnumerable<T> matched = [];
 
         if (success)
         {
@@ -3259,7 +3259,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// </param>
     public AndConstraint<TAssertions> StartWith(T element, string because = "", params object[] becauseArgs)
     {
-        return StartWith(new[] { element }, ObjectExtensions.GetComparer<T>(), because, becauseArgs);
+        return StartWith([element], ObjectExtensions.GetComparer<T>(), because, becauseArgs);
     }
 
     internal AndConstraint<SubsequentOrderingAssertions<T>> BeOrderedBy<TSelector>(
@@ -3312,7 +3312,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     {
         if (enumerable is null)
         {
-            return Enumerable.Empty<TExpectation>();
+            return [];
         }
 
         return RepeatAsManyAsIterator(value, enumerable);
@@ -3534,7 +3534,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .ForCondition(Subject is not null)
             .FailWith($"Expected {{context:collection}} to be in {sortOrder} order{{reason}}, but found <null>.");
 
-        IOrderedEnumerable<T> ordering = new List<T>(0).OrderBy(x => x);
+        IOrderedEnumerable<T> ordering = Array.Empty<T>().OrderBy(x => x);
 
         if (success)
         {

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -255,7 +255,7 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     public WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected,
         string because = "", params object[] becauseArgs)
     {
-        AndConstraint<TAssertions> andConstraint = ContainKeys(new[] { expected }, because, becauseArgs);
+        AndConstraint<TAssertions> andConstraint = ContainKeys([expected], because, becauseArgs);
 
         _ = TryGetValue(Subject, expected, out TValue value);
 
@@ -447,7 +447,7 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
         string because = "", params object[] becauseArgs)
     {
         AndWhichConstraint<TAssertions, IEnumerable<TValue>> innerConstraint =
-            ContainValuesAndWhich(new[] { expected }, because, becauseArgs);
+            ContainValuesAndWhich([expected], because, becauseArgs);
 
         return
             new AndWhichConstraint<TAssertions, TValue>(

--- a/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingProblem.cs
+++ b/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingProblem.cs
@@ -23,9 +23,9 @@ internal class MaximumMatchingProblem<TValue>
         Elements.AddRange(elements.Select((element, index) => new Element<TValue>(element, index)));
     }
 
-    public List<Predicate<TValue>> Predicates { get; } = new();
+    public List<Predicate<TValue>> Predicates { get; } = [];
 
-    public List<Element<TValue>> Elements { get; } = new();
+    public List<Element<TValue>> Elements { get; } = [];
 
     public MaximumMatchingSolution<TValue> Solve() => new MaximumMatchingSolver<TValue>(this).Solve();
 }

--- a/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolver.cs
+++ b/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolver.cs
@@ -14,7 +14,7 @@ namespace FluentAssertions.Collections.MaximumMatching;
 internal class MaximumMatchingSolver<TValue>
 {
     private readonly MaximumMatchingProblem<TValue> problem;
-    private readonly Dictionary<Predicate<TValue>, List<Element<TValue>>> matchingElementsByPredicate = new();
+    private readonly Dictionary<Predicate<TValue>, List<Element<TValue>>> matchingElementsByPredicate = [];
 
     public MaximumMatchingSolver(MaximumMatchingProblem<TValue> problem)
     {
@@ -76,7 +76,7 @@ internal class MaximumMatchingSolver<TValue>
             }
         }
 
-        return Enumerable.Empty<Match>();
+        return [];
     }
 
     private List<Element<TValue>> GetMatchingElements(Predicate<TValue> predicate)
@@ -98,7 +98,7 @@ internal class MaximumMatchingSolver<TValue>
 
     private sealed class MatchCollection : IEnumerable<Match>
     {
-        private readonly Dictionary<Element<TValue>, Match> matchesByElement = new();
+        private readonly Dictionary<Element<TValue>, Match> matchesByElement = [];
 
         public void UpdateFrom(IEnumerable<Match> matches)
         {
@@ -123,7 +123,7 @@ internal class MaximumMatchingSolver<TValue>
     private sealed class BreadthFirstSearchTracker
     {
         private readonly Queue<Predicate<TValue>> unmatchedPredicatesQueue = new();
-        private readonly Dictionary<Predicate<TValue>, Match> previousMatchByPredicate = new();
+        private readonly Dictionary<Predicate<TValue>, Match> previousMatchByPredicate = [];
 
         private readonly MatchCollection originalMatches;
 

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -253,7 +253,7 @@ public class StringCollectionAssertions<TCollection, TAssertions> : GenericColle
             .ForCondition(Subject is not null)
             .FailWith("Expected {context:collection} to contain a match of {0}{reason}, but found <null>.", wildcardPattern);
 
-        IEnumerable<string> matched = new List<string>(0);
+        IEnumerable<string> matched = [];
 
         if (success)
         {

--- a/Src/FluentAssertions/Common/FullFrameworkReflector.cs
+++ b/Src/FluentAssertions/Common/FullFrameworkReflector.cs
@@ -47,11 +47,11 @@ internal class FullFrameworkReflector : IReflector
         }
         catch (FileLoadException)
         {
-            return Enumerable.Empty<Type>();
+            return [];
         }
         catch (Exception)
         {
-            return Array.Empty<Type>();
+            return [];
         }
     }
 }

--- a/Src/FluentAssertions/Common/Services.cs
+++ b/Src/FluentAssertions/Common/Services.cs
@@ -76,7 +76,7 @@ public static class Services
         var currentAssembly = Assembly.GetExecutingAssembly();
         var currentAssemblyName = currentAssembly.GetName();
 
-        var attributes = Array.Empty<AssertionEngineInitializerAttribute>();
+        AssertionEngineInitializerAttribute[] attributes = [];
 
         try
         {

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -152,7 +152,7 @@ internal static class TypeExtensions
     {
         if (type.IsGenericType && type.GetGenericTypeDefinition() == openGenericType)
         {
-            return new[] { type };
+            return [type];
         }
 
         Type[] interfaces = type.GetInterfaces();
@@ -166,7 +166,7 @@ internal static class TypeExtensions
     public static bool OverridesEquals(this Type type)
     {
         MethodInfo method = type
-            .GetMethod("Equals", new[] { typeof(object) });
+            .GetMethod("Equals", [typeof(object)]);
 
         return method is not null
             && method.GetBaseDefinition().DeclaringType != method.DeclaringType;
@@ -499,9 +499,9 @@ internal static class TypeExtensions
         // and heuristic testing, apparently giving good results but not supported by official documentation.
         return type.BaseType == typeof(ValueType) &&
             type.GetMethod("PrintMembers", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly, null,
-                new[] { typeof(StringBuilder) }, null) is { } &&
+                [typeof(StringBuilder)], null) is { } &&
             type.GetMethod("op_Equality", BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly, null,
-                    new[] { type, type }, null)?
+                    [type, type], null)?
                 .IsDecoratedWith<CompilerGeneratedAttribute>() == true;
     }
 

--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -113,7 +113,7 @@ internal sealed class TypeMemberReflector
         Func<Type, IEnumerable<TMemberInfo>> getMembers)
         where TMemberInfo : MemberInfo
     {
-        List<TMemberInfo> members = new();
+        List<TMemberInfo> members = [];
 
         var considered = new List<Type>();
         var queue = new Queue<Type>();
@@ -149,7 +149,7 @@ internal sealed class TypeMemberReflector
         Func<Type, IEnumerable<TMemberInfo>> getMembers)
         where TMemberInfo : MemberInfo
     {
-        List<TMemberInfo> members = new();
+        List<TMemberInfo> members = [];
 
         while (typeToReflect != null)
         {

--- a/Src/FluentAssertions/Equivalency/ConversionSelector.cs
+++ b/Src/FluentAssertions/Equivalency/ConversionSelector.cs
@@ -30,7 +30,7 @@ public class ConversionSelector
     private readonly List<ConversionSelectorRule> exclusions;
 
     public ConversionSelector()
-        : this(new List<ConversionSelectorRule>(), new List<ConversionSelectorRule>())
+        : this([], [])
     {
     }
 

--- a/Src/FluentAssertions/Equivalency/EqualityStrategyProvider.cs
+++ b/Src/FluentAssertions/Equivalency/EqualityStrategyProvider.cs
@@ -10,8 +10,8 @@ namespace FluentAssertions.Equivalency;
 
 internal sealed class EqualityStrategyProvider
 {
-    private readonly List<Type> referenceTypes = new();
-    private readonly List<Type> valueTypes = new();
+    private readonly List<Type> referenceTypes = [];
+    private readonly List<Type> valueTypes = [];
     private readonly ConcurrentDictionary<Type, EqualityStrategy> typeCache = new();
 
     [CanBeNull]

--- a/Src/FluentAssertions/Equivalency/Execution/CyclicReferenceDetector.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CyclicReferenceDetector.cs
@@ -11,7 +11,7 @@ internal class CyclicReferenceDetector : ICloneable2
 {
     #region Private Definitions
 
-    private HashSet<ObjectReference> observedReferences = new();
+    private HashSet<ObjectReference> observedReferences = [];
 
     #endregion
 

--- a/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
+++ b/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
@@ -9,7 +9,7 @@ namespace FluentAssertions.Equivalency;
 /// </summary>
 public class OrderingRuleCollection : IEnumerable<IOrderingRule>
 {
-    private readonly List<IOrderingRule> rules = new();
+    private readonly List<IOrderingRule> rules = [];
 
     /// <summary>
     /// Initializes a new collection of ordering rules.

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -28,19 +28,19 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     private readonly EqualityStrategyProvider equalityStrategyProvider;
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private readonly List<IMemberSelectionRule> selectionRules = new();
+    private readonly List<IMemberSelectionRule> selectionRules = [];
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private readonly List<IMemberMatchingRule> matchingRules = new();
+    private readonly List<IMemberMatchingRule> matchingRules = [];
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private readonly List<IEquivalencyStep> userEquivalencySteps = new();
+    private readonly List<IEquivalencyStep> userEquivalencySteps = [];
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private CyclicReferenceHandling cyclicReferenceHandling = CyclicReferenceHandling.ThrowException;
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    protected OrderingRuleCollection OrderingRules { get; } = new();
+    protected OrderingRuleCollection OrderingRules { get; } = [];
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private bool isRecursive;

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionResultSet.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionResultSet.cs
@@ -10,7 +10,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// </summary>
 internal class AssertionResultSet
 {
-    private readonly Dictionary<object, string[]> set = new();
+    private readonly Dictionary<object, string[]> set = [];
 
     /// <summary>
     /// Adds the failures (if any) resulting from executing an assertion within a
@@ -33,7 +33,7 @@ internal class AssertionResultSet
     {
         if (ContainsSuccessfulSet())
         {
-            return Array.Empty<string>();
+            return [];
         }
 
         KeyValuePair<object, string[]>[] bestResultSets = GetBestResultSets();

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -94,7 +94,7 @@ internal sealed class DictionaryInterfaceInfo
         {
             if (Type.GetTypeCode(key) != TypeCode.Object)
             {
-                return Array.Empty<DictionaryInterfaceInfo>();
+                return [];
             }
 
             return key
@@ -125,7 +125,7 @@ internal sealed class DictionaryInterfaceInfo
             Type pairValueType = suitableKeyValuePairCollection.GenericTypeArguments[^1];
 
             var methodInfo = ConvertToDictionaryMethod.MakeGenericMethod(Key, pairValueType);
-            return methodInfo.Invoke(null, new[] { convertable });
+            return methodInfo.Invoke(null, [convertable]);
         }
 
         return null;

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -64,7 +64,7 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
         catch (InvalidOperationException) when (IsIgnorableArrayLikeType(value))
         {
             // This is probably a default ImmutableArray<T> or an empty ArraySegment.
-            return Array.Empty<object>();
+            return [];
         }
     }
 

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -76,8 +76,7 @@ internal class EnumerableEquivalencyValidator
 
     private void AssertElementGraphEquivalency<T>(object[] subjects, T[] expectations, INode currentNode)
     {
-        unmatchedSubjectIndexes = new List<int>(subjects.Length);
-        unmatchedSubjectIndexes.AddRange(Enumerable.Range(0, subjects.Length));
+        unmatchedSubjectIndexes = Enumerable.Range(0, subjects.Length).ToList();
 
         if (OrderingRules.IsOrderingStrictFor(new ObjectInfo(new Comparands(subjects, expectations, typeof(T[])), currentNode)))
         {

--- a/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -152,7 +152,7 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
     {
         AssertDictionaryEquivalenceMethod
             .MakeGenericMethod(actualDictionary.Key, actualDictionary.Value, expectedDictionary.Key, expectedDictionary.Value)
-            .Invoke(null, new[] { context, parent, context.Options, comparands.Subject, comparands.Expectation });
+            .Invoke(null, [context, parent, context.Options, comparands.Subject, comparands.Expectation]);
     }
 
     private static void AssertDictionaryEquivalence<TSubjectKey, TSubjectValue, TExpectedKey, TExpectedValue>(

--- a/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
@@ -48,7 +48,7 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
             try
             {
                 HandleMethod.MakeGenericMethod(typeOfEnumeration)
-                    .Invoke(null, new[] { validator, subjectAsArray, comparands.Expectation });
+                    .Invoke(null, [validator, subjectAsArray, comparands.Expectation]);
             }
             catch (TargetInvocationException e)
             {
@@ -95,7 +95,7 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
         // Avoid expensive calculation when the type in question can't possibly implement IEnumerable<>.
         if (Type.GetTypeCode(type) != TypeCode.Object)
         {
-            return Array.Empty<Type>();
+            return [];
         }
 
         Type soughtType = typeof(IEnumerable<>);
@@ -119,7 +119,7 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
         catch (InvalidOperationException) when (value.GetType().Name.Equals("ImmutableArray`1", StringComparison.Ordinal))
         {
             // This is probably a default ImmutableArray<T>
-            return Array.Empty<T>();
+            return [];
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
@@ -97,7 +97,7 @@ public class StructuralEqualityEquivalencyStep : IEquivalencyStep
     private static IEnumerable<IMember> GetMembersFromExpectation(INode currentNode, Comparands comparands,
         IEquivalencyOptions options)
     {
-        IEnumerable<IMember> members = Enumerable.Empty<IMember>();
+        IEnumerable<IMember> members = [];
 
         foreach (IMemberSelectionRule rule in options.SelectionRules)
         {

--- a/Src/FluentAssertions/Equivalency/Tracing/StringBuilderTraceWriter.cs
+++ b/Src/FluentAssertions/Equivalency/Tracing/StringBuilderTraceWriter.cs
@@ -28,7 +28,7 @@ public class StringBuilderTraceWriter : ITraceWriter
 
     private void WriteLine(string trace)
     {
-        foreach (string traceLine in trace.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries))
+        foreach (string traceLine in trace.Split([Environment.NewLine], StringSplitOptions.RemoveEmptyEntries))
         {
             builder.Append(new string(' ', depth * 2)).AppendLine(traceLine);
         }

--- a/Src/FluentAssertions/EquivalencyPlan.cs
+++ b/Src/FluentAssertions/EquivalencyPlan.cs
@@ -139,8 +139,8 @@ public class EquivalencyPlan : IEnumerable<IEquivalencyStep>
 
     private static List<IEquivalencyStep> GetDefaultSteps()
     {
-        return new List<IEquivalencyStep>(18)
-        {
+        return
+        [
             new RunAllUserStepsEquivalencyStep(),
             new AutoConversionStep(),
             new ReferenceEqualityEquivalencyStep(),
@@ -157,6 +157,6 @@ public class EquivalencyPlan : IEnumerable<IEquivalencyStep>
             new ValueTypeEquivalencyStep(),
             new StructuralEqualityEquivalencyStep(),
             new SimpleEqualityEquivalencyStep(),
-        };
+        ];
     }
 }

--- a/Src/FluentAssertions/Events/EventRecorder.cs
+++ b/Src/FluentAssertions/Events/EventRecorder.cs
@@ -15,7 +15,7 @@ namespace FluentAssertions.Events;
 internal sealed class EventRecorder : IEventRecording, IDisposable
 {
     private readonly Func<DateTime> utcNow;
-    private readonly BlockingCollection<RecordedEvent> raisedEvents = new();
+    private readonly BlockingCollection<RecordedEvent> raisedEvents = [];
     private readonly object lockable = new();
     private Action cleanup;
 

--- a/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
@@ -9,7 +9,7 @@ namespace FluentAssertions.Execution;
 
 internal class CollectingAssertionStrategy : IAssertionStrategy
 {
-    private readonly List<string> failureMessages = new();
+    private readonly List<string> failureMessages = [];
 
     /// <summary>
     /// Returns the messages for the assertion failures that happened until now.

--- a/Src/FluentAssertions/Execution/ContextDataItems.cs
+++ b/Src/FluentAssertions/Execution/ContextDataItems.cs
@@ -9,7 +9,7 @@ namespace FluentAssertions.Execution;
 /// </summary>
 internal class ContextDataItems
 {
-    private readonly List<DataItem> items = new();
+    private readonly List<DataItem> items = [];
 
     public IDictionary<string, object> GetReportable()
     {

--- a/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
@@ -9,13 +9,7 @@ internal class DefaultAssertionStrategy : IAssertionStrategy
     /// <summary>
     /// Returns the messages for the assertion failures that happened until now.
     /// </summary>
-    public IEnumerable<string> FailureMessages
-    {
-        get
-        {
-            return Array.Empty<string>();
-        }
-    }
+    public IEnumerable<string> FailureMessages => [];
 
     /// <summary>
     /// Instructs the strategy to handle a assertion failure.
@@ -28,10 +22,7 @@ internal class DefaultAssertionStrategy : IAssertionStrategy
     /// <summary>
     /// Discards and returns the failure messages that happened up to now.
     /// </summary>
-    public IEnumerable<string> DiscardFailures()
-    {
-        return Array.Empty<string>();
-    }
+    public IEnumerable<string> DiscardFailures() => [];
 
     /// <summary>
     /// Will throw a combined exception for any failures have been collected.

--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -20,7 +20,7 @@ internal class MessageBuilder
 
     #region Private Definitions
 
-    private readonly char[] blanks = { '\r', '\n', ' ', '\t' };
+    private readonly char[] blanks = ['\r', '\n', ' ', '\t'];
 
     #endregion
 

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -36,7 +36,7 @@ public class AttributeBasedFormatter : IValueFormatter
     {
         MethodInfo method = GetFormatter(value);
 
-        object[] parameters = { value, formattedGraph };
+        object[] parameters = [value, formattedGraph];
 
         method.Invoke(null, parameters);
     }

--- a/Src/FluentAssertions/Formatting/FormattedObjectGraph.cs
+++ b/Src/FluentAssertions/Formatting/FormattedObjectGraph.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Formatting;
 public class FormattedObjectGraph
 {
     private readonly int maxLines;
-    private readonly List<string> lines = new();
+    private readonly List<string> lines = [];
     private readonly StringBuilder lineBuilder = new();
     private int indentation;
     private string lineBuilderWhitespace = string.Empty;
@@ -148,7 +148,7 @@ public class FormattedObjectGraph
     /// </summary>
     public override string ToString()
     {
-        return string.Join(Environment.NewLine, lines.Concat(new[] { lineBuilder.ToString() }));
+        return string.Join(Environment.NewLine, lines.Concat([lineBuilder.ToString()]));
     }
 
     internal PossibleMultilineFragment KeepOnSingleLineAsLongAsPossible()

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -16,10 +16,10 @@ public static class Formatter
 {
     #region Private Definitions
 
-    private static readonly List<IValueFormatter> CustomFormatters = new();
+    private static readonly List<IValueFormatter> CustomFormatters = [];
 
-    private static readonly List<IValueFormatter> DefaultFormatters = new()
-    {
+    private static readonly List<IValueFormatter> DefaultFormatters =
+    [
         new XmlReaderValueFormatter(),
         new XmlNodeFormatter(),
         new AttributeBasedFormatter(),
@@ -57,7 +57,7 @@ public static class Formatter
         new EnumerableValueFormatter(),
         new EnumValueFormatter(),
         new DefaultValueFormatter()
-    };
+    ];
 
     /// <summary>
     /// Is used to detect recursive calls by <see cref="IValueFormatter"/> implementations.

--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -130,7 +130,7 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
     /// </summary>
     private sealed class AndOperatorChainExtractor : ExpressionVisitor
     {
-        public List<Expression> AndChain { get; } = new();
+        public List<Expression> AndChain { get; } = [];
 
         public override Expression Visit(Expression node)
         {

--- a/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
@@ -48,6 +48,6 @@ public class XElementValueFormatter : IValueFormatter
     private static string[] SplitIntoSeparateLines(XElement element)
     {
         string formattedXml = element.ToString();
-        return formattedXml.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+        return formattedXml.Split([Environment.NewLine], StringSplitOptions.None);
     }
 }

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -101,10 +101,10 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
                 exception.Should().BeOfType(expectedType, because, becauseArgs);
             }
 
-            return new ExceptionAssertions<TException>(new[] { exception as TException });
+            return new ExceptionAssertions<TException>([exception as TException]);
         }
 
-        return new ExceptionAssertions<TException>(Array.Empty<TException>());
+        return new ExceptionAssertions<TException>([]);
     }
 
     /// <summary>
@@ -133,7 +133,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
             return ThrowInternal<TException>(exception, because, becauseArgs);
         }
 
-        return new ExceptionAssertions<TException>(Array.Empty<TException>());
+        return new ExceptionAssertions<TException>([]);
     }
 
     /// <summary>
@@ -165,7 +165,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
             return AssertThrows<TException>(caughtException, timeSpan, because, becauseArgs);
         }
 
-        return new ExceptionAssertions<TException>(Array.Empty<TException>());
+        return new ExceptionAssertions<TException>([]);
     }
 
     private ExceptionAssertions<TException> AssertThrows<TException>(

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -50,7 +50,7 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
             return ThrowInternal<TException>(exception, because, becauseArgs);
         }
 
-        return new ExceptionAssertions<TException>(Array.Empty<TException>());
+        return new ExceptionAssertions<TException>([]);
     }
 
     /// <summary>
@@ -123,10 +123,10 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
                 exception.Should().BeOfType(expectedType, because, becauseArgs);
             }
 
-            return new ExceptionAssertions<TException>(new[] { exception as TException });
+            return new ExceptionAssertions<TException>([exception as TException]);
         }
 
-        return new ExceptionAssertions<TException>(Array.Empty<TException>());
+        return new ExceptionAssertions<TException>([]);
     }
 
     protected abstract void InvokeSubject();

--- a/Src/FluentAssertions/Types/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Types/AssemblyAssertions.cs
@@ -188,7 +188,7 @@ public class AssemblyAssertions : ReferenceTypeAssertions<Assembly, AssemblyAsse
 
         if (success)
         {
-            var bytes = Subject!.GetName().GetPublicKey() ?? Array.Empty<byte>();
+            var bytes = Subject!.GetName().GetPublicKey() ?? [];
             string assemblyKey = ToHexString(bytes);
 
             Execute.Assertion

--- a/Src/FluentAssertions/Types/MemberInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MemberInfoAssertions.cs
@@ -86,7 +86,7 @@ public abstract class MemberInfoAssertions<TSubject, TAssertions> : ReferenceTyp
                 $"Expected {Identifier} to be decorated with {typeof(TAttribute)}{{reason}}" +
                 ", but {context:member} is <null>.");
 
-        IEnumerable<TAttribute> attributes = Array.Empty<TAttribute>();
+        IEnumerable<TAttribute> attributes = [];
 
         if (success)
         {

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -21,7 +21,7 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
     /// <param name="type">The type from which to select methods.</param>
     /// <exception cref="ArgumentNullException"><paramref name="type"/> is <see langword="null"/>.</exception>
     public MethodInfoSelector(Type type)
-        : this(new[] { type })
+        : this([type])
     {
     }
 

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -20,7 +20,7 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
     /// <param name="type">The type from which to select properties.</param>
     /// <exception cref="ArgumentNullException"><paramref name="type"/> is <see langword="null"/>.</exception>
     public PropertyInfoSelector(Type type)
-        : this(new[] { type })
+        : this([type])
     {
     }
 

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1474,7 +1474,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveDefaultConstructor(
         string because = "", params object[] becauseArgs)
     {
-        return HaveConstructor(Array.Empty<Type>(), because, becauseArgs);
+        return HaveConstructor([], because, becauseArgs);
     }
 
     /// <summary>
@@ -1531,7 +1531,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     public AndWhichConstraint<TypeAssertions, ConstructorInfo> NotHaveDefaultConstructor(
         string because = "", params object[] becauseArgs)
     {
-        return NotHaveConstructor(Array.Empty<Type>(), because, becauseArgs);
+        return NotHaveConstructor([], because, becauseArgs);
     }
 
     private static string GetParameterString(IEnumerable<Type> parameterTypes)

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -15,7 +15,7 @@ public class TypeSelector : IEnumerable<Type>
     private List<Type> types;
 
     public TypeSelector(Type type)
-        : this(new[] { type })
+        : this([type])
     {
     }
 

--- a/Src/FluentAssertions/Xml/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/Node.cs
@@ -7,7 +7,7 @@ namespace FluentAssertions.Xml.Equivalency;
 
 internal sealed class Node
 {
-    private readonly List<Node> children = new();
+    private readonly List<Node> children = [];
     private readonly string name;
     private int count;
 

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -308,7 +308,7 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
             .BecauseOf(because, becauseArgs)
             .FailWith("Cannot assert the count if the document itself is <null>.");
 
-        IEnumerable<XElement> xElements = Enumerable.Empty<XElement>();
+        IEnumerable<XElement> xElements = [];
 
         if (success)
         {

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -327,7 +327,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
                 "Expected {context:subject} to have an element with count of {0}{reason}, but the element itself is <null>.",
                 expected.ToString());
 
-        IEnumerable<XElement> xElements = Enumerable.Empty<XElement>();
+        IEnumerable<XElement> xElements = [];
 
         if (success)
         {

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -57,9 +57,9 @@ public class BasicSpecs
     public void When_comparing_nested_collection_with_a_null_value_it_should_fail_with_the_correct_message()
     {
         // Arrange
-        var subject = new[] { new MyClass { Items = new[] { "a" } } };
+        MyClass[] subject = [new MyClass { Items = new[] { "a" } }];
 
-        var expectation = new[] { new MyClass() };
+        MyClass[] expectation = [new MyClass()];
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation);
@@ -344,8 +344,8 @@ public class BasicSpecs
     public void When_comparing_an_open_type_by_members_it_should_succeed()
     {
         // Arrange
-        var subject = new Option<int[]>(new[] { 1, 3, 2 });
-        var expected = new Option<int[]>(new[] { 1, 2, 3 });
+        var subject = new Option<int[]>([1, 3, 2]);
+        var expected = new Option<int[]>([1, 2, 3]);
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt
@@ -359,8 +359,8 @@ public class BasicSpecs
     public void When_threating_open_type_as_reference_type_and_a_closed_type_as_value_type_it_should_compare_by_value()
     {
         // Arrange
-        var subject = new Option<int[]>(new[] { 1, 3, 2 });
-        var expected = new Option<int[]>(new[] { 1, 2, 3 });
+        var subject = new Option<int[]>([1, 3, 2]);
+        var expected = new Option<int[]>([1, 2, 3]);
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt
@@ -375,8 +375,8 @@ public class BasicSpecs
     public void When_threating_open_type_as_value_type_and_a_closed_type_as_reference_type_it_should_compare_by_members()
     {
         // Arrange
-        var subject = new Option<int[]>(new[] { 1, 3, 2 });
-        var expected = new Option<int[]>(new[] { 1, 2, 3 });
+        var subject = new Option<int[]>([1, 3, 2]);
+        var expected = new Option<int[]>([1, 2, 3]);
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -146,7 +146,7 @@ public class CollectionSpecs
         public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
             MemberSelectionContext context)
         {
-            return Enumerable.Empty<IMember>();
+            return [];
         }
 
         bool IMemberSelectionRule.IncludesMembers => OverridesStandardIncludeRules;
@@ -154,7 +154,7 @@ public class CollectionSpecs
 
     public class UserRolesLookupElement
     {
-        private readonly Dictionary<Guid, List<string>> innerRoles = new();
+        private readonly Dictionary<Guid, List<string>> innerRoles = [];
 
         public virtual Dictionary<Guid, IEnumerable<string>> Roles
             => innerRoles.ToDictionary(x => x.Key, y => y.Value.Select(z => z));
@@ -200,7 +200,7 @@ public class CollectionSpecs
         object objectA = new();
         object objectB = new();
 
-        var actual = new[] { new[] { objectA, objectB } };
+        object[][] actual = [[objectA, objectB]];
         var expected = actual[0];
 
         // Act
@@ -279,9 +279,9 @@ public class CollectionSpecs
     public void When_a_collection_does_not_match_it_should_include_items_in_message()
     {
         // Arrange
-        var subject = new[] { 1, 2 };
+        int[] subject = [1, 2];
 
-        var expectation = new[] { 3, 2, 1 };
+        int[] expectation = [3, 2, 1];
 
         // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation);
@@ -440,11 +440,11 @@ public class CollectionSpecs
     public void When_two_deeply_nested_collections_are_equivalent_while_ignoring_the_order_it_should_not_throw()
     {
         // Arrange
-        var items = new[] { new int[0], new[] { 42 } };
+        var items = new[] { new int[0], [42] };
 
         // Act / Assert
         items.Should().BeEquivalentTo(
-            new[] { new[] { 42 }, new int[0] }
+            new[] { [42], new int[0] }
         );
     }
 
@@ -472,7 +472,7 @@ public class CollectionSpecs
     {
         // Arrange
         object item = new();
-        object[] array = { item };
+        object[] array = [item];
         IList readOnlyList = ArrayList.ReadOnly(array);
 
         // Act / Assert
@@ -643,7 +643,7 @@ public class CollectionSpecs
             };
 
             // Act / Assert
-            new[] { subject }.Should().BeEquivalentTo(new[] { expected },
+            new[] { subject }.Should().BeEquivalentTo([expected],
                 options => options
                     .For(x => x.Level.Collection)
                     .Exclude(x => x.Number));
@@ -1118,7 +1118,7 @@ public class CollectionSpecs
         var expected = new { A = "aaa", B = "ccc" };
 
         // Act
-        Action act = () => result.Should().BeEquivalentTo(new[] { expected }, options => options.Including(x => x.A));
+        Action act = () => result.Should().BeEquivalentTo([expected], options => options.Including(x => x.A));
 
         // Assert
         act.Should().NotThrow();
@@ -1683,7 +1683,7 @@ public class CollectionSpecs
     public void When_expectation_is_null_enumerable_it_should_throw()
     {
         // Arrange
-        var subject = Enumerable.Empty<object>();
+        IEnumerable<object> subject = [];
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo((IEnumerable<object>)null);
@@ -2142,13 +2142,13 @@ public class CollectionSpecs
         // Arrange
         var company1 = new MyCompany { Name = "Company" };
         var user1 = new MyUser { Name = "User", Company = company1 };
-        company1.Users = new List<MyUser> { user1 };
+        company1.Users = [user1];
         var logo1 = new MyCompanyLogo { Url = "blank", Company = company1, CreatedBy = user1 };
         company1.Logo = logo1;
 
         var company2 = new MyCompany { Name = "Company" };
         var user2 = new MyUser { Name = "User", Company = company2 };
-        company2.Users = new List<MyUser> { user2 };
+        company2.Users = [user2];
         var logo2 = new MyCompanyLogo { Url = "blank", Company = company2, CreatedBy = user2 };
         company2.Logo = logo2;
 

--- a/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
@@ -76,7 +76,7 @@ public class DictionarySpecs
 
     private class GenericDictionaryNotImplementingIDictionary<TKey, TValue> : IDictionary<TKey, TValue>
     {
-        private readonly Dictionary<TKey, TValue> dictionary = new();
+        private readonly Dictionary<TKey, TValue> dictionary = [];
 
         IEnumerator IEnumerable.GetEnumerator()
         {
@@ -233,7 +233,7 @@ public class DictionarySpecs
 
     public class UserRolesLookupElement
     {
-        private readonly Dictionary<Guid, List<string>> innerRoles = new();
+        private readonly Dictionary<Guid, List<string>> innerRoles = [];
 
         public virtual Dictionary<Guid, IEnumerable<string>> Roles =>
             innerRoles.ToDictionary(x => x.Key, y => y.Value.Select(z => z));
@@ -362,7 +362,7 @@ public class DictionarySpecs
     {
         // Arrange
         Dictionary<int, int> subject = null;
-        Dictionary<int, int> expectation = new();
+        Dictionary<int, int> expectation = [];
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, "because we do expect a valid dictionary");
@@ -1289,7 +1289,7 @@ internal class NonGenericChildDictionary : Dictionary<string, int>
 
 internal class NonGenericDictionary : IDictionary<string, int>
 {
-    private readonly Dictionary<string, int> innerDictionary = new();
+    private readonly Dictionary<string, int> innerDictionary = [];
 
     public int this[string key]
     {

--- a/Tests/FluentAssertions.Equivalency.Specs/EnumSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/EnumSpecs.cs
@@ -102,7 +102,7 @@ public class EnumSpecs
     public void Comparing_collections_of_numerics_with_collections_of_enums_includes_custom_message()
     {
         // Arrange
-        var actual = new[] { 1 };
+        int[] actual = [1];
 
         var expected = new[] { TestEnum.First };
 

--- a/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
@@ -51,12 +51,12 @@ public class MemberMatchingSpecs
     public void Nested_properties_can_be_mapped_using_a_nested_expression()
     {
         // Arrange
-        var subject = new ParentOfSubjectWithProperty1(new[] { new SubjectWithProperty1 { Property1 = "Hello" } });
+        var subject = new ParentOfSubjectWithProperty1([new SubjectWithProperty1 { Property1 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(new[]
-        {
+        var expectation = new ParentOfExpectationWithProperty2(
+        [
             new ExpectationWithProperty2 { Property2 = "Hello" }
-        });
+        ]);
 
         // Act / Assert
         subject.Should()
@@ -70,12 +70,12 @@ public class MemberMatchingSpecs
     public void Nested_properties_can_be_mapped_using_a_nested_type_and_property_names()
     {
         // Arrange
-        var subject = new ParentOfSubjectWithProperty1(new[] { new SubjectWithProperty1 { Property1 = "Hello" } });
+        var subject = new ParentOfSubjectWithProperty1([new SubjectWithProperty1 { Property1 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(new[]
-        {
+        var expectation = new ParentOfExpectationWithProperty2(
+        [
             new ExpectationWithProperty2 { Property2 = "Hello" }
-        });
+        ]);
 
         // Act / Assert
         subject.Should()
@@ -87,14 +87,14 @@ public class MemberMatchingSpecs
     public void Nested_explicitly_implemented_properties_can_be_mapped_using_a_nested_type_and_property_names()
     {
         // Arrange
-        var subject = new ParentOfSubjectWithExplicitlyImplementedProperty(new[] { new SubjectWithExplicitImplementedProperty() });
+        var subject = new ParentOfSubjectWithExplicitlyImplementedProperty([new SubjectWithExplicitImplementedProperty()]);
 
         ((IProperty)subject.Children[0]).Property = "Hello";
 
-        var expectation = new ParentOfExpectationWithProperty2(new[]
-        {
+        var expectation = new ParentOfExpectationWithProperty2(
+        [
             new ExpectationWithProperty2 { Property2 = "Hello" }
-        });
+        ]);
 
         // Act / Assert
         subject.Should()
@@ -121,12 +121,12 @@ public class MemberMatchingSpecs
     public void Nested_properties_can_be_mapped_using_a_nested_type_and_a_property_expression()
     {
         // Arrange
-        var subject = new ParentOfSubjectWithProperty1(new[] { new SubjectWithProperty1 { Property1 = "Hello" } });
+        var subject = new ParentOfSubjectWithProperty1([new SubjectWithProperty1 { Property1 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(new[]
-        {
+        var expectation = new ParentOfExpectationWithProperty2(
+        [
             new ExpectationWithProperty2 { Property2 = "Hello" }
-        });
+        ]);
 
         // Act / Assert
         subject.Should()
@@ -405,12 +405,12 @@ public class MemberMatchingSpecs
     public void Nested_types_and_dotted_expectation_member_paths_cannot_be_combined()
     {
         // Arrange
-        var subject = new ParentOfSubjectWithProperty1(new[] { new SubjectWithProperty1 { Property1 = "Hello" } });
+        var subject = new ParentOfSubjectWithProperty1([new SubjectWithProperty1 { Property1 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(new[]
-        {
+        var expectation = new ParentOfExpectationWithProperty2(
+        [
             new ExpectationWithProperty2 { Property2 = "Hello" }
-        });
+        ]);
 
         // Act
         Action act = () => subject.Should()
@@ -427,12 +427,12 @@ public class MemberMatchingSpecs
     public void Nested_types_and_dotted_subject_member_paths_cannot_be_combined()
     {
         // Arrange
-        var subject = new ParentOfSubjectWithProperty1(new[] { new SubjectWithProperty1 { Property1 = "Hello" } });
+        var subject = new ParentOfSubjectWithProperty1([new SubjectWithProperty1 { Property1 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(new[]
-        {
+        var expectation = new ParentOfExpectationWithProperty2(
+        [
             new ExpectationWithProperty2 { Property2 = "Hello" }
-        });
+        ]);
 
         // Act
         Action act = () => subject.Should()
@@ -449,12 +449,12 @@ public class MemberMatchingSpecs
     public void The_member_name_on_a_nested_type_mapping_must_be_a_valid_member()
     {
         // Arrange
-        var subject = new ParentOfSubjectWithProperty1(new[] { new SubjectWithProperty1 { Property1 = "Hello" } });
+        var subject = new ParentOfSubjectWithProperty1([new SubjectWithProperty1 { Property1 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(new[]
-        {
+        var expectation = new ParentOfExpectationWithProperty2(
+        [
             new ExpectationWithProperty2 { Property2 = "Hello" }
-        });
+        ]);
 
         // Act
         Action act = () => subject.Should()
@@ -529,8 +529,8 @@ public class MemberMatchingSpecs
             Name = "Test"
         };
 
-        var entityCol = new[] { entity };
-        var dtoCol = new[] { dto };
+        Entity[] entityCol = [entity];
+        EntityDto[] dtoCol = [dto];
 
         // Act / Assert
         dtoCol.Should().BeEquivalentTo(entityCol, c =>

--- a/Tests/FluentAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
@@ -307,9 +307,9 @@ public class NestedPropertiesSpecs
     public void Should_support_nested_collections_containing_empty_objects()
     {
         // Arrange
-        var orig = new[] { new OuterWithObject { MyProperty = new[] { new Inner() } } };
+        var orig = new[] { new OuterWithObject { MyProperty = [new Inner()] } };
 
-        var expectation = new[] { new OuterWithObject { MyProperty = new[] { new Inner() } } };
+        var expectation = new[] { new OuterWithObject { MyProperty = [new Inner()] } };
 
         // Act / Assert
         orig.Should().BeEquivalentTo(expectation);

--- a/Tests/FluentAssertions.Equivalency.Specs/RecordSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/RecordSpecs.cs
@@ -9,9 +9,9 @@ public class RecordSpecs
     [Fact]
     public void When_the_subject_is_a_record_it_should_compare_it_by_its_members()
     {
-        var actual = new MyRecord { StringField = "foo", CollectionProperty = new[] { "bar", "zip", "foo" } };
+        var actual = new MyRecord { StringField = "foo", CollectionProperty = ["bar", "zip", "foo"] };
 
-        var expected = new MyRecord { StringField = "foo", CollectionProperty = new[] { "foo", "bar", "zip" } };
+        var expected = new MyRecord { StringField = "foo", CollectionProperty = ["foo", "bar", "zip"] };
 
         actual.Should().BeEquivalentTo(expected);
     }
@@ -19,9 +19,9 @@ public class RecordSpecs
     [Fact]
     public void When_the_subject_is_a_record_struct_it_should_compare_it_by_its_members()
     {
-        var actual = new MyRecordStruct("foo", new[] { "bar", "zip", "foo" });
+        var actual = new MyRecordStruct("foo", ["bar", "zip", "foo"]);
 
-        var expected = new MyRecordStruct("foo", new[] { "bar", "zip", "foo" });
+        var expected = new MyRecordStruct("foo", ["bar", "zip", "foo"]);
 
         actual.Should().BeEquivalentTo(expected);
     }
@@ -42,9 +42,9 @@ public class RecordSpecs
     [Fact]
     public void When_a_record_should_be_treated_as_a_value_type_it_should_use_its_equality_for_comparing()
     {
-        var actual = new MyRecord { StringField = "foo", CollectionProperty = new[] { "bar", "zip", "foo" } };
+        var actual = new MyRecord { StringField = "foo", CollectionProperty = ["bar", "zip", "foo"] };
 
-        var expected = new MyRecord { StringField = "foo", CollectionProperty = new[] { "foo", "bar", "zip" } };
+        var expected = new MyRecord { StringField = "foo", CollectionProperty = ["foo", "bar", "zip"] };
 
         Action act = () => actual.Should().BeEquivalentTo(expected, o => o
             .ComparingByValue<MyRecord>());
@@ -57,9 +57,9 @@ public class RecordSpecs
     [Fact]
     public void When_all_records_should_be_treated_as_value_types_it_should_use_equality_for_comparing()
     {
-        var actual = new MyRecord { StringField = "foo", CollectionProperty = new[] { "bar", "zip", "foo" } };
+        var actual = new MyRecord { StringField = "foo", CollectionProperty = ["bar", "zip", "foo"] };
 
-        var expected = new MyRecord { StringField = "foo", CollectionProperty = new[] { "foo", "bar", "zip" } };
+        var expected = new MyRecord { StringField = "foo", CollectionProperty = ["foo", "bar", "zip"] };
 
         Action act = () => actual.Should().BeEquivalentTo(expected, o => o
             .ComparingRecordsByValue());
@@ -73,9 +73,9 @@ public class RecordSpecs
     public void
         When_all_records_except_a_specific_type_should_be_treated_as_value_types_it_should_compare_that_specific_type_by_its_members()
     {
-        var actual = new MyRecord { StringField = "foo", CollectionProperty = new[] { "bar", "zip", "foo" } };
+        var actual = new MyRecord { StringField = "foo", CollectionProperty = ["bar", "zip", "foo"] };
 
-        var expected = new MyRecord { StringField = "foo", CollectionProperty = new[] { "foo", "bar", "zip" } };
+        var expected = new MyRecord { StringField = "foo", CollectionProperty = ["foo", "bar", "zip"] };
 
         actual.Should().BeEquivalentTo(expected, o => o
             .ComparingRecordsByValue()
@@ -85,9 +85,9 @@ public class RecordSpecs
     [Fact]
     public void When_global_record_comparing_options_are_chained_it_should_ensure_the_last_one_wins()
     {
-        var actual = new MyRecord { CollectionProperty = new[] { "bar", "zip", "foo" } };
+        var actual = new MyRecord { CollectionProperty = ["bar", "zip", "foo"] };
 
-        var expected = new MyRecord { CollectionProperty = new[] { "foo", "bar", "zip" } };
+        var expected = new MyRecord { CollectionProperty = ["foo", "bar", "zip"] };
 
         actual.Should().BeEquivalentTo(expected, o => o
             .ComparingRecordsByValue()

--- a/Tests/FluentAssertions.Equivalency.Specs/TupleSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TupleSpecs.cs
@@ -24,8 +24,8 @@ public class TupleSpecs
     public void When_a_tuple_is_compared_it_should_compare_its_components()
     {
         // Arrange
-        var actual = new Tuple<string, bool, int[]>("Hello", true, new[] { 3, 2, 1 });
-        var expected = new Tuple<string, bool, int[]>("Hello", true, new[] { 1, 2, 3 });
+        var actual = new Tuple<string, bool, int[]>("Hello", true, [3, 2, 1]);
+        var expected = new Tuple<string, bool, int[]>("Hello", true, [1, 2, 3]);
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);

--- a/Tests/FluentAssertions.Specs/AndWhichConstraintSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AndWhichConstraintSpecs.cs
@@ -11,7 +11,7 @@ public class AndWhichConstraintSpecs
     public void When_many_objects_are_provided_accessing_which_should_throw_a_descriptive_exception()
     {
         // Arrange
-        var continuation = new AndWhichConstraint<StringCollectionAssertions, string>(null, new[] { "hello", "world" });
+        var continuation = new AndWhichConstraint<StringCollectionAssertions, string>(null, ["hello", "world"]);
 
         // Act
         Action act = () => _ = continuation.Which;

--- a/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
@@ -32,7 +32,7 @@ public class AssertionExtensionsSpecs
     private static bool OverridesEquals(Type t)
     {
         MethodInfo equals = t.GetMethod("Equals", BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public,
-            null, new[] { typeof(object) }, null);
+            null, [typeof(object)], null);
 
         return equals is not null;
     }
@@ -108,7 +108,7 @@ public class AssertionExtensionsSpecs
         }
 
         // Act
-        Action act = () => fakeOverload.Invoke(null, new object[] { null });
+        Action act = () => fakeOverload.Invoke(null, [null]);
 
         // Assert
         act.Should()

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeAssignableTo.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_types_in_a_collection_is_matched_against_a_null_type_it_should_throw()
         {
             // Arrange
-            var collection = Array.Empty<int>();
+            int[] collection = [];
 
             // Act
             Action act = () => collection.Should().AllBeAssignableTo(null);
@@ -31,7 +31,7 @@ public partial class CollectionAssertionSpecs
         public void All_items_in_an_empty_collection_are_assignable_to_a_generic_type()
         {
             // Arrange
-            var collection = Array.Empty<int>();
+            int[] collection = [];
 
             // Act / Assert
             collection.Should().AllBeAssignableTo<int>();
@@ -59,7 +59,7 @@ public partial class CollectionAssertionSpecs
         public void All_items_in_an_empty_collection_are_assignable_to_a_type()
         {
             // Arrange
-            var collection = Array.Empty<int>();
+            int[] collection = [];
 
             // Act / Assert
             collection.Should().AllBeAssignableTo(typeof(int));
@@ -69,7 +69,7 @@ public partial class CollectionAssertionSpecs
         public void When_all_of_the_types_in_a_collection_match_expected_type_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().AllBeAssignableTo(typeof(int));
@@ -79,7 +79,7 @@ public partial class CollectionAssertionSpecs
         public void When_all_of_the_types_in_a_collection_match_expected_generic_type_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().AllBeAssignableTo<int>();
@@ -89,7 +89,7 @@ public partial class CollectionAssertionSpecs
         public void When_matching_a_collection_against_a_type_it_should_return_the_casted_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().AllBeAssignableTo<int>()
@@ -152,7 +152,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_is_of_matching_types_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { typeof(Exception), typeof(ArgumentException) };
+            Type[] collection = [typeof(Exception), typeof(ArgumentException)];
 
             // Act / Assert
             collection.Should().AllBeAssignableTo<Exception>();
@@ -162,7 +162,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_of_types_contains_one_type_that_does_not_match_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
-            var collection = new[] { typeof(int), typeof(string), typeof(int) };
+            Type[] collection = [typeof(int), typeof(string), typeof(int)];
 
             // Act
             Action act = () => collection.Should().AllBeAssignableTo<int>("because they are of different type");

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeOfType.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeOfType.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_types_in_a_collection_is_matched_against_a_null_type_exactly_it_should_throw()
         {
             // Arrange
-            var collection = Array.Empty<int>();
+            int[] collection = [];
 
             // Act
             Action act = () => collection.Should().AllBeOfType(null);
@@ -31,7 +31,7 @@ public partial class CollectionAssertionSpecs
         public void All_items_in_an_empty_collection_are_of_a_generic_type()
         {
             // Arrange
-            var collection = Array.Empty<int>();
+            int[] collection = [];
 
             // Act / Assert
             collection.Should().AllBeOfType<int>();
@@ -41,7 +41,7 @@ public partial class CollectionAssertionSpecs
         public void All_items_in_an_empty_collection_are_of_a_type()
         {
             // Arrange
-            var collection = Array.Empty<int>();
+            int[] collection = [];
 
             // Act / Assert
             collection.Should().AllBeOfType(typeof(int));
@@ -69,7 +69,7 @@ public partial class CollectionAssertionSpecs
         public void When_all_of_the_types_in_a_collection_match_expected_type_exactly_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().AllBeOfType(typeof(int));
@@ -79,7 +79,7 @@ public partial class CollectionAssertionSpecs
         public void When_all_of_the_types_in_a_collection_match_expected_generic_type_exactly_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().AllBeOfType<int>();
@@ -89,7 +89,7 @@ public partial class CollectionAssertionSpecs
         public void When_matching_a_collection_against_an_exact_type_it_should_return_the_casted_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().AllBeOfType<int>()
@@ -142,7 +142,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_of_types_match_expected_type_exactly_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { typeof(int), typeof(int), typeof(int) };
+            Type[] collection = [typeof(int), typeof(int), typeof(int)];
 
             // Act / Assert
             collection.Should().AllBeOfType<int>();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
@@ -18,7 +18,7 @@ public partial class CollectionAssertionSpecs
         public void A_null_inspector_should_throw()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 1, 2 };
+            IEnumerable<int> collection = [1, 2];
 
             // Act
             Action act = () => collection.Should().AllSatisfy(null);
@@ -53,7 +53,7 @@ public partial class CollectionAssertionSpecs
         public void An_empty_collection_should_succeed()
         {
             // Arrange
-            var collection = Enumerable.Empty<int>();
+            IEnumerable<int> collection = [];
 
             // Act / Assert
             collection.Should().AllSatisfy(x => x.Should().Be(1));
@@ -75,8 +75,8 @@ public partial class CollectionAssertionSpecs
             // Arrange
             var customers = new[]
             {
-                new CustomerWithItems { Age = 21, Items = new[] { 1, 2 } },
-                new CustomerWithItems { Age = 22, Items = new[] { 3 } }
+                new CustomerWithItems { Age = 21, Items = [1, 2] },
+                new CustomerWithItems { Age = 22, Items = [3] }
             };
 
             // Act
@@ -113,7 +113,7 @@ public partial class CollectionAssertionSpecs
         public void Inspector_message_that_is_not_reformatable_should_not_throw()
         {
             // Arrange
-            byte[][] subject = { new byte[] { 1 } };
+            byte[][] subject = [[1]];
 
             // Act
             Action act = () => subject.Should().AllSatisfy(e => e.Should().BeEquivalentTo(new byte[] { 2, 3, 4 }));

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -28,7 +28,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_is_not_empty_unexpectedly_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().BeEmpty("that's what we expect");
@@ -42,7 +42,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_with_items_is_not_empty_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().NotBeEmpty();
@@ -171,7 +171,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_to_be_not_empty_it_should_enumerate_only_once()
         {
             // Arrange
-            var collection = new CountingGenericEnumerable<int>(new[] { 42 });
+            var collection = new CountingGenericEnumerable<int>([42]);
 
             // Act
             collection.Should().NotBeEmpty();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
@@ -18,8 +18,8 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_elements_it_should_treat_them_as_equivalent()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 3, 1, 2 };
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [3, 1, 2];
 
             // Act / Assert
             collection1.Should().BeEquivalentTo(collection2);
@@ -29,10 +29,10 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_contains_same_elements_it_should_treat_it_as_equivalent()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
-            collection.Should().BeEquivalentTo(new[] { 3, 1, 2 });
+            collection.Should().BeEquivalentTo([3, 1, 2]);
         }
 
         [Fact]
@@ -50,8 +50,8 @@ public partial class CollectionAssertionSpecs
         public void When_collections_are_not_equivalent_it_should_throw()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2 };
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [1, 2];
 
             // Act
             Action act = () => collection1.Should().BeEquivalentTo(collection2, "we treat {0} alike", "all");
@@ -65,8 +65,8 @@ public partial class CollectionAssertionSpecs
         public void When_collections_with_duplicates_are_not_equivalent_it_should_throw()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3, 1 };
-            var collection2 = new[] { 1, 2, 3, 3 };
+            int[] collection1 = [1, 2, 3, 1];
+            int[] collection2 = [1, 2, 3, 3];
 
             // Act
             Action act = () => collection1.Should().BeEquivalentTo(collection2);
@@ -80,8 +80,8 @@ public partial class CollectionAssertionSpecs
         public void When_testing_for_equivalence_against_empty_collection_it_should_throw()
         {
             // Arrange
-            var subject = new[] { 1, 2, 3 };
-            var otherCollection = new int[0];
+            int[] subject = [1, 2, 3];
+            int[] otherCollection = [];
 
             // Act
             Action act = () => subject.Should().BeEquivalentTo(otherCollection);
@@ -109,7 +109,7 @@ public partial class CollectionAssertionSpecs
         public void When_testing_for_equivalence_against_null_collection_it_should_throw()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
             int[] collection2 = null;
 
             // Act
@@ -125,7 +125,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             int[] collection = null;
-            var collection1 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
 
             // Act
             Action act =
@@ -166,8 +166,8 @@ public partial class CollectionAssertionSpecs
         public void When_collection_is_not_equivalent_to_another_smaller_collection_it_should_succeed()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 3, 1 };
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [3, 1];
 
             // Act / Assert
             collection1.Should().NotBeEquivalentTo(collection2);
@@ -191,8 +191,8 @@ public partial class CollectionAssertionSpecs
         public void When_collection_is_not_equivalent_to_another_equally_sized_collection_it_should_succeed()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 3, 1, 4 };
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [3, 1, 4];
 
             // Act / Assert
             collection1.Should().NotBeEquivalentTo(collection2);
@@ -202,8 +202,8 @@ public partial class CollectionAssertionSpecs
         public void When_collections_are_unexpectedly_equivalent_it_should_throw()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 3, 1, 2 };
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [3, 1, 2];
 
             // Act
             Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
@@ -218,7 +218,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             int[] actual = null;
-            var expectation = new[] { 1, 2, 3 };
+            int[] expectation = [1, 2, 3];
 
             // Act
             Action act = () =>
@@ -236,7 +236,7 @@ public partial class CollectionAssertionSpecs
         public void When_non_empty_collection_is_not_expected_to_be_equivalent_to_an_empty_collection_it_should_succeed()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
             var collection2 = new int[0];
 
             // Act
@@ -250,7 +250,7 @@ public partial class CollectionAssertionSpecs
         public void When_testing_collections_not_to_be_equivalent_against_null_collection_it_should_throw()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
             int[] collection2 = null;
 
             // Act
@@ -266,7 +266,7 @@ public partial class CollectionAssertionSpecs
         public void When_testing_collections_not_to_be_equivalent_against_same_collection_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             var collection1 = collection;
 
             // Act
@@ -301,7 +301,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             int[] actual = null;
-            int[] expectation = { 1, 2, 3 };
+            int[] expectation = [1, 2, 3];
 
             // Act
             Action act = () =>

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
@@ -37,7 +37,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
+            int[] collection = [1, 2, 2, 3];
 
             // Act / Assert
             collection.Should().BeInAscendingOrder();
@@ -48,7 +48,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
+            int[] collection = [1, 2, 2, 3];
 
             // Act / Assert
             collection.Should().BeInAscendingOrder(Comparer<int>.Default);
@@ -58,7 +58,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 6, 12, 15, 12, 17, 26 };
+            int[] collection = [1, 6, 12, 15, 12, 17, 26];
 
             // Act
             Action action = () => collection.Should().BeInAscendingOrder("because numbers are ordered");
@@ -74,7 +74,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 6, 12, 15, 12, 17, 26 };
+            int[] collection = [1, 6, 12, 15, 12, 17, 26];
 
             // Act
             Action action = () => collection.Should().BeInAscendingOrder(Comparer<int>.Default, "because numbers are ordered");
@@ -89,7 +89,7 @@ public partial class CollectionAssertionSpecs
         public void Items_can_be_ordered_by_the_identity_function()
         {
             // Arrange
-            var collection = new[] { 1, 2 };
+            int[] collection = [1, 2];
 
             // Act
             Action action = () => collection.Should().BeInAscendingOrder(x => x);
@@ -102,7 +102,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_empty_collection_with_no_parameters_ordered_in_ascending_it_should_succeed()
         {
             // Arrange
-            var collection = new int[] { };
+            int[] collection = [];
 
             // Act
             Action act = () => collection.Should().BeInAscendingOrder();
@@ -115,7 +115,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_empty_collection_by_property_expression_ordered_in_ascending_it_should_succeed()
         {
             // Arrange
-            var collection = Enumerable.Empty<SomeClass>();
+            IEnumerable<SomeClass> collection = [];
 
             // Act
             Action act = () => collection.Should().BeInAscendingOrder(o => o.Number);
@@ -128,7 +128,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_single_element_collection_with_no_parameters_ordered_in_ascending_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 42 };
+            int[] collection = [42];
 
             // Act
             Action act = () => collection.Should().BeInAscendingOrder();
@@ -292,7 +292,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_in_ascending_order_it_should_succeed()
         {
             // Arrange
-            string[] strings = { "alpha", "beta", "theta" };
+            string[] strings = ["alpha", "beta", "theta"];
 
             // Act
             Action act = () => strings.Should().BeInAscendingOrder();
@@ -305,7 +305,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_not_in_ascending_order_it_should_throw()
         {
             // Arrange
-            string[] strings = { "theta", "alpha", "beta" };
+            string[] strings = ["theta", "alpha", "beta"];
 
             // Act
             Action act = () => strings.Should().BeInAscendingOrder("of {0}", "reasons");
@@ -320,7 +320,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_in_ascending_order_according_to_a_custom_comparer_it_should_succeed()
         {
             // Arrange
-            string[] strings = { "alpha", "beta", "theta" };
+            string[] strings = ["alpha", "beta", "theta"];
 
             // Act
             Action act = () => strings.Should().BeInAscendingOrder(new ByLastCharacterComparer());
@@ -333,7 +333,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_not_in_ascending_order_according_to_a_custom_comparer_it_should_throw()
         {
             // Arrange
-            string[] strings = { "dennis", "roy", "thomas" };
+            string[] strings = ["dennis", "roy", "thomas"];
 
             // Act
             Action act = () => strings.Should().BeInAscendingOrder(new ByLastCharacterComparer(), "of {0}", "reasons");
@@ -348,7 +348,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_in_ascending_order_according_to_a_custom_lambda_it_should_succeed()
         {
             // Arrange
-            string[] strings = { "alpha", "beta", "theta" };
+            string[] strings = ["alpha", "beta", "theta"];
 
             // Act
             Action act = () => strings.Should().BeInAscendingOrder((sut, exp) => sut.Last().CompareTo(exp.Last()));
@@ -361,7 +361,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_not_in_ascending_order_according_to_a_custom_lambda_it_should_throw()
         {
             // Arrange
-            string[] strings = { "dennis", "roy", "thomas" };
+            string[] strings = ["dennis", "roy", "thomas"];
 
             // Act
             Action act = () =>
@@ -420,7 +420,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_a_collection_are_ordered_and_the_specified_property_is_null_it_should_throw()
         {
             // Arrange
-            var collection = Enumerable.Empty<SomeClass>();
+            IEnumerable<SomeClass> collection = [];
 
             // Act
             Action act = () => collection.Should().BeInAscendingOrder((Expression<Func<SomeClass, string>>)null);
@@ -435,7 +435,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_a_collection_are_ordered_and_the_given_comparer_is_null_it_should_throw()
         {
             // Arrange
-            var collection = Enumerable.Empty<SomeClass>();
+            IEnumerable<SomeClass> collection = [];
 
             // Act
             Action act = () => collection.Should().BeInAscendingOrder(comparer: null);
@@ -450,7 +450,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_ay_collection_are_ordered_using_an_invalid_property_expression_it_should_throw()
         {
             // Arrange
-            var collection = Enumerable.Empty<SomeClass>();
+            IEnumerable<SomeClass> collection = [];
 
             // Act
             Action act = () => collection.Should().BeInAscendingOrder(o => o.GetHashCode());
@@ -481,7 +481,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_an_unordered_collection_are_not_in_ascending_order_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 5, 3 };
+            int[] collection = [1, 5, 3];
 
             // Act / Assert
             collection.Should().NotBeInAscendingOrder();
@@ -492,7 +492,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_in_an_unordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 5, 3 };
+            int[] collection = [1, 5, 3];
 
             // Act / Assert
             collection.Should().NotBeInAscendingOrder(Comparer<int>.Default);
@@ -502,7 +502,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_not_in_ascending_order_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
+            int[] collection = [1, 2, 2, 3];
 
             // Act
             Action action = () => collection.Should().NotBeInAscendingOrder("because numbers are not ordered");
@@ -518,7 +518,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_in_an_ascendingly_ordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
+            int[] collection = [1, 2, 2, 3];
 
             // Act
             Action action = () =>
@@ -534,7 +534,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_empty_collection_by_property_expression_to_not_be_ordered_in_ascending_it_should_throw()
         {
             // Arrange
-            var collection = Enumerable.Empty<SomeClass>();
+            IEnumerable<SomeClass> collection = [];
 
             // Act
             Action act = () => collection.Should().NotBeInAscendingOrder(o => o.Number);
@@ -548,7 +548,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_empty_collection_with_no_parameters_not_be_ordered_in_ascending_it_should_throw()
         {
             // Arrange
-            var collection = new int[] { };
+            int[] collection = [];
 
             // Act
             Action act = () => collection.Should().NotBeInAscendingOrder("because I say {0}", "so");
@@ -562,7 +562,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_single_element_collection_with_no_parameters_not_be_ordered_in_ascending_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 42 };
+            int[] collection = [42];
 
             // Act
             Action act = () => collection.Should().NotBeInAscendingOrder();
@@ -594,7 +594,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_in_a_ascending_ordered_collection_are_not_ordered_ascending_using_the_given_comparer_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().NotBeInAscendingOrder(Comparer<int>.Default, "it should not be sorted");
@@ -609,7 +609,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_not_in_an_ascendingly_ordered_collection_are_not_ordered_ascending_using_the_given_comparer_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 3, 2, 1 };
+            int[] collection = [3, 2, 1];
 
             // Act
             Action act = () => collection.Should().NotBeInAscendingOrder(Comparer<int>.Default);
@@ -702,7 +702,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_not_in_ascending_order_it_should_succeed()
         {
             // Arrange
-            string[] strings = { "beta", "alpha", "theta" };
+            string[] strings = ["beta", "alpha", "theta"];
 
             // Act
             Action act = () => strings.Should().NotBeInAscendingOrder();
@@ -715,7 +715,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_in_ascending_order_unexpectedly_it_should_throw()
         {
             // Arrange
-            string[] strings = { "alpha", "beta", "theta" };
+            string[] strings = ["alpha", "beta", "theta"];
 
             // Act
             Action act = () => strings.Should().NotBeInAscendingOrder("of {0}", "reasons");
@@ -730,7 +730,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_not_in_ascending_order_according_to_a_custom_comparer_it_should_succeed()
         {
             // Arrange
-            string[] strings = { "dennis", "roy", "barbara" };
+            string[] strings = ["dennis", "roy", "barbara"];
 
             // Act
             Action act = () => strings.Should().NotBeInAscendingOrder(new ByLastCharacterComparer());
@@ -743,7 +743,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_unexpectedly_in_ascending_order_according_to_a_custom_comparer_it_should_throw()
         {
             // Arrange
-            string[] strings = { "dennis", "thomas", "roy" };
+            string[] strings = ["dennis", "thomas", "roy"];
 
             // Act
             Action act = () => strings.Should().NotBeInAscendingOrder(new ByLastCharacterComparer(), "of {0}", "reasons");
@@ -758,7 +758,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_not_in_ascending_order_according_to_a_custom_lambda_it_should_succeed()
         {
             // Arrange
-            string[] strings = { "roy", "dennis", "thomas" };
+            string[] strings = ["roy", "dennis", "thomas"];
 
             // Act
             Action act = () => strings.Should().NotBeInAscendingOrder((sut, exp) => sut.Last().CompareTo(exp.Last()));
@@ -771,7 +771,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_unexpectedly_in_ascending_order_according_to_a_custom_lambda_it_should_throw()
         {
             // Arrange
-            string[] strings = { "barbara", "dennis", "roy" };
+            string[] strings = ["barbara", "dennis", "roy"];
 
             // Act
             Action act = () =>
@@ -838,7 +838,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_a_collection_are_not_ordered_and_the_specified_property_is_null_it_should_throw()
         {
             // Arrange
-            var collection = Enumerable.Empty<SomeClass>();
+            IEnumerable<SomeClass> collection = [];
 
             // Act
             Action act = () => collection.Should().NotBeInAscendingOrder((Expression<Func<SomeClass, string>>)null);
@@ -852,7 +852,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_a_collection_are_not_ordered_and_the_given_comparer_is_null_it_should_throw()
         {
             // Arrange
-            var collection = Enumerable.Empty<SomeClass>();
+            IEnumerable<SomeClass> collection = [];
 
             // Act
             Action act = () => collection.Should().NotBeInAscendingOrder(comparer: null);
@@ -867,7 +867,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_in_ay_collection_are_not_ordered_using_an_invalid_property_expression_it_should_throw()
         {
             // Arrange
-            var collection = Enumerable.Empty<SomeClass>();
+            IEnumerable<SomeClass> collection = [];
 
             // Act
             Action act = () => collection.Should().NotBeInAscendingOrder(o => o.GetHashCode());

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInDescendingOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInDescendingOrder.cs
@@ -42,7 +42,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_empty_collection_by_property_expression_ordered_in_descending_it_should_succeed()
         {
             // Arrange
-            var collection = Enumerable.Empty<SomeClass>();
+            IEnumerable<SomeClass> collection = [];
 
             // Act
             Action act = () => collection.Should().BeInDescendingOrder(o => o.Number);
@@ -55,7 +55,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_empty_collection_with_no_parameters_ordered_in_descending_it_should_succeed()
         {
             // Arrange
-            var collection = new int[] { };
+            int[] collection = [];
 
             // Act
             Action act = () => collection.Should().BeInDescendingOrder();
@@ -68,7 +68,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_single_element_collection_with_no_parameters_ordered_in_descending_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 42 };
+            int[] collection = [42];
 
             // Act
             Action act = () => collection.Should().BeInDescendingOrder();
@@ -204,7 +204,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_in_descending_order_it_should_succeed()
         {
             // Arrange
-            string[] strings = { "theta", "beta", "alpha" };
+            string[] strings = ["theta", "beta", "alpha"];
 
             // Act
             Action act = () => strings.Should().BeInDescendingOrder();
@@ -217,7 +217,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_not_in_descending_order_it_should_throw()
         {
             // Arrange
-            string[] strings = { "theta", "alpha", "beta" };
+            string[] strings = ["theta", "alpha", "beta"];
 
             // Act
             Action act = () => strings.Should().BeInDescendingOrder("of {0}", "reasons");
@@ -232,7 +232,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_in_descending_order_based_on_a_custom_comparer_it_should_succeed()
         {
             // Arrange
-            string[] strings = { "roy", "dennis", "barbara" };
+            string[] strings = ["roy", "dennis", "barbara"];
 
             // Act
             Action act = () => strings.Should().BeInDescendingOrder(new ByLastCharacterComparer());
@@ -245,7 +245,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_not_in_descending_order_based_on_a_custom_comparer_it_should_throw()
         {
             // Arrange
-            string[] strings = { "dennis", "roy", "barbara" };
+            string[] strings = ["dennis", "roy", "barbara"];
 
             // Act
             Action act = () => strings.Should().BeInDescendingOrder(new ByLastCharacterComparer(), "of {0}", "reasons");
@@ -260,7 +260,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_in_descending_order_based_on_a_custom_lambda_it_should_succeed()
         {
             // Arrange
-            string[] strings = { "roy", "dennis", "barbara" };
+            string[] strings = ["roy", "dennis", "barbara"];
 
             // Act
             Action act = () => strings.Should().BeInDescendingOrder((sut, exp) => sut.Last().CompareTo(exp.Last()));
@@ -273,7 +273,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_not_in_descending_order_based_on_a_custom_lambda_it_should_throw()
         {
             // Arrange
-            string[] strings = { "dennis", "roy", "barbara" };
+            string[] strings = ["dennis", "roy", "barbara"];
 
             // Act
             Action act = () =>
@@ -345,7 +345,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_empty_collection_by_property_expression_to_not_be_ordered_in_descending_it_should_throw()
         {
             // Arrange
-            var collection = Enumerable.Empty<SomeClass>();
+            IEnumerable<SomeClass> collection = [];
 
             // Act
             Action act = () => collection.Should().NotBeInDescendingOrder(o => o.Number);
@@ -359,7 +359,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_empty_collection_with_no_parameters_not_be_ordered_in_descending_it_should_throw()
         {
             // Arrange
-            var collection = new int[] { };
+            int[] collection = [];
 
             // Act
             Action act = () => collection.Should().NotBeInDescendingOrder("because I say {0}", "so");
@@ -373,7 +373,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_single_element_collection_with_no_parameters_not_be_ordered_in_descending_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 42 };
+            int[] collection = [42];
 
             // Act
             Action act = () => collection.Should().NotBeInDescendingOrder();
@@ -405,7 +405,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_in_a_descending_ordered_collection_are_not_ordered_descending_using_the_given_comparer_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 3, 2, 1 };
+            int[] collection = [3, 2, 1];
 
             // Act
             Action act = () => collection.Should().NotBeInDescendingOrder(Comparer<int>.Default, "it should not be sorted");
@@ -420,7 +420,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_not_in_an_descendingly_ordered_collection_are_not_ordered_descending_using_the_given_comparer_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().NotBeInDescendingOrder(Comparer<int>.Default);
@@ -513,7 +513,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_not_in_descending_order_it_should_succeed()
         {
             // Arrange
-            string[] strings = { "beta", "theta", "alpha" };
+            string[] strings = ["beta", "theta", "alpha"];
 
             // Act
             Action act = () => strings.Should().NotBeInDescendingOrder();
@@ -526,7 +526,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_unexpectedly_in_descending_order_it_should_throw()
         {
             // Arrange
-            string[] strings = { "theta", "beta", "alpha" };
+            string[] strings = ["theta", "beta", "alpha"];
 
             // Act
             Action act = () => strings.Should().NotBeInDescendingOrder("of {0}", "reasons");
@@ -541,7 +541,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_not_in_descending_order_based_on_a_custom_comparer_it_should_succeed()
         {
             // Arrange
-            string[] strings = { "roy", "barbara", "dennis" };
+            string[] strings = ["roy", "barbara", "dennis"];
 
             // Act
             Action act = () => strings.Should().NotBeInDescendingOrder(new ByLastCharacterComparer());
@@ -554,7 +554,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_unexpectedly_in_descending_order_based_on_a_custom_comparer_it_should_throw()
         {
             // Arrange
-            string[] strings = { "roy", "dennis", "barbara" };
+            string[] strings = ["roy", "dennis", "barbara"];
 
             // Act
             Action act = () => strings.Should().NotBeInDescendingOrder(new ByLastCharacterComparer(), "of {0}", "reasons");
@@ -569,7 +569,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_not_in_descending_order_based_on_a_custom_lambda_it_should_succeed()
         {
             // Arrange
-            string[] strings = { "dennis", "roy", "barbara" };
+            string[] strings = ["dennis", "roy", "barbara"];
 
             // Act
             Action act = () => strings.Should().NotBeInDescendingOrder((sut, exp) => sut.Last().CompareTo(exp.Last()));
@@ -582,7 +582,7 @@ public partial class CollectionAssertionSpecs
         public void When_strings_are_unexpectedly_in_descending_order_based_on_a_custom_lambda_it_should_throw()
         {
             // Arrange
-            string[] strings = { "roy", "dennis", "barbara" };
+            string[] strings = ["roy", "dennis", "barbara"];
 
             // Act
             Action act = () =>

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
@@ -38,7 +38,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_non_empty_collection_to_be_null_or_empty_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().BeNullOrEmpty("because we want to test the failure {0}", "message");
@@ -108,7 +108,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_to_not_be_null_or_empty_it_should_enumerate_only_once()
         {
             // Arrange
-            var collection = new CountingGenericEnumerable<int>(new[] { 42 });
+            var collection = new CountingGenericEnumerable<int>([42]);
 
             // Act
             collection.Should().NotBeNullOrEmpty();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeSubsetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeSubsetOf.cs
@@ -16,8 +16,8 @@ public partial class CollectionAssertionSpecs
         public void When_collection_is_subset_of_a_specified_collection_it_should_not_throw()
         {
             // Arrange
-            var subset = new[] { 1, 2 };
-            var superset = new[] { 1, 2, 3 };
+            int[] subset = [1, 2];
+            int[] superset = [1, 2, 3];
 
             // Act / Assert
             subset.Should().BeSubsetOf(superset);
@@ -27,8 +27,8 @@ public partial class CollectionAssertionSpecs
         public void When_collection_is_not_a_subset_of_another_it_should_throw_with_the_reason()
         {
             // Arrange
-            var subset = new[] { 1, 2, 3, 6 };
-            var superset = new[] { 1, 2, 4, 5 };
+            int[] subset = [1, 2, 3, 6];
+            int[] superset = [1, 2, 4, 5];
 
             // Act
             Action act = () => subset.Should().BeSubsetOf(superset, "because we want to test the failure {0}", "message");
@@ -43,8 +43,8 @@ public partial class CollectionAssertionSpecs
         public void When_an_empty_collection_is_tested_against_a_superset_it_should_succeed()
         {
             // Arrange
-            var subset = new int[0];
-            var superset = new[] { 1, 2, 4, 5 };
+            int[] subset = [];
+            int[] superset = [1, 2, 4, 5];
 
             // Act
             Action act = () => subset.Should().BeSubsetOf(superset);
@@ -57,7 +57,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_subset_is_tested_against_a_null_superset_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
-            var subset = new[] { 1, 2, 3 };
+            int[] subset = [1, 2, 3];
             int[] superset = null;
 
             // Act
@@ -72,8 +72,8 @@ public partial class CollectionAssertionSpecs
         public void When_a_set_is_expected_to_be_not_a_subset_it_should_succeed()
         {
             // Arrange
-            var subject = new[] { 1, 2, 4 };
-            var otherSet = new[] { 1, 2, 3 };
+            int[] subject = [1, 2, 4];
+            int[] otherSet = [1, 2, 3];
 
             // Act / Assert
             subject.Should().NotBeSubsetOf(otherSet);
@@ -86,8 +86,8 @@ public partial class CollectionAssertionSpecs
         public void When_an_empty_set_is_not_supposed_to_be_a_subset_of_another_set_it_should_throw()
         {
             // Arrange
-            var subject = new int[] { };
-            var otherSet = new[] { 1, 2, 3 };
+            int[] subject = [];
+            int[] otherSet = [1, 2, 3];
 
             // Act
             Action act = () => subject.Should().NotBeSubsetOf(otherSet);
@@ -101,8 +101,8 @@ public partial class CollectionAssertionSpecs
         public void Should_fail_when_asserting_collection_is_not_subset_of_a_superset_collection()
         {
             // Arrange
-            var subject = new[] { 1, 2 };
-            var otherSet = new[] { 1, 2, 3 };
+            int[] subject = [1, 2];
+            int[] otherSet = [1, 2, 3];
 
             // Act
             Action act = () => subject.Should().NotBeSubsetOf(otherSet, "because I'm {0}", "mistaken");
@@ -117,7 +117,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             int[] collection = null;
-            var collection1 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
 
             // Act
             Action act = () =>
@@ -135,7 +135,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_to_not_be_subset_against_same_collection_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             var collection1 = collection;
 
             // Act
@@ -157,7 +157,7 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotBeSubsetOf(new[] { 1, 2, 3 }, "we want to test the failure {0}", "message");
+                collection.Should().NotBeSubsetOf([1, 2, 3], "we want to test the failure {0}", "message");
             };
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_contains_an_item_from_the_collection()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().Contain(1);
@@ -27,17 +27,17 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_contains_multiple_items_from_the_collection_in_any_order()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
-            collection.Should().Contain(new[] { 2, 1 });
+            collection.Should().Contain([2, 1]);
         }
 
         [Fact]
         public void When_a_collection_does_not_contain_single_item_it_should_throw_with_clear_explanation()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().Contain(4, "because {0}", "we do");
@@ -69,10 +69,10 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_does_not_contain_another_collection_it_should_throw_with_clear_explanation()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().Contain(new[] { 3, 4, 5 }, "because {0}", "we do");
+            Action act = () => collection.Should().Contain([3, 4, 5], "because {0}", "we do");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -83,10 +83,10 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_does_not_contain_a_single_element_collection_it_should_throw_with_clear_explanation()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().Contain(new[] { 4 }, "because {0}", "we do");
+            Action act = () => collection.Should().Contain([4], "because {0}", "we do");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -98,13 +98,13 @@ public partial class CollectionAssertionSpecs
             When_a_collection_does_not_contain_other_collection_with_assertion_scope_it_should_throw_with_clear_explanation()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().Contain(new[] { 4 }).And.Contain(new[] { 5, 6 });
+                collection.Should().Contain([4]).And.Contain([5, 6]);
             };
 
             // Assert
@@ -116,7 +116,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_contents_of_a_collection_are_checked_against_an_empty_collection_it_should_throw_clear_explanation()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().Contain(new int[0]);
@@ -136,7 +136,7 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().Contain(new[] { 1, 2 }, "we want to test the failure {0}", "message");
+                collection.Should().Contain([1, 2], "we want to test the failure {0}", "message");
             };
 
             // Assert
@@ -148,7 +148,7 @@ public partial class CollectionAssertionSpecs
         public void When_injecting_a_null_predicate_into_Contain_it_should_throw()
         {
             // Arrange
-            IEnumerable<int> collection = new int[] { };
+            IEnumerable<int> collection = [];
 
             // Act
             Action act = () => collection.Should().Contain(predicate: null);
@@ -162,7 +162,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_contain_an_expected_item_matching_a_predicate_it_should_throw()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 1, 2, 3 };
+            IEnumerable<int> collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().Contain(item => item > 3, "at least {0} item should be larger than 3", 1);
@@ -176,7 +176,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_contain_an_expected_item_matching_a_predicate_it_should_allow_chaining_it()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 1, 2, 3 };
+            IEnumerable<int> collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().Contain(item => item == 2).Which.Should().BeGreaterThan(4);
@@ -190,7 +190,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_contain_an_expected_item_matching_a_predicate_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 1, 2, 3 };
+            IEnumerable<int> collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().Contain(item => item == 2);
@@ -278,7 +278,7 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_does_not_contain_an_item_that_is_not_in_the_collection()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().NotContain(4);
@@ -288,17 +288,17 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_does_not_contain_any_items_that_is_not_in_the_collection()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 1, 2, 3 };
+            IEnumerable<int> collection = [1, 2, 3];
 
             // Act / Assert
-            collection.Should().NotContain(new[] { 4, 5 });
+            collection.Should().NotContain([4, 5]);
         }
 
         [Fact]
         public void When_collection_contains_an_unexpected_item_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().NotContain(1, "because we {0} like it, but found it anyhow", "don't");
@@ -312,7 +312,7 @@ public partial class CollectionAssertionSpecs
         public void When_injecting_a_null_predicate_into_NotContain_it_should_throw()
         {
             // Arrange
-            IEnumerable<int> collection = new int[] { };
+            IEnumerable<int> collection = [];
 
             // Act
             Action act = () => collection.Should().NotContain(predicate: null);
@@ -326,7 +326,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_contain_an_unexpected_item_matching_a_predicate_it_should_throw()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 1, 2, 3 };
+            IEnumerable<int> collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().NotContain(item => item == 2, "because {0}s are evil", 2);
@@ -340,7 +340,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_contain_an_unexpected_item_matching_a_predicate_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 1, 2, 3 };
+            IEnumerable<int> collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().NotContain(item => item == 4);
@@ -368,11 +368,11 @@ public partial class CollectionAssertionSpecs
         public void When_collection_contains_unexpected_item_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should()
-                .NotContain(new[] { 2 }, "because we {0} like them", "don't");
+                .NotContain([2], "because we {0} like them", "don't");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -383,11 +383,11 @@ public partial class CollectionAssertionSpecs
         public void When_collection_contains_unexpected_items_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should()
-                .NotContain(new[] { 1, 2, 4 }, "because we {0} like them", "don't");
+                .NotContain([1, 2, 4], "because we {0} like them", "don't");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -398,13 +398,13 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_multiple_collection_in_assertion_scope_all_should_be_reported()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContain(new[] { 1, 2 }).And.NotContain(new[] { 3 });
+                collection.Should().NotContain([1, 2]).And.NotContain([3]);
             };
 
             // Assert
@@ -416,10 +416,10 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_to_not_contain_an_empty_collection_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().NotContain(Array.Empty<int>());
+            Action act = () => collection.Should().NotContain([]);
 
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage("Cannot verify*");
@@ -453,7 +453,7 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContain(new[] { 1, 2, 4 }, "we want to test the failure {0}", "message");
+                collection.Should().NotContain([1, 2, 4], "we want to test the failure {0}", "message");
             };
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainEquivalentOf.cs
@@ -49,7 +49,7 @@ public partial class CollectionAssertionSpecs
         public void When_string_collection_does_contain_same_string_with_other_case_it_should_throw()
         {
             // Arrange
-            string[] collection = { "a", "b", "c" };
+            string[] collection = ["a", "b", "c"];
             string item = "C";
 
             // Act
@@ -64,7 +64,7 @@ public partial class CollectionAssertionSpecs
         public void When_string_collection_does_contain_same_string_it_should_throw_with_a_useful_message()
         {
             // Arrange
-            string[] collection = { "a" };
+            string[] collection = ["a"];
             string item = "b";
 
             // Act
@@ -80,7 +80,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_contain_object_equivalent_of_another_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             int item = 4;
 
             // Act
@@ -127,7 +127,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_contain_equivalent_null_object_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             int? item = null;
 
             // Act
@@ -248,7 +248,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_contains_object_equivalent_of_boxed_object_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             object boxedValue = 2;
 
             // Act / Assert
@@ -263,7 +263,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             var item = 1;
-            var collection = new[] { 0, 1 };
+            int[] collection = [0, 1];
 
             // Act
             Action act = () =>
@@ -280,7 +280,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             var item = 1;
-            var collection = new[] { 0, 1, 1 };
+            int[] collection = [0, 1, 1];
 
             // Act
             Action act = () =>
@@ -354,7 +354,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_contain_object_equivalent_of_unexpected_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             int item = 4;
 
             // Act / Assert
@@ -392,7 +392,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_to_not_contain_equivalent_it_should_allow_combining_inside_assertion_scope()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             int another = 3;
 
             // Act

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInConsecutiveOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInConsecutiveOrder.cs
@@ -16,7 +16,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_first_collection_contains_a_duplicate_item_without_affecting_the_explicit_order_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3, 2 };
+            int[] collection = [1, 2, 3, 2];
 
             // Act / Assert
             collection.Should().ContainInConsecutiveOrder(1, 2, 3);
@@ -26,7 +26,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_second_collection_contains_just_1_item_included_in_the_first_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3, 2 };
+            int[] collection = [1, 2, 3, 2];
 
             // Act / Assert
             collection.Should().ContainInConsecutiveOrder(2);
@@ -37,7 +37,7 @@ public partial class CollectionAssertionSpecs
             When_the_first_collection_contains_a_partial_duplicate_sequence_at_the_start_without_affecting_the_explicit_order_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 1, 2, 3, 2 };
+            int[] collection = [1, 2, 1, 2, 3, 2];
 
             // Act / Assert
             collection.Should().ContainInConsecutiveOrder(1, 2, 3);
@@ -47,7 +47,7 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_duplicate_items_in_the_same_explicit_order_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 1, 2, 12, 2, 2 };
+            int[] collection = [1, 2, 1, 2, 12, 2, 2];
 
             // Act / Assert
             collection.Should().ContainInConsecutiveOrder(1, 2, 1, 2, 12, 2, 2);
@@ -57,7 +57,7 @@ public partial class CollectionAssertionSpecs
         public void When_checking_for_an_empty_list_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 1, 2, 12, 2, 2 };
+            int[] collection = [1, 2, 1, 2, 12, 2, 2];
 
             // Act / Assert
             collection.Should().ContainInConsecutiveOrder();
@@ -77,7 +77,7 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_items_but_not_in_the_same_explicit_order_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
+            int[] collection = [1, 2, 2, 3];
 
             // Act / Assert
             Action act = () => collection.Should().ContainInConsecutiveOrder(1, 2, 3);
@@ -91,7 +91,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_second_collection_contains_just_1_item_not_included_in_the_first_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
+            int[] collection = [1, 2, 2, 3];
 
             // Act / Assert
             Action act = () => collection.Should().ContainInConsecutiveOrder(4);
@@ -105,7 +105,7 @@ public partial class CollectionAssertionSpecs
         public void When_end_of_first_collection_is_a_partial_match_of_second_at_end_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 3, 1, 2 };
+            int[] collection = [1, 3, 1, 2];
 
             // Act / Assert
             Action act = () => collection.Should().ContainInConsecutiveOrder(1, 2, 3);
@@ -119,7 +119,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_does_not_contain_a_range_twice_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 1, 2, 3, 12, 2, 2 };
+            int[] collection = [1, 2, 1, 2, 3, 12, 2, 2];
 
             // Act
             Action act = () => collection.Should().ContainInConsecutiveOrder(1, 2, 1, 1, 2);
@@ -133,7 +133,7 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_throw_with_a_clear_explanation()
         {
             // Act
-            Action act = () => new[] { 1, 2, 3 }.Should().ContainInConsecutiveOrder(new[] { 3, 1 }, "because we said so");
+            Action act = () => new[] { 1, 2, 3 }.Should().ContainInConsecutiveOrder([3, 1], "because we said so");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -144,7 +144,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_does_not_contain_an_ordered_item_it_should_throw_with_a_clear_explanation()
         {
             // Act
-            Action act = () => new[] { 1, 2, 3 }.Should().ContainInConsecutiveOrder(new[] { 4, 1 }, "we failed");
+            Action act = () => new[] { 1, 2, 3 }.Should().ContainInConsecutiveOrder([4, 1], "we failed");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -175,7 +175,7 @@ public partial class CollectionAssertionSpecs
                 using var _ = new AssertionScope();
 
                 collection.Should()
-                    .ContainInConsecutiveOrder(new[] { 4 }, "because we're checking how it reacts to a null subject");
+                    .ContainInConsecutiveOrder([4], "because we're checking how it reacts to a null subject");
             };
 
             // Assert
@@ -190,7 +190,7 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().NotContainInConsecutiveOrder(2, 1);
@@ -200,7 +200,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_second_collection_contains_just_1_item_not_included_in_the_first_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().NotContainInConsecutiveOrder(4);
@@ -210,7 +210,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_does_not_contain_an_ordered_item_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().NotContainInConsecutiveOrder(4, 1);
@@ -220,7 +220,7 @@ public partial class CollectionAssertionSpecs
         public void When_checking_for_an_empty_list_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().NotContainInConsecutiveOrder();
@@ -230,7 +230,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_contains_less_items_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2 };
+            int[] collection = [1, 2];
 
             // Act / Assert
             collection.Should().NotContainInConsecutiveOrder(1, 2, 3);
@@ -240,7 +240,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_does_not_contain_a_range_twice_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 1, 2, 3, 12, 2, 2 };
+            int[] collection = [1, 2, 1, 2, 3, 12, 2, 2];
 
             // Act / Assert
             collection.Should().NotContainInConsecutiveOrder(1, 2, 1, 1, 2);
@@ -250,10 +250,10 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_items_not_in_the_same_explicit_order_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 1, 2, 2, 3 };
+            int[] collection = [1, 2, 1, 2, 2, 3];
 
             // Act
-            collection.Should().NotContainInConsecutiveOrder(new[] { 1, 2, 3 }, "that's what we expect");
+            collection.Should().NotContainInConsecutiveOrder([1, 2, 3], "that's what we expect");
         }
 
         [Fact]
@@ -280,7 +280,7 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContainInConsecutiveOrder(new[] { 1, 2, 3 }, "we want to test the failure {0}", "message");
+                collection.Should().NotContainInConsecutiveOrder([1, 2, 3], "we want to test the failure {0}", "message");
             };
 
             // Assert
@@ -322,7 +322,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_first_collection_contains_a_duplicate_item_without_affecting_the_order_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3, 2 };
+            int[] collection = [1, 2, 3, 2];
 
             // Act
             Action act = () => collection.Should().NotContainInConsecutiveOrder(1, 2, 3);
@@ -337,7 +337,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_first_collection_contains_a_duplicate_item_not_at_start_without_affecting_the_order_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 1, 2, 3, 4, 5, 1, 2 };
+            int[] collection = [1, 2, 1, 2, 3, 4, 5, 1, 2];
 
             // Act
             Action act = () => collection.Should().NotContainInConsecutiveOrder(1, 2, 3);
@@ -352,7 +352,7 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_duplicate_items_in_the_same_order_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 1, 2, 12, 2, 2 };
+            int[] collection = [1, 2, 1, 2, 12, 2, 2];
 
             // Act
             Action act = () => collection.Should().NotContainInConsecutiveOrder(1, 2, 1, 2, 12, 2, 2);
@@ -367,7 +367,7 @@ public partial class CollectionAssertionSpecs
         public void When_passing_in_null_while_checking_for_absence_of_ordered_containment_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().NotContainInConsecutiveOrder(null);

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInOrder.cs
@@ -16,7 +16,7 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_items_in_the_same_order_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
+            int[] collection = [1, 2, 2, 3];
 
             // Act / Assert
             collection.Should().ContainInOrder(1, 2, 3);
@@ -36,7 +36,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_first_collection_contains_a_duplicate_item_without_affecting_the_order_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3, 2 };
+            int[] collection = [1, 2, 3, 2];
 
             // Act / Assert
             collection.Should().ContainInOrder(1, 2, 3);
@@ -46,7 +46,7 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_duplicate_items_in_the_same_order_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 1, 2, 12, 2, 2 };
+            int[] collection = [1, 2, 1, 2, 12, 2, 2];
 
             // Act / Assert
             collection.Should().ContainInOrder(1, 2, 1, 2, 12, 2, 2);
@@ -56,7 +56,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_does_not_contain_a_range_twice_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 1, 3, 12, 2, 2 };
+            int[] collection = [1, 2, 1, 3, 12, 2, 2];
 
             // Act
             Action act = () => collection.Should().ContainInOrder(1, 2, 1, 1, 2);
@@ -70,7 +70,7 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_throw_with_a_clear_explanation()
         {
             // Act
-            Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder(new[] { 3, 1 }, "because we said so");
+            Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder([3, 1], "because we said so");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -81,7 +81,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_does_not_contain_an_ordered_item_it_should_throw_with_a_clear_explanation()
         {
             // Act
-            Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder(new[] { 4, 1 }, "we failed");
+            Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder([4, 1], "we failed");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -139,7 +139,7 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                ints.Should().ContainInOrder(new[] { 4 }, "because we're checking how it reacts to a null subject");
+                ints.Should().ContainInOrder([4], "because we're checking how it reacts to a null subject");
             };
 
             // Assert
@@ -154,7 +154,7 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().NotContainInOrder(2, 1);
@@ -164,7 +164,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_does_not_contain_an_ordered_item_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().NotContainInOrder(4, 1);
@@ -174,7 +174,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_contains_less_items_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2 };
+            int[] collection = [1, 2];
 
             // Act / Assert
             collection.Should().NotContainInOrder(1, 2, 3);
@@ -184,7 +184,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_does_not_contain_a_range_twice_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 1, 3, 12, 2, 2 };
+            int[] collection = [1, 2, 1, 3, 12, 2, 2];
 
             // Act / Assert
             collection.Should().NotContainInOrder(1, 2, 1, 1, 2);
@@ -208,10 +208,10 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_items_in_the_same_order_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 2, 3 };
+            int[] collection = [1, 2, 2, 3];
 
             // Act
-            Action act = () => collection.Should().NotContainInOrder(new[] { 1, 2, 3 }, "that's what we expect");
+            Action act = () => collection.Should().NotContainInOrder([1, 2, 3], "that's what we expect");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -229,7 +229,7 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContainInOrder(new[] { 1, 2, 3 }, "we want to test the failure {0}", "message");
+                collection.Should().NotContainInOrder([1, 2, 3], "we want to test the failure {0}", "message");
             };
 
             // Assert
@@ -256,7 +256,7 @@ public partial class CollectionAssertionSpecs
         public void When_the_first_collection_contains_a_duplicate_item_without_affecting_the_order_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3, 2 };
+            int[] collection = [1, 2, 3, 2];
 
             // Act
             Action act = () => collection.Should().NotContainInOrder(1, 2, 3);
@@ -271,7 +271,7 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_duplicate_items_in_the_same_order_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 1, 2, 12, 2, 2 };
+            int[] collection = [1, 2, 1, 2, 12, 2, 2];
 
             // Act
             Action act = () => collection.Should().NotContainInOrder(1, 2, 1, 2, 12, 2, 2);
@@ -286,7 +286,7 @@ public partial class CollectionAssertionSpecs
         public void When_passing_in_null_while_checking_for_absence_of_ordered_containment_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().NotContainInOrder(null);

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
@@ -59,7 +59,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_is_empty_an_exception_should_be_thrown()
         {
             // Arrange
-            int[] collection = Array.Empty<int>();
+            int[] collection = [];
 
             // Act
             Action act = () => collection.Should().ContainItemsAssignableTo<int>();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
     public void When_injecting_a_null_predicate_into_ContainSingle_it_should_throw()
     {
         // Arrange
-        IEnumerable<int> collection = new int[] { };
+        IEnumerable<int> collection = [];
 
         // Act
         Action act = () => collection.Should().ContainSingle(predicate: null);
@@ -31,7 +31,7 @@ public partial class CollectionAssertionSpecs
     public void When_a_collection_contains_a_single_item_matching_a_predicate_it_should_succeed()
     {
         // Arrange
-        IEnumerable<int> collection = new[] { 1, 2, 3 };
+        IEnumerable<int> collection = [1, 2, 3];
         Expression<Func<int, bool>> expression = item => item == 2;
 
         // Act
@@ -45,7 +45,7 @@ public partial class CollectionAssertionSpecs
     public void When_asserting_an_empty_collection_contains_a_single_item_matching_a_predicate_it_should_throw()
     {
         // Arrange
-        IEnumerable<int> collection = Enumerable.Empty<int>();
+        IEnumerable<int> collection = [];
         Expression<Func<int, bool>> expression = item => item == 2;
 
         // Act
@@ -83,7 +83,7 @@ public partial class CollectionAssertionSpecs
     public void When_non_empty_collection_does_not_contain_a_single_item_matching_a_predicate_it_should_throw()
     {
         // Arrange
-        IEnumerable<int> collection = new[] { 1, 3 };
+        IEnumerable<int> collection = [1, 3];
         Expression<Func<int, bool>> expression = item => item == 2;
 
         // Act
@@ -100,7 +100,7 @@ public partial class CollectionAssertionSpecs
     public void When_non_empty_collection_contains_more_than_a_single_item_matching_a_predicate_it_should_throw()
     {
         // Arrange
-        IEnumerable<int> collection = new[] { 1, 2, 2, 2, 3 };
+        IEnumerable<int> collection = [1, 2, 2, 2, 3];
         Expression<Func<int, bool>> expression = item => item == 2;
 
         // Act
@@ -117,7 +117,7 @@ public partial class CollectionAssertionSpecs
     public void When_single_item_matching_a_predicate_is_found_it_should_allow_continuation()
     {
         // Arrange
-        IEnumerable<int> collection = new[] { 1, 2, 3 };
+        IEnumerable<int> collection = [1, 2, 3];
 
         // Act
         Action act = () => collection.Should().ContainSingle(item => item == 2).Which.Should().BeGreaterThan(4);
@@ -158,7 +158,7 @@ public partial class CollectionAssertionSpecs
     public void When_a_collection_contains_a_single_item_it_should_succeed()
     {
         // Arrange
-        IEnumerable<int> collection = new[] { 1 };
+        IEnumerable<int> collection = [1];
 
         // Act
         Action act = () => collection.Should().ContainSingle();
@@ -171,7 +171,7 @@ public partial class CollectionAssertionSpecs
     public void When_asserting_an_empty_collection_contains_a_single_item_it_should_throw()
     {
         // Arrange
-        IEnumerable<int> collection = Enumerable.Empty<int>();
+        IEnumerable<int> collection = [];
 
         // Act
         Action act = () => collection.Should().ContainSingle("more is not allowed");
@@ -204,7 +204,7 @@ public partial class CollectionAssertionSpecs
     public void When_non_empty_collection_does_not_contain_a_single_item_it_should_throw()
     {
         // Arrange
-        IEnumerable<int> collection = new[] { 1, 3 };
+        IEnumerable<int> collection = [1, 3];
 
         // Act
         Action act = () => collection.Should().ContainSingle();
@@ -219,7 +219,7 @@ public partial class CollectionAssertionSpecs
     public void When_non_empty_collection_contains_more_than_a_single_item_it_should_throw()
     {
         // Arrange
-        IEnumerable<int> collection = new[] { 1, 2 };
+        IEnumerable<int> collection = [1, 2];
 
         // Act
         Action act = () => collection.Should().ContainSingle();
@@ -234,7 +234,7 @@ public partial class CollectionAssertionSpecs
     public void When_single_item_is_found_it_should_allow_continuation()
     {
         // Arrange
-        IEnumerable<int> collection = new[] { 3 };
+        IEnumerable<int> collection = [3];
 
         // Act
         Action act = () => collection.Should().ContainSingle().Which.Should().BeGreaterThan(4);

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.EndWith.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.EndWith.cs
@@ -229,7 +229,7 @@ public partial class CollectionAssertionSpecs
         public void When_empty_collection_ends_with_the_empty_sequence_it_should_not_throw()
         {
             // Arrange
-            var collection = new string[] { };
+            string[] collection = [];
 
             // Act
             Action act = () => collection.Should().EndWith(new string[] { });

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Equal.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Equal.cs
@@ -17,8 +17,8 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_is_equal_to_the_same_collection()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [1, 2, 3];
 
             // Act / Assert
             collection1.Should().Equal(collection2);
@@ -28,7 +28,7 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_is_equal_to_the_same_list_of_elements()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().Equal(1, 2, 3);
@@ -65,8 +65,8 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_are_not_equal_because_one_item_differs_it_should_throw_using_the_reason()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2, 5 };
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [1, 2, 5];
 
             // Act
             Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
@@ -81,8 +81,8 @@ public partial class CollectionAssertionSpecs
             When_two_collections_are_not_equal_because_the_actual_collection_contains_more_items_it_should_throw_using_the_reason()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2 };
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [1, 2];
 
             // Act
             Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
@@ -97,8 +97,8 @@ public partial class CollectionAssertionSpecs
             When_two_collections_are_not_equal_because_the_actual_collection_contains_less_items_it_should_throw_using_the_reason()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2, 3, 4 };
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [1, 2, 3, 4];
 
             // Act
             Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
@@ -112,8 +112,8 @@ public partial class CollectionAssertionSpecs
         public void When_two_multidimensional_collections_are_not_equal_and_it_should_format_the_collections_properly()
         {
             // Arrange
-            var collection1 = new[] { new[] { 1, 2 }, new[] { 3, 4 } };
-            var collection2 = new[] { new[] { 5, 6 }, new[] { 7, 8 } };
+            object[][] collection1 = [[1, 2], [3, 4]];
+            object[][] collection2 = [[5, 6], [7, 8]];
 
             // Act
             Action act = () => collection1.Should().Equal(collection2);
@@ -128,7 +128,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             int[] collection = null;
-            var collection1 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
 
             // Act
             Action act = () =>
@@ -143,7 +143,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collections_to_be_equal_but_expected_collection_is_null_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             int[] collection1 = null;
 
             // Act
@@ -161,7 +161,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             var collection1 = new int[0];
-            var collection2 = new[] { 1, 2, 3 };
+            int[] collection2 = [1, 2, 3];
 
             // Act
             Action act = () => collection1.Should().Equal(collection2);
@@ -175,7 +175,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_non_empty_collection_is_compared_for_equality_to_an_empty_collection_it_should_throw()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
             var collection2 = new int[0];
 
             // Act
@@ -250,8 +250,8 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_identical_collections_to_be_equal_it_should_enumerate_the_subject_only_once()
         {
             // Arrange
-            var actual = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
-            var expected = new[] { 1, 2, 3 };
+            var actual = new CountingGenericEnumerable<int>([1, 2, 3]);
+            int[] expected = [1, 2, 3];
 
             // Act
             actual.Should().Equal(expected);
@@ -264,8 +264,8 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_identical_collections_to_not_be_equal_it_should_enumerate_the_subject_only_once()
         {
             // Arrange
-            var actual = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
-            var expected = new[] { 1, 2, 3 };
+            var actual = new CountingGenericEnumerable<int>([1, 2, 3]);
+            int[] expected = [1, 2, 3];
 
             // Act
             try
@@ -285,8 +285,8 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_different_collections_to_be_equal_it_should_enumerate_the_subject_once()
         {
             // Arrange
-            var actual = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
-            var expected = new[] { 1, 2, 4 };
+            var actual = new CountingGenericEnumerable<int>([1, 2, 3]);
+            int[] expected = [1, 2, 4];
 
             // Act
             try
@@ -306,8 +306,8 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_different_collections_to_not_be_equal_it_should_enumerate_the_subject_only_once()
         {
             // Arrange
-            var actual = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
-            var expected = new[] { 1, 2, 4 };
+            var actual = new CountingGenericEnumerable<int>([1, 2, 3]);
+            int[] expected = [1, 2, 4];
 
             // Act
             actual.Should().NotEqual(expected);
@@ -321,7 +321,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_equality_with_a_collection_built_from_params_arguments_that_are_assignable_to_the_subjects_type_parameter_it_should_succeed_by_treating_the_arguments_as_of_that_type()
         {
             // Arrange
-            byte[] byteArray = { 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10 };
+            byte[] byteArray = [0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10];
 
             // Act
             Action act = () => byteArray.Should().Equal(0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10);
@@ -337,8 +337,8 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_is_not_equal_to_a_different_collection()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 3, 1, 2 };
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [3, 1, 2];
 
             // Act / Assert
             collection1.Should()
@@ -349,8 +349,8 @@ public partial class CollectionAssertionSpecs
         public void When_two_equal_collections_are_not_expected_to_be_equal_it_should_throw()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [1, 2, 3];
 
             // Act
             Action act = () => collection1.Should().NotEqual(collection2);
@@ -364,8 +364,8 @@ public partial class CollectionAssertionSpecs
         public void When_two_equal_collections_are_not_expected_to_be_equal_it_should_report_a_clear_explanation()
         {
             // Arrange
-            var collection1 = new[] { 1, 2, 3 };
-            var collection2 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [1, 2, 3];
 
             // Act
             Action act = () => collection1.Should().NotEqual(collection2, "because we want to test the failure {0}", "message");
@@ -380,7 +380,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             int[] collection = null;
-            var collection1 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
 
             // Act
             Action act = () =>
@@ -398,7 +398,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collections_not_to_be_equal_but_expected_collection_is_null_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             int[] collection1 = null;
 
             // Act

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCount.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCount.cs
@@ -16,7 +16,7 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_has_a_count_that_equals_the_number_of_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().HaveCount(3);
@@ -26,7 +26,7 @@ public partial class CollectionAssertionSpecs
         public void Should_fail_when_asserting_collection_has_a_count_that_is_different_from_the_number_of_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().HaveCount(4);
@@ -40,7 +40,7 @@ public partial class CollectionAssertionSpecs
             When_collection_has_a_count_that_is_different_from_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action action = () => collection.Should().HaveCount(4, "because we want to test the failure {0}", "message");
@@ -55,7 +55,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_has_a_count_larger_than_the_minimum_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().HaveCount(c => c >= 3);
@@ -65,7 +65,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_a_collection_with_incorrect_predicates_in_assertion_scope_all_are_reported()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () =>
@@ -83,7 +83,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_has_a_count_that_not_matches_the_predicate_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().HaveCount(c => c >= 4, "a minimum of 4 is required");
@@ -97,7 +97,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_count_is_matched_against_a_null_predicate_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().HaveCount(null);
@@ -147,7 +147,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_count_is_matched_against_a_predicate_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().HaveCount(c => (c % 2) == 1);
@@ -160,7 +160,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_count_is_matched_against_a_predicate_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().HaveCount(c => (c % 2) == 0);
@@ -173,7 +173,7 @@ public partial class CollectionAssertionSpecs
         public void When_counting_generic_enumerable_it_should_enumerate()
         {
             // Arrange
-            var enumerable = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
+            var enumerable = new CountingGenericEnumerable<int>([1, 2, 3]);
 
             // Act
             enumerable.Should().HaveCount(3);
@@ -186,7 +186,7 @@ public partial class CollectionAssertionSpecs
         public void When_counting_generic_collection_it_should_not_enumerate()
         {
             // Arrange
-            var collection = new CountingGenericCollection<int>(new[] { 1, 2, 3 });
+            var collection = new CountingGenericCollection<int>([1, 2, 3]);
 
             // Act
             collection.Should().HaveCount(3);
@@ -203,7 +203,7 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_has_a_count_different_from_the_number_of_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().NotHaveCount(2);
@@ -213,7 +213,7 @@ public partial class CollectionAssertionSpecs
         public void Should_fail_when_asserting_collection_has_a_count_that_equals_the_number_of_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().NotHaveCount(3);
@@ -226,7 +226,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_has_a_count_that_equals_than_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action action = () => collection.Should().NotHaveCount(3, "because we want to test the failure {0}", "message");

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThan.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThan.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_has_a_count_greater_than_less_the_number_of_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().HaveCountGreaterThan(2);
@@ -27,7 +27,7 @@ public partial class CollectionAssertionSpecs
         public void Should_fail_when_asserting_collection_has_a_count_greater_than_the_number_of_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().HaveCountGreaterThan(3);
@@ -40,7 +40,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_has_a_count_greater_than_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action action = () =>

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
@@ -16,7 +16,7 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_has_a_count_greater_than_or_equal_to_less_the_number_of_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().HaveCountGreaterThanOrEqualTo(3);
@@ -26,7 +26,7 @@ public partial class CollectionAssertionSpecs
         public void Should_fail_when_asserting_collection_has_a_count_greater_than_or_equal_to_the_number_of_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().HaveCountGreaterThanOrEqualTo(4);
@@ -40,7 +40,7 @@ public partial class CollectionAssertionSpecs
             When_collection_has_a_count_greater_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action action = () =>
@@ -74,7 +74,7 @@ public partial class CollectionAssertionSpecs
         public void Chaining_after_one_assertion()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().HaveCountGreaterThanOrEqualTo(3).And.Contain(1);

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThan.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThan.cs
@@ -16,7 +16,7 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_has_a_count_less_than_less_the_number_of_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().HaveCountLessThan(4);
@@ -26,7 +26,7 @@ public partial class CollectionAssertionSpecs
         public void Should_fail_when_asserting_collection_has_a_count_less_than_the_number_of_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().HaveCountLessThan(3);
@@ -39,7 +39,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_has_a_count_less_than_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action action = () => collection.Should().HaveCountLessThan(3, "because we want to test the failure {0}", "message");

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
@@ -16,7 +16,7 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_has_a_count_less_than_or_equal_to_less_the_number_of_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().HaveCountLessThanOrEqualTo(3);
@@ -26,7 +26,7 @@ public partial class CollectionAssertionSpecs
         public void Should_fail_when_asserting_collection_has_a_count_less_than_or_equal_to_the_number_of_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().HaveCountLessThanOrEqualTo(2);
@@ -40,7 +40,7 @@ public partial class CollectionAssertionSpecs
             When_collection_has_a_count_less_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action action = () =>
@@ -74,7 +74,7 @@ public partial class CollectionAssertionSpecs
         public void Chaining_after_one_assertion()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().HaveCountLessThanOrEqualTo(3).And.Contain(1);

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementAt.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementAt.cs
@@ -16,7 +16,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_has_expected_element_at_specific_index_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().HaveElementAt(1, 2);
@@ -26,7 +26,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_have_the_expected_element_at_specific_index_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().HaveElementAt(1, 3, "we put it {0}", "there");
@@ -40,7 +40,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_have_an_element_at_the_specific_index_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().HaveElementAt(4, 3, "we put it {0}", "there");

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveSameCount.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveSameCount.cs
@@ -16,8 +16,8 @@ public partial class CollectionAssertionSpecs
         public void When_both_collections_have_the_same_number_elements_it_should_succeed()
         {
             // Arrange
-            var firstCollection = new[] { 1, 2, 3 };
-            var secondCollection = new[] { 4, 5, 6 };
+            int[] firstCollection = [1, 2, 3];
+            int[] secondCollection = [4, 5, 6];
 
             // Act / Assert
             firstCollection.Should().HaveSameCount(secondCollection);
@@ -27,8 +27,8 @@ public partial class CollectionAssertionSpecs
         public void When_both_collections_do_not_have_the_same_number_of_elements_it_should_fail()
         {
             // Arrange
-            var firstCollection = new[] { 1, 2, 3 };
-            var secondCollection = new[] { 4, 6 };
+            int[] firstCollection = [1, 2, 3];
+            int[] secondCollection = [4, 6];
 
             // Act
             Action act = () => firstCollection.Should().HaveSameCount(secondCollection);
@@ -42,8 +42,8 @@ public partial class CollectionAssertionSpecs
         public void When_comparing_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
         {
             // Arrange
-            var firstCollection = new[] { 1, 2, 3 };
-            var secondCollection = new[] { 4, 6 };
+            int[] firstCollection = [1, 2, 3];
+            int[] secondCollection = [4, 6];
 
             // Act
             Action act = () => firstCollection.Should().HaveSameCount(secondCollection, "we want to test the {0}", "reason");
@@ -58,7 +58,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             int[] collection = null;
-            var collection1 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
 
             // Act
             Action act = () =>
@@ -76,7 +76,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collections_to_have_same_count_against_an_other_null_collection_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             int[] otherCollection = null;
 
             // Act
@@ -94,8 +94,8 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_not_same_count_and_collections_have_different_number_elements_it_should_succeed()
         {
             // Arrange
-            var firstCollection = new[] { 1, 2, 3 };
-            var secondCollection = new[] { 4, 6 };
+            int[] firstCollection = [1, 2, 3];
+            int[] secondCollection = [4, 6];
 
             // Act / Assert
             firstCollection.Should().NotHaveSameCount(secondCollection);
@@ -105,8 +105,8 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_not_same_count_and_both_collections_have_the_same_number_elements_it_should_fail()
         {
             // Arrange
-            var firstCollection = new[] { 1, 2, 3 };
-            var secondCollection = new[] { 4, 5, 6 };
+            int[] firstCollection = [1, 2, 3];
+            int[] secondCollection = [4, 5, 6];
 
             // Act
             Action act = () => firstCollection.Should().NotHaveSameCount(secondCollection);
@@ -120,8 +120,8 @@ public partial class CollectionAssertionSpecs
         public void When_comparing_not_same_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
         {
             // Arrange
-            var firstCollection = new[] { 1, 2, 3 };
-            var secondCollection = new[] { 4, 5, 6 };
+            int[] firstCollection = [1, 2, 3];
+            int[] secondCollection = [4, 5, 6];
 
             // Act
             Action act = () => firstCollection.Should().NotHaveSameCount(secondCollection, "we want to test the {0}", "reason");
@@ -136,7 +136,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             int[] collection = null;
-            var collection1 = new[] { 1, 2, 3 };
+            int[] collection1 = [1, 2, 3];
 
             // Act
             Action act = () =>
@@ -154,7 +154,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collections_to_not_have_same_count_against_an_other_null_collection_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             int[] otherCollection = null;
 
             // Act
@@ -170,7 +170,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_collections_to_not_have_same_count_but_both_collections_references_the_same_object_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             var collection1 = collection;
 
             // Act

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.IntersectWith.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.IntersectWith.cs
@@ -17,8 +17,8 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_an_two_intersecting_collections_intersect_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
-            var otherCollection = new[] { 3, 4, 5 };
+            int[] collection = [1, 2, 3];
+            int[] otherCollection = [3, 4, 5];
 
             // Act / Assert
             collection.Should().IntersectWith(otherCollection);
@@ -28,8 +28,8 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_an_two_non_intersecting_collections_intersect_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
-            var otherCollection = new[] { 4, 5 };
+            int[] collection = [1, 2, 3];
+            int[] otherCollection = [4, 5];
 
             // Act
             Action action = () => collection.Should().IntersectWith(otherCollection, "they should share items");
@@ -50,7 +50,7 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().IntersectWith(new[] { 4, 5 }, "we want to test the failure {0}", "message");
+                collection.Should().IntersectWith([4, 5], "we want to test the failure {0}", "message");
             };
 
             // Assert
@@ -65,8 +65,8 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_an_two_non_intersecting_collections_do_not_intersect_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
-            var otherCollection = new[] { 4, 5 };
+            int[] collection = [1, 2, 3];
+            int[] otherCollection = [4, 5];
 
             // Act / Assert
             collection.Should().NotIntersectWith(otherCollection);
@@ -76,8 +76,8 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_an_two_intersecting_collections_do_not_intersect_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
-            var otherCollection = new[] { 2, 3, 4 };
+            int[] collection = [1, 2, 3];
+            int[] otherCollection = [2, 3, 4];
 
             // Act
             Action action = () => collection.Should().NotIntersectWith(otherCollection, "they should not share items");
@@ -92,7 +92,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_to_not_intersect_with_same_collection_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
             var otherCollection = collection;
 
             // Act
@@ -114,7 +114,7 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotIntersectWith(new[] { 4, 5 }, "we want to test the failure {0}", "message");
+                collection.Should().NotIntersectWith([4, 5], "we want to test the failure {0}", "message");
             };
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainItemsAssignableTo.cs
@@ -43,7 +43,7 @@ public partial class CollectionAssertionSpecs
         public void Succeeds_when_collection_is_empty()
         {
             // Arrange
-            var collection = Array.Empty<int>();
+            int[] collection = [];
 
             // Act / Assert
             collection.Should().NotContainItemsAssignableTo<int>();
@@ -53,7 +53,7 @@ public partial class CollectionAssertionSpecs
         public void Throws_when_the_passed_type_argument_is_null()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             var act = () => collection.Should().NotContainItemsAssignableTo(null);
@@ -66,7 +66,7 @@ public partial class CollectionAssertionSpecs
         public void Succeed_when_type_as_parameter_is_valid_type()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().NotContainItemsAssignableTo(typeof(string));

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainNulls.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainNulls.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_contain_nulls_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should().NotContainNulls();
@@ -105,7 +105,7 @@ public partial class CollectionAssertionSpecs
         public void When_injecting_a_null_predicate_into_NotContainNulls_it_should_throw()
         {
             // Arrange
-            IEnumerable<SomeClass> collection = new SomeClass[] { };
+            IEnumerable<SomeClass> collection = [];
 
             // Act
             Action act = () => collection.Should().NotContainNulls<string>(predicate: null);

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyContain.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyContain.cs
@@ -32,7 +32,7 @@ public partial class CollectionAssertionSpecs
         public void When_injecting_a_null_predicate_into_OnlyContain_it_should_throw()
         {
             // Arrange
-            IEnumerable<int> collection = new int[] { };
+            IEnumerable<int> collection = [];
 
             // Act
             Action act = () => collection.Should().OnlyContain(predicate: null);
@@ -46,7 +46,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_contains_items_not_matching_a_predicate_it_should_throw()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 2, 12, 3, 11, 2 };
+            IEnumerable<int> collection = [2, 12, 3, 11, 2];
 
             // Act
             Action act = () => collection.Should().OnlyContain(i => i <= 10, "10 is the maximum");
@@ -60,7 +60,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_is_empty_and_should_contain_only_items_matching_a_predicate_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> strings = Enumerable.Empty<string>();
+            IEnumerable<string> strings = [];
 
             // Act / Assert
             strings.Should().OnlyContain(e => e.Length > 0);
@@ -70,7 +70,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_contains_only_items_matching_a_predicate_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 2, 9, 3, 8, 2 };
+            IEnumerable<int> collection = [2, 9, 3, 8, 2];
 
             // Act
             Action act = () => collection.Should().OnlyContain(i => i <= 10);

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyHaveUniqueItems.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyHaveUniqueItems.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_with_unique_items_contains_only_unique_items()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3, 4 };
+            int[] collection = [1, 2, 3, 4];
 
             // Act / Assert
             collection.Should().OnlyHaveUniqueItems();
@@ -27,7 +27,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_contains_duplicate_items_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3, 3 };
+            int[] collection = [1, 2, 3, 3];
 
             // Act
             Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
@@ -41,7 +41,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_contains_duplicate_items_it_supports_chaining()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3, 3 };
+            int[] collection = [1, 2, 3, 3];
 
             // Act
             Action act = () =>
@@ -59,7 +59,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_contains_multiple_duplicate_items_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 2, 3, 3 };
+            int[] collection = [1, 2, 2, 3, 3];
 
             // Act
             Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
@@ -73,7 +73,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_contains_multiple_duplicate_items_it_supports_chaining()
         {
             // Arrange
-            var collection = new[] { 1, 2, 2, 3, 3 };
+            int[] collection = [1, 2, 2, 3, 3];
 
             // Act
             Action act = () =>
@@ -109,7 +109,7 @@ public partial class CollectionAssertionSpecs
         public void When_injecting_a_null_predicate_into_OnlyHaveUniqueItems_it_should_throw()
         {
             // Arrange
-            IEnumerable<SomeClass> collection = new SomeClass[] { };
+            IEnumerable<SomeClass> collection = [];
 
             // Act
             Action act = () => collection.Should().OnlyHaveUniqueItems<string>(predicate: null);

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Satisfy.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Satisfy.cs
@@ -19,7 +19,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_element_at_each_position_matches_predicate_at_same_position_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().Satisfy(
@@ -35,7 +35,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_element_at_each_position_matches_predicate_at_reverse_position_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().Satisfy(
@@ -51,7 +51,7 @@ public partial class CollectionAssertionSpecs
         public void When_one_element_does_not_have_matching_predicate_Satisfy_should_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2 };
+            int[] collection = [1, 2];
 
             // Act
             Action act = () => collection.Should().Satisfy(
@@ -71,7 +71,7 @@ public partial class CollectionAssertionSpecs
             When_some_predicates_have_multiple_matching_elements_and_most_restricitve_predicates_are_last_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3, 4 };
+            int[] collection = [1, 2, 3, 4];
 
             // Act
             Action act = () => collection.Should().Satisfy(
@@ -89,7 +89,7 @@ public partial class CollectionAssertionSpecs
             When_some_predicates_have_multiple_matching_elements_and_most_restricitve_predicates_are_first_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3, 4 };
+            int[] collection = [1, 2, 3, 4];
 
             // Act
             Action act = () => collection.Should().Satisfy(
@@ -106,7 +106,7 @@ public partial class CollectionAssertionSpecs
         public void When_second_predicate_matches_first_and_last_element_and_solution_exists_should_not_throw()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().Satisfy(
@@ -156,7 +156,7 @@ public partial class CollectionAssertionSpecs
         public void When_Satisfy_asserting_against_null_inspectors_it_should_throw_with_clear_explanation()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 1, 2 };
+            IEnumerable<int> collection = [1, 2];
 
             // Act
             Action act = () => collection.Should().Satisfy(null);
@@ -170,7 +170,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_against_empty_inspectors_should_throw_with_clear_explanation()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 1, 2 };
+            IEnumerable<int> collection = [1, 2];
 
             // Act
             Action act = () => collection.Should().Satisfy();
@@ -210,7 +210,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_which_is_empty_should_throw()
         {
             // Arrange
-            var collection = Enumerable.Empty<int>();
+            IEnumerable<int> collection = [];
 
             // Act
             Action act = () => collection.Should().Satisfy(

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.SatisfyRespectively.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.SatisfyRespectively.cs
@@ -18,7 +18,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_asserting_against_null_inspectors_it_should_throw_with_clear_explanation()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 1, 2 };
+            IEnumerable<int> collection = [1, 2];
 
             // Act
             Action act = () => collection.Should().SatisfyRespectively(null);
@@ -32,7 +32,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_asserting_against_empty_inspectors_it_should_throw_with_clear_explanation()
         {
             // Arrange
-            IEnumerable<int> collection = new[] { 1, 2 };
+            IEnumerable<int> collection = [1, 2];
 
             // Act
             Action act = () => collection.Should().SatisfyRespectively();
@@ -66,7 +66,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_which_is_asserting_against_inspectors_is_empty_it_should_throw()
         {
             // Arrange
-            var collection = Enumerable.Empty<int>();
+            IEnumerable<int> collection = [];
 
             // Act
             Action act = () => collection.Should().SatisfyRespectively(new Action<int>[] { x => x.Should().Be(1) },
@@ -103,8 +103,8 @@ public partial class CollectionAssertionSpecs
             // Arrange
             var customers = new[]
             {
-                new CustomerWithItems { Age = 21, Items = new[] { 1, 2 } },
-                new CustomerWithItems { Age = 22, Items = new[] { 3 } }
+                new CustomerWithItems { Age = 21, Items = [1, 2] },
+                new CustomerWithItems { Age = 22, Items = [3] }
             };
 
             // Act
@@ -148,7 +148,7 @@ public partial class CollectionAssertionSpecs
         public void When_inspector_message_is_not_reformatable_it_should_not_throw()
         {
             // Arrange
-            byte[][] subject = { new byte[] { 1 } };
+            byte[][] subject = [[1]];
 
             // Act
             Action act = () => subject.Should().SatisfyRespectively(e => e.Should().BeEquivalentTo(new byte[] { 2, 3, 4 }));
@@ -161,7 +161,7 @@ public partial class CollectionAssertionSpecs
         public void When_inspectors_count_does_not_equal_asserting_collection_length_it_should_throw_with_a_useful_message()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => collection.Should().SatisfyRespectively(

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.StartWith.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.StartWith.cs
@@ -156,7 +156,7 @@ public partial class CollectionAssertionSpecs
         public void When_empty_collection_starts_with_the_empty_sequence_it_should_not_throw()
         {
             // Arrange
-            var collection = new string[] { };
+            string[] collection = [];
 
             // Act
             Action act = () => collection.Should().StartWith(new string[] { });

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -18,7 +18,7 @@ public partial class CollectionAssertionSpecs
         public void Should_support_chaining_constraints_with_and()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act / Assert
             collection.Should()

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.AllSatisfy.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.AllSatisfy.cs
@@ -12,7 +12,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void All_items_satisfying_inspector_should_succeed()
         {
             // Arrange
-            string[] collection = { "John", "John" };
+            string[] collection = ["John", "John"];
 
             // Act / Assert
             collection.Should().AllSatisfy(value => value.Should().Be("John"));
@@ -22,7 +22,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void Any_items_not_satisfying_inspector_should_throw()
         {
             // Arrange
-            string[] collection = { "Jack", "Jessica" };
+            string[] collection = ["Jack", "Jessica"];
 
             // Act
             Action act = () => collection.Should()

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEquivalentTo.cs
@@ -100,8 +100,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_two_arrays_contain_the_same_elements_it_should_treat_them_as_equivalent()
         {
             // Arrange
-            string[] array1 = { "one", "two", "three" };
-            string[] array2 = { "three", "two", "one" };
+            string[] array1 = ["one", "two", "three"];
+            string[] array2 = ["three", "two", "one"];
 
             // Act / Assert
             array1.Should().BeEquivalentTo(array2);

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeSubsetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeSubsetOf.cs
@@ -114,7 +114,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_an_empty_set_is_not_supposed_to_be_a_subset_of_another_set_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> subject = new string[] { };
+            IEnumerable<string> subject = [];
             IEnumerable<string> otherSet = new[] { "one", "two", "three" };
 
             // Act

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.ContainMatch.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.ContainMatch.cs
@@ -84,7 +84,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_empty_collection_for_match_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new string[] { };
+            IEnumerable<string> collection = [];
 
             // Act
             Action action = () => collection.Should().ContainMatch("* failed");

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.SatisfyRespectively.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.SatisfyRespectively.cs
@@ -12,7 +12,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_string_collection_satisfies_all_inspectors_it_should_succeed()
         {
             // Arrange
-            string[] collection = { "John", "Jane" };
+            string[] collection = ["John", "Jane"];
 
             // Act / Assert
             collection.Should().SatisfyRespectively(
@@ -25,7 +25,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_string_collection_does_not_satisfy_all_inspectors_it_should_throw()
         {
             // Arrange
-            string[] collection = { "Jack", "Jessica" };
+            string[] collection = ["Jack", "Jessica"];
 
             // Act
             Action act = () => collection.Should().SatisfyRespectively(new Action<string>[]

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.Contain.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.Contain.cs
@@ -171,11 +171,11 @@ public partial class GenericDictionaryAssertionSpecs
             // Arrange
             Dictionary<int, string> dictionary = null;
 
-            List<KeyValuePair<int, string>> keyValuePairs = new()
-            {
+            List<KeyValuePair<int, string>> keyValuePairs =
+            [
                 new KeyValuePair<int, string>(1, "One"),
                 new KeyValuePair<int, string>(1, "Two")
-            };
+            ];
 
             // Act
             Action act = () =>
@@ -199,7 +199,7 @@ public partial class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            List<KeyValuePair<int, string>> keyValuePairs = new();
+            List<KeyValuePair<int, string>> keyValuePairs = [];
 
             // Act
             Action act = () => dictionary1.Should().Contain(keyValuePairs,
@@ -558,11 +558,11 @@ public partial class GenericDictionaryAssertionSpecs
             // Arrange
             Dictionary<int, string> dictionary = null;
 
-            List<KeyValuePair<int, string>> keyValuePairs = new()
-            {
+            List<KeyValuePair<int, string>> keyValuePairs =
+            [
                 new KeyValuePair<int, string>(1, "One"),
                 new KeyValuePair<int, string>(1, "Two")
-            };
+            ];
 
             // Act
             Action act = () =>
@@ -587,7 +587,7 @@ public partial class GenericDictionaryAssertionSpecs
                 [2] = "Two"
             };
 
-            List<KeyValuePair<int, string>> keyValuePair = new();
+            List<KeyValuePair<int, string>> keyValuePair = [];
 
             // Act
             Action act = () => dictionary1.Should().NotContain(keyValuePair,

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.ContainKeys.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.ContainKeys.cs
@@ -35,7 +35,7 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().ContainKeys(new[] { 2, 3 }, "because {0}", "we do");
+            Action act = () => dictionary.Should().ContainKeys([2, 3], "because {0}", "we do");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -52,7 +52,7 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().ContainKeys(new[] { 2, 3 }, "because {0}", "we do");
+                dictionary.Should().ContainKeys([2, 3], "because {0}", "we do");
             };
 
             // Assert
@@ -110,7 +110,7 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainKeys(new[] { 2, 3 }, "because {0}", "we do");
+            Action act = () => dictionary.Should().NotContainKeys([2, 3], "because {0}", "we do");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -128,7 +128,7 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainKeys(new[] { 2 }, "because {0}", "we do");
+            Action act = () => dictionary.Should().NotContainKeys([2], "because {0}", "we do");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -145,7 +145,7 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().NotContainKeys(new[] { 2 }, "because {0}", "we do");
+                dictionary.Should().NotContainKeys([2], "because {0}", "we do");
             };
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveSameCount.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveSameCount.cs
@@ -20,7 +20,7 @@ public partial class GenericDictionaryAssertionSpecs
                 [3] = "Three"
             };
 
-            var collection = new[] { 4, 5, 6 };
+            int[] collection = [4, 5, 6];
 
             // Act / Assert
             dictionary.Should().HaveSameCount(collection);
@@ -37,7 +37,7 @@ public partial class GenericDictionaryAssertionSpecs
                 [3] = "Three"
             };
 
-            var collection = new[] { 4, 6 };
+            int[] collection = [4, 6];
 
             // Act
             Action act = () => dictionary.Should().HaveSameCount(collection);
@@ -58,7 +58,7 @@ public partial class GenericDictionaryAssertionSpecs
                 [3] = "Three"
             };
 
-            var collection = new[] { 4, 6 };
+            int[] collection = [4, 6];
 
             // Act
             Action act = () => dictionary.Should().HaveSameCount(collection, "we want to test the {0}", "reason");
@@ -73,7 +73,7 @@ public partial class GenericDictionaryAssertionSpecs
         {
             // Arrange
             Dictionary<string, int> dictionary = null;
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => dictionary.Should().HaveSameCount(collection,
@@ -119,7 +119,7 @@ public partial class GenericDictionaryAssertionSpecs
                 [3] = "Three"
             };
 
-            var collection = new[] { 4, 6 };
+            int[] collection = [4, 6];
 
             // Act / Assert
             dictionary.Should().NotHaveSameCount(collection);
@@ -136,7 +136,7 @@ public partial class GenericDictionaryAssertionSpecs
                 [3] = "Three"
             };
 
-            var collection = new[] { 4, 5, 6 };
+            int[] collection = [4, 5, 6];
 
             // Act
             Action act = () => dictionary.Should().NotHaveSameCount(collection);
@@ -157,7 +157,7 @@ public partial class GenericDictionaryAssertionSpecs
                 [3] = "Three"
             };
 
-            var collection = new[] { 4, 5, 6 };
+            int[] collection = [4, 5, 6];
 
             // Act
             Action act = () => dictionary.Should().NotHaveSameCount(collection, "we want to test the {0}", "reason");
@@ -172,7 +172,7 @@ public partial class GenericDictionaryAssertionSpecs
         {
             // Arrange
             Dictionary<int, string> dictionary = null;
-            var collection = new[] { 1, 2, 3 };
+            int[] collection = [1, 2, 3];
 
             // Act
             Action act = () => dictionary.Should().NotHaveSameCount(collection,

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -135,12 +135,12 @@ public partial class GenericDictionaryAssertionSpecs
 
         public static object[] Dictionaries()
         {
-            return new object[]
-            {
+            return
+            [
                 new Dictionary<int, int> { [1] = 42 },
                 new TrueReadOnlyDictionary<int, int>(new Dictionary<int, int> { [1] = 42 }),
                 new List<KeyValuePair<int, int>> { new(1, 42) }
-            };
+            ];
         }
 
         public static IEnumerable<object[]> DictionariesData()
@@ -346,7 +346,7 @@ public partial class GenericDictionaryAssertionSpecs
 
     internal class DictionaryNotImplementingIReadOnlyDictionary<TKey, TValue> : IDictionary<TKey, TValue>
     {
-        private readonly Dictionary<TKey, TValue> dictionary = new();
+        private readonly Dictionary<TKey, TValue> dictionary = [];
 
         public TValue this[TKey key] { get => dictionary[key]; set => throw new NotImplementedException(); }
 

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedFactAttributeDiscoverer.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedFactAttributeDiscoverer.cs
@@ -18,11 +18,11 @@ public class CulturedFactAttributeDiscoverer : IXunitTestCaseDiscoverer
         IAttributeInfo factAttribute)
     {
         var ctorArgs = factAttribute.GetConstructorArguments().ToArray();
-        var cultures = Reflector.ConvertArguments(ctorArgs, new[] { typeof(string[]) }).Cast<string[]>().Single();
+        var cultures = Reflector.ConvertArguments(ctorArgs, [typeof(string[])]).Cast<string[]>().Single();
 
         if (cultures is null || cultures.Length == 0)
         {
-            cultures = new[] { "en-US", "fr-FR" };
+            cultures = ["en-US", "fr-FR"];
         }
 
         TestMethodDisplay methodDisplay = discoveryOptions.MethodDisplayOrDefault();

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedTheoryAttributeDiscoverer.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedTheoryAttributeDiscoverer.cs
@@ -35,11 +35,11 @@ public class CulturedTheoryAttributeDiscoverer : TheoryDiscoverer
     private static string[] GetCultures(IAttributeInfo culturedTheoryAttribute)
     {
         var ctorArgs = culturedTheoryAttribute.GetConstructorArguments().ToArray();
-        var cultures = Reflector.ConvertArguments(ctorArgs, new[] { typeof(string[]) }).Cast<string[]>().Single();
+        var cultures = Reflector.ConvertArguments(ctorArgs, [typeof(string[])]).Cast<string[]>().Single();
 
         if (cultures is null || cultures.Length == 0)
         {
-            cultures = new[] { "en-US", "fr-FR" };
+            cultures = ["en-US", "fr-FR"];
         }
 
         return cultures;

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -744,7 +744,7 @@ public class EventAssertionSpecs
             string typeName = baseType.Name + "_GeneratedForTest";
 
             TypeBuilder typeBuilder =
-                moduleBuilder.DefineType(typeName, TypeAttributes.Public, baseType, new[] { interfaceType });
+                moduleBuilder.DefineType(typeName, TypeAttributes.Public, baseType, [interfaceType]);
 
             MethodBuilder addHandler = EmitAddRemoveEventHandler("add");
             typeBuilder.DefineMethodOverride(addHandler, interfaceType.GetMethod("add_InterfaceEvent"));

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -288,7 +288,7 @@ namespace FluentAssertions.Specs.Execution
 
         public class CustomAssertionStrategy : IAssertionStrategy
         {
-            private readonly List<string> failureMessages = new();
+            private readonly List<string> failureMessages = [];
 
             public IEnumerable<string> FailureMessages => failureMessages;
 

--- a/Tests/FluentAssertions.Specs/Extensions/ObjectExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/ObjectExtensionsSpecs.cs
@@ -135,8 +135,8 @@ public class ObjectExtensionsSpecs
 
     private static object[] GetNumericIConvertibles()
     {
-        return new object[]
-        {
+        return
+        [
             (byte)1,
             (sbyte)1,
             (short)1,
@@ -148,18 +148,18 @@ public class ObjectExtensionsSpecs
             1F,
             1D,
             1M,
-        };
+        ];
     }
 
     private static object[] GetNonNumericIConvertibles()
     {
-        return new object[]
-        {
+        return
+        [
             true,
             '\u0001',
             new DateTime(1),
             DBNull.Value,
             "1"
-        };
+        ];
     }
 }

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -179,13 +179,13 @@ public class FormatterSpecs
             {
                 StuffId = 1,
                 Description = "Stuff_1",
-                Children = new List<int> { 1, 2, 3, 4 }
+                Children = [1, 2, 3, 4]
             },
             new()
             {
                 StuffId = 2,
                 Description = "Stuff_2",
-                Children = new List<int> { 1, 2, 3, 4 }
+                Children = [1, 2, 3, 4]
             }
         };
 
@@ -195,13 +195,13 @@ public class FormatterSpecs
             {
                 StuffId = 1,
                 Description = "Stuff_1",
-                Children = new List<int> { 1, 2, 3, 4 }
+                Children = [1, 2, 3, 4]
             },
             new()
             {
                 StuffId = 2,
                 Description = "WRONG_DESCRIPTION",
-                Children = new List<int> { 1, 2, 3, 4 }
+                Children = [1, 2, 3, 4]
             }
         };
 
@@ -249,7 +249,7 @@ public class FormatterSpecs
     public void When_the_object_is_a_user_defined_type_it_should_show_the_name_on_the_initial_line()
     {
         // Arrange
-        var stuff = new StuffRecord(42, "description", new(24), new List<int> { 10, 20, 30, 40 });
+        var stuff = new StuffRecord(42, "description", new(24), [10, 20, 30, 40]);
 
         // Act
         Action act = () => stuff.Should().BeNull();
@@ -396,7 +396,7 @@ public class FormatterSpecs
     public void When_the_object_is_a_tuple_it_should_show_the_properties_recursively()
     {
         // Arrange
-        (int TupleId, string Description, List<int> Children) stuff = (1, "description", new() { 1, 2, 3, 4 });
+        (int TupleId, string Description, List<int> Children) stuff = (1, "description", [1, 2, 3, 4]);
 
         (int, string, List<int>) expectedStuff = (2, "WRONG_DESCRIPTION", new List<int> { 4, 5, 6, 7 });
 
@@ -429,7 +429,7 @@ public class FormatterSpecs
             RecordId: 9,
             RecordDescription: "descriptive",
             SingleChild: new(ChildRecordId: 80),
-            RecordChildren: new() { 4, 5, 6, 7 });
+            RecordChildren: [4, 5, 6, 7]);
 
         var expectedStuff = new
         {
@@ -910,7 +910,7 @@ public class FormatterSpecs
         When_formatting_multiple_items_with_a_custom_string_representation_using_line_breaks_it_should_end_lines_with_a_comma()
     {
         // Arrange
-        var subject = new[] { typeof(A), typeof(B) };
+        Type[] subject = [typeof(A), typeof(B)];
 
         // Act
         string result = Formatter.ToString(subject, new FormattingOptions { UseLineBreaks = true });
@@ -1257,7 +1257,7 @@ internal class Node
 {
     public Node()
     {
-        Children = new List<Node>();
+        Children = [];
     }
 
     public static Node Default { get; } = new();

--- a/Tests/FluentAssertions.Specs/Formatting/MultidimensionalArrayFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/MultidimensionalArrayFormatterSpecs.cs
@@ -54,8 +54,8 @@ public class MultidimensionalArrayFormatterSpecs
     public void When_formatting_a_multi_dimensional_array_with_bounds_it_should_show_structure()
     {
         // Arrange
-        var lengthsArray = new[] { 2, 3, 4 };
-        var boundsArray = new[] { 1, 5, 7 };
+        int[] lengthsArray = [2, 3, 4];
+        int[] boundsArray = [1, 5, 7];
         var value = Array.CreateInstance(typeof(string), lengthsArray, boundsArray);
 
         for (int i = value.GetLowerBound(0); i <= value.GetUpperBound(0); i++)
@@ -64,7 +64,7 @@ public class MultidimensionalArrayFormatterSpecs
             {
                 for (int k = value.GetLowerBound(2); k <= value.GetUpperBound(2); k++)
                 {
-                    var indices = new[] { i, j, k };
+                    int[] indices = [i, j, k];
                     value.SetValue($"{i}-{j}-{k}", indices);
                 }
             }

--- a/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
@@ -92,7 +92,7 @@ public class PredicateLambdaExpressionValueFormatterSpecs
     public void When_condition_contains_linq_extension_method_then_extension_method_must_be_formatted()
     {
         // Arrange
-        var allowed = new[] { 1, 2, 3 };
+        int[] allowed = [1, 2, 3];
 
         // Act
         string result = Format<int>(a => allowed.Contains(a));

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.BeOneOf.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.BeOneOf.cs
@@ -30,7 +30,7 @@ public partial class NumericAssertionSpecs
             int value = 3;
 
             // Act
-            Action act = () => value.Should().BeOneOf(new[] { 4, 5 }, "because those are the valid values");
+            Action act = () => value.Should().BeOneOf([4, 5], "because those are the valid values");
 
             // Assert
             act

--- a/Tests/FluentAssertions.Specs/Primitives/EnumAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/EnumAssertionSpecs.cs
@@ -783,7 +783,7 @@ public class EnumAssertionSpecs
             BindingFlags flags = BindingFlags.DeclaredOnly;
 
             // Act / Assert
-            Action act = () => flags.Should().BeOneOf(Array.Empty<BindingFlags>());
+            Action act = () => flags.Should().BeOneOf([]);
 
             act.Should()
                 .Throw<ArgumentException>()

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeOneOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeOneOf.cs
@@ -97,7 +97,7 @@ public partial class ObjectAssertionSpecs
             object value = new SomeClass(3);
 
             // Act
-            Action act = () => value.Should().BeOneOf(Array.Empty<SomeClass>(), new SomeClassEqualityComparer());
+            Action act = () => value.Should().BeOneOf([], new SomeClassEqualityComparer());
 
             // Assert
             act.Should().Throw<XunitException>();
@@ -125,7 +125,7 @@ public partial class ObjectAssertionSpecs
             var value = new SomeClass(3);
 
             // Act
-            Action act = () => value.Should().BeOneOf(Array.Empty<SomeClass>(), new SomeClassEqualityComparer());
+            Action act = () => value.Should().BeOneOf([], new SomeClassEqualityComparer());
 
             // Assert
             act.Should().Throw<XunitException>();
@@ -179,7 +179,7 @@ public partial class ObjectAssertionSpecs
             object value = new SomeClass(3);
 
             // Act
-            Action act = () => value.Should().BeOneOf(Array.Empty<SomeClass>(), comparer: null);
+            Action act = () => value.Should().BeOneOf([], comparer: null);
 
             // Assert
             act.Should().Throw<ArgumentNullException>().WithParameterName("comparer");
@@ -192,7 +192,7 @@ public partial class ObjectAssertionSpecs
             var value = new SomeClass(3);
 
             // Act
-            Action act = () => value.Should().BeOneOf(Array.Empty<SomeClass>(), comparer: null);
+            Action act = () => value.Should().BeOneOf([], comparer: null);
 
             // Assert
             act.Should().Throw<ArgumentNullException>().WithParameterName("comparer");
@@ -215,7 +215,7 @@ public partial class ObjectAssertionSpecs
             var value = new object();
 
             // Act / Assert
-            value.Should().BeOneOf<object>(new[] { value }, new DumbObjectEqualityComparer()).And.NotBeNull();
+            value.Should().BeOneOf<object>([value], new DumbObjectEqualityComparer()).And.NotBeNull();
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainAll.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainAll.cs
@@ -103,7 +103,7 @@ public partial class StringAssertionSpecs
             var testString = $"{red} {green}";
 
             // Act
-            Action act = () => testString.Should().ContainAll(new[] { yellow, blue }, "some {0} reason", "special");
+            Action act = () => testString.Should().ContainAll([yellow, blue], "some {0} reason", "special");
 
             // Assert
             act
@@ -187,7 +187,7 @@ public partial class StringAssertionSpecs
             var testString = $"{red} {green} {yellow}";
 
             // Act
-            Action act = () => testString.Should().NotContainAll(new[] { red, green, yellow }, "some {0} reason", "special");
+            Action act = () => testString.Should().NotContainAll([red, green, yellow], "some {0} reason", "special");
 
             // Assert
             act

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainAny.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainAny.cs
@@ -121,7 +121,7 @@ public partial class StringAssertionSpecs
             var testString = $"{red} {green}";
 
             // Act
-            Action act = () => testString.Should().ContainAny(new[] { blue, purple }, "some {0} reason", "special");
+            Action act = () => testString.Should().ContainAny([blue, purple], "some {0} reason", "special");
 
             // Assert
             act
@@ -204,7 +204,7 @@ public partial class StringAssertionSpecs
             var testString = $"{red} {green} {yellow}";
 
             // Act
-            Action act = () => testString.Should().NotContainAny(new[] { red }, "some {0} reason", "special");
+            Action act = () => testString.Should().NotContainAny([red], "some {0} reason", "special");
 
             // Assert
             act

--- a/Tests/FluentAssertions.Specs/TypeEnumerableExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/TypeEnumerableExtensionsSpecs.cs
@@ -71,7 +71,7 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_types_in_namespace_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(BaseNamespaceClass), typeof(NestedNamespaceClass) };
+            Type[] types = [typeof(JustAClass), typeof(BaseNamespaceClass), typeof(NestedNamespaceClass)];
 
             types.ThatAreInNamespace(typeof(BaseNamespaceClass).Namespace)
                 .Should()
@@ -82,7 +82,7 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_types_under_namespace_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(BaseNamespaceClass), typeof(NestedNamespaceClass) };
+            Type[] types = [typeof(JustAClass), typeof(BaseNamespaceClass), typeof(NestedNamespaceClass)];
 
             types.ThatAreUnderNamespace(typeof(BaseNamespaceClass).Namespace)
                 .Should()
@@ -94,7 +94,7 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_derived_classes_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(SomeBaseClass), typeof(SomeClassDerivedFromSomeBaseClass) };
+            Type[] types = [typeof(JustAClass), typeof(SomeBaseClass), typeof(SomeClassDerivedFromSomeBaseClass)];
 
             types.ThatDeriveFrom<SomeBaseClass>()
                 .Should()
@@ -105,7 +105,7 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_types_that_implement_interface_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(ClassImplementingJustAnInterface), typeof(IJustAnInterface) };
+            Type[] types = [typeof(JustAClass), typeof(ClassImplementingJustAnInterface), typeof(IJustAnInterface)];
 
             types.ThatImplement<IJustAnInterface>()
                 .Should()
@@ -116,7 +116,7 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_only_the_classes_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(IJustAnInterface) };
+            Type[] types = [typeof(JustAClass), typeof(IJustAnInterface)];
 
             types.ThatAreClasses()
                 .Should()
@@ -127,7 +127,7 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_not_a_classes_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(IJustAnInterface) };
+            Type[] types = [typeof(JustAClass), typeof(IJustAnInterface)];
 
             types.ThatAreNotClasses()
                 .Should()
@@ -138,7 +138,7 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_static_classes_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(AStaticClass) };
+            Type[] types = [typeof(JustAClass), typeof(AStaticClass)];
 
             types.ThatAreStatic()
                 .Should()
@@ -149,7 +149,7 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_not_a_static_classes_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(AStaticClass) };
+            Type[] types = [typeof(JustAClass), typeof(AStaticClass)];
 
             types.ThatAreNotStatic()
                 .Should()
@@ -160,7 +160,7 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_types_with_predicate_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(JustAClass), typeof(AStaticClass) };
+            Type[] types = [typeof(JustAClass), typeof(AStaticClass)];
 
             types.ThatSatisfy(t => t.IsSealed && t.IsAbstract)
                 .Should()

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
@@ -414,7 +414,7 @@ public class MethodInfoAssertionSpecs
         {
             // Arrange
             ConstructorInfo constructorMethodInfo =
-                typeof(ClassWithMethodWithImplementationAttribute).GetConstructor(new[] { typeof(string) });
+                typeof(ClassWithMethodWithImplementationAttribute).GetConstructor([typeof(string)]);
 
             // Act
             Action act = () =>

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveConstructor.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveConstructor.cs
@@ -21,7 +21,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should()
-                    .HaveConstructor(new[] { typeof(string) })
+                    .HaveConstructor([typeof(string)])
                     .Which.Should().HaveAccessModifier(CSharpAccessModifier.Private);
 
             // Assert
@@ -36,7 +36,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveConstructor(new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                type.Should().HaveConstructor([typeof(int), typeof(Type)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -53,7 +53,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveConstructor(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+                type.Should().HaveConstructor([typeof(string)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -87,7 +87,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should()
-                    .NotHaveConstructor(new[] { typeof(string) });
+                    .NotHaveConstructor([typeof(string)]);
 
             // Assert
             act.Should().NotThrow();
@@ -101,7 +101,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveConstructor(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+                type.Should().NotHaveConstructor([typeof(string)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -117,7 +117,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveConstructor(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+                type.Should().NotHaveConstructor([typeof(string)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveIndexer.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveIndexer.cs
@@ -21,7 +21,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should()
-                    .HaveIndexer(typeof(string), new[] { typeof(string) })
+                    .HaveIndexer(typeof(string), [typeof(string)])
                     .Which.Should()
                     .BeWritable(CSharpAccessModifier.Internal)
                     .And.BeReadable(CSharpAccessModifier.Private);
@@ -39,7 +39,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveIndexer(
-                    typeof(string), new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                    typeof(string), [typeof(int), typeof(Type)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -57,7 +57,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveIndexer(
-                    typeof(string), new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                    typeof(string), [typeof(int), typeof(Type)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -73,7 +73,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveIndexer(typeof(string), new[] { typeof(string) }, "we want to test the failure {0}", "message");
+                type.Should().HaveIndexer(typeof(string), [typeof(string)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -88,7 +88,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveIndexer(null, new[] { typeof(string) });
+                type.Should().HaveIndexer(null, [typeof(string)]);
 
             // Assert
             act.Should().ThrowExactly<ArgumentNullException>()
@@ -121,7 +121,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveIndexer(new[] { typeof(string) });
+                type.Should().NotHaveIndexer([typeof(string)]);
 
             // Assert
             act.Should().NotThrow();
@@ -135,7 +135,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveIndexer(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+                type.Should().NotHaveIndexer([typeof(string)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -150,7 +150,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveIndexer(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+                type.Should().NotHaveIndexer([typeof(string)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveMethod.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveMethod.cs
@@ -21,7 +21,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should()
-                    .HaveMethod("VoidMethod", new Type[] { })
+                    .HaveMethod("VoidMethod", [])
                     .Which.Should()
                     .HaveAccessModifier(CSharpAccessModifier.Private)
                     .And.ReturnVoid();
@@ -39,7 +39,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveMethod(
-                    "NonExistentMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                    "NonExistentMethod", [typeof(int), typeof(Type)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -57,7 +57,7 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveMethod(
-                    "VoidMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                    "VoidMethod", [typeof(int), typeof(Type)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -74,7 +74,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveMethod("Name", new[] { typeof(string) }, "we want to test the failure {0}", "message");
+                type.Should().HaveMethod("Name", [typeof(string)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -89,7 +89,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveMethod(null, new[] { typeof(string) });
+                type.Should().HaveMethod(null, [typeof(string)]);
 
             // Assert
             act.Should().ThrowExactly<ArgumentNullException>()
@@ -104,7 +104,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveMethod(string.Empty, new[] { typeof(string) });
+                type.Should().HaveMethod(string.Empty, [typeof(string)]);
 
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
@@ -137,7 +137,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveMethod("NonExistentMethod", new Type[] { });
+                type.Should().NotHaveMethod("NonExistentMethod", []);
 
             // Assert
             act.Should().NotThrow();
@@ -151,7 +151,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveMethod("VoidMethod", new[] { typeof(int) });
+                type.Should().NotHaveMethod("VoidMethod", [typeof(int)]);
 
             // Assert
             act.Should().NotThrow();
@@ -165,7 +165,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveMethod("VoidMethod", new Type[] { }, "we want to test the failure {0}", "message");
+                type.Should().NotHaveMethod("VoidMethod", [], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -180,7 +180,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveMethod("Name", new[] { typeof(string) }, "we want to test the failure {0}", "message");
+                type.Should().NotHaveMethod("Name", [typeof(string)], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -195,7 +195,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveMethod(null, new[] { typeof(string) });
+                type.Should().NotHaveMethod(null, [typeof(string)]);
 
             // Assert
             act.Should().ThrowExactly<ArgumentNullException>()
@@ -210,7 +210,7 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveMethod(string.Empty, new[] { typeof(string) });
+                type.Should().NotHaveMethod(string.Empty, [typeof(string)]);
 
             // Assert
             act.Should().ThrowExactly<ArgumentException>()

--- a/Tests/FluentAssertions.Specs/Types/TypeExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeExtensionsSpecs.cs
@@ -204,7 +204,7 @@ public class TypeExtensionsSpecs
         return methods.SingleOrDefault(m =>
             m.Name == name
             && m.ReturnType == returnType
-            && m.GetParameters().Select(p => p.ParameterType).SequenceEqual(new[] { type })
+            && m.GetParameters().Select(p => p.ParameterType).SequenceEqual([type])
         );
     }
 

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -667,7 +667,7 @@ namespace FluentAssertions.Specs.Types
                 .UnwrapTaskTypes();
 
             types.Should()
-                .BeEquivalentTo(new[] { typeof(int), typeof(void), typeof(void), typeof(string), typeof(bool) });
+                .BeEquivalentTo([typeof(int), typeof(void), typeof(void), typeof(string), typeof(bool)]);
         }
 
         [Fact]
@@ -897,8 +897,8 @@ namespace Internal.UnwrapSelectorTestTypes.Test
 
     internal class ClassImplementingMultipleEnumerable : IEnumerable<int>, IEnumerable<string>
     {
-        private readonly IEnumerable<int> integers = Enumerable.Empty<int>();
-        private readonly IEnumerable<string> strings = Enumerable.Empty<string>();
+        private readonly IEnumerable<int> integers = [];
+        private readonly IEnumerable<string> strings = [];
 
         public IEnumerator<int> GetEnumerator() => integers.GetEnumerator();
 


### PR DESCRIPTION
Enable C# 12 and .NET 8 SDK analyzers.

Replace the following things with [collection expressions](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/collection-expressions) where possible:
* `Enumerable.Empty<T>()`
* `Array.Empty<T>()`
* `new()` (for collection types)
* collection initializers

Besides the more terse syntax this gives the compiler more freedom.
E.g. for `IEnumerable<T>` it can pick any type that implements the interface, it's even allowed to synthesize a custom type.
Collection initializers for e.g. `List<T>` is only syntax sugar over repeatedly calling `.Add`, whereas for collection expressions the desugared code just needs to return a `List<T>` with the given elements. It does not specify _how_ that `List<T>` is constructed.
This e.g. allows the compiler to preallocate the `List<T>` and avoid dynamic resizing.

If you hadn't guessed by now, collection expressions is by far my favorite C# 12 feature 😍 

I didn't find any places to apply the new spread operation `..`

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
