### PR TITLE
Cleanups

### DIFF
--- a/Src/FluentAssertions/Common/Guard.cs
+++ b/Src/FluentAssertions/Common/Guard.cs
@@ -120,7 +120,5 @@ internal static class Guard
     /// https://github.com/dotnet/roslyn-analyzers/issues/3451#issuecomment-606690452
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
-    private sealed class ValidatedNotNullAttribute : Attribute
-    {
-    }
+    private sealed class ValidatedNotNullAttribute : Attribute;
 }

--- a/Src/FluentAssertions/CustomAssertionAttribute.cs
+++ b/Src/FluentAssertions/CustomAssertionAttribute.cs
@@ -8,6 +8,4 @@ namespace FluentAssertions;
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
 #pragma warning disable CA1813 // Avoid unsealed attributes. This type has shipped.
-public class CustomAssertionAttribute : Attribute
-{
-}
+public class CustomAssertionAttribute : Attribute;

--- a/Src/FluentAssertions/CustomAssertionsAssemblyAttribute.cs
+++ b/Src/FluentAssertions/CustomAssertionsAssemblyAttribute.cs
@@ -7,6 +7,4 @@ namespace FluentAssertions;
 /// internally, or directly uses the <c>Execute.Assertion</c>.
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly)]
-public sealed class CustomAssertionsAssemblyAttribute : Attribute
-{
-}
+public sealed class CustomAssertionsAssemblyAttribute : Attribute;

--- a/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using FluentAssertions.Common;
 

--- a/Src/FluentAssertions/Formatting/ValueFormatterAttribute.cs
+++ b/Src/FluentAssertions/Formatting/ValueFormatterAttribute.cs
@@ -7,6 +7,4 @@ namespace FluentAssertions.Formatting;
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
 #pragma warning disable CA1813 // Avoid unsealed attributes. This type has shipped.
-public class ValueFormatterAttribute : Attribute
-{
-}
+public class ValueFormatterAttribute : Attribute;

--- a/Tests/AssemblyB/ClassB.cs
+++ b/Tests/AssemblyB/ClassB.cs
@@ -1,5 +1,3 @@
 ﻿namespace AssemblyB;
 
-public class ClassB
-{
-}
+public class ClassB;

--- a/Tests/AssemblyB/ClassC.cs
+++ b/Tests/AssemblyB/ClassC.cs
@@ -1,5 +1,3 @@
 ﻿namespace AssemblyB;
 
-public class ClassC
-{
-}
+public class ClassC;

--- a/Tests/FluentAssertions.Equivalency.Specs/AssertionRuleSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/AssertionRuleSpecs.cs
@@ -245,9 +245,7 @@ public class AssertionRuleSpecs
         act.Should().Throw<XunitException>().WithMessage("*ConcreteClassEqualityComparer*");
     }
 
-    private interface IInterface
-    {
-    }
+    private interface IInterface;
 
     private class ConcreteClass : IInterface
     {

--- a/Tests/FluentAssertions.Equivalency.Specs/IsExternalInit.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/IsExternalInit.cs
@@ -8,6 +8,4 @@ namespace System.Runtime.CompilerServices;
 /// This class should not be used by developers in source code.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
-internal static class IsExternalInit
-{
-}
+internal static class IsExternalInit;

--- a/Tests/FluentAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
@@ -315,9 +315,7 @@ public class NestedPropertiesSpecs
         orig.Should().BeEquivalentTo(expectation);
     }
 
-    public class Inner
-    {
-    }
+    public class Inner;
 
     public class OuterWithObject
     {

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Basic.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Basic.cs
@@ -292,8 +292,6 @@ public partial class SelectionRulesSpecs
             public ClassWithoutProperty ClassWithoutProperty { get; } = new();
         }
 
-        internal class ClassWithoutProperty
-        {
-        }
+        internal class ClassWithoutProperty;
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Interfaces.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Interfaces.cs
@@ -371,8 +371,6 @@ public partial class SelectionRulesSpecs
             public int Value2 { get; set; }
         }
 
-        public class DerivedClassImplementingInterface : BaseProvidingSamePropertiesAsInterface, IInterfaceWithTwoProperties
-        {
-        }
+        public class DerivedClassImplementingInterface : BaseProvidingSamePropertiesAsInterface, IInterfaceWithTwoProperties;
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
@@ -114,9 +114,7 @@ internal class ClassWithEnumFour
     public EnumFour Enum { get; set; }
 }
 
-internal class ClassWithNoMembers
-{
-}
+internal class ClassWithNoMembers;
 
 internal class ClassWithOnlyAField
 {
@@ -138,9 +136,7 @@ internal class ClassWithOnlyAProperty
     public int Value { get; set; }
 }
 
-internal struct StructWithNoMembers
-{
-}
+internal struct StructWithNoMembers;
 
 internal class ClassWithSomeFieldsAndProperties
 {

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -16,9 +16,7 @@ public class AssertionOptionsSpecs
 {
     // Due to tests that call AssertionOptions
     [CollectionDefinition("AssertionOptionsSpecs", DisableParallelization = true)]
-    public class AssertionOptionsSpecsDefinition
-    {
-    }
+    public class AssertionOptionsSpecsDefinition;
 
     public abstract class Given_temporary_global_assertion_options : GivenWhenThen
     {

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions.Execution;
 using Xunit;

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyContain.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyContain.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Satisfy.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Satisfy.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions.Execution;
 using Xunit;

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.SatisfyRespectively.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.SatisfyRespectively.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/FluentAssertions.Specs/ConfigurationSpecs.cs
+++ b/Tests/FluentAssertions.Specs/ConfigurationSpecs.cs
@@ -33,6 +33,4 @@ public class ConfigurationSpecs
 
 // Due to tests that call Configuration.Current
 [CollectionDefinition("ConfigurationSpecs", DisableParallelization = true)]
-public class ConfigurationSpecsDefinition
-{
-}
+public class ConfigurationSpecsDefinition;

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -984,13 +984,9 @@ public class EventAssertionSpecs
         }
     }
 
-    public class B
-    {
-    }
+    public class B;
 
-    public class C
-    {
-    }
+    public class C;
 
     public class ClassThatRaisesEventsItself : IInheritsEventRaisingInterface
     {
@@ -1055,9 +1051,7 @@ public class EventAssertionSpecs
         event EventHandler Interface3Event;
     }
 
-    public interface IInheritsEventRaisingInterface : IEventRaisingInterface
-    {
-    }
+    public interface IInheritsEventRaisingInterface : IEventRaisingInterface;
 
     public class EventRaisingClass : INotifyPropertyChanged
     {

--- a/Tests/FluentAssertions.Specs/Extensions/ObjectCastingSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/ObjectCastingSpecs.cs
@@ -20,9 +20,7 @@ public class ObjectCastingSpecs
         derivedInstance.DerivedProperty.Should().Be("hello");
     }
 
-    private class SomeBaseClass
-    {
-    }
+    private class SomeBaseClass;
 
     private class SomeDerivedClass : SomeBaseClass
     {

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -51,9 +51,7 @@ public class FormatterSpecs
         exception.Message.Should().NotContainEquivalentOf("cyclic");
     }
 
-    private class A
-    {
-    }
+    private class A;
 
     private class B
     {
@@ -1095,17 +1093,11 @@ public class FormatterSpecs
         }
     }
 
-    public class SomeClassInheritedFromClassWithCustomFormatterLvl1 : SomeClassWithCustomFormatter
-    {
-    }
+    public class SomeClassInheritedFromClassWithCustomFormatterLvl1 : SomeClassWithCustomFormatter;
 
-    public class SomeClassInheritedFromClassWithCustomFormatterLvl2 : SomeClassInheritedFromClassWithCustomFormatterLvl1
-    {
-    }
+    public class SomeClassInheritedFromClassWithCustomFormatterLvl2 : SomeClassInheritedFromClassWithCustomFormatterLvl1;
 
-    public class SomeClassInheritedFromClassWithCustomFormatterLvl3 : SomeClassInheritedFromClassWithCustomFormatterLvl2
-    {
-    }
+    public class SomeClassInheritedFromClassWithCustomFormatterLvl3 : SomeClassInheritedFromClassWithCustomFormatterLvl2;
 
     public static class CustomFormatter
     {
@@ -1229,9 +1221,7 @@ public class FormatterSpecs
 
 // Due to the tests that call Configuration.Current
 [CollectionDefinition("FormatterSpecs", DisableParallelization = true)]
-public class FormatterSpecsDefinition
-{
-}
+public class FormatterSpecsDefinition;
 
 internal class ExceptionThrowingClass
 {

--- a/Tests/FluentAssertions.Specs/IsExternalInit.cs
+++ b/Tests/FluentAssertions.Specs/IsExternalInit.cs
@@ -8,6 +8,4 @@ namespace System.Runtime.CompilerServices;
 /// This class should not be used by developers in source code.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
-internal static class IsExternalInit
-{
-}
+internal static class IsExternalInit;

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -45,9 +45,7 @@ public partial class ObjectAssertionSpecs
     }
 }
 
-internal class DummyBaseClass
-{
-}
+internal class DummyBaseClass;
 
 internal sealed class DummyImplementingClass : DummyBaseClass, IDisposable
 {

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -538,8 +538,7 @@ internal class ClassWithCustomEqualMethod
     }
 }
 
-public abstract class SimpleComplexBase
-{ }
+public abstract class SimpleComplexBase;
 
 public class Simple : SimpleComplexBase
 {

--- a/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
@@ -371,6 +371,4 @@ public class StringComparisonSpecs
 
 // Due to CulturedTheory changing CultureInfo
 [CollectionDefinition(nameof(StringComparisonSpecs), DisableParallelization = true)]
-public class StringComparisonDefinition
-{
-}
+public class StringComparisonDefinition;

--- a/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
@@ -387,6 +387,4 @@ public class AssemblyAssertionSpecs
 }
 
 [DummyClass("name", true)]
-public class WellKnownClassWithAttribute
-{
-}
+public class WellKnownClassWithAttribute;

--- a/Tests/FluentAssertions.Specs/TypeEnumerableExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/TypeEnumerableExtensionsSpecs.cs
@@ -198,57 +198,35 @@ namespace FluentAssertions.Specs
 
 namespace TypeEnumerableExtensionsSpecs.BaseNamespace
 {
-    internal class BaseNamespaceClass
-    {
-    }
+    internal class BaseNamespaceClass;
 }
 
 namespace TypeEnumerableExtensionsSpecs.BaseNamespace.Nested
 {
-    internal class NestedNamespaceClass
-    {
-    }
+    internal class NestedNamespaceClass;
 }
 
 namespace TypeEnumerableExtensionsSpecs.Internal
 {
-    internal interface IJustAnInterface
-    {
-    }
+    internal interface IJustAnInterface;
 
-    internal class JustAClass
-    {
-    }
+    internal class JustAClass;
 
-    internal static class AStaticClass
-    {
-    }
+    internal static class AStaticClass;
 
-    internal class SomeBaseClass
-    {
-    }
+    internal class SomeBaseClass;
 
-    internal class SomeClassDerivedFromSomeBaseClass : SomeBaseClass
-    {
-    }
+    internal class SomeClassDerivedFromSomeBaseClass : SomeBaseClass;
 
-    internal class ClassImplementingJustAnInterface : IJustAnInterface
-    {
-    }
+    internal class ClassImplementingJustAnInterface : IJustAnInterface;
 
     [Some]
-    internal class ClassWithSomeAttribute
-    {
-    }
+    internal class ClassWithSomeAttribute;
 
-    internal class ClassDerivedFromClassWithSomeAttribute : ClassWithSomeAttribute
-    {
-    }
+    internal class ClassDerivedFromClassWithSomeAttribute : ClassWithSomeAttribute;
 
     [AttributeUsage(AttributeTargets.Class)]
-    internal class SomeAttribute : Attribute
-    {
-    }
+    internal class SomeAttribute : Attribute;
 }
 
 #endregion

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveDefaultConstructor.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveDefaultConstructor.cs
@@ -179,13 +179,9 @@ public partial class TypeAssertionSpecs
         }
     }
 
-    internal class ClassWithNoMembers
-    {
-    }
+    internal class ClassWithNoMembers;
 
-    internal class ClassWithCctor
-    {
-    }
+    internal class ClassWithCctor;
 
     internal class ClassWithCctorAndNonDefaultConstructor
     {

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -6,28 +6,18 @@ namespace FluentAssertions.Specs.Types
     /// <summary>
     /// Type assertion specs.
     /// </summary>
-    public partial class TypeAssertionSpecs
-    {
-    }
+    public partial class TypeAssertionSpecs;
 
     #region Internal classes used in unit tests
 
     [DummyClass("Expected", true)]
-    public class ClassWithAttribute
-    {
-    }
+    public class ClassWithAttribute;
 
-    public class ClassWithInheritedAttribute : ClassWithAttribute
-    {
-    }
+    public class ClassWithInheritedAttribute : ClassWithAttribute;
 
-    public class ClassWithoutAttribute
-    {
-    }
+    public class ClassWithoutAttribute;
 
-    public class OtherClassWithoutAttribute
-    {
-    }
+    public class OtherClassWithoutAttribute;
 
     [AttributeUsage(AttributeTargets.Class)]
     public class DummyClassAttribute : Attribute
@@ -43,29 +33,17 @@ namespace FluentAssertions.Specs.Types
         }
     }
 
-    public interface IDummyInterface
-    {
-    }
+    public interface IDummyInterface;
 
-    public interface IDummyInterface<T>
-    {
-    }
+    public interface IDummyInterface<T>;
 
-    public class ClassThatImplementsInterface : IDummyInterface, IDummyInterface<IDummyInterface>
-    {
-    }
+    public class ClassThatImplementsInterface : IDummyInterface, IDummyInterface<IDummyInterface>;
 
-    public class ClassThatDoesNotImplementInterface
-    {
-    }
+    public class ClassThatDoesNotImplementInterface;
 
-    public class DummyBaseType<T> : IDummyInterface<IDummyInterface>
-    {
-    }
+    public class DummyBaseType<T> : IDummyInterface<IDummyInterface>;
 
-    public class ClassWithGenericBaseType : DummyBaseType<ClassWithGenericBaseType>
-    {
-    }
+    public class ClassWithGenericBaseType : DummyBaseType<ClassWithGenericBaseType>;
 
     public class ClassWithMembers
     {
@@ -132,25 +110,15 @@ namespace FluentAssertions.Specs.Types
         void ExplicitImplicitMethod(string overload);
     }
 
-    public class ClassWithoutMembers
-    {
-    }
+    public class ClassWithoutMembers;
 
-    public interface IPublicInterface
-    {
-    }
+    public interface IPublicInterface;
 
-    internal interface IInternalInterface
-    {
-    }
+    internal interface IInternalInterface;
 
-    internal class InternalClass
-    {
-    }
+    internal class InternalClass;
 
-    internal struct InternalStruct
-    {
-    }
+    internal struct InternalStruct;
 
     internal enum InternalEnum
     {
@@ -160,23 +128,15 @@ namespace FluentAssertions.Specs.Types
 
     internal class Nested
     {
-        private class PrivateClass
-        {
-        }
+        private class PrivateClass;
 
         protected enum ProtectedEnum { }
 
-        public interface IPublicInterface
-        {
-        }
+        public interface IPublicInterface;
 
-        internal class InternalClass
-        {
-        }
+        internal class InternalClass;
 
-        protected internal interface IProtectedInternalInterface
-        {
-        }
+        protected internal interface IProtectedInternalInterface;
     }
 
     internal readonly struct TypeWithConversionOperators
@@ -195,31 +155,19 @@ namespace FluentAssertions.Specs.Types
             (byte)typeWithConversionOperators.value;
     }
 
-    internal sealed class Sealed
-    {
-    }
+    internal sealed class Sealed;
 
-    internal abstract class Abstract
-    {
-    }
+    internal abstract class Abstract;
 
-    internal static class Static
-    {
-    }
+    internal static class Static;
 
-    internal struct Struct
-    {
-    }
+    internal struct Struct;
 
     public delegate void ExampleDelegate();
 
-    internal class ClassNotInDummyNamespace
-    {
-    }
+    internal class ClassNotInDummyNamespace;
 
-    internal class OtherClassNotInDummyNamespace
-    {
-    }
+    internal class OtherClassNotInDummyNamespace;
 
     #endregion
 }
@@ -232,9 +180,7 @@ namespace AssemblyB
     /// A class that intentionally has the exact same name and namespace as the ClassC from the AssemblyB
     /// assembly. This class is used to test the behavior of comparisons on such types.
     /// </summary>
-    internal class ClassC
-    {
-    }
+    internal class ClassC;
 
 #pragma warning restore 436
 }
@@ -243,23 +189,17 @@ namespace AssemblyB
 
 namespace DummyNamespace
 {
-    internal class ClassInDummyNamespace
-    {
-    }
+    internal class ClassInDummyNamespace;
 
     namespace InnerDummyNamespace
     {
-        internal class ClassInInnerDummyNamespace
-        {
-        }
+        internal class ClassInInnerDummyNamespace;
     }
 }
 
 namespace DummyNamespaceTwo
 {
-    internal class ClassInDummyNamespaceTwo
-    {
-    }
+    internal class ClassInDummyNamespaceTwo;
 }
 
 #endregion

--- a/Tests/FluentAssertions.Specs/Types/TypeExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeExtensionsSpecs.cs
@@ -208,13 +208,9 @@ public class TypeExtensionsSpecs
         );
     }
 
-    private class InheritedType
-    {
-    }
+    private class InheritedType;
 
-    private class InheritingType : InheritedType
-    {
-    }
+    private class InheritingType : InheritedType;
 
     private readonly struct TypeWithFakeConversionOperators
     {

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -727,40 +727,26 @@ namespace FluentAssertions.Specs.Types
 
 namespace Internal.Main.Test
 {
-    internal class SomeBaseClass
-    {
-    }
+    internal class SomeBaseClass;
 
-    internal class ClassDerivedFromSomeBaseClass : SomeBaseClass
-    {
-    }
+    internal class ClassDerivedFromSomeBaseClass : SomeBaseClass;
 
     internal class SomeGenericBaseClass<T>
     {
         public T Value { get; set; }
     }
 
-    internal class ClassDerivedFromSomeGenericBaseClass : SomeGenericBaseClass<int>
-    {
-    }
+    internal class ClassDerivedFromSomeGenericBaseClass : SomeGenericBaseClass<int>;
 
-    internal interface ISomeInterface
-    {
-    }
+    internal interface ISomeInterface;
 
-    internal class ClassImplementingSomeInterface : ISomeInterface
-    {
-    }
+    internal class ClassImplementingSomeInterface : ISomeInterface;
 
     [AttributeUsage(AttributeTargets.Class)]
-    internal class SomeAttribute : Attribute
-    {
-    }
+    internal class SomeAttribute : Attribute;
 
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-    internal class SomeNonInheritableAttribute : Attribute
-    {
-    }
+    internal class SomeNonInheritableAttribute : Attribute;
 
     [Some]
     internal class ClassWithSomeAttribute
@@ -772,9 +758,7 @@ namespace Internal.Main.Test
         }
     }
 
-    internal class ClassWithSomeAttributeDerived : ClassWithSomeAttribute
-    {
-    }
+    internal class ClassWithSomeAttributeDerived : ClassWithSomeAttribute;
 
     [SomeNonInheritable]
     internal class ClassWithSomeNonInheritableAttribute
@@ -786,9 +770,7 @@ namespace Internal.Main.Test
         }
     }
 
-    internal class ClassWithSomeNonInheritableAttributeDerived : ClassWithSomeNonInheritableAttribute
-    {
-    }
+    internal class ClassWithSomeNonInheritableAttributeDerived : ClassWithSomeNonInheritableAttribute;
 
     [Some]
     internal class ClassWithSomeAttributeThatImplementsSomeInterface : ISomeInterface
@@ -803,72 +785,48 @@ namespace Internal.Main.Test
 
 namespace Internal.Other.Test
 {
-    internal class SomeOtherClass
-    {
-    }
+    internal class SomeOtherClass;
 }
 
 namespace Internal.Other.Test.Common
 {
-    internal class SomeCommonClass
-    {
-    }
+    internal class SomeCommonClass;
 }
 
 namespace Internal.NotOnlyClasses.Test
 {
-    internal class NotOnlyClassesClass
-    {
-    }
+    internal class NotOnlyClassesClass;
 
     internal enum NotOnlyClassesEnumeration
     {
     }
 
-    internal interface INotOnlyClassesInterface
-    {
-    }
+    internal interface INotOnlyClassesInterface;
 }
 
 namespace Internal.StaticAndNonStaticClasses.Test
 {
-    internal static class StaticClass
-    {
-    }
+    internal static class StaticClass;
 
-    internal class NotAStaticClass
-    {
-    }
+    internal class NotAStaticClass;
 }
 
 namespace Internal.AbstractAndNotAbstractClasses.Test
 {
-    internal abstract class AbstractClass
-    {
-    }
+    internal abstract class AbstractClass;
 
-    internal class NotAbstractClass
-    {
-    }
+    internal class NotAbstractClass;
 
-    internal static class NotAbstractStaticClass
-    {
-    }
+    internal static class NotAbstractStaticClass;
 }
 
 namespace Internal.InterfaceAndClasses.Test
 {
-    internal interface InternalInterface
-    {
-    }
+    internal interface InternalInterface;
 
-    internal abstract class InternalAbstractClass
-    {
-    }
+    internal abstract class InternalAbstractClass;
 
-    internal class InternalNotInterfaceClass
-    {
-    }
+    internal class InternalNotInterfaceClass;
 }
 
 namespace Internal.UnwrapSelectorTestTypes.Test
@@ -910,26 +868,18 @@ namespace Internal.UnwrapSelectorTestTypes.Test
 
 namespace Internal.SealedAndNotSealedClasses.Test
 {
-    internal sealed class SealedClass
-    {
-    }
+    internal sealed class SealedClass;
 
-    internal class NotSealedClass
-    {
-    }
+    internal class NotSealedClass;
 }
 
 namespace Internal.ValueTypesAndNotValueTypes.Test
 {
-    internal struct InternalStructValueType
-    {
-    }
+    internal struct InternalStructValueType;
 
     internal record struct InternalRecordStructValueType;
 
-    internal class InternalClassNotValueType
-    {
-    }
+    internal class InternalClassNotValueType;
 
     internal record class InternalRecordClass;
 
@@ -937,15 +887,11 @@ namespace Internal.ValueTypesAndNotValueTypes.Test
     {
     }
 
-    internal interface InternalInterfaceNotValueType
-    {
-    }
+    internal interface InternalInterfaceNotValueType;
 }
 
 #pragma warning disable RCS1110, S3903 // Declare type inside namespace.
-internal class ClassInGlobalNamespace
-{
-}
+internal class ClassInGlobalNamespace;
 #pragma warning restore RCS1110, S3903
 
 #endregion

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using FluentAssertions.Types;

--- a/Tests/FluentAssertions.Specs/UIFactsDefinition.cs
+++ b/Tests/FluentAssertions.Specs/UIFactsDefinition.cs
@@ -4,6 +4,4 @@ namespace FluentAssertions.Specs;
 
 // Try to stabilize UIFact tests
 [CollectionDefinition("UIFacts", DisableParallelization = true)]
-public class UIFactsDefinition
-{
-}
+public class UIFactsDefinition;


### PR DESCRIPTION
In #2489 The qodana report had new issues, see https://qodana.cloud/projects/AgRgk/reports/v45jn

This PR fixes those.

We haven't decided on how we feel about using primary constructors in general, but for empty types I don't see any problems.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
