### PR TITLE
Add `BeValidJson` extensions for strings

### DIFF
--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2126,6 +2126,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeUpperCased(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, System.Text.Json.JsonDocument> BeValidJson(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, System.Text.Json.JsonDocument> BeValidJson(System.Text.Json.JsonDocumentOptions options, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeValidJson.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeValidJson.cs
@@ -1,0 +1,130 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Text.Json;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Primitives;
+
+public partial class StringAssertionSpecs
+{
+    public class BeValidJson
+    {
+        [Fact]
+        public void Allow_consecutive_assertions()
+        {
+            // Arrange
+            string subject = """{ "id": 42, "admin": true }""";
+
+            // Act
+            object which = subject.Should().BeValidJson().Which;
+
+            // Assert
+            which.Should().BeAssignableTo<JsonDocument>();
+        }
+
+        [Fact]
+        public void Fail_for_null_string()
+        {
+            // Arrange
+            string subject = null;
+
+            // Act
+            Action act = () => subject.Should().BeValidJson("null is not allowed");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected subject to be valid JSON because null is not allowed, but found null.");
+        }
+
+        [Fact]
+        public void Fail_for_empty_string()
+        {
+            // Arrange
+            string subject = "";
+
+            // Act
+            Action act = () => subject.Should().BeValidJson("empty string is not allowed");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected subject to be valid JSON because empty string is not allowed, but parsing failed*");
+        }
+
+        [Fact]
+        public void Fail_for_invalid_string()
+        {
+            // Arrange
+            string subject = "invalid json";
+
+            // Act
+            Action act = () => subject.Should().BeValidJson("we like {0}", "JSON");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected subject to be valid JSON because we like JSON, but parsing failed*");
+        }
+
+        [Theory]
+        [InlineData("""{{"id":1}""")]
+        [InlineData("""{"id":1}}""")]
+        [InlineData("""[[{"id":1}]""")]
+        [InlineData("""[{"id":1}]]""")]
+        public void Fail_for_string_with_unmatched_paranthesis(string subject)
+        {
+            // Act
+            Action act = () => subject.Should().BeValidJson("it contains unmatched paranthesis");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected subject to be valid JSON because it contains unmatched paranthesis, but parsing failed*");
+        }
+
+        [Fact]
+        public void Succeed_for_empty_object_string()
+        {
+            // Arrange
+            string subject = "{}";
+
+            // Act / Assert
+            subject.Should().BeValidJson();
+        }
+
+        [Theory]
+        [InlineData("""{ "id": 42, "admin": true }""")]
+        [InlineData("""[{ "id": 1 }, { "id": 2 }]""")]
+        public void Succeed_for_valid_string(string subject)
+        {
+            // Act / Assert
+            subject.Should().BeValidJson();
+        }
+
+        [Fact]
+        public void Fail_with_trailing_commas_when_not_allowed_by_provided_options()
+        {
+            // Arrange
+            string subject = """{"values":[1,2,3,]}""";
+
+            // Act
+            Action act = () => subject.Should().BeValidJson(
+                new JsonDocumentOptions { AllowTrailingCommas = false },
+                "trailing commas are not allowed");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected subject to be valid JSON because trailing commas are not allowed, but parsing failed*");
+        }
+
+        [Fact]
+        public void Succeed_with_trailing_commas_when_allowed_by_provided_options()
+        {
+            // Arrange
+            string subject = """{"values":[1,2,3,]}""";
+
+            // Act / Assert
+            subject.Should().BeValidJson(
+                new JsonDocumentOptions { AllowTrailingCommas = true });
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Draft for #2556 

Add the following methods to the `StringAssertions` (similar to [`StringAssertionsExtensions` in `FluentAssertions.Json`](https://github.com/fluentassertions/fluentassertions.json/blob/master/Src/FluentAssertions.Json/StringAssertionsExtensions.cs)):
```csharp
public AndWhichConstraint<TAssertions, JsonDocument> BeValidJson(string because = "", params object[] becauseArgs);
public AndWhichConstraint<TAssertions, JsonDocument> BeValidJson(JsonDocumentOptions options, string because = "", params object[] becauseArgs);
```

These methods should assert that the string is a valid JSON document.


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
