### PR TITLE
Added an extra assertion engine initializer that throws for extra coverage

### DIFF
--- a/Tests/FluentAssertions.Extensibility.Specs/AssertionEngineInitializer.cs
+++ b/Tests/FluentAssertions.Extensibility.Specs/AssertionEngineInitializer.cs
@@ -1,9 +1,14 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 
 // With specific initialization code to invoke before the first assertion happens
 [assembly: FluentAssertions.Extensibility.AssertionEngineInitializer(
     typeof(FluentAssertions.Extensibility.Specs.AssertionEngineInitializer),
     nameof(FluentAssertions.Extensibility.Specs.AssertionEngineInitializer.InitializeBeforeFirstAssertion))]
+
+[assembly: FluentAssertions.Extensibility.AssertionEngineInitializer(
+    typeof(FluentAssertions.Extensibility.Specs.AssertionEngineInitializer),
+    nameof(FluentAssertions.Extensibility.Specs.AssertionEngineInitializer.InitializeBeforeFirstAssertionButThrow))]
 
 namespace FluentAssertions.Extensibility.Specs;
 
@@ -16,5 +21,10 @@ public static class AssertionEngineInitializer
     public static void InitializeBeforeFirstAssertion()
     {
         Interlocked.Increment(ref shouldBeCalledOnlyOnce);
+    }
+
+    public static void InitializeBeforeFirstAssertionButThrow()
+    {
+        throw new InvalidOperationException("Bogus exception to make sure the engine ignores them");
     }
 }


### PR DESCRIPTION
To address https://github.com/fluentassertions/fluentassertions/pull/2292#issuecomment-1781529207, I've added an additional `[AssertionEngineInitializer]` assembly attribute to point to an initializer method that throws. That should cover a bit more of the code in `Services.ExecuteCustomInitializers`.

