### PR TITLE
Collection expressions, spread operator and Tuple.Create

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -272,14 +272,14 @@ class Build : NukeBuild
         .OnlyWhenDynamic(() => RunAllTargets || HasSourceChanges)
         .Executes(() =>
         {
-            var projects = new[]
-            {
+            Project[] projects =
+            [
                 Solution.TestFrameworks.MSpec_Specs,
                 Solution.TestFrameworks.MSTestV2_Specs,
                 Solution.TestFrameworks.NUnit3_Specs,
                 Solution.TestFrameworks.NUnit4_Specs,
                 Solution.TestFrameworks.XUnit2_Specs
-            };
+            ];
 
             var testCombinations =
                 from project in projects

--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -18,7 +18,7 @@ internal sealed class TypeMemberReflector
     {
         Properties = LoadProperties(typeToReflect, visibility);
         Fields = LoadFields(typeToReflect, visibility);
-        Members = Properties.Concat<MemberInfo>(Fields).ToArray();
+        Members = [.. Properties, .. Fields];
     }
 
     public MemberInfo[] Members { get; }

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -57,7 +57,7 @@ public class BasicSpecs
     public void When_comparing_nested_collection_with_a_null_value_it_should_fail_with_the_correct_message()
     {
         // Arrange
-        MyClass[] subject = [new MyClass { Items = new[] { "a" } }];
+        MyClass[] subject = [new MyClass { Items = ["a"] }];
 
         MyClass[] expectation = [new MyClass()];
 
@@ -209,12 +209,8 @@ public class BasicSpecs
     public void When_treating_a_value_type_in_a_collection_as_a_complex_type_it_should_compare_them_by_members()
     {
         // Arrange
-        var subject = new[] { new ClassWithValueSemanticsOnSingleProperty { Key = "SameKey", NestedProperty = "SomeValue" } };
-
-        var expected = new[]
-        {
-            new ClassWithValueSemanticsOnSingleProperty { Key = "SameKey", NestedProperty = "OtherValue" }
-        };
+        ClassWithValueSemanticsOnSingleProperty[] subject = [new() { Key = "SameKey", NestedProperty = "SomeValue" }];
+        ClassWithValueSemanticsOnSingleProperty[] expected = [new() { Key = "SameKey", NestedProperty = "OtherValue" }];
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expected,

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -338,13 +338,13 @@ public class CollectionSpecs
         var logbookEntry = new LogbookEntryProjection
         {
             Logbook = logbook,
-            LogbookRelations = new[] { new LogbookRelation { Logbook = logbook } }
+            LogbookRelations = [new LogbookRelation { Logbook = logbook }]
         };
 
         var equivalentLogbookEntry = new LogbookEntryProjection
         {
             Logbook = logbook,
-            LogbookRelations = new[] { new LogbookRelation { Logbook = logbook } }
+            LogbookRelations = [new LogbookRelation { Logbook = logbook }]
         };
 
         // Act
@@ -440,12 +440,11 @@ public class CollectionSpecs
     public void When_two_deeply_nested_collections_are_equivalent_while_ignoring_the_order_it_should_not_throw()
     {
         // Arrange
-        var items = new[] { new int[0], [42] };
+        int[][] subject = [[], [42]];
+        int[][] expectation = [[42], []];
 
         // Act / Assert
-        items.Should().BeEquivalentTo(
-            new[] { [42], new int[0] }
-        );
+        subject.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
@@ -1170,7 +1169,7 @@ public class CollectionSpecs
     public void When_some_string_in_the_collection_is_not_equal_to_the_expected_string_it_should_throw()
     {
         // Arrange
-        var subject = new[] { "one", "two", "six" };
+        string[] subject = ["one", "two", "six"];
 
         // Act
         Action action = () => subject.Should().AllBe("one");
@@ -1185,7 +1184,7 @@ public class CollectionSpecs
     public void When_some_string_in_the_collection_is_in_different_case_than_expected_string_it_should_throw()
     {
         // Arrange
-        var subject = new[] { "one", "One", "ONE" };
+        string[] subject = ["one", "One", "ONE"];
 
         // Act
         Action action = () => subject.Should().AllBe("one");
@@ -1296,7 +1295,7 @@ public class CollectionSpecs
     public void When_some_subject_items_are_not_equivalent_to_expectation_object_it_should_throw()
     {
         // Arrange
-        var subject = new[] { 1, 2, 3 };
+        int[] subject = [1, 2, 3];
 
         // Act
         Action action = () => subject.Should().AllBeEquivalentTo(1);
@@ -1611,8 +1610,8 @@ public class CollectionSpecs
         When_asserting_equivalence_of_collections_and_configured_to_use_runtime_properties_it_should_respect_the_runtime_type()
     {
         // Arrange
-        ICollection collection1 = new NonGenericCollection(new[] { new Customer() });
-        ICollection collection2 = new NonGenericCollection(new[] { new Car() });
+        ICollection collection1 = new NonGenericCollection([new Customer()]);
+        ICollection collection2 = new NonGenericCollection([new Car()]);
 
         // Act
         Action act =
@@ -1642,8 +1641,8 @@ public class CollectionSpecs
     public void When_asserting_equivalence_of_non_generic_collections_it_should_respect_the_runtime_type()
     {
         // Arrange
-        ICollection subject = new NonGenericCollection(new[] { new Customer() });
-        ICollection expectation = new NonGenericCollection(new[] { new Car() });
+        ICollection subject = new NonGenericCollection([new Customer()]);
+        ICollection expectation = new NonGenericCollection([new Car()]);
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation);
@@ -1971,7 +1970,7 @@ public class CollectionSpecs
     public void When_the_expectation_is_null_it_should_throw()
     {
         // Arrange
-        var actual = new[,]
+        int[,] actual =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
@@ -1991,7 +1990,7 @@ public class CollectionSpecs
         // Arrange
         Array actual = null;
 
-        var expectation = new[,]
+        int[,] expectation =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
@@ -2011,7 +2010,7 @@ public class CollectionSpecs
         // Arrange
         var actual = new object();
 
-        var expectation = new[,]
+        int[,] expectation =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
@@ -2029,13 +2028,13 @@ public class CollectionSpecs
     public void When_the_length_of_the_2nd_dimension_differs_between_the_arrays_it_should_throw()
     {
         // Arrange
-        var actual = new[,]
+        int[,] actual =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
 
-        var expectation = new[,] { { 1, 2, 3 } };
+        int[,] expectation = { { 1, 2, 3 } };
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation);
@@ -2049,13 +2048,13 @@ public class CollectionSpecs
     public void When_the_length_of_the_first_dimension_differs_between_the_arrays_it_should_throw()
     {
         // Arrange
-        var actual = new[,]
+        int[,] actual =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
 
-        var expectation = new[,]
+        int[,] expectation =
         {
             { 1, 2 },
             { 4, 5 }
@@ -2074,7 +2073,7 @@ public class CollectionSpecs
     {
         // Arrange
 #pragma warning disable format // VS and Rider disagree on how to format a multidimensional array initializer
-        var actual = new[,,]
+        int[,,] actual =
         {
             {
                 { 1 },
@@ -2089,7 +2088,7 @@ public class CollectionSpecs
         };
 #pragma warning restore format
 
-        var expectation = new[,]
+        int[,] expectation =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
@@ -2308,8 +2307,8 @@ public class CollectionSpecs
         When_two_collections_have_properties_of_the_contained_items_excluded_but_still_differ_it_should_throw()
     {
         // Arrange
-        var list1 = new[] { new KeyValuePair<int, int>(1, 123) };
-        var list2 = new[] { new KeyValuePair<int, int>(2, 321) };
+        KeyValuePair<int, int>[] list1 = [new(1, 123)];
+        KeyValuePair<int, int>[] list2 = [new(2, 321)];
 
         // Act
         Action act = () => list1.Should().BeEquivalentTo(list2, config => config
@@ -2409,13 +2408,13 @@ public class CollectionSpecs
     public void When_two_multi_dimensional_arrays_are_equivalent_it_should_not_throw()
     {
         // Arrange
-        var subject = new[,]
+        int[,] subject =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
 
-        var expectation = new[,]
+        int[,] expectation =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
@@ -2432,13 +2431,13 @@ public class CollectionSpecs
     public void When_two_multi_dimensional_arrays_are_not_equivalent_it_should_throw()
     {
         // Arrange
-        var actual = new[,]
+        int[,] actual =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
 
-        var expectation = new[,]
+        int[,] expectation =
         {
             { 1, 2, 4 },
             { 4, -5, 6 }
@@ -2561,10 +2560,10 @@ public class CollectionSpecs
     public void When_two_unordered_lists_are_structurally_equivalent_and_order_is_strict_it_should_fail()
     {
         // Arrange
-        var subject = new[]
-        {
+        Customer[] subject =
+        [
             new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
-        };
+        ];
 
         var expectation = new Collection<Customer>
         {
@@ -2585,10 +2584,10 @@ public class CollectionSpecs
     public void When_two_unordered_lists_are_structurally_equivalent_and_order_was_reset_to_strict_it_should_fail()
     {
         // Arrange
-        var subject = new[]
-        {
+        Customer[] subject =
+        [
             new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
-        };
+        ];
 
         var expectation = new Collection<Customer>
         {
@@ -2614,10 +2613,10 @@ public class CollectionSpecs
     public void When_two_unordered_lists_are_structurally_equivalent_and_order_was_reset_to_not_strict_it_should_succeed()
     {
         // Arrange
-        var subject = new[]
-        {
+        Customer[] subject =
+        [
             new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
-        };
+        ];
 
         var expectation = new Collection<Customer>
         {
@@ -2637,10 +2636,10 @@ public class CollectionSpecs
     public void When_two_unordered_lists_are_structurally_equivalent_it_should_succeed()
     {
         // Arrange
-        var subject = new[]
-        {
+        Customer[] subject =
+        [
             new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
-        };
+        ];
 
         var expectation = new Collection<Customer>
         {

--- a/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs.cs
@@ -234,7 +234,7 @@ public class CyclicReferencesSpecs
 
         // Assert
         Action act = () => actual.Should().BeEquivalentTo(
-            new[] { new SelfReturningEnumerable(), new SelfReturningEnumerable() },
+            [new SelfReturningEnumerable(), new SelfReturningEnumerable()],
             "we want to test the failure {0}", "message");
 
         // Assert

--- a/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
@@ -319,15 +319,15 @@ public class DictionarySpecs
             new ReadOnlyDictionary<string, IEnumerable<string>>(
                 new Dictionary<string, IEnumerable<string>>
                 {
-                    ["Key2"] = new[] { "Value2" },
-                    ["Key1"] = new[] { "Value1" }
+                    ["Key2"] = ["Value2"],
+                    ["Key1"] = ["Value1"]
                 });
 
         // Act
         Action act = () => dictionary.Should().BeEquivalentTo(new Dictionary<string, IEnumerable<string>>
         {
-            ["Key1"] = new[] { "Value1" },
-            ["Key2"] = new[] { "Value2" }
+            ["Key1"] = ["Value1"],
+            ["Key2"] = ["Value2"]
         });
 
         // Assert
@@ -342,15 +342,15 @@ public class DictionarySpecs
             new ReadOnlyDictionary<string, IEnumerable<string>>(
                 new Dictionary<string, IEnumerable<string>>
                 {
-                    ["Key2"] = new[] { "Value2" },
-                    ["Key1"] = new[] { "Value1" }
+                    ["Key2"] = ["Value2"],
+                    ["Key1"] = ["Value1"]
                 });
 
         // Act
         Action act = () => dictionary.Should().BeEquivalentTo(new Dictionary<string, IEnumerable<string>>
         {
-            ["Key2"] = new[] { "Value3" },
-            ["Key1"] = new[] { "Value1" }
+            ["Key2"] = ["Value3"],
+            ["Key1"] = ["Value1"]
         });
 
         // Assert

--- a/Tests/FluentAssertions.Equivalency.Specs/EnumSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/EnumSpecs.cs
@@ -71,8 +71,8 @@ public class EnumSpecs
     public void Comparing_collections_of_enums_by_value_includes_custom_message()
     {
         // Arrange
-        var subject = new[] { EnumOne.One };
-        var expectation = new[] { EnumOne.Two };
+        EnumOne[] subject = [EnumOne.One];
+        EnumOne[] expectation = [EnumOne.Two];
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, "some {0}", "reason");
@@ -86,8 +86,8 @@ public class EnumSpecs
     public void Comparing_collections_of_enums_by_name_includes_custom_message()
     {
         // Arrange
-        var subject = new[] { EnumOne.Two };
-        var expectation = new[] { EnumFour.Three };
+        EnumOne[] subject = [EnumOne.Two];
+        EnumFour[] expectation = [EnumFour.Three];
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, config => config.ComparingEnumsByName(),
@@ -104,7 +104,7 @@ public class EnumSpecs
         // Arrange
         int[] actual = [1];
 
-        var expected = new[] { TestEnum.First };
+        TestEnum[] expected = [TestEnum.First];
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByValue(),

--- a/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
@@ -162,8 +162,8 @@ public class ExtensibilitySpecs
     public void When_an_ordering_rule_is_added_it_should_be_evaluated_after_all_existing_rules()
     {
         // Arrange
-        var subject = new[] { "First", "Second" };
-        var expected = new[] { "First", "Second" };
+        string[] subject = ["First", "Second"];
+        string[] expected = ["First", "Second"];
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(
@@ -178,8 +178,8 @@ public class ExtensibilitySpecs
     public void When_an_ordering_rule_is_added_it_should_appear_in_the_exception_message()
     {
         // Arrange
-        var subject = new[] { "First", "Second" };
-        var expected = new[] { "Second", "First" };
+        string[] subject = ["First", "Second"];
+        string[] expected = ["Second", "First"];
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(

--- a/Tests/FluentAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
@@ -155,7 +155,7 @@ public class NestedPropertiesSpecs
         public StringContainer(string mainValue, string subValue = null)
         {
             MainValue = mainValue;
-            SubValues = new[] { new StringSubContainer { SubValue = subValue } };
+            SubValues = [new StringSubContainer { SubValue = subValue }];
         }
 
         public string MainValue { get; set; }
@@ -174,20 +174,20 @@ public class NestedPropertiesSpecs
     public void When_deeply_nested_strings_dont_match_it_should_properly_report_the_mismatches()
     {
         // Arrange
-        var expected = new[]
-        {
+        MyClass2[] expected =
+        [
             new MyClass2 { One = new StringContainer("EXPECTED", "EXPECTED"), Two = new StringContainer("CORRECT") },
             new MyClass2()
-        };
+        ];
 
-        var actual = new[]
-        {
+        MyClass2[] actual =
+        [
             new MyClass2
             {
                 One = new StringContainer("INCORRECT", "INCORRECT"), Two = new StringContainer("CORRECT")
             },
             new MyClass2()
-        };
+        ];
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
@@ -307,9 +307,9 @@ public class NestedPropertiesSpecs
     public void Should_support_nested_collections_containing_empty_objects()
     {
         // Arrange
-        var orig = new[] { new OuterWithObject { MyProperty = [new Inner()] } };
+        OuterWithObject[] orig = [new OuterWithObject { MyProperty = [new Inner()] }];
 
-        var expectation = new[] { new OuterWithObject { MyProperty = [new Inner()] } };
+        OuterWithObject[] expectation = [new OuterWithObject { MyProperty = [new Inner()] }];
 
         // Act / Assert
         orig.Should().BeEquivalentTo(expectation);

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Basic.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Basic.cs
@@ -276,13 +276,13 @@ public partial class SelectionRulesSpecs
             };
 
             // Act / Assert
-            sut.Should().BeEquivalentTo(new[]
-            {
+            sut.Should().BeEquivalentTo(
+            [
                 new BaseClassPointingToClassWithoutProperties
                 {
                     Name = "theName"
                 }
-            });
+            ]);
         }
 
         internal class BaseClassPointingToClassWithoutProperties

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Interfaces.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Interfaces.cs
@@ -306,22 +306,22 @@ public partial class SelectionRulesSpecs
         {
             // Arrange
             IInterfaceWithTwoProperties[] actual =
-            {
+            [
                 new DerivedClassImplementingInterface
                 {
                     Value1 = 1,
                     Value2 = 2
                 }
-            };
+            ];
 
             IInterfaceWithTwoProperties[] expected =
-            {
+            [
                 new DerivedClassImplementingInterface
                 {
                     Value1 = 999,
                     Value2 = 2
                 }
-            };
+            ];
 
             // Act / Assert
             actual.Should().BeEquivalentTo(expected, options => options
@@ -334,22 +334,22 @@ public partial class SelectionRulesSpecs
         {
             // Arrange
             IInterfaceWithTwoProperties[] actual =
-            {
+            [
                 new DerivedClassImplementingInterface
                 {
                     Value1 = 1,
                     Value2 = 2
                 }
-            };
+            ];
 
             IInterfaceWithTwoProperties[] expected =
-            {
+            [
                 new DerivedClassImplementingInterface
                 {
                     Value1 = 999,
                     Value2 = 2
                 }
-            };
+            ];
 
             // Act / Assert
             actual.Should().BeEquivalentTo(expected, options => options

--- a/Tests/FluentAssertions.Equivalency.Specs/TupleSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TupleSpecs.cs
@@ -24,8 +24,8 @@ public class TupleSpecs
     public void When_a_tuple_is_compared_it_should_compare_its_components()
     {
         // Arrange
-        var actual = new Tuple<string, bool, int[]>("Hello", true, [3, 2, 1]);
-        var expected = new Tuple<string, bool, int[]>("Hello", true, [1, 2, 3]);
+        var actual = Tuple.Create("Hello", true, new[] { 3, 2, 1 });
+        var expected = Tuple.Create("Hello", true, new[] { 1, 2, 3 });
 
         // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);

--- a/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
@@ -129,21 +129,21 @@ public class AssertionExtensionsSpecs
             .Where(m => m.Name == "Should")
             .ToList();
 
-        List<Type> realOverloads = shouldOverloads
-            .Where(m => !IsGuardOverload(m))
-            .Select(t => GetMostParentType(t.ReturnType))
-            .Distinct()
-            .Concat(new[]
-            {
-                // @jnyrup: DateTimeRangeAssertions and DateTimeOffsetRangeAssertions are manually added here,
-                // because they expose AndConstraints,
-                // and hence should have a guarding Should(DateTimeRangeAssertions _) overloads,
-                // but they do not have a regular Should() overload,
-                // as they are always constructed through the fluent API.
-                typeof(DateTimeRangeAssertions<>),
-                typeof(DateTimeOffsetRangeAssertions<>),
-            })
-            .ToList();
+        List<Type> realOverloads =
+        [
+            ..shouldOverloads
+                .Where(m => !IsGuardOverload(m))
+                .Select(t => GetMostParentType(t.ReturnType))
+                .Distinct(),
+
+            // @jnyrup: DateTimeRangeAssertions and DateTimeOffsetRangeAssertions are manually added here,
+            // because they expose AndConstraints,
+            // and hence should have a guarding Should(DateTimeRangeAssertions _) overloads,
+            // but they do not have a regular Should() overload,
+            // as they are always constructed through the fluent API.
+            typeof(DateTimeRangeAssertions<>),
+            typeof(DateTimeOffsetRangeAssertions<>)
+        ];
 
         List<Type> fakeOverloads = shouldOverloads
             .Where(m => IsGuardOverload(m))

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
@@ -63,7 +63,7 @@ public partial class CollectionAssertionSpecs
         public void All_items_satisfying_inspector_should_succeed()
         {
             // Arrange
-            var collection = new[] { new Customer { Age = 21, Name = "John" }, new Customer { Age = 21, Name = "Jane" } };
+            Customer[] collection = [new Customer { Age = 21, Name = "John" }, new Customer { Age = 21, Name = "Jane" }];
 
             // Act / Assert
             collection.Should().AllSatisfy(x => x.Age.Should().Be(21));
@@ -73,11 +73,11 @@ public partial class CollectionAssertionSpecs
         public void Any_items_not_satisfying_inspector_should_throw()
         {
             // Arrange
-            var customers = new[]
-            {
+            CustomerWithItems[] customers =
+            [
                 new CustomerWithItems { Age = 21, Items = [1, 2] },
                 new CustomerWithItems { Age = 22, Items = [3] }
-            };
+            ];
 
             // Act
             Action act = () => customers.Should()

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -18,7 +18,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_is_empty_as_expected_it_should_not_throw()
         {
             // Arrange
-            var collection = new int[0];
+            int[] collection = [];
 
             // Act / Assert
             collection.Should().BeEmpty();
@@ -65,7 +65,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_without_items_is_not_empty_it_should_fail()
         {
             // Arrange
-            var collection = new int[0];
+            int[] collection = [];
 
             // Act
             Action act = () => collection.Should().NotBeEmpty();
@@ -78,7 +78,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_without_items_is_not_empty_it_should_fail_with_descriptive_message_()
         {
             // Arrange
-            var collection = new int[0];
+            int[] collection = [];
 
             // Act
             Action act = () => collection.Should().NotBeEmpty("because we want to test the failure {0}", "message");
@@ -110,7 +110,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_to_be_empty_it_should_enumerate_only_once()
         {
             // Arrange
-            var collection = new CountingGenericEnumerable<int>(new int[0]);
+            var collection = new CountingGenericEnumerable<int>([]);
 
             // Act
             collection.Should().BeEmpty();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
@@ -95,8 +95,8 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_are_both_empty_it_should_treat_them_as_equivalent()
         {
             // Arrange
-            var subject = new int[0];
-            var otherCollection = new int[0];
+            int[] subject = [];
+            int[] otherCollection = [];
 
             // Act
             Action act = () => subject.Should().BeEquivalentTo(otherCollection);
@@ -237,7 +237,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             int[] collection1 = [1, 2, 3];
-            var collection2 = new int[0];
+            int[] collection2 = [];
 
             // Act
             Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
@@ -282,8 +282,8 @@ public partial class CollectionAssertionSpecs
         public void When_a_collections_is_equivalent_to_an_approximate_copy_it_should_throw()
         {
             // Arrange
-            var collection = new[] { 1.0, 2.0, 3.0 };
-            var collection1 = new[] { 1.5, 2.5, 3.5 };
+            double[] collection = [1.0, 2.0, 3.0];
+            double[] collection1 = [1.5, 2.5, 3.5];
 
             // Act
             Action act = () => collection.Should().NotBeEquivalentTo(collection1, opt => opt

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
@@ -170,10 +170,10 @@ public partial class CollectionAssertionSpecs
         public void Can_use_an_index_into_a_list_in_the_ordering_expression()
         {
             // Arrange
-            var collection = new[]
-            {
-                new List<SomeClass> { new() { Text = "a", Number = 1 } }
-            };
+            List<SomeClass>[] collection =
+            [
+                [new() { Text = "a", Number = 1 }]
+            ];
 
             // Act & Assert
             collection.Should().BeInAscendingOrder(o => o[0].Number);
@@ -183,10 +183,10 @@ public partial class CollectionAssertionSpecs
         public void Can_use_an_index_into_an_array_in_the_ordering_expression()
         {
             // Arrange
-            var collection = new[]
-            {
-                new[] { new SomeClass { Text = "a", Number = 1 } }
-            };
+            SomeClass[][] collection =
+            [
+                [new SomeClass { Text = "a", Number = 1 }]
+            ];
 
             // Act & Assert
             collection.Should().BeInAscendingOrder(o => o[0].Number);

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInDescendingOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeInDescendingOrder.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { "z", "y", "x" };
+            string[] collection = ["z", "y", "x"];
 
             // Act / Assert
             collection.Should().BeInDescendingOrder();
@@ -27,7 +27,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "z", "x", "y" };
+            string[] collection = ["z", "x", "y"];
 
             // Act
             Action action = () => collection.Should().BeInDescendingOrder("because letters are ordered");
@@ -98,7 +98,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_using_the_given_comparer_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "z", "x", "y" };
+            string[] collection = ["z", "x", "y"];
 
             // Act
             Action action = () =>
@@ -115,7 +115,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_using_the_given_comparer_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { "z", "y", "x" };
+            string[] collection = ["z", "y", "x"];
 
             // Act / Assert
             collection.Should().BeInDescendingOrder(Comparer<object>.Default);
@@ -292,7 +292,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_an_unordered_collection_are_not_in_descending_order_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { "x", "y", "x" };
+            string[] collection = ["x", "y", "x"];
 
             // Act / Assert
             collection.Should().NotBeInDescendingOrder();
@@ -303,7 +303,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_in_an_unordered_collection_are_not_in_descending_order_using_the_given_comparer_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { "x", "y", "x" };
+            string[] collection = ["x", "y", "x"];
 
             // Act / Assert
             collection.Should().NotBeInDescendingOrder(Comparer<object>.Default);
@@ -313,7 +313,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_the_items_in_a_descending_ordered_collection_are_not_in_descending_order_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "c", "b", "a" };
+            string[] collection = ["c", "b", "a"];
 
             // Act
             Action action = () => collection.Should().NotBeInDescendingOrder("because numbers are not ordered");
@@ -329,7 +329,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_the_items_in_a_descending_ordered_collection_are_not_in_descending_order_using_the_given_comparer_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "c", "b", "a" };
+            string[] collection = ["c", "b", "a"];
 
             // Act
             Action action = () =>

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
@@ -27,7 +27,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_an_empty_collection_to_be_null_or_empty_it_should_succeed()
         {
             // Arrange
-            var collection = new int[0];
+            int[] collection = [];
 
             // Act / Assert
             collection.Should().BeNullOrEmpty();
@@ -53,7 +53,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_to_be_null_or_empty_it_should_enumerate_only_once()
         {
             // Arrange
-            var collection = new CountingGenericEnumerable<int>(new int[0]);
+            var collection = new CountingGenericEnumerable<int>([]);
 
             // Act
             collection.Should().BeNullOrEmpty();
@@ -70,7 +70,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_non_empty_collection_to_not_be_null_or_empty_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { new object() };
+            object[] collection = [new object()];
 
             // Act / Assert
             collection.Should().NotBeNullOrEmpty();
@@ -95,7 +95,7 @@ public partial class CollectionAssertionSpecs
             When_asserting_empty_collection_to_not_be_null_or_empty_it_should_throw()
         {
             // Arrange
-            var collection = new int[0];
+            int[] collection = [];
 
             // Act
             Action act = () => collection.Should().NotBeNullOrEmpty();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
@@ -119,7 +119,7 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().Contain(new int[0]);
+            Action act = () => collection.Should().Contain([]);
 
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
@@ -200,7 +200,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_of_strings_contains_the_expected_string_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> strings = new[] { "string1", "string2", "string3" };
+            IEnumerable<string> strings = ["string1", "string2", "string3"];
 
             // Act / Assert
             strings.Should().Contain("string2");
@@ -210,7 +210,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_of_strings_does_not_contain_the_expected_string_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> strings = new[] { "string1", "string2", "string3" };
+            IEnumerable<string> strings = ["string1", "string2", "string3"];
 
             // Act
             Action act = () => strings.Should().Contain("string4", "because {0} is required", "4");
@@ -244,7 +244,7 @@ public partial class CollectionAssertionSpecs
             // Arrange
             DateTime now = DateTime.Now;
 
-            IEnumerable<DateTime> collection = new[] { now, DateTime.SpecifyKind(now, DateTimeKind.Unspecified) };
+            IEnumerable<DateTime> collection = [now, DateTime.SpecifyKind(now, DateTimeKind.Unspecified)];
 
             // Act
             Action act = () => collection.Should().Contain(now).Which.Kind.Should().Be(DateTimeKind.Local);

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainEquivalentOf.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             var item = new Customer { Name = "John" };
-            var collection = new[] { new Customer { Name = "Jane" }, item };
+            Customer[] collection = [new Customer { Name = "Jane" }, item];
 
             // Act / Assert
             collection.Should().ContainEquivalentOf(item);
@@ -27,7 +27,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_contains_object_equivalent_of_another_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { new Customer { Name = "Jane" }, new Customer { Name = "John" } };
+            Customer[] collection = [new Customer { Name = "Jane" }, new Customer { Name = "John" }];
             var item = new Customer { Name = "John" };
 
             // Act / Assert
@@ -113,7 +113,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_contains_equivalent_null_object_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { 1, 2, 3, (int?)null };
+            int?[] collection = [1, 2, 3, null];
             int? item = null;
 
             // Act
@@ -141,7 +141,7 @@ public partial class CollectionAssertionSpecs
         public void When_empty_collection_does_not_contain_equivalent_it_should_throw()
         {
             // Arrange
-            var collection = new int[0];
+            int[] collection = [];
             int item = 1;
 
             // Act
@@ -155,8 +155,8 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_contain_equivalent_because_of_second_property_it_should_throw()
         {
             // Arrange
-            var subject = new[]
-            {
+            Customer[] subject =
+            [
                 new Customer
                 {
                     Name = "John",
@@ -167,7 +167,7 @@ public partial class CollectionAssertionSpecs
                     Name = "Jane",
                     Age = 18
                 }
-            };
+            ];
 
             var item = new Customer { Name = "John", Age = 20 };
 
@@ -182,8 +182,8 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_contain_equivalent_by_including_single_property_it_should_not_throw()
         {
             // Arrange
-            var collection = new[]
-            {
+            Customer[] collection =
+            [
                 new Customer
                 {
                     Name = "John",
@@ -194,7 +194,7 @@ public partial class CollectionAssertionSpecs
                     Name = "Jane",
                     Age = 18
                 }
-            };
+            ];
 
             var item = new Customer { Name = "John", Age = 20 };
 
@@ -206,8 +206,8 @@ public partial class CollectionAssertionSpecs
         public void Tracing_should_be_included_in_the_assertion_output()
         {
             // Arrange
-            var collection = new[]
-            {
+            Customer[] collection =
+            [
                 new Customer
                 {
                     Name = "John",
@@ -218,7 +218,7 @@ public partial class CollectionAssertionSpecs
                     Name = "Jane",
                     Age = 18
                 }
-            };
+            ];
 
             var item = new Customer { Name = "John", Age = 21 };
 
@@ -325,7 +325,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_empty_collection_to_not_contain_equivalent_it_should_succeed()
         {
             // Arrange
-            var collection = new int[0];
+            int[] collection = [];
             int item = 4;
 
             // Act / Assert
@@ -365,8 +365,8 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_to_not_contain_equivalent_it_should_respect_config()
         {
             // Arrange
-            var collection = new[]
-            {
+            Customer[] collection =
+            [
                 new Customer
                 {
                     Name = "John",
@@ -377,7 +377,7 @@ public partial class CollectionAssertionSpecs
                     Name = "Jane",
                     Age = 18
                 }
-            };
+            ];
 
             var item = new Customer { Name = "John", Age = 20 };
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_collection_with_all_items_of_same_type_only_contains_item_of_one_type()
         {
             // Arrange
-            var collection = new[] { "1", "2", "3" };
+            string[] collection = ["1", "2", "3"];
 
             // Act / Assert
             collection.Should().ContainItemsAssignableTo<string>();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
@@ -130,7 +130,7 @@ public partial class CollectionAssertionSpecs
     public void When_single_item_contains_brackets_it_should_format_them_properly()
     {
         // Arrange
-        IEnumerable<string> collection = new[] { "" };
+        IEnumerable<string> collection = [""];
 
         // Act
         Action act = () => collection.Should().ContainSingle(item => item == "{123}");
@@ -144,7 +144,7 @@ public partial class CollectionAssertionSpecs
     public void When_single_item_contains_string_interpolation_it_should_format_brackets_properly()
     {
         // Arrange
-        IEnumerable<string> collection = new[] { "" };
+        IEnumerable<string> collection = [""];
 
         // Act
         Action act = () => collection.Should().ContainSingle(item => item == $"{123}");

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.EndWith.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.EndWith.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_end_with_a_specific_element_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "john", "jane", "mike" };
+            string[] collection = ["john", "jane", "mike"];
 
             // Act
             Action act = () => collection.Should().EndWith("ryan", "of some reason");
@@ -31,7 +31,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_end_with_a_specific_element_and_because_format_is_incorrect_it_should_not_fail()
         {
             // Arrange
-            var collection = new[] { "john", "jane", "mike" };
+            string[] collection = ["john", "jane", "mike"];
 
             // Act
             Action act = () => collection.Should().EndWith("mike", "of some reason {0,abc}", 1, 2);
@@ -44,10 +44,10 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_end_with_a_specific_element_in_a_sequence_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
+            string[] collection = ["john", "bill", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().EndWith(new[] { "bill", "ryan", "mike" }, "of some reason");
+            Action act = () => collection.Should().EndWith(["bill", "ryan", "mike"], "of some reason");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -58,7 +58,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_end_with_a_null_sequence_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "john" };
+            string[] collection = ["john"];
 
             // Act
             Action act = () => collection.Should().EndWith((IEnumerable<string>)null);
@@ -72,7 +72,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_end_with_a_null_sequence_using_a_comparer_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "john" };
+            string[] collection = ["john"];
 
             // Act
             Action act = () => collection.Should().EndWith((IEnumerable<string>)null, (_, _) => true);
@@ -87,10 +87,10 @@ public partial class CollectionAssertionSpecs
             When_collection_does_not_end_with_a_specific_element_in_a_sequence_using_custom_equality_comparison_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
+            string[] collection = ["john", "bill", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().EndWith(new[] { "bill", "ryan", "mike" },
+            Action act = () => collection.Should().EndWith(["bill", "ryan", "mike"],
                 (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "of some reason");
 
             // Assert
@@ -102,7 +102,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_ends_with_the_specific_element_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "john", "jane", "mike" };
+            string[] collection = ["john", "jane", "mike"];
 
             // Act
             Action act = () => collection.Should().EndWith("mike");
@@ -115,10 +115,10 @@ public partial class CollectionAssertionSpecs
         public void When_collection_ends_with_the_specific_sequence_of_elements_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
+            string[] collection = ["john", "bill", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().EndWith(new[] { "jane", "mike" });
+            Action act = () => collection.Should().EndWith(["jane", "mike"]);
 
             // Assert
             act.Should().NotThrow();
@@ -129,10 +129,10 @@ public partial class CollectionAssertionSpecs
             When_collection_ends_with_the_specific_sequence_of_elements_using_custom_equality_comparison_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
+            string[] collection = ["john", "bill", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().EndWith(new[] { "JaNe", "mIkE" },
+            Action act = () => collection.Should().EndWith(["JaNe", "mIkE"],
                 (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
 
             // Assert
@@ -143,7 +143,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_ends_with_the_specific_null_element_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "jane", "mike", null };
+            string[] collection = ["jane", "mike", null];
 
             // Act
             Action act = () => collection.Should().EndWith((string)null);
@@ -156,10 +156,10 @@ public partial class CollectionAssertionSpecs
         public void When_collection_ends_with_the_specific_sequence_with_null_elements_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "john", "bill", "jane", null, "mike", null };
+            string[] collection = ["john", "bill", "jane", null, "mike", null];
 
             // Act
-            Action act = () => collection.Should().EndWith(new[] { "jane", null, "mike", null });
+            Action act = () => collection.Should().EndWith(["jane", null, "mike", null]);
 
             // Assert
             act.Should().NotThrow();
@@ -170,10 +170,10 @@ public partial class CollectionAssertionSpecs
             When_collection_ends_with_the_specific_sequence_with_null_elements_using_custom_equality_comparison_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "john", "bill", "jane", null, "mike", null };
+            string[] collection = ["john", "bill", "jane", null, "mike", null];
 
             // Act
-            Action act = () => collection.Should().EndWith(new[] { "JaNe", null, "mIkE", null },
+            Action act = () => collection.Should().EndWith(["JaNe", null, "mIkE", null],
                 (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
 
             // Assert
@@ -184,7 +184,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_ends_with_null_but_that_wasnt_expected_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "jane", "mike", null };
+            string[] collection = ["jane", "mike", null];
 
             // Act
             Action act = () => collection.Should().EndWith("john");
@@ -216,7 +216,7 @@ public partial class CollectionAssertionSpecs
         public void When_non_empty_collection_ends_with_the_empty_sequence_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "jane", "mike" };
+            string[] collection = ["jane", "mike"];
 
             // Act
             Action act = () => collection.Should().EndWith(new string[] { });

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Equal.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Equal.cs
@@ -160,7 +160,7 @@ public partial class CollectionAssertionSpecs
         public void When_an_empty_collection_is_compared_for_equality_to_a_non_empty_collection_it_should_throw()
         {
             // Arrange
-            var collection1 = new int[0];
+            int[] collection1 = [];
             int[] collection2 = [1, 2, 3];
 
             // Act
@@ -176,7 +176,7 @@ public partial class CollectionAssertionSpecs
         {
             // Arrange
             int[] collection1 = [1, 2, 3];
-            var collection2 = new int[0];
+            int[] collection2 = [];
 
             // Act
             Action act = () => collection1.Should().Equal(collection2);
@@ -414,7 +414,7 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_collections_not_to_be_equal_but_both_collections_reference_the_same_object_it_should_throw()
         {
-            var collection1 = new[] { "one", "two", "three" };
+            string[] collection1 = ["one", "two", "three"];
             var collection2 = collection1;
 
             // Act

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementPreceding.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementPreceding.cs
@@ -19,7 +19,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_has_the_correct_element_preceding_another_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "cris", "mick", "john" };
+            string[] collection = ["cris", "mick", "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementPreceding("mick", "cris");
@@ -33,7 +33,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_has_the_wrong_element_preceding_another_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "cris", "mick", "john" };
+            string[] collection = ["cris", "mick", "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementPreceding("john", "cris", "because of some reason");
@@ -48,7 +48,7 @@ public partial class CollectionAssertionSpecs
         public void When_nothing_is_preceding_an_element_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "cris", "mick", "john" };
+            string[] collection = ["cris", "mick", "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementPreceding("cris", "jane");
@@ -77,7 +77,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_null_element_is_preceding_another_element_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { null, "mick", "john" };
+            string[] collection = [null, "mick", "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementPreceding("mick", null);
@@ -91,7 +91,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_null_element_is_not_preceding_another_element_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "cris", "mick", "john" };
+            string[] collection = ["cris", "mick", "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementPreceding("mick", null);
@@ -105,7 +105,7 @@ public partial class CollectionAssertionSpecs
         public void When_an_element_is_preceding_a_null_element_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "mick", null, "john" };
+            string[] collection = ["mick", null, "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementPreceding(null, "mick");
@@ -118,7 +118,7 @@ public partial class CollectionAssertionSpecs
         public void When_an_element_is_not_preceding_a_null_element_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "mick", null, "john" };
+            string[] collection = ["mick", null, "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementPreceding(null, "cris");

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementSucceeding.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementSucceeding.cs
@@ -19,7 +19,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_has_the_correct_element_succeeding_another_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "cris", "mick", "john" };
+            string[] collection = ["cris", "mick", "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementSucceeding("cris", "mick");
@@ -33,7 +33,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_has_the_wrong_element_succeeding_another_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "cris", "mick", "john" };
+            string[] collection = ["cris", "mick", "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementSucceeding("mick", "cris", "because of some reason");
@@ -48,7 +48,7 @@ public partial class CollectionAssertionSpecs
         public void When_nothing_is_succeeding_an_element_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "cris", "mick", "john" };
+            string[] collection = ["cris", "mick", "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementSucceeding("john", "jane");
@@ -76,7 +76,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_null_element_is_succeeding_another_element_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "mick", null, "john" };
+            string[] collection = ["mick", null, "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementSucceeding("mick", null);
@@ -89,7 +89,7 @@ public partial class CollectionAssertionSpecs
         public void When_a_null_element_is_not_succeeding_another_element_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "cris", "mick", "john" };
+            string[] collection = ["cris", "mick", "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementSucceeding("mick", null);
@@ -103,7 +103,7 @@ public partial class CollectionAssertionSpecs
         public void When_an_element_is_succeeding_a_null_element_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "mick", null, "john" };
+            string[] collection = ["mick", null, "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementSucceeding(null, "john");
@@ -116,7 +116,7 @@ public partial class CollectionAssertionSpecs
         public void When_an_element_is_not_succeeding_a_null_element_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "mick", null, "john" };
+            string[] collection = ["mick", null, "john"];
 
             // Act
             Action act = () => collection.Should().HaveElementSucceeding(null, "cris");

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainItemsAssignableTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainItemsAssignableTo.cs
@@ -12,7 +12,7 @@ public partial class CollectionAssertionSpecs
         public void Succeeds_when_the_collection_does_not_contain_items_of_the_unexpected_type()
         {
             // Arrange
-            var collection = new[] { "1", "2", "3" };
+            string[] collection = ["1", "2", "3"];
 
             // Act / Assert
             collection.Should().NotContainItemsAssignableTo<int>();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainNulls.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainNulls.cs
@@ -27,7 +27,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_contains_nulls_that_are_unexpected_it_should_throw()
         {
             // Arrange
-            var collection = new[] { new object(), null };
+            object[] collection = [new object(), null];
 
             // Act
             Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
@@ -41,7 +41,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_contains_nulls_that_are_unexpected_it_supports_chaining()
         {
             // Arrange
-            var collection = new[] { new object(), null };
+            object[] collection = [new object(), null];
 
             // Act
             Action act = () =>
@@ -59,7 +59,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_contains_multiple_nulls_that_are_unexpected_it_should_throw()
         {
             // Arrange
-            var collection = new[] { new object(), null, new object(), null };
+            object[] collection = [new object(), null, new object(), null];
 
             // Act
             Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
@@ -73,7 +73,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_contains_multiple_nulls_that_are_unexpected_it_supports_chaining()
         {
             // Arrange
-            var collection = new[] { new object(), null, new object(), null };
+            object[] collection = [new object(), null, new object(), null];
 
             // Act
             Action act = () =>
@@ -119,12 +119,12 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_contain_nulls_with_a_predicate_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<SomeClass> collection = new[]
-            {
+            IEnumerable<SomeClass> collection =
+            [
                 new SomeClass { Text = "one" },
                 new SomeClass { Text = "two" },
                 new SomeClass { Text = "three" }
-            };
+            ];
 
             // Act / Assert
             collection.Should().NotContainNulls(e => e.Text);
@@ -134,11 +134,11 @@ public partial class CollectionAssertionSpecs
         public void When_collection_contains_nulls_that_are_unexpected_with_a_predicate_it_should_throw()
         {
             // Arrange
-            IEnumerable<SomeClass> collection = new[]
-            {
+            IEnumerable<SomeClass> collection =
+            [
                 new SomeClass { Text = "" },
                 new SomeClass { Text = null }
-            };
+            ];
 
             // Act
             Action act = () => collection.Should().NotContainNulls(e => e.Text, "because they are {0}", "evil");
@@ -152,13 +152,13 @@ public partial class CollectionAssertionSpecs
         public void When_collection_contains_multiple_nulls_that_are_unexpected_with_a_predicate_it_should_throw()
         {
             // Arrange
-            IEnumerable<SomeClass> collection = new[]
-            {
+            IEnumerable<SomeClass> collection =
+            [
                 new SomeClass { Text = "" },
                 new SomeClass { Text = null },
                 new SomeClass { Text = "" },
                 new SomeClass { Text = null }
-            };
+            ];
 
             // Act
             Action act = () => collection.Should().NotContainNulls(e => e.Text, "because they are {0}", "evil");

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyHaveUniqueItems.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyHaveUniqueItems.cs
@@ -123,13 +123,13 @@ public partial class CollectionAssertionSpecs
         public void Should_succeed_when_asserting_with_a_predicate_a_collection_with_unique_items_contains_only_unique_items()
         {
             // Arrange
-            IEnumerable<SomeClass> collection = new[]
-            {
+            IEnumerable<SomeClass> collection =
+            [
                 new SomeClass { Text = "one" },
                 new SomeClass { Text = "two" },
                 new SomeClass { Text = "three" },
                 new SomeClass { Text = "four" }
-            };
+            ];
 
             // Act / Assert
             collection.Should().OnlyHaveUniqueItems(e => e.Text);
@@ -139,13 +139,13 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_contains_duplicate_items_with_predicate_it_should_throw()
         {
             // Arrange
-            IEnumerable<SomeClass> collection = new[]
-            {
+            IEnumerable<SomeClass> collection =
+            [
                 new SomeClass { Text = "one" },
                 new SomeClass { Text = "two" },
                 new SomeClass { Text = "three" },
                 new SomeClass { Text = "three" }
-            };
+            ];
 
             // Act
             Action act = () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "{0} don't like {1}", "we", "duplicates");
@@ -159,14 +159,14 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_contains_multiple_duplicate_items_with_a_predicate_it_should_throw()
         {
             // Arrange
-            IEnumerable<SomeClass> collection = new[]
-            {
+            IEnumerable<SomeClass> collection =
+            [
                 new SomeClass { Text = "one" },
                 new SomeClass { Text = "two" },
                 new SomeClass { Text = "two" },
                 new SomeClass { Text = "three" },
                 new SomeClass { Text = "three" }
-            };
+            ];
 
             // Act
             Action act = () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "{0} don't like {1}", "we", "duplicates");
@@ -180,14 +180,14 @@ public partial class CollectionAssertionSpecs
         public void When_a_collection_contains_multiple_duplicates_on_different_properties_all_should_be_reported()
         {
             // Arrange
-            IEnumerable<SomeClass> collection = new[]
-            {
+            IEnumerable<SomeClass> collection =
+            [
                 new SomeClass { Text = "one", Number = 1 },
                 new SomeClass { Text = "two", Number = 2 },
                 new SomeClass { Text = "two", Number = 2 },
                 new SomeClass { Text = "three", Number = 3 },
                 new SomeClass { Text = "three", Number = 4 }
-            };
+            ];
 
             // Act
             Action act = () =>

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Satisfy.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Satisfy.cs
@@ -123,13 +123,13 @@ public partial class CollectionAssertionSpecs
             When_assertion_fails_then_failure_message_must_contain_predicates_without_matching_elements_and_elements_without_matching_predicates()
         {
             // Arrange
-            IEnumerable<SomeClass> collection = new[]
-            {
+            IEnumerable<SomeClass> collection =
+            [
                 new SomeClass { Text = "one", Number = 1 },
                 new SomeClass { Text = "two", Number = 3 },
                 new SomeClass { Text = "three", Number = 3 },
                 new SomeClass { Text = "four", Number = 4 },
-            };
+            ];
 
             // Act
             Action act = () => collection.Should().Satisfy(

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.SatisfyRespectively.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.SatisfyRespectively.cs
@@ -81,7 +81,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_satisfies_all_inspectors_it_should_succeed()
         {
             // Arrange
-            var collection = new[] { new Customer { Age = 21, Name = "John" }, new Customer { Age = 22, Name = "Jane" } };
+            Customer[] collection = [new Customer { Age = 21, Name = "John" }, new Customer { Age = 22, Name = "Jane" }];
 
             // Act / Assert
             collection.Should().SatisfyRespectively(
@@ -101,11 +101,11 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_collection_does_not_satisfy_any_inspector_it_should_throw()
         {
             // Arrange
-            var customers = new[]
-            {
+            CustomerWithItems[] customers =
+            [
                 new CustomerWithItems { Age = 21, Items = [1, 2] },
                 new CustomerWithItems { Age = 22, Items = [3] }
-            };
+            ];
 
             // Act
             Action act = () => customers.Should().SatisfyRespectively(
@@ -177,7 +177,7 @@ public partial class CollectionAssertionSpecs
         public void When_inspectors_count_does_not_equal_asserting_collection_length_it_should_fail_with_a_useful_message()
         {
             // Arrange
-            var collection = new int[0];
+            int[] collection = [];
 
             // Act
             Action act = () => collection.Should().SatisfyRespectively(

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.StartWith.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.StartWith.cs
@@ -17,7 +17,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_start_with_a_specific_element_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "john", "jane", "mike" };
+            string[] collection = ["john", "jane", "mike"];
 
             // Act
             Action act = () => collection.Should().StartWith("ryan", "of some reason");
@@ -31,7 +31,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_start_with_a_null_sequence_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "john" };
+            string[] collection = ["john"];
 
             // Act
             Action act = () => collection.Should().StartWith((IEnumerable<string>)null);
@@ -45,7 +45,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_start_with_a_null_sequence_using_a_comparer_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "john" };
+            string[] collection = ["john"];
 
             // Act
             Action act = () => collection.Should().StartWith((IEnumerable<string>)null, (_, _) => true);
@@ -59,10 +59,10 @@ public partial class CollectionAssertionSpecs
         public void When_collection_does_not_start_with_a_specific_element_in_a_sequence_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
+            string[] collection = ["john", "bill", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().StartWith(new[] { "john", "ryan", "jane" }, "of some reason");
+            Action act = () => collection.Should().StartWith(["john", "ryan", "jane"], "of some reason");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -74,10 +74,10 @@ public partial class CollectionAssertionSpecs
             When_collection_does_not_start_with_a_specific_element_in_a_sequence_using_custom_equality_comparison_it_should_throw()
         {
             // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
+            string[] collection = ["john", "bill", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().StartWith(new[] { "john", "ryan", "jane" },
+            Action act = () => collection.Should().StartWith(["john", "ryan", "jane"],
                 (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "of some reason");
 
             // Assert
@@ -89,7 +89,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_starts_with_the_specific_element_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "john", "jane", "mike" };
+            string[] collection = ["john", "jane", "mike"];
 
             // Act
             Action act = () => collection.Should().StartWith("john");
@@ -102,10 +102,10 @@ public partial class CollectionAssertionSpecs
         public void When_collection_starts_with_the_specific_sequence_of_elements_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
+            string[] collection = ["john", "bill", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().StartWith(new[] { "john", "bill" });
+            Action act = () => collection.Should().StartWith(["john", "bill"]);
 
             // Assert
             act.Should().NotThrow();
@@ -116,10 +116,10 @@ public partial class CollectionAssertionSpecs
             When_collection_starts_with_the_specific_sequence_of_elements_using_custom_equality_comparison_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "john", "bill", "jane", "mike" };
+            string[] collection = ["john", "bill", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().StartWith(new[] { "JoHn", "bIlL" },
+            Action act = () => collection.Should().StartWith(["JoHn", "bIlL"],
                 (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
 
             // Assert
@@ -130,7 +130,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_starts_with_the_specific_null_element_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { null, "jane", "mike" };
+            string[] collection = [null, "jane", "mike"];
 
             // Act
             Action act = () => collection.Should().StartWith((string)null);
@@ -143,7 +143,7 @@ public partial class CollectionAssertionSpecs
         public void When_non_empty_collection_starts_with_the_empty_sequence_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { "jane", "mike" };
+            string[] collection = ["jane", "mike"];
 
             // Act
             Action act = () => collection.Should().StartWith(new string[] { });
@@ -169,10 +169,10 @@ public partial class CollectionAssertionSpecs
         public void When_collection_starts_with_the_specific_sequence_with_null_elements_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { null, "john", null, "bill", "jane", "mike" };
+            string[] collection = [null, "john", null, "bill", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().StartWith(new[] { null, "john", null, "bill" });
+            Action act = () => collection.Should().StartWith([null, "john", null, "bill"]);
 
             // Assert
             act.Should().NotThrow();
@@ -183,10 +183,10 @@ public partial class CollectionAssertionSpecs
             When_collection_starts_with_the_specific_sequence_with_null_elements_using_custom_equality_comparison_it_should_not_throw()
         {
             // Arrange
-            var collection = new[] { null, "john", null, "bill", "jane", "mike" };
+            string[] collection = [null, "john", null, "bill", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().StartWith(new[] { null, "JoHn", null, "bIlL" },
+            Action act = () => collection.Should().StartWith([null, "JoHn", null, "bIlL"],
                 (s1, s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase));
 
             // Assert
@@ -197,7 +197,7 @@ public partial class CollectionAssertionSpecs
         public void When_collection_starts_with_null_but_that_wasnt_expected_it_should_throw()
         {
             // Arrange
-            var collection = new[] { null, "jane", "mike" };
+            string[] collection = [null, "jane", "mike"];
 
             // Act
             Action act = () => collection.Should().StartWith("john");

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -33,13 +33,13 @@ public partial class CollectionAssertionSpecs
         public void When_the_collection_is_ordered_according_to_the_subsequent_ascending_assertion_it_should_succeed()
         {
             // Arrange
-            var collection = new[]
-            {
+            (int, string)[] collection =
+            [
                 (1, "a"),
                 (2, "b"),
                 (2, "c"),
                 (3, "a")
-            };
+            ];
 
             // Act
             Action action = () => collection.Should()
@@ -55,13 +55,13 @@ public partial class CollectionAssertionSpecs
         public void When_the_collection_is_not_ordered_according_to_the_subsequent_ascending_assertion_it_should_fail()
         {
             // Arrange
-            var collection = new[]
-            {
+            (int, string)[] collection =
+            [
                 (1, "a"),
                 (2, "b"),
                 (2, "c"),
                 (3, "a")
-            };
+            ];
 
             // Act
             Action action = () => collection.Should()
@@ -79,13 +79,13 @@ public partial class CollectionAssertionSpecs
             When_the_collection_is_ordered_according_to_the_subsequent_ascending_assertion_with_comparer_it_should_succeed()
         {
             // Arrange
-            var collection = new[]
-            {
+            (int, string)[] collection =
+            [
                 (1, "a"),
                 (2, "B"),
                 (2, "b"),
                 (3, "a")
-            };
+            ];
 
             // Act
             Action action = () => collection.Should()
@@ -101,13 +101,13 @@ public partial class CollectionAssertionSpecs
         public void When_the_collection_is_ordered_according_to_the_multiple_subsequent_ascending_assertions_it_should_succeed()
         {
             // Arrange
-            var collection = new[]
-            {
+            (int, string, double)[] collection =
+            [
                 (1, "a", 1.1),
                 (2, "b", 1.2),
                 (2, "c", 1.3),
                 (3, "a", 1.1)
-            };
+            ];
 
             // Act
             Action action = () => collection.Should()
@@ -125,13 +125,13 @@ public partial class CollectionAssertionSpecs
         public void When_the_collection_is_ordered_according_to_the_subsequent_descending_assertion_it_should_succeed()
         {
             // Arrange
-            var collection = new[]
-            {
+            (int, string)[] collection =
+            [
                 (3, "a"),
                 (2, "c"),
                 (2, "b"),
                 (1, "a")
-            };
+            ];
 
             // Act
             Action action = () => collection.Should()
@@ -147,13 +147,13 @@ public partial class CollectionAssertionSpecs
         public void When_the_collection_is_not_ordered_according_to_the_subsequent_descending_assertion_it_should_fail()
         {
             // Arrange
-            var collection = new[]
-            {
+            (int, string)[] collection =
+            [
                 (3, "a"),
                 (2, "c"),
                 (2, "b"),
                 (1, "a")
-            };
+            ];
 
             // Act
             Action action = () => collection.Should()
@@ -171,13 +171,13 @@ public partial class CollectionAssertionSpecs
             When_the_collection_is_ordered_according_to_the_subsequent_descending_assertion_with_comparer_it_should_succeed()
         {
             // Arrange
-            var collection = new[]
-            {
+            (int, string)[] collection =
+            [
                 (3, "a"),
                 (2, "b"),
                 (2, "B"),
                 (1, "a")
-            };
+            ];
 
             // Act
             Action action = () => collection.Should()
@@ -193,13 +193,13 @@ public partial class CollectionAssertionSpecs
         public void When_the_collection_is_ordered_according_to_the_multiple_subsequent_descending_assertions_it_should_succeed()
         {
             // Arrange
-            var collection = new[]
-            {
+            (int, string, double)[] collection =
+            [
                 (3, "a", 1.1),
                 (2, "c", 1.3),
                 (2, "b", 1.2),
                 (1, "a", 1.1)
-            };
+            ];
 
             // Act
             Action action = () => collection.Should()

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEmpty.cs
@@ -13,7 +13,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void Should_fail_when_asserting_collection_with_items_is_empty()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().BeEmpty();
@@ -50,7 +50,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_the_collection_is_not_empty_unexpectedly_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().BeEmpty("because we want to test the failure {0}", "message");
@@ -83,7 +83,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collection_with_items_is_not_empty_it_should_succeed()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act / Assert
             collection.Should().NotBeEmpty();

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEquivalentTo.cs
@@ -14,7 +14,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         {
             // Arrange
             IEnumerable<string> collection = null;
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
 
             // Act
             Action act =
@@ -30,8 +30,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collections_with_duplicates_are_not_equivalent_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three", "one" };
-            IEnumerable<string> collection2 = new[] { "one", "two", "three", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three", "one"];
+            IEnumerable<string> collection2 = ["one", "two", "three", "three"];
 
             // Act
             Action act = () => collection1.Should().BeEquivalentTo(collection2);
@@ -45,7 +45,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_testing_for_equivalence_against_empty_collection_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> subject = new[] { "one", "two", "three" };
+            IEnumerable<string> subject = ["one", "two", "three"];
             IEnumerable<string> otherCollection = new string[0];
 
             // Act
@@ -60,7 +60,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_testing_for_equivalence_against_null_collection_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
             IEnumerable<string> collection2 = null;
 
             // Act
@@ -89,8 +89,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_two_collections_contain_the_same_elements_it_should_treat_them_as_equivalent()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
-            IEnumerable<string> collection2 = new[] { "three", "two", "one" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
+            IEnumerable<string> collection2 = ["three", "two", "one"];
 
             // Act / Assert
             collection1.Should().BeEquivalentTo(collection2);
@@ -114,8 +114,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void Should_succeed_when_asserting_collection_is_not_equivalent_to_a_different_collection()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
-            IEnumerable<string> collection2 = new[] { "three", "one" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
+            IEnumerable<string> collection2 = ["three", "one"];
 
             // Act / Assert
             collection1.Should().NotBeEquivalentTo(collection2);
@@ -126,7 +126,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         {
             // Arrange
             IEnumerable<string> actual = null;
-            IEnumerable<string> expectation = new[] { "one", "two", "three" };
+            IEnumerable<string> expectation = ["one", "two", "three"];
 
             // Act
             Action act = () => actual.Should().NotBeEquivalentTo(expectation,
@@ -141,8 +141,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collections_are_unexpectedly_equivalent_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
-            IEnumerable<string> collection2 = new[] { "three", "one", "two" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
+            IEnumerable<string> collection2 = ["three", "one", "two"];
 
             // Act
             Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
@@ -156,7 +156,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_non_empty_collection_is_not_expected_to_be_equivalent_to_an_empty_collection_it_should_succeed()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
             IEnumerable<string> collection2 = new string[0];
 
             // Act
@@ -170,7 +170,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_testing_collections_not_to_be_equivalent_against_null_collection_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
             IEnumerable<string> collection2 = null;
 
             // Act
@@ -185,7 +185,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_testing_collections_not_to_be_equivalent_against_same_collection_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
             IEnumerable<string> collection1 = collection;
 
             // Act

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeSubsetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeSubsetOf.cs
@@ -13,7 +13,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_a_subset_is_tested_against_a_null_superset_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
-            IEnumerable<string> subset = new[] { "one", "two", "three" };
+            IEnumerable<string> subset = ["one", "two", "three"];
             IEnumerable<string> superset = null;
 
             // Act
@@ -29,7 +29,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         {
             // Arrange
             IEnumerable<string> subset = new string[0];
-            IEnumerable<string> superset = new[] { "one", "two", "four", "five" };
+            IEnumerable<string> superset = ["one", "two", "four", "five"];
 
             // Act
             Action act = () => subset.Should().BeSubsetOf(superset);
@@ -43,7 +43,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         {
             // Arrange
             IEnumerable<string> collection = null;
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
 
             // Act
             Action act =
@@ -58,8 +58,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_is_not_a_subset_of_another_it_should_throw_with_the_reason()
         {
             // Arrange
-            IEnumerable<string> subset = new[] { "one", "two", "three", "six" };
-            IEnumerable<string> superset = new[] { "one", "two", "four", "five" };
+            IEnumerable<string> subset = ["one", "two", "three", "six"];
+            IEnumerable<string> superset = ["one", "two", "four", "five"];
 
             // Act
             Action act = () => subset.Should().BeSubsetOf(superset, "because we want to test the failure {0}", "message");
@@ -74,8 +74,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_is_subset_of_a_specified_collection_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> subset = new[] { "one", "two" };
-            IEnumerable<string> superset = new[] { "one", "two", "three" };
+            IEnumerable<string> subset = ["one", "two"];
+            IEnumerable<string> superset = ["one", "two", "three"];
 
             // Act / Assert
             subset.Should().BeSubsetOf(superset);
@@ -88,8 +88,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void Should_fail_when_asserting_collection_is_not_subset_of_a_superset_collection()
         {
             // Arrange
-            IEnumerable<string> subject = new[] { "one", "two" };
-            IEnumerable<string> otherSet = new[] { "one", "two", "three" };
+            IEnumerable<string> subject = ["one", "two"];
+            IEnumerable<string> otherSet = ["one", "two", "three"];
 
             // Act
             Action act = () => subject.Should().NotBeSubsetOf(otherSet, "because I'm {0}", "mistaken");
@@ -103,8 +103,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_a_set_is_expected_to_be_not_a_subset_it_should_succeed()
         {
             // Arrange
-            IEnumerable<string> subject = new[] { "one", "two", "four" };
-            IEnumerable<string> otherSet = new[] { "one", "two", "three" };
+            IEnumerable<string> subject = ["one", "two", "four"];
+            IEnumerable<string> otherSet = ["one", "two", "three"];
 
             // Act / Assert
             subject.Should().NotBeSubsetOf(otherSet);
@@ -115,7 +115,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         {
             // Arrange
             IEnumerable<string> subject = [];
-            IEnumerable<string> otherSet = new[] { "one", "two", "three" };
+            IEnumerable<string> otherSet = ["one", "two", "three"];
 
             // Act
             Action act = () => subject.Should().NotBeSubsetOf(otherSet);
@@ -129,7 +129,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collection_to_not_be_subset_against_same_collection_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
             IEnumerable<string> otherCollection = collection;
 
             // Act

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.Contain.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.Contain.cs
@@ -13,10 +13,10 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_a_collection_does_not_contain_another_collection_it_should_throw_with_clear_explanation()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().Contain(new[] { "three", "four", "five" }, "because {0}", "we do");
+            Action act = () => collection.Should().Contain(["three", "four", "five"], "because {0}", "we do");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -27,7 +27,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_a_collection_does_not_contain_single_item_it_should_throw_with_clear_explanation()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().Contain("four", "because {0}", "we do");
@@ -56,7 +56,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collection_contains_an_item_from_the_collection_it_should_succeed()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().Contain("one");
@@ -69,10 +69,10 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collection_contains_multiple_items_from_the_collection_in_any_order_it_should_succeed()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().Contain(new[] { "two", "one" });
+            Action act = () => collection.Should().Contain(["two", "one"]);
 
             // Assert
             act.Should().NotThrow<XunitException>();
@@ -82,7 +82,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_the_contents_of_a_collection_are_checked_against_an_empty_collection_it_should_throw_clear_explanation()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().Contain(new string[0]);
@@ -96,7 +96,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_the_expected_object_exists_it_should_allow_chaining_additional_assertions()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().Contain("one").Which.Should().HaveLength(4);
@@ -127,7 +127,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_contains_an_unexpected_item_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().NotContain("one", "because we {0} like it, but found it anyhow", "don't");
@@ -141,7 +141,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_does_contain_an_unexpected_item_matching_a_predicate_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().NotContain(item => item == "two", "because {0}s are evil", "two");
@@ -155,7 +155,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_does_not_contain_an_item_that_is_not_in_the_collection_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().NotContain("four");
@@ -168,7 +168,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_does_not_contain_an_unexpected_item_matching_a_predicate_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act / Assert
             collection.Should().NotContain(item => item == "four");

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.ContainInOrder.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.ContainInOrder.cs
@@ -13,7 +13,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_a_collection_does_not_contain_a_range_twice_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "one", "three", "twelve", "two", "two" };
+            IEnumerable<string> collection = ["one", "two", "one", "three", "twelve", "two", "two"];
 
             // Act
             Action act = () => collection.Should().ContainInOrder("one", "two", "one", "one", "two");
@@ -27,7 +27,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_a_collection_does_not_contain_an_ordered_item_it_should_throw_with_a_clear_explanation()
         {
             // Act
-            Action act = () => new[] { "one", "two", "three" }.Should().ContainInOrder(new[] { "four", "one" }, "we failed");
+            Action act = () => new[] { "one", "two", "three" }.Should().ContainInOrder(["four", "one"], "we failed");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -44,7 +44,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
             // Act
             Action act =
                 () => strings.Should()
-                    .ContainInOrder(new[] { "string4" }, "because we're checking how it reacts to a null subject");
+                    .ContainInOrder(["string4"], "because we're checking how it reacts to a null subject");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -55,7 +55,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_contains_null_value_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", null, "two", "string" };
+            IEnumerable<string> collection = ["one", null, "two", "string"];
 
             // Act / Assert
             collection.Should().ContainInOrder("one", null, "string");
@@ -76,7 +76,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_the_first_collection_contains_a_duplicate_item_without_affecting_the_order_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three", "two" };
+            IEnumerable<string> collection = ["one", "two", "three", "two"];
 
             // Act / Assert
             collection.Should().ContainInOrder("one", "two", "three");
@@ -86,7 +86,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_two_collections_contain_the_same_duplicate_items_in_the_same_order_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "one", "two", "twelve", "two", "two" };
+            IEnumerable<string> collection = ["one", "two", "one", "two", "twelve", "two", "two"];
 
             // Act / Assert
             collection.Should().ContainInOrder("one", "two", "one", "two", "twelve", "two", "two");
@@ -97,7 +97,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         {
             // Act
             Action act = () =>
-                new[] { "one", "two", "three" }.Should().ContainInOrder(new[] { "three", "one" }, "because we said so");
+                new[] { "one", "two", "three" }.Should().ContainInOrder(["three", "one"], "because we said so");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -108,7 +108,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_two_collections_contain_the_same_items_in_the_same_order_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "two", "three"];
 
             // Act / Assert
             collection.Should().ContainInOrder("one", "two", "three");
@@ -121,7 +121,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act / Assert
             collection.Should().NotContainInOrder("two", "one");
@@ -131,7 +131,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_a_collection_does_not_contain_an_ordered_item_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act / Assert
             collection.Should().NotContainInOrder("four", "one");
@@ -141,7 +141,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_a_collection_contains_less_items_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two" };
+            IEnumerable<string> collection = ["one", "two"];
 
             // Act / Assert
             collection.Should().NotContainInOrder("one", "two", "three");
@@ -151,7 +151,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_a_collection_does_not_contain_a_range_twice_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "one", "three", "twelve", "two", "two" };
+            IEnumerable<string> collection = ["one", "two", "one", "three", "twelve", "two", "two"];
 
             // Act / Assert
             collection.Should().NotContainInOrder("one", "two", "one", "one", "two");
@@ -175,10 +175,10 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_two_collections_contain_the_same_items_in_the_same_order_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().NotContainInOrder(new[] { "one", "two", "three" }, "that's what we expect");
+            Action act = () => collection.Should().NotContainInOrder(["one", "two", "three"], "that's what we expect");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -190,7 +190,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_contains_contain_the_same_items_in_the_same_order_with_null_value_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", null, "two", "three" };
+            IEnumerable<string> collection = ["one", null, "two", "three"];
 
             // Act
             Action act = () => collection.Should().NotContainInOrder("one", null, "three");
@@ -205,7 +205,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_the_first_collection_contains_a_duplicate_item_without_affecting_the_order_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three", "two" };
+            IEnumerable<string> collection = ["one", "two", "three", "two"];
 
             // Act
             Action act = () => collection.Should().NotContainInOrder("one", "two", "three");
@@ -220,7 +220,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_two_collections_contain_the_same_duplicate_items_in_the_same_order_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "one", "twelve", "two" };
+            IEnumerable<string> collection = ["one", "two", "one", "twelve", "two"];
 
             // Act
             Action act = () => collection.Should().NotContainInOrder("one", "two", "one", "twelve", "two");
@@ -235,7 +235,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_passing_in_null_while_checking_for_absence_of_ordered_containment_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().NotContainInOrder(null);

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.ContainMatch.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.ContainMatch.cs
@@ -14,7 +14,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_contains_a_match_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test failed" };
+            IEnumerable<string> collection = ["build succeded", "test failed"];
 
             // Act
             Action action = () => collection.Should().ContainMatch("* failed");
@@ -27,7 +27,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_contains_multiple_matches_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test failed", "pack failed" };
+            IEnumerable<string> collection = ["build succeded", "test failed", "pack failed"];
 
             // Act
             Action action = () => collection.Should().ContainMatch("* failed");
@@ -40,7 +40,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_contains_multiple_matches_which_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test failed", "pack failed" };
+            IEnumerable<string> collection = ["build succeded", "test failed", "pack failed"];
 
             // Act
             Action action = () => _ = collection.Should().ContainMatch("* failed").Which;
@@ -55,7 +55,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_does_not_contain_a_match_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test failed" };
+            IEnumerable<string> collection = ["build succeded", "test failed"];
 
             // Act
             Action action = () => collection.Should().ContainMatch("* stopped", "because {0}", "we do");
@@ -70,7 +70,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_contains_a_match_that_differs_in_casing_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test failed" };
+            IEnumerable<string> collection = ["build succeded", "test failed"];
 
             // Act
             Action action = () => collection.Should().ContainMatch("* Failed");
@@ -116,7 +116,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collection_to_have_null_match_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test failed" };
+            IEnumerable<string> collection = ["build succeded", "test failed"];
 
             // Act
             Action action = () => collection.Should().ContainMatch(null);
@@ -132,7 +132,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collection_to_have_empty_string_match_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test failed" };
+            IEnumerable<string> collection = ["build succeded", "test failed"];
 
             // Act
             Action action = () => collection.Should().ContainMatch(string.Empty);
@@ -151,7 +151,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_doesnt_contain_a_match_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test" };
+            IEnumerable<string> collection = ["build succeded", "test"];
 
             // Act
             Action action = () => collection.Should().NotContainMatch("* failed");
@@ -164,7 +164,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_doesnt_contain_multiple_matches_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test", "pack" };
+            IEnumerable<string> collection = ["build succeded", "test", "pack"];
 
             // Act
             Action action = () => collection.Should().NotContainMatch("* failed");
@@ -177,7 +177,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_contains_a_match_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test failed" };
+            IEnumerable<string> collection = ["build succeded", "test failed"];
 
             // Act
             Action action = () => collection.Should().NotContainMatch("* failed", "because {0}", "it shouldn't");
@@ -192,7 +192,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_contains_multiple_matches_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build failed", "test failed" };
+            IEnumerable<string> collection = ["build failed", "test failed"];
 
             // Act
             Action action = () => collection.Should().NotContainMatch("* failed", "because {0}", "it shouldn't");
@@ -207,7 +207,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_contains_a_match_with_different_casing_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test failed" };
+            IEnumerable<string> collection = ["build succeded", "test failed"];
 
             // Act
             Action action = () => collection.Should().NotContainMatch("* Failed");
@@ -220,7 +220,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collection_to_not_have_null_match_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test failed" };
+            IEnumerable<string> collection = ["build succeded", "test failed"];
 
             // Act
             Action action = () => collection.Should().NotContainMatch(null);
@@ -236,7 +236,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collection_to_not_have_empty_string_match_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "build succeded", "test failed" };
+            IEnumerable<string> collection = ["build succeded", "test failed"];
 
             // Act
             Action action = () => collection.Should().NotContainMatch(string.Empty);

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.Equal.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.Equal.cs
@@ -13,8 +13,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void Should_succeed_when_asserting_collection_is_equal_to_the_same_collection()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
-            IEnumerable<string> collection2 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
+            IEnumerable<string> collection2 = ["one", "two", "three"];
 
             // Act / Assert
             collection1.Should().Equal(collection2);
@@ -24,7 +24,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void Should_succeed_when_asserting_collection_is_equal_to_the_same_list_of_elements()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act / Assert
             collection.Should().Equal("one", "two", "three");
@@ -50,7 +50,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         {
             // Arrange
             var collection1 = new string[0];
-            IEnumerable<string> collection2 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection2 = ["one", "two", "three"];
 
             // Act
             Action act = () => collection1.Should().Equal(collection2);
@@ -97,7 +97,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collections_to_be_equal_but_expected_collection_is_null_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
             IEnumerable<string> collection1 = null;
 
             // Act
@@ -115,7 +115,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         {
             // Arrange
             IEnumerable<string> collection = null;
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
 
             // Act
             Action act = () =>
@@ -143,8 +143,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_two_collections_are_not_equal_because_one_item_differs_it_should_throw_using_the_reason()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
-            IEnumerable<string> collection2 = new[] { "one", "two", "five" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
+            IEnumerable<string> collection2 = ["one", "two", "five"];
 
             // Act
             Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
@@ -159,8 +159,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
             When_two_collections_are_not_equal_because_the_actual_collection_contains_less_items_it_should_throw_using_the_reason()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
-            IEnumerable<string> collection2 = new[] { "one", "two", "three", "four" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
+            IEnumerable<string> collection2 = ["one", "two", "three", "four"];
 
             // Act
             Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
@@ -175,8 +175,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
             When_two_collections_are_not_equal_because_the_actual_collection_contains_more_items_it_should_throw_using_the_reason()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
-            IEnumerable<string> collection2 = new[] { "one", "two" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
+            IEnumerable<string> collection2 = ["one", "two"];
 
             // Act
             Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
@@ -207,8 +207,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void Should_succeed_when_asserting_collection_is_not_equal_to_a_different_collection()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
-            IEnumerable<string> collection2 = new[] { "three", "one", "two" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
+            IEnumerable<string> collection2 = ["three", "one", "two"];
 
             // Act / Assert
             collection1.Should()
@@ -218,7 +218,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         [Fact]
         public void When_asserting_collections_not_to_be_equal_but_both_collections_reference_the_same_object_it_should_throw()
         {
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
             IEnumerable<string> collection2 = collection1;
 
             // Act
@@ -234,7 +234,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collections_not_to_be_equal_but_expected_collection_is_null_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
             IEnumerable<string> collection1 = null;
 
             // Act
@@ -252,7 +252,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         {
             // Arrange
             IEnumerable<string> collection = null;
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
 
             // Act
             Action act =
@@ -267,8 +267,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_two_equal_collections_are_not_expected_to_be_equal_it_should_report_a_clear_explanation()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
-            IEnumerable<string> collection2 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
+            IEnumerable<string> collection2 = ["one", "two", "three"];
 
             // Act
             Action act = () => collection1.Should().NotEqual(collection2, "because we want to test the failure {0}", "message");
@@ -282,8 +282,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_two_equal_collections_are_not_expected_to_be_equal_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
-            IEnumerable<string> collection2 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
+            IEnumerable<string> collection2 = ["one", "two", "three"];
 
             // Act
             Action act = () => collection1.Should().NotEqual(collection2);

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.HaveCount.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.HaveCount.cs
@@ -13,7 +13,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void Should_fail_when_asserting_collection_has_a_count_that_is_different_from_the_number_of_items()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().HaveCount(4);
@@ -26,7 +26,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void Should_succeed_when_asserting_collection_has_a_count_that_equals_the_number_of_items()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act / Assert
             collection.Should().HaveCount(3);
@@ -36,7 +36,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void Should_support_chaining_constraints_with_and()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act / Assert
             collection.Should()
@@ -50,7 +50,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_count_is_matched_against_a_null_predicate_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().HaveCount(null);
@@ -93,7 +93,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_has_a_count_larger_than_the_minimum_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act / Assert
             collection.Should().HaveCount(c => c >= 3);
@@ -104,7 +104,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
             When_collection_has_a_count_that_is_different_from_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action action = () => collection.Should().HaveCount(4, "because we want to test the failure {0}", "message");
@@ -119,7 +119,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_has_a_count_that_not_matches_the_predicate_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().HaveCount(c => c >= 4, "a minimum of 4 is required");

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.HaveElementAt.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.HaveElementAt.cs
@@ -28,7 +28,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_does_not_have_an_element_at_the_specific_index_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().HaveElementAt(4, "three", "we put it {0}", "there");
@@ -42,7 +42,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_does_not_have_the_expected_element_at_specific_index_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().HaveElementAt(1, "three", "we put it {0}", "there");
@@ -56,7 +56,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_has_expected_element_at_specific_index_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act / Assert
             collection.Should().HaveElementAt(1, "two");

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.HaveSameCount.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.HaveSameCount.cs
@@ -13,7 +13,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collections_to_have_same_count_against_an_other_null_collection_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
             IEnumerable<string> otherCollection = null;
 
             // Act
@@ -29,7 +29,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         {
             // Arrange
             IEnumerable<string> collection = null;
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().HaveSameCount(collection1,
@@ -44,8 +44,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_both_collections_do_not_have_the_same_number_of_elements_it_should_fail()
         {
             // Arrange
-            IEnumerable<string> firstCollection = new[] { "one", "two", "three" };
-            IEnumerable<string> secondCollection = new[] { "four", "six" };
+            IEnumerable<string> firstCollection = ["one", "two", "three"];
+            IEnumerable<string> secondCollection = ["four", "six"];
 
             // Act
             Action act = () => firstCollection.Should().HaveSameCount(secondCollection);
@@ -59,8 +59,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_both_collections_have_the_same_number_elements_it_should_succeed()
         {
             // Arrange
-            IEnumerable<string> firstCollection = new[] { "one", "two", "three" };
-            IEnumerable<string> secondCollection = new[] { "four", "five", "six" };
+            IEnumerable<string> firstCollection = ["one", "two", "three"];
+            IEnumerable<string> secondCollection = ["four", "five", "six"];
 
             // Act / Assert
             firstCollection.Should().HaveSameCount(secondCollection);
@@ -70,8 +70,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_comparing_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
         {
             // Arrange
-            IEnumerable<string> firstCollection = new[] { "one", "two", "three" };
-            IEnumerable<string> secondCollection = new[] { "four", "six" };
+            IEnumerable<string> firstCollection = ["one", "two", "three"];
+            IEnumerable<string> secondCollection = ["four", "six"];
 
             // Act
             Action act = () => firstCollection.Should().HaveSameCount(secondCollection, "we want to test the {0}", "reason");
@@ -88,7 +88,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collections_to_not_have_same_count_against_an_other_null_collection_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
             IEnumerable<string> otherCollection = null;
 
             // Act
@@ -104,7 +104,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         {
             // Arrange
             IEnumerable<string> collection = null;
-            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = ["one", "two", "three"];
 
             // Act
             Action act = () => collection.Should().NotHaveSameCount(collection1,
@@ -120,7 +120,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
             When_asserting_collections_to_not_have_same_count_but_both_collections_references_the_same_object_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
             IEnumerable<string> otherCollection = collection;
 
             // Act
@@ -136,8 +136,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_not_same_count_and_both_collections_have_the_same_number_elements_it_should_fail()
         {
             // Arrange
-            IEnumerable<string> firstCollection = new[] { "one", "two", "three" };
-            IEnumerable<string> secondCollection = new[] { "four", "five", "six" };
+            IEnumerable<string> firstCollection = ["one", "two", "three"];
+            IEnumerable<string> secondCollection = ["four", "five", "six"];
 
             // Act
             Action act = () => firstCollection.Should().NotHaveSameCount(secondCollection);
@@ -151,8 +151,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_not_same_count_and_collections_have_different_number_elements_it_should_succeed()
         {
             // Arrange
-            IEnumerable<string> firstCollection = new[] { "one", "two", "three" };
-            IEnumerable<string> secondCollection = new[] { "four", "six" };
+            IEnumerable<string> firstCollection = ["one", "two", "three"];
+            IEnumerable<string> secondCollection = ["four", "six"];
 
             // Act / Assert
             firstCollection.Should().NotHaveSameCount(secondCollection);
@@ -162,8 +162,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_comparing_not_same_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
         {
             // Arrange
-            IEnumerable<string> firstCollection = new[] { "one", "two", "three" };
-            IEnumerable<string> secondCollection = new[] { "four", "five", "six" };
+            IEnumerable<string> firstCollection = ["one", "two", "three"];
+            IEnumerable<string> secondCollection = ["four", "five", "six"];
 
             // Act
             Action act = () => firstCollection.Should().NotHaveSameCount(secondCollection, "we want to test the {0}", "reason");

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.IntersectWith.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.IntersectWith.cs
@@ -13,8 +13,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_the_items_in_an_two_intersecting_collections_intersect_it_should_succeed()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
-            IEnumerable<string> otherCollection = new[] { "three", "four", "five" };
+            IEnumerable<string> collection = ["one", "two", "three"];
+            IEnumerable<string> otherCollection = ["three", "four", "five"];
 
             // Act / Assert
             collection.Should().IntersectWith(otherCollection);
@@ -24,8 +24,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_the_items_in_an_two_non_intersecting_collections_intersect_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
-            IEnumerable<string> otherCollection = new[] { "four", "five" };
+            IEnumerable<string> collection = ["one", "two", "three"];
+            IEnumerable<string> otherCollection = ["four", "five"];
 
             // Act
             Action action = () => collection.Should().IntersectWith(otherCollection, "they should share items");
@@ -43,7 +43,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_collection_to_not_intersect_with_same_collection_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
             IEnumerable<string> otherCollection = collection;
 
             // Act
@@ -59,8 +59,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_the_items_in_an_two_intersecting_collections_do_not_intersect_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
-            IEnumerable<string> otherCollection = new[] { "two", "three", "four" };
+            IEnumerable<string> collection = ["one", "two", "three"];
+            IEnumerable<string> otherCollection = ["two", "three", "four"];
 
             // Act
             Action action = () => collection.Should().NotIntersectWith(otherCollection, "they should not share items");
@@ -76,8 +76,8 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_asserting_the_items_in_an_two_non_intersecting_collections_do_not_intersect_it_should_succeed()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
-            IEnumerable<string> otherCollection = new[] { "four", "five" };
+            IEnumerable<string> collection = ["one", "two", "three"];
+            IEnumerable<string> otherCollection = ["four", "five"];
 
             // Act / Assert
             collection.Should().NotIntersectWith(otherCollection);

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.NotContainNulls.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.NotContainNulls.cs
@@ -27,7 +27,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_contains_multiple_nulls_that_are_unexpected_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "", null, "", null };
+            IEnumerable<string> collection = ["", null, "", null];
 
             // Act
             Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
@@ -41,7 +41,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_contains_nulls_that_are_unexpected_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "", null };
+            IEnumerable<string> collection = ["", null];
 
             // Act
             Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
@@ -55,7 +55,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_collection_does_not_contain_nulls_it_should_not_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act / Assert
             collection.Should().NotContainNulls();

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.OnlyHaveUniqueItems.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.OnlyHaveUniqueItems.cs
@@ -13,7 +13,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void Should_succeed_when_asserting_collection_with_unique_items_contains_only_unique_items()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three", "four" };
+            IEnumerable<string> collection = ["one", "two", "three", "four"];
 
             // Act / Assert
             collection.Should().OnlyHaveUniqueItems();
@@ -23,7 +23,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_a_collection_contains_duplicate_items_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "three", "three" };
+            IEnumerable<string> collection = ["one", "two", "three", "three"];
 
             // Act
             Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
@@ -37,7 +37,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_a_collection_contains_multiple_duplicate_items_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = new[] { "one", "two", "two", "three", "three" };
+            IEnumerable<string> collection = ["one", "two", "two", "three", "three"];
 
             // Act
             Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -29,11 +29,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             select new { method.Name, method.ReturnType };
 
         // Assert
-        var expectedTypes = new[]
-        {
+        Type[] expectedTypes =
+        [
             typeof(AndConstraint<StringCollectionAssertions<IEnumerable<string>>>),
             typeof(AndConstraint<SubsequentOrderingAssertions<string>>)
-        };
+        ];
 
         methods.Should().OnlyContain(method => expectedTypes.Any(e => e.IsAssignableFrom(method.ReturnType)));
     }

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.ContainValues.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.ContainValues.cs
@@ -38,7 +38,7 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().ContainValues(new[] { "Two", "Three" }, "because {0}", "we do");
+            Action act = () => dictionary.Should().ContainValues(["Two", "Three"], "because {0}", "we do");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -95,7 +95,7 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainValues(new[] { "Two" }, "because {0}", "we do");
+            Action act = () => dictionary.Should().NotContainValues(["Two"], "because {0}", "we do");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -113,7 +113,7 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainValues(new[] { "Two", "Three" }, "because {0}", "we do");
+            Action act = () => dictionary.Should().NotContainValues(["Two", "Three"], "because {0}", "we do");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -149,7 +149,7 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().NotContainValues(new[] { "Two", "Three" }, "because {0}", "we do");
+                dictionary.Should().NotContainValues(["Two", "Three"], "because {0}", "we do");
             };
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Common/ConfigurationSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Common/ConfigurationSpecs.cs
@@ -11,7 +11,7 @@ public class ConfigurationSpecs
     public void Value_formatter_detection_mode_is_disabled_with_empty_store()
     {
         // Arrange
-        var store = new DummyConfigurationStore(new Dictionary<string, string>());
+        var store = new DummyConfigurationStore([]);
         var sut = new Configuration(store);
 
         // Act / Assert

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -665,8 +665,8 @@ public class EventAssertionSpecs
             EventMetadata[] metadata = eventMonitor.MonitoredEvents;
 
             // Assert
-            metadata.Should().BeEquivalentTo(new[]
-            {
+            metadata.Should().BeEquivalentTo(
+            [
                 new
                 {
                     EventName = nameof(ClassThatRaisesEventsItself.InterfaceEvent),
@@ -677,7 +677,7 @@ public class EventAssertionSpecs
                     EventName = nameof(ClassThatRaisesEventsItself.PropertyChanged),
                     HandlerType = typeof(PropertyChangedEventHandler)
                 }
-            });
+            ]);
         }
 
         [Fact]
@@ -691,14 +691,14 @@ public class EventAssertionSpecs
             EventMetadata[] metadata = monitor.MonitoredEvents;
 
             // Assert
-            metadata.Should().BeEquivalentTo(new[]
-            {
+            metadata.Should().BeEquivalentTo(
+            [
                 new
                 {
                     EventName = nameof(IEventRaisingInterface.InterfaceEvent),
                     HandlerType = typeof(EventHandler)
                 }
-            });
+            ]);
         }
 
 #if NETFRAMEWORK // DefineDynamicAssembly is obsolete in .NET Core
@@ -804,8 +804,8 @@ public class EventAssertionSpecs
             eventSource.RaiseNonConventionalEvent("first", 123, "third");
 
             // Assert
-            monitor.OccurredEvents.Should().BeEquivalentTo(new[]
-            {
+            monitor.OccurredEvents.Should().BeEquivalentTo(
+            [
                 new
                 {
                     EventName = "PropertyChanged",
@@ -818,7 +818,7 @@ public class EventAssertionSpecs
                     TimestampUtc = utcNow,
                     Parameters = new object[] { "first", 123, "third" }
                 }
-            }, o => o.WithStrictOrdering());
+            ], o => o.WithStrictOrdering());
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -213,18 +213,18 @@ public class AsyncFunctionExceptionAssertionSpecs
 
     public static TheoryData<Func<Task>, Exception> AggregateExceptionTestData()
     {
-        var tasks = new[]
-        {
+        Func<Task>[] tasks =
+        [
             AggregateExceptionWithLeftNestedException,
             AggregateExceptionWithRightNestedException
-        };
+        ];
 
-        var types = new Exception[]
-        {
+        Exception[] types =
+        [
             new AggregateException(),
             new ArgumentNullException(),
             new InvalidOperationException()
-        };
+        ];
 
         var data = new TheoryData<Func<Task>, Exception>();
 

--- a/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
@@ -45,18 +45,18 @@ public class ExceptionAssertionSpecs
 
     public static TheoryData<Action, Exception> AggregateExceptionTestData()
     {
-        var tasks = new[]
-        {
+        Action[] tasks =
+        [
             AggregateExceptionWithLeftNestedException,
             AggregateExceptionWithRightNestedException
-        };
+        ];
 
-        var types = new Exception[]
-        {
+        Exception[] types =
+        [
             new AggregateException(),
             new ArgumentNullException(),
             new InvalidOperationException()
-        };
+        ];
 
         var data = new TheoryData<Action, Exception>();
 

--- a/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
@@ -68,18 +68,18 @@ public class FunctionExceptionAssertionSpecs
 
     public static TheoryData<Func<int>, Exception> AggregateExceptionTestData()
     {
-        var tasks = new[]
-        {
+        Func<int>[] tasks =
+        [
             AggregateExceptionWithLeftNestedException,
             AggregateExceptionWithRightNestedException
-        };
+        ];
 
-        var types = new Exception[]
-        {
+        Exception[] types =
+        [
             new AggregateException(),
             new ArgumentNullException(),
             new InvalidOperationException()
-        };
+        ];
 
         var data = new TheoryData<Func<int>, Exception>();
 

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeOneOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeOneOf.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Linq;
+using System.Collections.Generic;
 using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
@@ -51,7 +51,7 @@ public partial class DateTimeOffsetAssertionSpecs
         {
             // Arrange
             var value = new DateTimeOffset(31.December(2016), 1.Hours());
-            var expected = new[] { value, value + 1.Hours() }.AsEnumerable();
+            IEnumerable<DateTimeOffset> expected = [value, value + 1.Hours()];
 
             // Act / Assert
             value.Should().BeOneOf(expected)
@@ -63,7 +63,7 @@ public partial class DateTimeOffsetAssertionSpecs
         {
             // Arrange
             var value = new DateTimeOffset(31.December(2016), 1.Hours());
-            var expected = new DateTimeOffset?[] { null, value, value + 1.Hours() }.AsEnumerable();
+            IEnumerable<DateTimeOffset?> expected = [null, value, value + 1.Hours()];
 
             // Act / Assert
             value.Should().BeOneOf(expected)

--- a/Tests/FluentAssertions.Specs/Primitives/EnumAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/EnumAssertionSpecs.cs
@@ -769,7 +769,7 @@ public class EnumAssertionSpecs
 
             // Act / Assert
             Action act = () =>
-                flags.Should().BeOneOf(new[] { BindingFlags.Public, BindingFlags.ExactBinding }, "that's what we need");
+                flags.Should().BeOneOf([BindingFlags.Public, BindingFlags.ExactBinding], "that's what we need");
 
             act.Should()
                 .Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeOneOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeOneOf.cs
@@ -32,7 +32,7 @@ public partial class ObjectAssertionSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeOneOf(new[] { new ClassWithCustomEqualMethod(4), new ClassWithCustomEqualMethod(5) },
+                value.Should().BeOneOf([new ClassWithCustomEqualMethod(4), new ClassWithCustomEqualMethod(5)],
                     "because those are the valid values");
 
             // Assert
@@ -62,7 +62,7 @@ public partial class ObjectAssertionSpecs
             object value = new SomeClass(5);
 
             // Act / Assert
-            value.Should().BeOneOf(new[] { new SomeClass(4), new SomeClass(5) }, new SomeClassEqualityComparer());
+            value.Should().BeOneOf([new SomeClass(4), new SomeClass(5)], new SomeClassEqualityComparer());
         }
 
         [Fact]
@@ -72,7 +72,7 @@ public partial class ObjectAssertionSpecs
             var value = new SomeClass(5);
 
             // Act / Assert
-            value.Should().BeOneOf(new[] { new SomeClass(4), new SomeClass(5) }, new SomeClassEqualityComparer());
+            value.Should().BeOneOf([new SomeClass(4), new SomeClass(5)], new SomeClassEqualityComparer());
         }
 
         [Fact]
@@ -82,7 +82,7 @@ public partial class ObjectAssertionSpecs
             object value = new SomeClass(3);
 
             // Act
-            Action act = () => value.Should().BeOneOf(new[] { new SomeClass(4), new SomeClass(5) },
+            Action act = () => value.Should().BeOneOf([new SomeClass(4), new SomeClass(5)],
                 new SomeClassEqualityComparer(), "I said so");
 
             // Assert
@@ -110,7 +110,7 @@ public partial class ObjectAssertionSpecs
             var value = new SomeClass(3);
 
             // Act
-            Action act = () => value.Should().BeOneOf(new[] { new SomeClass(4), new SomeClass(5) },
+            Action act = () => value.Should().BeOneOf([new SomeClass(4), new SomeClass(5)],
                 new SomeClassEqualityComparer(), "I said so");
 
             // Assert
@@ -138,7 +138,7 @@ public partial class ObjectAssertionSpecs
             var value = new ClassWithCustomEqualMethod(3);
 
             // Act
-            Action act = () => value.Should().BeOneOf(new[] { new SomeClass(4), new SomeClass(5) },
+            Action act = () => value.Should().BeOneOf([new SomeClass(4), new SomeClass(5)],
                 new SomeClassEqualityComparer(), "I said so");
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeOneOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeOneOf.cs
@@ -32,7 +32,7 @@ public partial class StringAssertionSpecs
             string value = "abc";
 
             // Act
-            Action action = () => value.Should().BeOneOf(new[] { "def", "xyz" }, "because those are the valid values");
+            Action action = () => value.Should().BeOneOf(["def", "xyz"], "because those are the valid values");
 
             // Assert
             action.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/TypeEnumerableExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/TypeEnumerableExtensionsSpecs.cs
@@ -13,10 +13,10 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_types_that_decorated_with_attribute_it_should_return_the_correct_type()
         {
-            var types = new[]
-            {
+            Type[] types =
+            [
                 typeof(JustAClass), typeof(ClassWithSomeAttribute), typeof(ClassDerivedFromClassWithSomeAttribute)
-            };
+            ];
 
             types.ThatAreDecoratedWith<SomeAttribute>()
                 .Should()
@@ -27,10 +27,10 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_types_that_decorated_with_attribute_or_inherit_it_should_return_the_correct_type()
         {
-            var types = new[]
-            {
+            Type[] types =
+            [
                 typeof(JustAClass), typeof(ClassWithSomeAttribute), typeof(ClassDerivedFromClassWithSomeAttribute)
-            };
+            ];
 
             types.ThatAreDecoratedWithOrInherit<SomeAttribute>()
                 .Should()
@@ -42,10 +42,10 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_types_that_not_decorated_with_attribute_it_should_return_the_correct_type()
         {
-            var types = new[]
-            {
+            Type[] types =
+            [
                 typeof(JustAClass), typeof(ClassWithSomeAttribute), typeof(ClassDerivedFromClassWithSomeAttribute)
-            };
+            ];
 
             types.ThatAreNotDecoratedWith<SomeAttribute>()
                 .Should()
@@ -57,10 +57,10 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_selecting_types_that_not_decorated_with_attribute_or_inherit_it_should_return_the_correct_type()
         {
-            var types = new[]
-            {
+            Type[] types =
+            [
                 typeof(JustAClass), typeof(ClassWithSomeAttribute), typeof(ClassDerivedFromClassWithSomeAttribute)
-            };
+            ];
 
             types.ThatAreNotDecoratedWithOrInherit<SomeAttribute>()
                 .Should()
@@ -171,7 +171,7 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_unwrap_task_types_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(Task<JustAClass>), typeof(List<IJustAnInterface>) };
+            Type[] types = [typeof(Task<JustAClass>), typeof(List<IJustAnInterface>)];
 
             types.UnwrapTaskTypes()
                 .Should()
@@ -183,7 +183,7 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_unwrap_enumerable_types_it_should_return_the_correct_type()
         {
-            var types = new[] { typeof(Task<JustAClass>), typeof(List<IJustAnInterface>) };
+            Type[] types = [typeof(Task<JustAClass>), typeof(List<IJustAnInterface>)];
 
             types.UnwrapEnumerableTypes()
                 .Should()

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -344,11 +344,11 @@ public class PropertyInfoSelectorSpecs
 
         // Assert
         returnTypes.Should()
-            .BeEquivalentTo(new[]
-            {
+            .BeEquivalentTo(
+            [
                 typeof(string), typeof(string), typeof(string), typeof(string), typeof(string), typeof(string), typeof(string),
                 typeof(string), typeof(int), typeof(int), typeof(int), typeof(int)
-            });
+            ]);
     }
 
     public class ThatArePublicOrInternal

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorAssertionSpecs.cs
@@ -16,10 +16,10 @@ public class TypeSelectorAssertionSpecs
         public void When_all_types_are_sealed_it_succeeds()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(Sealed)
-            });
+            ]);
 
             // Act / Assert
             types.Should().BeSealed();
@@ -29,11 +29,11 @@ public class TypeSelectorAssertionSpecs
         public void When_any_type_is_not_sealed_it_fails_with_a_meaningful_message()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(Sealed),
                 typeof(Abstract)
-            });
+            ]);
 
             // Act
             Action act = () => types.Should().BeSealed("we want to test the failure {0}", "message");
@@ -51,10 +51,10 @@ public class TypeSelectorAssertionSpecs
         public void When_all_types_are_not_sealed_it_succeeds()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(Abstract)
-            });
+            ]);
 
             // Act / Assert
             types.Should().NotBeSealed();
@@ -64,11 +64,11 @@ public class TypeSelectorAssertionSpecs
         public void When_any_type_is_sealed_it_fails_with_a_meaningful_message()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(Abstract),
                 typeof(Sealed)
-            });
+            ]);
 
             // Act
             Action act = () => types.Should().NotBeSealed("we want to test the failure {0}", "message");
@@ -85,10 +85,10 @@ public class TypeSelectorAssertionSpecs
         public void When_asserting_a_selection_of_decorated_types_is_decorated_with_an_attribute_it_succeeds()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassWithAttribute)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -102,12 +102,12 @@ public class TypeSelectorAssertionSpecs
         public void When_asserting_a_selection_of_non_decorated_types_is_decorated_with_an_attribute_it_fails()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassWithAttribute),
                 typeof(ClassWithoutAttribute),
                 typeof(OtherClassWithoutAttribute)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -140,12 +140,12 @@ public class TypeSelectorAssertionSpecs
         public void When_asserting_a_selection_of_types_with_unexpected_attribute_property_it_fails()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassWithAttribute),
                 typeof(ClassWithoutAttribute),
                 typeof(OtherClassWithoutAttribute)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -168,10 +168,10 @@ public class TypeSelectorAssertionSpecs
         public void When_asserting_a_selection_of_decorated_types_inheriting_an_attribute_it_succeeds()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassWithInheritedAttribute)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -185,12 +185,12 @@ public class TypeSelectorAssertionSpecs
         public void When_asserting_a_selection_of_non_decorated_types_inheriting_an_attribute_it_fails()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassWithAttribute),
                 typeof(ClassWithoutAttribute),
                 typeof(OtherClassWithoutAttribute)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -224,13 +224,13 @@ public class TypeSelectorAssertionSpecs
             When_asserting_a_selection_of_types_with_some_inheriting_attributes_with_unexpected_attribute_property_it_fails()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassWithAttribute),
                 typeof(ClassWithInheritedAttribute),
                 typeof(ClassWithoutAttribute),
                 typeof(OtherClassWithoutAttribute)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -253,11 +253,11 @@ public class TypeSelectorAssertionSpecs
         public void When_asserting_a_selection_of_non_decorated_types_is_not_decorated_with_an_attribute_it_succeeds()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassWithoutAttribute),
                 typeof(OtherClassWithoutAttribute)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -271,11 +271,11 @@ public class TypeSelectorAssertionSpecs
         public void When_asserting_a_selection_of_decorated_types_is_not_decorated_with_an_attribute_it_fails()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassWithoutAttribute),
                 typeof(ClassWithAttribute)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -307,11 +307,11 @@ public class TypeSelectorAssertionSpecs
         public void When_asserting_a_selection_of_types_with_unexpected_attribute_and_unexpected_attribute_property_it_fails()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassWithoutAttribute),
                 typeof(ClassWithAttribute)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -334,11 +334,11 @@ public class TypeSelectorAssertionSpecs
         public void When_asserting_a_selection_of_non_decorated_types_does_not_inherit_an_attribute_it_succeeds()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassWithoutAttribute),
                 typeof(OtherClassWithoutAttribute)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -352,11 +352,11 @@ public class TypeSelectorAssertionSpecs
         public void When_asserting_a_selection_of_decorated_types_does_not_inherit_an_attribute_it_fails()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassWithoutAttribute),
                 typeof(ClassWithInheritedAttribute)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -437,12 +437,12 @@ public class TypeSelectorAssertionSpecs
         public void When_a_type_is_not_in_the_expected_namespace_it_should_throw()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassInDummyNamespace),
                 typeof(ClassNotInDummyNamespace),
                 typeof(OtherClassNotInDummyNamespace)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -488,12 +488,12 @@ public class TypeSelectorAssertionSpecs
         public void When_a_type_is_not_in_the_expected_global_namespace_it_should_throw()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassInDummyNamespace),
                 typeof(ClassNotInDummyNamespace),
                 typeof(OtherClassNotInDummyNamespace)
-            });
+            ]);
 
             // Act
             Action act = () => types.Should().BeInNamespace(null);
@@ -539,12 +539,12 @@ public class TypeSelectorAssertionSpecs
         public void When_a_type_is_in_the_unexpected_namespace_it_should_throw()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassInDummyNamespace),
                 typeof(ClassNotInDummyNamespace),
                 typeof(OtherClassNotInDummyNamespace)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -617,12 +617,12 @@ public class TypeSelectorAssertionSpecs
         public void When_a_type_is_under_the_expected_global_namespace_it_should_not_throw()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassInDummyNamespace),
                 typeof(ClassNotInDummyNamespace),
                 typeof(OtherClassNotInDummyNamespace)
-            });
+            ]);
 
             // Act
             Action act = () => types.Should().BeUnderNamespace(null);
@@ -651,11 +651,11 @@ public class TypeSelectorAssertionSpecs
         public void When_asserting_a_selection_of_types_not_under_a_namespace_is_under_that_namespace_it_fails()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassInDummyNamespace),
                 typeof(ClassInInnerDummyNamespace)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -675,12 +675,12 @@ public class TypeSelectorAssertionSpecs
         public void When_a_types_is_not_under_the_unexpected_namespace_it_should_not_throw()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassInDummyNamespace),
                 typeof(ClassNotInDummyNamespace),
                 typeof(OtherClassNotInDummyNamespace)
-            });
+            ]);
 
             // Act
             Action act = () =>
@@ -760,12 +760,12 @@ public class TypeSelectorAssertionSpecs
         public void When_a_type_is_under_the_unexpected_parent_global_namespace_it_should_throw()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassInDummyNamespace),
                 typeof(ClassNotInDummyNamespace),
                 typeof(OtherClassNotInDummyNamespace)
-            });
+            ]);
 
             // Act
             Action act = () => types.Should().NotBeUnderNamespace(null);
@@ -797,10 +797,10 @@ public class TypeSelectorAssertionSpecs
         public void When_accidentally_using_equals_it_should_throw_a_helpful_error()
         {
             // Arrange
-            var types = new TypeSelector(new[]
-            {
+            var types = new TypeSelector(
+            [
                 typeof(ClassWithAttribute)
-            });
+            ]);
 
             // Act
             var action = () => types.Should().Equals(null);


### PR DESCRIPTION
Found some more places where I could apply collection expressions and two places for the `..` spread operator.


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
