### PR TITLE
Add missing `NotBeIn(DateTimeKind)` `DateTime` assertion

### DIFF
--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -950,7 +950,7 @@ public class DateTimeAssertions<TAssertions>
             .ForCondition(subject => subject.HasValue)
             .FailWith(", but found a <null> DateTime.")
             .Then
-            .ForCondition(subject => subject.GetValueOrDefault()!.Kind != unexpectedKind)
+            .ForCondition(subject => subject.GetValueOrDefault().Kind != unexpectedKind)
             .FailWith(", but it was.")
             .Then
             .ClearExpectation();

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -950,7 +950,7 @@ public class DateTimeAssertions<TAssertions>
             .ForCondition(subject => subject.HasValue)
             .FailWith(", but found a <null> DateTime.")
             .Then
-            .ForCondition(subject => subject.Value!.Kind != unexpectedKind)
+            .ForCondition(subject => subject!.Value.Kind != unexpectedKind)
             .FailWith(", but it was.")
             .Then
             .ClearExpectation();

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -928,6 +928,36 @@ public class DateTimeAssertions<TAssertions>
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
+    /// <summary>
+    /// Asserts that the <see cref="DateTime"/> does not represent a value in a specific kind.
+    /// </summary>
+    /// <param name="unexpectedKind">
+    /// The <see cref="DateTimeKind"/> that the current value should not represent.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public AndConstraint<TAssertions> NotBeIn(DateTimeKind unexpectedKind, string because = "", params object[] becauseArgs)
+    {
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .WithExpectation("Did not expect {context:the date and time} to be in " + unexpectedKind + "{reason}")
+            .Given(() => Subject)
+            .ForCondition(subject => subject.HasValue)
+            .FailWith(", but found a <null> DateTime.")
+            .Then
+            .ForCondition(subject => subject.Value!.Kind != unexpectedKind)
+            .FailWith(", but it was.")
+            .Then
+            .ClearExpectation();
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
         throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean Be() instead?");

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -950,7 +950,7 @@ public class DateTimeAssertions<TAssertions>
             .ForCondition(subject => subject.HasValue)
             .FailWith(", but found a <null> DateTime.")
             .Then
-            .ForCondition(subject => subject!.Value.Kind != unexpectedKind)
+            .ForCondition(subject => subject.GetValueOrDefault()!.Kind != unexpectedKind)
             .FailWith(", but it was.")
             .Then
             .ClearExpectation();

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1709,6 +1709,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeIn(System.DateTimeKind unexpectedKind, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1767,6 +1767,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeIn(System.DateTimeKind unexpectedKind, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1660,6 +1660,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeIn(System.DateTimeKind unexpectedKind, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1709,6 +1709,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeIn(System.DateTimeKind unexpectedKind, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeIn.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeIn.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using FluentAssertions.Execution;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
@@ -47,6 +49,51 @@ public partial class DateTimeAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected subject to be in Utc, but found a <null> DateTime.");
+        }
+    }
+
+    public class NotBeIn
+    {
+        [Fact]
+        public void Date_is_not_in_kind()
+        {
+            // Arrange
+            DateTime subject = 5.January(2024).AsLocal();
+
+            // Act / Assert
+            subject.Should().NotBeIn(DateTimeKind.Utc);
+        }
+
+        [Fact]
+        public void Date_is_in_kind_but_should_not()
+        {
+            // Arrange
+            DateTime subject = 5.January(2024).AsLocal();
+
+            // Act
+            Action act = () => subject.Should().NotBeIn(DateTimeKind.Local);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect subject to be in Local, but it was.");
+        }
+
+        [Fact]
+        public void Date_is_null_on_kind_check()
+        {
+            // Arrange
+            DateTime? subject = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                subject.Should().NotBeIn(DateTimeKind.Utc);
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not*<null>*");
         }
     }
 }

--- a/docs/_pages/datetimespans.md
+++ b/docs/_pages/datetimespans.md
@@ -30,6 +30,7 @@ theDatetime.Should().NotBeBefore(1.February(2010));
 theDatetime.Should().NotBeOnOrAfter(2.March(2010));
 theDatetime.Should().NotBeOnOrBefore(1.February(2010));
 theDatetime.Should().NotBeSameDateAs(2.March(2010));
+theDatetime.Should().NotBeIn(DateTimeKind.Utc);
 
 theDatetime.Should().BeOneOf(
     1.March(2010).At(21, 15),

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,6 +14,7 @@ sidebar:
 * Introduced a new assembly-level attribute that you can use to initialize Fluent Assertions before the first assertion - [#2292](https://github.com/fluentassertions/fluentassertions/pull/2292)
 * Ensure compatibility with .NET 8 - [#2466](https://github.com/fluentassertions/fluentassertions/pull/2466)
 * Add support for NUnit 4 - [#2483](https://github.com/fluentassertions/fluentassertions/pull/2483)
+* Added `NotBeIn` to check if a `DateTime` is not in a given `DateTimeKind` - [#2536](https://github.com/fluentassertions/fluentassertions/pull/2536)
 
 ### Improvements
 * Improve failure message for string assertions when checking for equality - [#2307](https://github.com/fluentassertions/fluentassertions/pull/2307)


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Closes #2434 

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
