### PR TITLE
Add `BeJsonSerializable` extensions for objects

### DIFF
--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2054,6 +2054,11 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(TSubject expected, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeJsonSerializable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeJsonSerializable<T>(string because = "", params object[] becauseArgs)
+            where T :  class { }
+        public FluentAssertions.AndConstraint<TAssertions> BeJsonSerializable<T>(System.Func<FluentAssertions.Equivalency.EquivalencyOptions<T>, FluentAssertions.Equivalency.EquivalencyOptions<T>> options, string because = "", params object[] becauseArgs)
+            where T :  class { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params TSubject[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<TSubject> validValues, System.Collections.Generic.IEqualityComparer<TSubject> comparer, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeJsonSerializable.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeJsonSerializable.cs
@@ -1,0 +1,155 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace FluentAssertions.Specs.Primitives;
+
+public partial class ObjectAssertionSpecs
+{
+    public class BeJsonSerializable
+    {
+        [Fact]
+        public void Can_serialize_simple_classes()
+        {
+            // Arrange
+            var subject = new SimpleClassWithPrimitiveTypes()
+            {
+                Integer = 1,
+                Long = long.MaxValue - 2,
+                Decimal = 0.2M,
+                Double = 0.3,
+                Float = 42.0F,
+                Guid = Guid.NewGuid(),
+                String = "foo",
+                DateTime = DateTime.UtcNow,
+                Bool = true,
+                ByteArray = [0x20, 0x21, 0x22, 0x23],
+                Char = 'c'
+            };
+
+            // Act / Assert
+            subject.Should().BeJsonSerializable();
+        }
+
+        [Fact]
+        public void Can_serialize_nested_classes()
+        {
+            // Arrange
+            var subject = new ClassWithNestedClasses
+            {
+                Id = 1,
+                MestedClass = new NestedClass
+                {
+                    Value = "foo"
+                }
+            };
+
+            // Act / Assert
+            subject.Should().BeJsonSerializable();
+        }
+
+        [Fact]
+        public void Cannot_serialize_classes_without_default_constructor()
+        {
+            // Arrange
+            const string reasonText = "this is the reason";
+            var subject = new ClassWithoutDefaultConstructor(10);
+
+            // Act
+            Action act = () => subject.Should().BeJsonSerializable(reasonText);
+
+            // Assert
+            act.Should().Throw<Xunit.Sdk.XunitException>()
+                .WithMessage($"*to be JSON serializable*{reasonText}*but serializing*failed with*");
+        }
+
+        [Fact]
+        public void Cannot_serialize_classes_with_ignored_property()
+        {
+            // Arrange
+            const string reasonText = "it has an ignored property";
+            var subject = new SimpleClassWithIgnoredProperty()
+            {
+                IgnoredProperty = DateTime.Now
+            };
+
+            // Act
+            Action act = () => subject.Should().BeJsonSerializable(reasonText);
+
+            // Assert
+            act.Should().Throw<Xunit.Sdk.XunitException>()
+                .WithMessage($"*to be JSON serializable*{reasonText}*but serializing*failed with*");
+        }
+
+        [Fact]
+        public void Use_explicit_type_for_serialization()
+        {
+            // Arrange
+            var subject = new SimpleClassWithIgnoredProperty()
+            {
+                IgnoredProperty = DateTime.Now
+            };
+
+            // Act / Assert
+            subject.Should().BeJsonSerializable<SimpleClassWithPrimitiveTypes>();
+        }
+
+        // ReSharper disable UnusedAutoPropertyAccessor.Local
+        private class SimpleClassWithIgnoredProperty : SimpleClassWithPrimitiveTypes
+        {
+            [JsonIgnore]
+            public DateTime IgnoredProperty { get; set; }
+        }
+
+        private class SimpleClassWithPrimitiveTypes
+        {
+            public int Integer { get; set; }
+
+            public long Long { get; set; }
+
+            public Guid Guid { get; set; }
+
+            public string String { get; set; }
+
+            public DateTime DateTime { get; set; }
+
+            public decimal Decimal { get; set; }
+
+            public double Double { get; set; }
+
+            public float Float { get; set; }
+
+            public bool Bool { get; set; }
+
+#pragma warning disable CA1819 // Properties should not return arrays
+            public byte[] ByteArray { get; set; }
+#pragma warning restore CA1819 // Properties should not return arrays
+
+            public char Char { get; set; }
+        }
+
+        private class ClassWithoutDefaultConstructor
+        {
+            public int Id { get; }
+
+            public ClassWithoutDefaultConstructor(int value)
+            {
+                Id = value;
+            }
+        }
+
+        private class ClassWithNestedClasses
+        {
+            public int Id { get; set; }
+
+            public NestedClass MestedClass { get; set; }
+        }
+
+        private class NestedClass
+        {
+            public string Value { get; set; }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Draft for #2555 

Add the following methods for `ObjectAssertions` (similar to [`ObjectAssertionsExtensions` in `FluentAssertions.Json`](https://github.com/fluentassertions/fluentassertions.json/blob/master/Src/FluentAssertions.Json/ObjectAssertionsExtensions.cs)):
```csharp
public AndConstraint<TAssertions> BeJsonSerializable(string because = "", params object[] becauseArgs);
public AndConstraint<TAssertions> BeJsonSerializable<T>(string because = "", params object[] becauseArgs);
public AndConstraint<TAssertions> BeJsonSerializable<T>(Func<EquivalencyOptions<T>, EquivalencyOptions<T>> options, string because = "", params object[] becauseArgs)
```

These methods should assert that an object can be serialized to and deserialized from JSON and retains the values of all members.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
