### PR TITLE
BeEmpty() materializes IEnumerable<T> only once, even on failure

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -639,13 +639,14 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// </param>
     public AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs)
     {
-        var nullOrEmpty = Subject is null || !Subject.Any();
+        var singleItemArray = Subject?.Take(1).ToArray();
+        var nullOrEmpty = singleItemArray is null || singleItemArray.Length == 0;
 
         Execute.Assertion.ForCondition(nullOrEmpty)
             .BecauseOf(because, becauseArgs)
             .FailWith(
-                "Expected {context:collection} to be null or empty{reason}, but found {0}.",
-                Subject);
+                "Expected {context:collection} to be null or empty{reason}, but found at least one item {0}.",
+                singleItemArray);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -294,7 +294,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .FailWith("but found <null>.")
             .Then
             .ForCondition(subject => subject.Length == 0)
-            .FailWith("but found at least 1 item {0}.", singleItemArray)
+            .FailWith("but found at least one item {0}.", singleItemArray)
             .Then
             .ClearExpectation();
 

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -285,15 +285,16 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// </param>
     public AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs)
     {
+        var singleItemArray = Subject?.Take(1).ToArray();
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:collection} to be empty{reason}, ")
-            .Given(() => Subject)
+            .Given(() => singleItemArray)
             .ForCondition(subject => subject is not null)
             .FailWith("but found <null>.")
             .Then
-            .ForCondition(subject => !subject.Any())
-            .FailWith("but found {0}.", Subject)
+            .ForCondition(subject => subject.Length == 0)
+            .FailWith("but found at least 1 item {0}.", singleItemArray)
             .Then
             .ClearExpectation();
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -35,7 +35,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty because that's what we expect, but found*1*2*3*");
+                .WithMessage("*to be empty because that's what we expect, but found at least 1 item {1}.");
         }
 
         [Fact]
@@ -116,6 +116,21 @@ public partial class CollectionAssertionSpecs
             collection.Should().BeEmpty();
 
             // Assert
+            collection.GetEnumeratorCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void When_asserting_non_empty_collection_is_empty_it_should_enumerate_only_once()
+        {
+            // Arrange
+            var collection = new CountingGenericEnumerable<int>([1, 2, 3]);
+
+            // Act
+            Action act = () => collection.Should().BeEmpty();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*to be empty, but found at least 1 item {1}.");
             collection.GetEnumeratorCallCount.Should().Be(1);
         }
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -35,7 +35,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty because that's what we expect, but found at least 1 item {1}.");
+                .WithMessage("*to be empty because that's what we expect, but found at least one item*1*");
         }
 
         [Fact]
@@ -130,7 +130,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty, but found at least 1 item {1}.");
+                .WithMessage("*to be empty, but found at least one item {1}.");
             collection.GetEnumeratorCallCount.Should().Be(1);
         }
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
@@ -61,6 +61,21 @@ public partial class CollectionAssertionSpecs
             // Assert
             collection.GetEnumeratorCallCount.Should().Be(1);
         }
+
+        [Fact]
+        public void When_asserting_non_empty_collection_is_null_or_empty_it_should_enumerate_only_once()
+        {
+            // Arrange
+            var collection = new CountingGenericEnumerable<int>([1, 2, 3]);
+
+            // Act
+            Action act = () => collection.Should().BeNullOrEmpty();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*to be null or empty, but found at least one item {1}.");
+            collection.GetEnumeratorCallCount.Should().Be(1);
+        }
     }
 
     public class NotBeNullOrEmpty

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
@@ -46,7 +46,7 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to be null or empty because we want to test the failure message, but found {1, 2, 3}.");
+                    "Expected collection to be null or empty because we want to test the failure message, but found at least one item {1}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEmpty.cs
@@ -59,7 +59,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to be empty because we want to test the failure message, but found*one*two*three*");
+                    "Expected collection to be empty because we want to test the failure message, but found at least one item*one*");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.BeEmpty.cs
@@ -50,7 +50,7 @@ public partial class GenericDictionaryAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected dictionary to be empty because we want to test the failure message, but found {[1] = \"One\"}.");
+                    "Expected dictionary to be empty because we want to test the failure message, but found at least one item {[1, One]}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -56,14 +56,13 @@ public class ReferenceTypeAssertionsSpecs
     [Fact]
     public void When_a_derived_class_has_longer_formatting_than_the_base_class()
     {
-        var subject = new SimpleComplexBase[] { new Simple(), new Complex("goodbye") };
+        var subject = new SimpleComplexBase[] { new Complex("goodbye"), new Simple() };
         Action act = () => subject.Should().BeEmpty();
         act.Should().Throw<XunitException>()
             .WithMessage(
             """
-            Expected subject to be empty, but found 
+            Expected subject to be empty, but found at least one item 
             {
-                Simple(Hello), 
                 FluentAssertions.Specs.Primitives.Complex
                 {
                     Statement = "goodbye"


### PR DESCRIPTION
- Make BeEmpty() materialize only the first item, as no further processing is needed for validation
- The error message now mentions "but found at least one item" and outputs the said item

Fixes #2490

<!-- Please provide a description of your changes above the IMPORTANT checklist -->

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
