### PR TITLE
Add assertions on `JsonElement`

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -11,6 +11,9 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions.Collections;
 using FluentAssertions.Common;
+#if NET6_0_OR_GREATER
+using FluentAssertions.Json;
+#endif
 using FluentAssertions.Numeric;
 using FluentAssertions.Primitives;
 using FluentAssertions.Specialized;
@@ -713,6 +716,38 @@ public static class AssertionExtensions
     {
         return new StringAssertions(actualValue);
     }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Returns an <see cref="JsonElementAssertions"/> object that can be used to assert the
+    /// root element of the current <see cref="System.Text.Json.JsonDocument"/>.
+    /// </summary>
+    [Pure]
+    public static JsonElementAssertions Should(this System.Text.Json.JsonDocument actualValue)
+    {
+        return new JsonElementAssertions(actualValue.RootElement);
+    }
+
+    /// <summary>
+    /// Returns an <see cref="JsonElementAssertions"/> object that can be used to assert the
+    /// current <see cref="System.Text.Json.JsonElement"/>.
+    /// </summary>
+    [Pure]
+    public static JsonElementAssertions Should(this System.Text.Json.JsonElement? actualValue)
+    {
+        return new JsonElementAssertions(actualValue);
+    }
+
+    /// <summary>
+    /// Returns an <see cref="JsonElementAssertions"/> object that can be used to assert the
+    /// current <see cref="System.Text.Json.JsonElement"/>.
+    /// </summary>
+    [Pure]
+    public static JsonElementAssertions Should(this System.Text.Json.JsonElement actualValue)
+    {
+        return new JsonElementAssertions(actualValue);
+    }
+#endif
 
     /// <summary>
     /// Returns an <see cref="SimpleTimeSpanAssertions"/> object that can be used to assert the

--- a/Src/FluentAssertions/Json/JsonElementAssertions.cs
+++ b/Src/FluentAssertions/Json/JsonElementAssertions.cs
@@ -1,0 +1,147 @@
+﻿#if NET6_0_OR_GREATER
+using System.Diagnostics;
+using System.Linq;
+using System.Text.Json;
+using FluentAssertions.Common;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+namespace FluentAssertions.Json;
+
+/// <summary>
+/// Contains a number of methods to assert that a <see cref="JsonElement"/> is in the expected state.
+/// </summary>
+[DebuggerNonUserCode]
+public class JsonElementAssertions : JsonElementAssertions<JsonElementAssertions>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonElementAssertions"/> class.
+    /// </summary>
+    public JsonElementAssertions(JsonElement? value)
+        : base(value)
+    {
+    }
+}
+
+/// <summary>
+/// Contains a number of methods to assert that a <see cref="JsonElement"/> is in the expected state.
+/// </summary>
+[DebuggerNonUserCode]
+public class JsonElementAssertions<TAssertions> : ReferenceTypeAssertions<JsonElement?, TAssertions>
+    where TAssertions : JsonElementAssertions<TAssertions>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonElementAssertions{TAssertions}"/> class.
+    /// </summary>
+    public JsonElementAssertions(JsonElement? value)
+        : base(value)
+    {
+    }
+
+    /// <summary>
+    /// Returns the type of the subject the assertion applies on.
+    /// </summary>
+    protected override string Identifier => nameof(JsonElement);
+
+    /// <summary>
+    /// Asserts that the number of items in the current <see cref="JsonElement" /> matches the supplied <paramref name="expected" /> amount.
+    /// </summary>
+    /// <param name="expected">The expected number of items in the current <see cref="JsonElement" />.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public AndConstraint<TAssertions> HaveCount(int expected,
+        string because = "", params object[] becauseArgs)
+    {
+        Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected JSON element to contain {0} item(s){reason}, but it was <null>.", expected);
+
+        Execute.Assertion
+            .ForCondition(Subject?.ValueKind is JsonValueKind.Array or JsonValueKind.Object)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected JSON element {0} to contain {1} item(s){reason}, but it is of type {2}.", Subject, expected, Subject.Value.ValueKind);
+
+        int? count = Subject.Value.ValueKind switch
+        {
+            JsonValueKind.Array => Subject.Value.GetArrayLength(),
+            JsonValueKind.Object => Subject.Value.EnumerateObject().Count(),
+            _ => 0
+        };
+        Execute.Assertion
+            .ForCondition(count == expected)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected JSON element {0} to contain {1} item(s){reason}, but found {2}.", Subject, expected, count);
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
+    /// Asserts that the current <see cref="JsonElement" /> has a direct child element with the specified
+    /// <paramref name="expected" /> name.
+    /// </summary>
+    /// <param name="expected">
+    /// The name of the expected child element
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <see paramref="because" />.
+    /// </param>
+    public AndWhichConstraint<TAssertions, JsonElement> HaveElement(string expected,
+        string because = "", params object[] becauseArgs)
+    {
+        Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected JSON element to have element \"" + expected.EscapePlaceholders() + "\"{reason}, but it was <null>.", expected);
+
+        JsonElement property = default;
+        bool? isFound = Subject?.TryGetProperty(expected, out property);
+
+        Execute.Assertion
+            .ForCondition(isFound == true)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected JSON element {0} to have element \"" + expected.EscapePlaceholders() + "\"{reason}" +
+                      ", but no such element was found.", Subject);
+
+        return new AndWhichConstraint<TAssertions, JsonElement>((TAssertions)this, property);
+    }
+
+    /// <summary>
+    /// Asserts that the current <see cref="JsonElement" /> has no direct child element with the specified
+    /// <paramref name="expected" /> name.
+    /// </summary>
+    /// <param name="expected">
+    /// The name of the expected child element
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <see paramref="because" />.
+    /// </param>
+    public AndConstraint<TAssertions> NotHaveElement(string expected,
+        string because = "", params object[] becauseArgs)
+    {
+        JsonElement property = default;
+        bool? isFound = Subject?.TryGetProperty(expected, out property);
+
+        Execute.Assertion
+            .ForCondition(isFound != true)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected JSON element {0} to have no element \"" + expected.EscapePlaceholders() + "\"{reason}" +
+                      ", but element was found with value {1}.", Subject, property);
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+}
+#endif

--- a/Src/FluentAssertions/Json/JsonElementAssertions.cs
+++ b/Src/FluentAssertions/Json/JsonElementAssertions.cs
@@ -82,6 +82,43 @@ public class JsonElementAssertions<TAssertions> : ReferenceTypeAssertions<JsonEl
     }
 
     /// <summary>
+    /// Asserts that the number of items in the current <see cref="JsonElement" /> does not match the supplied <paramref name="unexpected" /> amount.
+    /// </summary>
+    /// <param name="unexpected">The number of items not expected in the current <see cref="JsonElement" />.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs)
+    {
+        Execute.Assertion
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected JSON element to not contain {0} item(s){reason}, but it was <null>.", unexpected);
+
+        Execute.Assertion
+            .ForCondition(Subject?.ValueKind is JsonValueKind.Array or JsonValueKind.Object)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected JSON element {0} to not contain {1} item(s){reason}, but it is of type {2}.", Subject, unexpected, Subject.Value.ValueKind);
+
+        int? count = Subject.Value.ValueKind switch
+        {
+            JsonValueKind.Array => Subject.Value.GetArrayLength(),
+            JsonValueKind.Object => Subject.Value.EnumerateObject().Count(),
+            _ => 0
+        };
+        Execute.Assertion
+            .ForCondition(count != unexpected)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected JSON element {0} to not contain {1} item(s){reason}, but found them.", Subject, unexpected);
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
     /// Asserts that the current <see cref="JsonElement" /> has a direct child element with the specified
     /// <paramref name="expected" /> name.
     /// </summary>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1630,6 +1630,7 @@ namespace FluentAssertions.Json
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, System.Text.Json.JsonElement> HaveElement(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveElement(string expected, string because = "", params object[] becauseArgs) { }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -75,6 +75,9 @@ namespace FluentAssertions
         public static FluentAssertions.Types.ConstructorInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
         public static FluentAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Json.JsonElementAssertions Should(this System.Text.Json.JsonDocument actualValue) { }
+        public static FluentAssertions.Json.JsonElementAssertions Should(this System.Text.Json.JsonElement actualValue) { }
+        public static FluentAssertions.Json.JsonElementAssertions Should(this System.Text.Json.JsonElement? actualValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions Should(this System.Threading.Tasks.TaskCompletionSource tcs) { }
         public static FluentAssertions.Primitives.TimeOnlyAssertions Should(this System.TimeOnly actualValue) { }
         public static FluentAssertions.Primitives.NullableTimeOnlyAssertions Should(this System.TimeOnly? actualValue) { }
@@ -1612,6 +1615,22 @@ namespace FluentAssertions.Formatting
         public XmlReaderValueFormatter() { }
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}
+namespace FluentAssertions.Json
+{
+    public class JsonElementAssertions : FluentAssertions.Json.JsonElementAssertions<FluentAssertions.Json.JsonElementAssertions>
+    {
+        public JsonElementAssertions(System.Text.Json.JsonElement? value) { }
+    }
+    public class JsonElementAssertions<TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Text.Json.JsonElement?, TAssertions>
+        where TAssertions : FluentAssertions.Json.JsonElementAssertions<TAssertions>
+    {
+        public JsonElementAssertions(System.Text.Json.JsonElement? value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, System.Text.Json.JsonElement> HaveElement(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveElement(string expected, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Numeric

--- a/Tests/FluentAssertions.Specs/Json/JsonElementAssertionsSpecs.HaveCount.cs
+++ b/Tests/FluentAssertions.Specs/Json/JsonElementAssertionsSpecs.HaveCount.cs
@@ -115,5 +115,105 @@ public partial class JsonElementAssertionsSpecs
                 .WithMessage("Expected JSON element 42 to contain 0 item(s) because type matters, but it is of type JsonValueKind.Number*");
         }
     }
+
+    public class NotHaveCount
+    {
+        [Fact]
+        public void Fail_for_null_json_element()
+        {
+            // Arrange
+            JsonElement? subject = null;
+
+            // Act
+            Action act = () => subject.Should().NotHaveCount(1, "null is not allowed");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element to not contain 1 item(s) because null is not allowed, but it was <null>.");
+        }
+
+        [Fact]
+        public void Succeed_for_json_object_with_fewer_properties()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""{ "id": 42, "admin": true }""");
+
+            // Act / Assert
+            subject.Should().NotHaveCount(3);
+        }
+
+        [Fact]
+        public void Succeed_for_json_object_with_more_properties()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""{ "id": 42, "admin": true }""");
+
+            // Act / Assert
+            subject.Should().NotHaveCount(1);
+        }
+
+        [Fact]
+        public void Fail_for_json_object_with_matching_property_count()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("{ }");
+
+            // Act
+            Action act = () => subject.Should().NotHaveCount(0, "numbers matter");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element * to not contain 0 item(s) because numbers matter, but found them.");
+        }
+
+        [Fact]
+        public void Succeed_for_json_array_with_fewer_properties()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""[ "Hello", "World!" ]""");
+
+            // Act / Assert
+            subject.Should().NotHaveCount(3);
+        }
+
+        [Fact]
+        public void Succeed_for_json_array_with_more_properties()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""[ "Hello", "World!" ]""");
+
+            // Act / Assert
+            subject.Should().NotHaveCount(1);
+        }
+
+        [Fact]
+        public void Fail_for_json_array_with_matching_property_count()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""[ "Hello", "World!" ]""");
+
+            // Act
+            Action act = () => subject.Should().NotHaveCount(2, "numbers matter");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element * to not contain 2 item(s) because numbers matter, but found them.");
+        }
+
+        [Fact]
+        public void Fail_for_unsupported_value_type()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""{ "id": 42, "admin": true }""")
+                .RootElement.GetProperty("id");
+
+            // Act
+            Action act = () => subject.Should().NotHaveCount(0, "type matters");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element 42 to not contain 0 item(s) because type matters, but it is of type JsonValueKind.Number*");
+        }
+    }
 }
 #endif

--- a/Tests/FluentAssertions.Specs/Json/JsonElementAssertionsSpecs.HaveCount.cs
+++ b/Tests/FluentAssertions.Specs/Json/JsonElementAssertionsSpecs.HaveCount.cs
@@ -1,0 +1,119 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Text.Json;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Json;
+
+public partial class JsonElementAssertionsSpecs
+{
+    public class HaveCount
+    {
+        [Fact]
+        public void Fail_for_null_json_element()
+        {
+            // Arrange
+            JsonElement? subject = null;
+
+            // Act
+            Action act = () => subject.Should().HaveCount(1, "null is not allowed");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element to contain 1 item(s) because null is not allowed, but it was <null>.");
+        }
+
+        [Fact]
+        public void Succeed_for_json_object_with_matching_property_count()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""{ "id": 42, "admin": true }""");
+
+            // Act / Assert
+            subject.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void Fail_for_json_object_with_fewer_properties()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("{ }");
+
+            // Act
+            Action act = () => subject.Should().HaveCount(1, "numbers matter");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element * to contain 1 item(s) because numbers matter, but found 0.");
+        }
+
+        [Fact]
+        public void Fail_for_json_object_with_more_properties()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""{ "id": 42, "admin": true }""");
+
+            // Act
+            Action act = () => subject.Should().HaveCount(1, "numbers matter");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element * to contain 1 item(s) because numbers matter, but found 2.");
+        }
+
+        [Fact]
+        public void Succeed_for_json_array_with_matching_array_count()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""[ "Hello", "World!" ]""");
+
+            // Act / Assert
+            subject.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void Fail_for_json_array_with_fewer_array_count()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""[ "Hello", "World!" ]""");
+
+            // Act
+            Action act = () => subject.Should().HaveCount(3, "numbers matter");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element [ \"Hello\", \"World!\" ] to contain 3 item(s) because numbers matter, but found 2.");
+        }
+
+        [Fact]
+        public void Fail_for_json_array_with_more_array_count()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""[ "Hello", "World!" ]""").RootElement;
+
+            // Act
+            Action act = () => subject.Should().HaveCount(1, "numbers matter");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element [ \"Hello\", \"World!\" ] to contain 1 item(s) because numbers matter, but found 2.");
+        }
+
+        [Fact]
+        public void Fail_for_unsupported_value_type()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""{ "id": 42, "admin": true }""")
+                .RootElement.GetProperty("id");
+
+            // Act
+            Action act = () => subject.Should().HaveCount(0, "type matters");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element 42 to contain 0 item(s) because type matters, but it is of type JsonValueKind.Number*");
+        }
+    }
+}
+#endif

--- a/Tests/FluentAssertions.Specs/Json/JsonElementAssertionsSpecs.HaveElement.cs
+++ b/Tests/FluentAssertions.Specs/Json/JsonElementAssertionsSpecs.HaveElement.cs
@@ -1,0 +1,110 @@
+﻿#if NET6_0_OR_GREATER
+using System.Text.Json;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Json;
+
+public partial class JsonElementAssertionsSpecs
+{
+    public class HaveElement
+    {
+        [Fact]
+        public void Succeed_for_json_object_with_matching_element()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""{ "id": 42 }""");
+
+            // Act / Assert
+            subject.Should().HaveElement("id");
+        }
+
+        [Fact]
+        public void Succeed_for_nested_json_object_with_matching_elements()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""{ "id": { "name": "foo" } }""");
+
+            // Act / Assert
+            subject.Should().HaveElement("id").Which.Should().HaveElement("name");
+        }
+
+        [Fact]
+        public void Fail_for_json_object_without_matching_element()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""{ "id": 42 }""");
+
+            // Act
+            var act = () => subject.Should().HaveElement("name", "because element is not defined");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element { \"id\": 42 } to have element \"name\" because element is not defined, but no such element was found.");
+        }
+
+        [Fact]
+        public void Fail_for_json_object_with_case_different_matching_element()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""{ "id": 42 }""");
+
+            // Act
+            var act = () => subject.Should().HaveElement("ID", "because casing is different");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element { \"id\": 42 } to have element \"ID\" because casing is different, but no such element was found.");
+        }
+
+        [Fact]
+        public void Fail_for_null()
+        {
+            // Arrange
+            JsonElement? subject = null;
+
+            // Act
+            var act = () => subject.Should().HaveElement("id", "it is null");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element to have element \"id\" because it is null, but it was <null>.");
+        }
+    }
+
+    public class NotHaveElement
+    {
+        [Fact]
+        public void Succeed_for_json_object_without_matching_element()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""{ "id": 42 }""");
+
+            // Act / Assert
+            subject.Should().NotHaveElement("name");
+        }
+
+        [Fact]
+        public void Fail_for_json_object_with_matching_element()
+        {
+            // Arrange
+            var subject = JsonDocument.Parse("""{ "id": 42 }""");
+
+            // Act / Assert
+            subject.Should().Invoking(x => x.NotHaveElement("id", "because element is defined"))
+                .Should().Throw<XunitException>()
+                .WithMessage("Expected JSON element { \"id\": 42 } to have no element \"id\" because element is defined, but element was found with value 42.");
+        }
+
+        [Fact]
+        public void Succeed_for_null()
+        {
+            // Arrange
+            JsonElement? subject = null;
+
+            // Act / Assert
+            subject.Should().NotHaveElement("id");
+        }
+    }
+}
+#endif

--- a/Tests/FluentAssertions.Specs/Json/JsonElementAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Json/JsonElementAssertionsSpecs.cs
@@ -1,0 +1,22 @@
+﻿#if NET6_0_OR_GREATER
+using System.Text.Json;
+using Xunit;
+
+namespace FluentAssertions.Specs.Json;
+
+public partial class JsonElementAssertionsSpecs
+{
+    [Fact]
+    public void Allow_chaining_multiple_checks()
+    {
+        // Arrange
+        var subject = JsonDocument.Parse("""{ "id": 42 }""").RootElement;
+
+        // Act / Assert
+        subject.Should()
+            .HaveCount(1).And
+            .HaveElement("id").And
+            .NotHaveElement("bar");
+    }
+}
+#endif


### PR DESCRIPTION
Draft for #2559 

Add a new class `JsonElementAssertions` which contains assertion methods on `JsonElement?`).
This class can then be extended with assertions similar to [`JTokenAssertions` in `FluentAssertions.Json`](https://github.com/fluentassertions/fluentassertions.json/blob/master/Src/FluentAssertions.Json/JTokenAssertions.cs).

In the first step, I would keep the public surface quite small and only add the following methods:
```C#
/// <summary>
/// Asserts that the number of items in the current <see cref="JsonElement" /> matches the supplied <paramref name="expected" /> amount.
/// </summary>
public AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs);

/// <summary>
/// Asserts that the number of items in the current <see cref="JsonElement" /> does not match the supplied <paramref name="unexpected" /> amount.
/// </summary>
public AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs);

/// <summary>
/// Asserts that the current <see cref="JsonElement" /> has a direct child element with the specified <paramref name="expected" /> name.
/// </summary>
public AndWhichConstraint<TAssertions, JsonElement> HaveElement(string expected, string because = "", params object[] becauseArgs)

/// <summary>
/// Asserts that the current <see cref="JsonElement" /> has no direct child element with the specified <paramref name="expected" /> name.
/// </summary>
public AndConstraint<TAssertions> NotHaveElement(string expected, string because = "", params object[] becauseArgs)
```

In order to use these assertions, I would add the following methods to the `AssertionExtensions`:
```C#
public static JsonElementAssertions Should(this JsonDocument actualValue);
public static JsonElementAssertions Should(this JsonElement? actualValue);
```

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
