### PR TITLE
Address various Qodana issues to bring the threshold back to 0

### DIFF
--- a/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
+++ b/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
@@ -33,6 +33,9 @@ public class MultidimensionalArrayFormatter : IValueFormatter
         int[] dimensionIndices = Enumerable.Range(0, arr.Rank).Select(dimension => arr.GetLowerBound(dimension)).ToArray();
 
         int currentLoopIndex = 0;
+
+        // ReSharper disable once NotDisposedResource (false positive)
+        // See https://youtrack.jetbrains.com/issue/QD-8114/It-is-not-a-problem-Local-variable-enumerator-is-never-disposed
         IEnumerator enumerator = arr.GetEnumerator();
 
         // Emulate n-ary loop

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -162,6 +162,10 @@ resharper_keep_user_linebreaks = true
 # Make class static
 dotnet_diagnostic.RCS1102.severity = none
 
+# Unnecessary semicolon at the end of declaration
+# see https://github.com/dotnet/roslynator/issues/1359
+dotnet_diagnostic.RCS1055.severity = none
+
 # Mark local variable as const.
 dotnet_diagnostic.RCS1118.severity = none
 

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -2716,7 +2716,7 @@ public class CollectionSpecs
         var genericCollectionB = new List<ExceptionThrowingClass> { new() };
 
         var expectedTargetSite = typeof(ExceptionThrowingClass)
-            .GetProperty(nameof(ExceptionThrowingClass.ExceptionThrowingProperty)).GetMethod;
+            .GetProperty(nameof(ExceptionThrowingClass.ExceptionThrowingProperty))!.GetMethod;
 
         // Act
         Action act = () => genericCollectionA.Should().BeEquivalentTo(genericCollectionB);

--- a/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Extensions;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
 
@@ -1012,6 +1013,7 @@ public class ExtensibilitySpecs
 
     private class ClassWithNullableStructProperty
     {
+        [UsedImplicitly]
         public StructWithProperties? Value { get; set; }
     }
 

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Accessibility.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Accessibility.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
 
@@ -133,10 +134,13 @@ public partial class SelectionRulesSpecs
 
         private class ClassWithInternalProperty
         {
+            [UsedImplicitly]
             public string PublicProperty { get; set; }
 
+            [UsedImplicitly]
             internal string InternalProperty { get; set; }
 
+            [UsedImplicitly]
             protected internal string ProtectedInternalProperty { get; set; }
         }
 
@@ -189,10 +193,13 @@ public partial class SelectionRulesSpecs
 
         private class ClassWithInternalField
         {
+            [UsedImplicitly]
             public string PublicField;
 
+            [UsedImplicitly]
             internal string InternalField;
 
+            [UsedImplicitly]
             protected internal string ProtectedInternalField;
         }
 
@@ -237,8 +244,10 @@ public partial class SelectionRulesSpecs
                 Value = value;
             }
 
+            [UsedImplicitly]
             public string Name { get; }
 
+            [UsedImplicitly]
             private protected int Value { get; }
         }
 
@@ -261,8 +270,10 @@ public partial class SelectionRulesSpecs
                 this.value = value;
             }
 
+            [UsedImplicitly]
             public string Name;
 
+            [UsedImplicitly]
             private protected int value;
         }
     }

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Basic.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Basic.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
 
@@ -57,7 +58,7 @@ public partial class SelectionRulesSpecs
 
         private class ClassWithFieldInLowerCase
         {
-            [JetBrains.Annotations.UsedImplicitly]
+            [UsedImplicitly]
 #pragma warning disable SA1307
             public string name;
 #pragma warning restore SA1307
@@ -65,7 +66,7 @@ public partial class SelectionRulesSpecs
 
         private class ClassWithFieldInUpperCase
         {
-            [JetBrains.Annotations.UsedImplicitly]
+            [UsedImplicitly]
             public string Name;
         }
 
@@ -92,6 +93,7 @@ public partial class SelectionRulesSpecs
 
         public class ClassWithIndexer
         {
+            [UsedImplicitly]
             public object Foo { get; set; }
 
             public string this[int n] =>
@@ -287,8 +289,10 @@ public partial class SelectionRulesSpecs
 
         internal class BaseClassPointingToClassWithoutProperties
         {
+            [UsedImplicitly]
             public string Name { get; set; }
 
+            [UsedImplicitly]
             public ClassWithoutProperty ClassWithoutProperty { get; } = new();
         }
 

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Browsability.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Browsability.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
 
@@ -543,46 +544,60 @@ public partial class SelectionRulesSpecs
 
         private class ClassWithNonBrowsableMembers
         {
+            [UsedImplicitly]
             public int BrowsableField = -1;
 
+            [UsedImplicitly]
             public int BrowsableProperty { get; set; }
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Always)]
             public int ExplicitlyBrowsableField = -1;
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Always)]
             public int ExplicitlyBrowsableProperty { get; set; }
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Advanced)]
             public int AdvancedBrowsableField = -1;
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Advanced)]
             public int AdvancedBrowsableProperty { get; set; }
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Never)]
             public int NonBrowsableField = -1;
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Never)]
             public int NonBrowsableProperty { get; set; }
         }
 
         private class ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable
         {
+            [UsedImplicitly]
             public int BrowsableProperty { get; set; }
 
+            [UsedImplicitly]
             public int FieldThatMightBeNonBrowsable = -1;
 
+            [UsedImplicitly]
             public int PropertyThatMightBeNonBrowsable { get; set; }
         }
 
         private class ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable
         {
+            [UsedImplicitly]
             public int BrowsableProperty { get; set; }
 
             [EditorBrowsable(EditorBrowsableState.Never)]
+            [UsedImplicitly]
             public int FieldThatMightBeNonBrowsable = -1;
 
             [EditorBrowsable(EditorBrowsableState.Never)]
+            [UsedImplicitly]
             public int PropertyThatMightBeNonBrowsable { get; set; }
         }
     }

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Covariance.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Covariance.cs
@@ -1,6 +1,7 @@
 ﻿#if NET5_0_OR_GREATER
 
 using System;
+using JetBrains.Annotations;
 using Xunit;
 
 namespace FluentAssertions.Equivalency.Specs;
@@ -70,11 +71,13 @@ public partial class SelectionRulesSpecs
 
         private class BaseWithProperty
         {
+            [UsedImplicitly]
             public string BaseProperty { get; set; }
         }
 
         private class DerivedWithProperty : BaseWithProperty
         {
+            [UsedImplicitly]
             public string DerivedProperty { get; set; }
         }
 
@@ -87,6 +90,7 @@ public partial class SelectionRulesSpecs
         {
             public override DerivedWithProperty Property { get; }
 
+            [UsedImplicitly]
             public string OtherProp { get; set; }
 
             public DerivedWithCovariantOverride(DerivedWithProperty prop)

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Including.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Including.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
 
@@ -162,6 +163,7 @@ public partial class SelectionRulesSpecs
 
         public class CustomType
         {
+            [UsedImplicitly]
             public string Name { get; set; }
         }
 

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.MemberHiding.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.MemberHiding.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 using Xunit;
 
 namespace FluentAssertions.Equivalency.Specs;
@@ -143,26 +144,31 @@ public partial class SelectionRulesSpecs
 
         private class BaseWithProperty
         {
+            [UsedImplicitly]
             public object Property { get; set; }
         }
 
         private class SubclassAHidingProperty<T> : BaseWithProperty
         {
+            [UsedImplicitly]
             public new T Property { get; set; }
         }
 
         private class BaseWithStringProperty
         {
+            [UsedImplicitly]
             public string Property { get; set; }
         }
 
         private class SubclassHidingStringProperty : BaseWithStringProperty
         {
+            [UsedImplicitly]
             public new string Property { get; set; }
         }
 
         private class AnotherBaseWithProperty
         {
+            [UsedImplicitly]
             public object Property { get; set; }
         }
 
@@ -291,21 +297,25 @@ public partial class SelectionRulesSpecs
 
         private class BaseWithField
         {
+            [UsedImplicitly]
             public string Field;
         }
 
         private class SubclassAHidingField : BaseWithField
         {
+            [UsedImplicitly]
             public new string Field;
         }
 
         private class AnotherBaseWithField
         {
+            [UsedImplicitly]
             public string Field;
         }
 
         private class SubclassBHidingField : AnotherBaseWithField
         {
+            [UsedImplicitly]
             public new string Field;
         }
     }

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScope.ChainingApiSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScope.ChainingApiSpecs.cs
@@ -186,7 +186,7 @@ public partial class AssertionScopeSpecs
     public void When_the_previous_assertion_failed_it_should_not_execute_the_succeeding_failure()
     {
         // Arrange
-        using var scope = new AssertionScope();
+        var scope = new AssertionScope();
 
         // Act
         Execute.Assertion
@@ -532,7 +532,7 @@ public partial class AssertionScopeSpecs
     public void Does_not_continue_a_chained_assertion_after_the_first_one_failed_the_occurrence_check()
     {
         // Arrange
-        using var scope = new AssertionScope();
+        var scope = new AssertionScope();
 
         // Act
         Execute.Assertion

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Chill" Version="4.1.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageReference Include="xunit" Version="2.6.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeDataContractSerializable.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeDataContractSerializable.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 using FluentAssertions.Extensions;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
 
@@ -103,6 +104,7 @@ public partial class ObjectAssertionSpecs
 
     public class DataContractSerializableClass
     {
+        [UsedImplicitly]
         public string Name { get; set; }
 
         public int Id;

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeXmlSerializable.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeXmlSerializable.cs
@@ -4,6 +4,7 @@ using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
 using FluentAssertions.Extensions;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
 
@@ -69,6 +70,7 @@ public partial class ObjectAssertionSpecs
 
     public class XmlSerializableClass
     {
+        [UsedImplicitly]
         public string Name { get; set; }
 
         public int Id;
@@ -76,6 +78,7 @@ public partial class ObjectAssertionSpecs
 
     public class XmlSerializableClassNotRestoringAllProperties : IXmlSerializable
     {
+        [UsedImplicitly]
         public string Name { get; set; }
 
         public DateTime BirthDay { get; set; }
@@ -98,6 +101,7 @@ public partial class ObjectAssertionSpecs
 
     internal class NonPublicClass
     {
+        [UsedImplicitly]
         public string Name { get; set; }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -39,7 +39,11 @@ public partial class ObjectAssertionSpecs
 
     internal class DumbObjectEqualityComparer : IEqualityComparer<object>
     {
-        public new bool Equals(object x, object y) => x.Equals(y);
+        // ReSharper disable once MemberHidesStaticFromOuterClass
+        public new bool Equals(object x, object y)
+        {
+            return (x == y) || (x is not null && y is not null && x.Equals(y));
+        }
 
         public int GetHashCode(object obj) => obj.GetHashCode();
     }
@@ -69,7 +73,10 @@ internal class SomeClass
 
 internal class SomeClassEqualityComparer : IEqualityComparer<SomeClass>
 {
-    public bool Equals(SomeClass x, SomeClass y) => x.Key == y.Key;
+    public bool Equals(SomeClass x, SomeClass y)
+    {
+        return (x == y) || (x is not null && y is not null && x.Key.Equals(y.Key));
+    }
 
     public int GetHashCode(SomeClass obj) => obj.Key;
 }

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -130,7 +130,7 @@ namespace FluentAssertions.Specs.Types
     {
         private class PrivateClass;
 
-        protected enum ProtectedEnum { }
+        protected enum ProtectedEnum;
 
         public interface IPublicInterface;
 

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -796,9 +796,7 @@ namespace Internal.NotOnlyClasses.Test
 {
     internal class NotOnlyClassesClass;
 
-    internal enum NotOnlyClassesEnumeration
-    {
-    }
+    internal enum NotOnlyClassesEnumeration;
 
     internal interface INotOnlyClassesInterface;
 }
@@ -882,9 +880,7 @@ namespace Internal.ValueTypesAndNotValueTypes.Test
 
     internal record InternalRecordClass;
 
-    internal enum InternalEnumValueType
-    {
-    }
+    internal enum InternalEnumValueType;
 
     internal interface InternalInterfaceNotValueType;
 }

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -33,3 +33,9 @@ exclude:
   - name: SwitchExpressionHandlesSomeKnownEnumValuesWithExceptionInDefault
   - name: UnusedMemberInSuper.Global
   - name: ArrangeAccessorOwnerBody
+  - name: CollectionNeverUpdated.Local
+    paths:
+      - Tests
+  - name: PossibleMultipleEnumeration
+    paths:
+      - Tests

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,7 +1,7 @@
 version: "1.0"
 
 ide: QDNET
-failThreshold: 20
+failThreshold: 0
 
 profile:
   path: profile.yaml


### PR DESCRIPTION
**Note to Reviewer** commit-by-commit. 

Since PRs cannot be used to verify the net affect, check out https://github.com/fluentassertions/fluentassertions/actions/runs/7512592573

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
