### PR TITLE
Simplify the API approval test

### DIFF
--- a/Tests/Approval.Tests/ApiApproval.cs
+++ b/Tests/Approval.Tests/ApiApproval.cs
@@ -42,11 +42,7 @@ public class ApiApproval
             var csproj = CombinedPaths("Src", "FluentAssertions", "FluentAssertions.csproj");
             var project = XDocument.Load(csproj);
             var targetFrameworks = project.XPathSelectElement("/Project/PropertyGroup/TargetFrameworks");
-
-            foreach (string targetFramework in targetFrameworks!.Value.Split(';'))
-            {
-                Add(targetFramework);
-            }
+            AddRange(targetFrameworks!.Value.Split(';'));
         }
     }
 


### PR DESCRIPTION
[xUnit.net 2.6.5][1] introduced a new `AddRange` method that can be used to simplify the implementation of `TargetFrameworksTheoryData`.

[1]: https://xunit.net/releases/v2/2.6.5
