### PR TITLE
Add option to ignore newline style when comparing strings for equivalency

### DIFF
--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -121,6 +121,12 @@ internal static class StringExtensions
             .Replace("\r", string.Empty, StringComparison.Ordinal);
     }
 
+    public static string RemoveNewlineStyle(this string @this)
+    {
+        return @this.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace("\r", "\n", StringComparison.Ordinal);
+    }
+
     /// <summary>
     /// Counts the number of times the <paramref name="substring"/> appears within a string by using the specified <paramref name="comparer"/>.
     /// </summary>

--- a/Src/FluentAssertions/Equivalency/Execution/CollectionMemberOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CollectionMemberOptionsDecorator.cs
@@ -79,5 +79,9 @@ internal class CollectionMemberOptionsDecorator : IEquivalencyOptions
 
     public bool IgnoreCase => inner.IgnoreCase;
 
+    public bool IgnoreAllNewlines => inner.IgnoreAllNewlines;
+
+    public bool IgnoreNewlineStyle => inner.IgnoreNewlineStyle;
+
     public ITraceWriter TraceWriter => inner.TraceWriter;
 }

--- a/Src/FluentAssertions/Equivalency/Execution/CollectionMemberOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CollectionMemberOptionsDecorator.cs
@@ -79,8 +79,6 @@ internal class CollectionMemberOptionsDecorator : IEquivalencyOptions
 
     public bool IgnoreCase => inner.IgnoreCase;
 
-    public bool IgnoreAllNewlines => inner.IgnoreAllNewlines;
-
     public bool IgnoreNewlineStyle => inner.IgnoreNewlineStyle;
 
     public ITraceWriter TraceWriter => inner.TraceWriter;

--- a/Src/FluentAssertions/Equivalency/IEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyOptions.cs
@@ -113,4 +113,20 @@ public interface IEquivalencyOptions
     /// Gets a value indicating whether a case-insensitive comparer is used when comparing <see langword="string" />s.
     /// </summary>
     bool IgnoreCase { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether all newlines are ignored when comparing <see langword="string" />s.
+    /// </summary>
+    /// <remarks>
+    /// Enabling this option will remove all newlines from the strings before comparing them.
+    /// </remarks>
+    bool IgnoreAllNewlines { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the newline style is ignored when comparing <see langword="string" />s.
+    /// </summary>
+    /// <remarks>
+    /// Enabling this option will replace all occurences of <c>\r\n</c> and <c>\r</c> with <c>\n</c> in the strings before comparing them.
+    /// </remarks>
+    bool IgnoreNewlineStyle { get; }
 }

--- a/Src/FluentAssertions/Equivalency/IEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyOptions.cs
@@ -115,18 +115,10 @@ public interface IEquivalencyOptions
     bool IgnoreCase { get; }
 
     /// <summary>
-    /// Gets a value indicating whether all newlines are ignored when comparing <see langword="string" />s.
-    /// </summary>
-    /// <remarks>
-    /// Enabling this option will remove all newlines from the strings before comparing them.
-    /// </remarks>
-    bool IgnoreAllNewlines { get; }
-
-    /// <summary>
     /// Gets a value indicating whether the newline style is ignored when comparing <see langword="string" />s.
     /// </summary>
     /// <remarks>
-    /// Enabling this option will replace all occurences of <c>\r\n</c> and <c>\r</c> with <c>\n</c> in the strings before comparing them.
+    /// Enabling this option will replace all occurrences of <c>\r\n</c> and <c>\r</c> with <c>\n</c> in the strings before comparing them.
     /// </remarks>
     bool IgnoreNewlineStyle { get; }
 }

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -739,7 +739,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     }
 
     /// <summary>
-    /// Instructs the comparison ignore all newlines when comparing <see langword="string" />s.
+    /// Instructs the comparison to ignore all newlines when comparing <see langword="string" />s.
     /// </summary>
     /// <remarks>
     /// Enabling this option will remove all newlines from the strings before comparing them.
@@ -751,7 +751,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     }
 
     /// <summary>
-    /// Instructs the comparison ignore the newline style when comparing <see langword="string" />s.
+    /// Instructs the comparison to ignore the newline style when comparing <see langword="string" />s.
     /// </summary>
     /// <remarks>
     /// Enabling this option will replace all occurences of <c>\r\n</c> and <c>\r</c> with <c>\n</c> in the strings before comparing them.

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -91,6 +91,8 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
         IgnoreLeadingWhitespace = defaults.IgnoreLeadingWhitespace;
         IgnoreTrailingWhitespace = defaults.IgnoreTrailingWhitespace;
         IgnoreCase = defaults.IgnoreCase;
+        IgnoreAllNewlines = defaults.IgnoreAllNewlines;
+        IgnoreNewlineStyle = defaults.IgnoreNewlineStyle;
 
         ConversionSelector = defaults.ConversionSelector.Clone();
 
@@ -190,6 +192,10 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     public bool IgnoreTrailingWhitespace { get; private set; }
 
     public bool IgnoreCase { get; private set; }
+
+    public bool IgnoreAllNewlines { get; private set; }
+
+    public bool IgnoreNewlineStyle { get; private set; }
 
     public ITraceWriter TraceWriter { get; private set; }
 
@@ -729,6 +735,30 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     public TSelf IgnoringCase()
     {
         IgnoreCase = true;
+        return (TSelf)this;
+    }
+
+    /// <summary>
+    /// Instructs the comparison ignore all newlines when comparing <see langword="string" />s.
+    /// </summary>
+    /// <remarks>
+    /// Enabling this option will remove all newlines from the strings before comparing them.
+    /// </remarks>
+    public TSelf IgnoringAllNewlines()
+    {
+        IgnoreAllNewlines = true;
+        return (TSelf)this;
+    }
+
+    /// <summary>
+    /// Instructs the comparison ignore the newline style when comparing <see langword="string" />s.
+    /// </summary>
+    /// <remarks>
+    /// Enabling this option will replace all occurences of <c>\r\n</c> and <c>\r</c> with <c>\n</c> in the strings before comparing them.
+    /// </remarks>
+    public TSelf IgnoringNewlineStyle()
+    {
+        IgnoreNewlineStyle = true;
         return (TSelf)this;
     }
 

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -91,7 +91,6 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
         IgnoreLeadingWhitespace = defaults.IgnoreLeadingWhitespace;
         IgnoreTrailingWhitespace = defaults.IgnoreTrailingWhitespace;
         IgnoreCase = defaults.IgnoreCase;
-        IgnoreAllNewlines = defaults.IgnoreAllNewlines;
         IgnoreNewlineStyle = defaults.IgnoreNewlineStyle;
 
         ConversionSelector = defaults.ConversionSelector.Clone();
@@ -192,8 +191,6 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     public bool IgnoreTrailingWhitespace { get; private set; }
 
     public bool IgnoreCase { get; private set; }
-
-    public bool IgnoreAllNewlines { get; private set; }
 
     public bool IgnoreNewlineStyle { get; private set; }
 
@@ -735,18 +732,6 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     public TSelf IgnoringCase()
     {
         IgnoreCase = true;
-        return (TSelf)this;
-    }
-
-    /// <summary>
-    /// Instructs the comparison to ignore all newlines when comparing <see langword="string" />s.
-    /// </summary>
-    /// <remarks>
-    /// Enabling this option will remove all newlines from the strings before comparing them.
-    /// </remarks>
-    public TSelf IgnoringAllNewlines()
-    {
-        IgnoreAllNewlines = true;
         return (TSelf)this;
     }
 

--- a/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -59,11 +59,6 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
                 o.IgnoringCase();
             }
 
-            if (existingOptions.IgnoreAllNewlines)
-            {
-                o.IgnoringAllNewlines();
-            }
-
             if (existingOptions.IgnoreNewlineStyle)
             {
                 o.IgnoringNewlineStyle();

--- a/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -59,6 +59,16 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
                 o.IgnoringCase();
             }
 
+            if (existingOptions.IgnoreAllNewlines)
+            {
+                o.IgnoringAllNewlines();
+            }
+
+            if (existingOptions.IgnoreNewlineStyle)
+            {
+                o.IgnoringNewlineStyle();
+            }
+
             return o;
         };
 

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -471,7 +471,6 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             new StringWildcardMatchingStrategy
             {
                 IgnoreCase = options.IgnoreCase,
-                IgnoreAllNewlines = options.IgnoreAllNewlines,
                 IgnoreNewlineStyle = options.IgnoreNewlineStyle,
             },
             because, becauseArgs);
@@ -597,7 +596,6 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             new StringWildcardMatchingStrategy
             {
                 IgnoreCase = options.IgnoreCase,
-                IgnoreAllNewlines = options.IgnoreAllNewlines,
                 IgnoreNewlineStyle = options.IgnoreNewlineStyle,
                 Negate = true
             },
@@ -1998,7 +1996,6 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// <remarks>
     /// When <see cref="IEquivalencyOptions.IgnoreLeadingWhitespace"/> is set, whitespace is removed from the start of the <paramref name="value"/>.<br />
     /// When <see cref="IEquivalencyOptions.IgnoreTrailingWhitespace"/> is set, whitespace is removed from the end of the <paramref name="value"/>.<br />
-    /// When <see cref="IEquivalencyOptions.IgnoreAllNewlines"/> is set, all newlines are removed from the <paramref name="value"/>.<br />
     /// When <see cref="IEquivalencyOptions.IgnoreNewlineStyle"/> is set, all newlines (<c>\r\n</c> and <c>\r</c>) are replaced with <c>\n</c> in the <paramref name="value"/>.<br />
     /// </remarks>
     private static string ApplyStringSettings(string value, IEquivalencyOptions options)
@@ -2011,11 +2008,6 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         if (options.IgnoreTrailingWhitespace)
         {
             value = value.TrimEnd();
-        }
-
-        if (options.IgnoreAllNewlines)
-        {
-            value = value.RemoveNewLines();
         }
 
         if (options.IgnoreNewlineStyle)

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -406,7 +406,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             new StringWildcardMatchingStrategy
             {
                 IgnoreCase = true,
-                IgnoreNewLineDifferences = true
+                IgnoreAllNewlines = true
             },
             because, becauseArgs);
 
@@ -471,7 +471,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             new StringWildcardMatchingStrategy
             {
                 IgnoreCase = options.IgnoreCase,
-                IgnoreNewLineDifferences = options.IgnoreNewlineStyle
+                IgnoreAllNewlines = options.IgnoreAllNewlines
             },
             because, becauseArgs);
 
@@ -530,7 +530,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             new StringWildcardMatchingStrategy
             {
                 IgnoreCase = true,
-                IgnoreNewLineDifferences = true,
+                IgnoreAllNewlines = true,
                 Negate = true
             },
             because, becauseArgs);
@@ -596,7 +596,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             new StringWildcardMatchingStrategy
             {
                 IgnoreCase = options.IgnoreCase,
-                IgnoreNewLineDifferences = options.IgnoreNewlineStyle,
+                IgnoreAllNewlines = options.IgnoreNewlineStyle,
                 Negate = true
             },
             because, becauseArgs);

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -471,7 +471,8 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             new StringWildcardMatchingStrategy
             {
                 IgnoreCase = options.IgnoreCase,
-                IgnoreAllNewlines = options.IgnoreAllNewlines
+                IgnoreAllNewlines = options.IgnoreAllNewlines,
+                IgnoreNewlineStyle = options.IgnoreNewlineStyle,
             },
             because, becauseArgs);
 
@@ -596,7 +597,8 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             new StringWildcardMatchingStrategy
             {
                 IgnoreCase = options.IgnoreCase,
-                IgnoreAllNewlines = options.IgnoreNewlineStyle,
+                IgnoreAllNewlines = options.IgnoreAllNewlines,
+                IgnoreNewlineStyle = options.IgnoreNewlineStyle,
                 Negate = true
             },
             because, becauseArgs);
@@ -2013,16 +2015,12 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
 
         if (options.IgnoreAllNewlines)
         {
-            value = value
-                .Replace("\r", string.Empty, StringComparison.Ordinal)
-                .Replace("\n", string.Empty, StringComparison.Ordinal);
+            value = value.RemoveNewLines();
         }
 
         if (options.IgnoreNewlineStyle)
         {
-            value = value
-                .Replace("\r\n", "\n", StringComparison.Ordinal)
-                .Replace("\r", "\n", StringComparison.Ordinal);
+            value = value.RemoveNewlineStyle();
         }
 
         return value;

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -470,7 +470,8 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         var stringWildcardMatchingValidator = new StringValidator(
             new StringWildcardMatchingStrategy
             {
-                IgnoreCase = options.IgnoreCase
+                IgnoreCase = options.IgnoreCase,
+                IgnoreNewLineDifferences = options.IgnoreNewlineStyle
             },
             because, becauseArgs);
 
@@ -595,6 +596,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             new StringWildcardMatchingStrategy
             {
                 IgnoreCase = options.IgnoreCase,
+                IgnoreNewLineDifferences = options.IgnoreNewlineStyle,
                 Negate = true
             },
             because, becauseArgs);
@@ -1994,6 +1996,8 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// <remarks>
     /// When <see cref="IEquivalencyOptions.IgnoreLeadingWhitespace"/> is set, whitespace is removed from the start of the <paramref name="value"/>.<br />
     /// When <see cref="IEquivalencyOptions.IgnoreTrailingWhitespace"/> is set, whitespace is removed from the end of the <paramref name="value"/>.<br />
+    /// When <see cref="IEquivalencyOptions.IgnoreAllNewlines"/> is set, all newlines are removed from the <paramref name="value"/>.<br />
+    /// When <see cref="IEquivalencyOptions.IgnoreNewlineStyle"/> is set, all newlines (<c>\r\n</c> and <c>\r</c>) are replaced with <c>\n</c> in the <paramref name="value"/>.<br />
     /// </remarks>
     private static string ApplyStringSettings(string value, IEquivalencyOptions options)
     {
@@ -2005,6 +2009,20 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         if (options.IgnoreTrailingWhitespace)
         {
             value = value.TrimEnd();
+        }
+
+        if (options.IgnoreAllNewlines)
+        {
+            value = value
+                .Replace("\r", string.Empty, StringComparison.Ordinal)
+                .Replace("\n", string.Empty, StringComparison.Ordinal);
+        }
+
+        if (options.IgnoreNewlineStyle)
+        {
+            value = value
+                .Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Replace("\r", "\n", StringComparison.Ordinal);
         }
 
         return value;

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingStrategy.cs
@@ -50,7 +50,7 @@ internal class StringWildcardMatchingStrategy : IStringComparisonStrategy
 
     private string CleanNewLines(string input)
     {
-        return IgnoreNewLineDifferences ? input.RemoveNewLines() : input;
+        return IgnoreAllNewlines ? input.RemoveNewLines() : input;
     }
 
     public string ExpectationDescription
@@ -82,5 +82,5 @@ internal class StringWildcardMatchingStrategy : IStringComparisonStrategy
     /// <summary>
     /// Ignores the difference between environment newline differences
     /// </summary>
-    public bool IgnoreNewLineDifferences { get; init; }
+    public bool IgnoreAllNewlines { get; init; }
 }

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingStrategy.cs
@@ -50,7 +50,17 @@ internal class StringWildcardMatchingStrategy : IStringComparisonStrategy
 
     private string CleanNewLines(string input)
     {
-        return IgnoreAllNewlines ? input.RemoveNewLines() : input;
+        if (IgnoreAllNewlines)
+        {
+            return input.RemoveNewLines();
+        }
+
+        if (IgnoreNewlineStyle)
+        {
+            return input.RemoveNewlineStyle();
+        }
+
+        return input;
     }
 
     public string ExpectationDescription
@@ -80,7 +90,12 @@ internal class StringWildcardMatchingStrategy : IStringComparisonStrategy
     public bool IgnoreCase { get; init; }
 
     /// <summary>
-    /// Ignores the difference between environment newline differences
+    /// Ignores all newline differences
     /// </summary>
     public bool IgnoreAllNewlines { get; init; }
+
+    /// <summary>
+    /// Ignores the difference between environment newline differences
+    /// </summary>
+    public bool IgnoreNewlineStyle { get; init; }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -756,8 +756,10 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
+        bool IgnoreAllNewlines { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
+        bool IgnoreNewlineStyle { get; }
         bool IgnoreNonBrowsableOnSubject { get; }
         bool IgnoreTrailingWhitespace { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
@@ -920,8 +922,10 @@ namespace FluentAssertions.Equivalency
         protected SelfReferenceEquivalencyOptions(FluentAssertions.Equivalency.IEquivalencyOptions defaults) { }
         public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        public bool IgnoreAllNewlines { get; }
         public bool IgnoreCase { get; }
         public bool IgnoreLeadingWhitespace { get; }
+        public bool IgnoreNewlineStyle { get; }
         public bool IgnoreTrailingWhitespace { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -943,9 +947,11 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNestedObjects() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
+        public TSelf IgnoringAllNewlines() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf IgnoringLeadingWhitespace() { }
+        public TSelf IgnoringNewlineStyle() { }
         public TSelf IgnoringNonBrowsableMembersOnSubject() { }
         public TSelf IgnoringTrailingWhitespace() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -756,7 +756,6 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
-        bool IgnoreAllNewlines { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
         bool IgnoreNewlineStyle { get; }
@@ -922,7 +921,6 @@ namespace FluentAssertions.Equivalency
         protected SelfReferenceEquivalencyOptions(FluentAssertions.Equivalency.IEquivalencyOptions defaults) { }
         public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
-        public bool IgnoreAllNewlines { get; }
         public bool IgnoreCase { get; }
         public bool IgnoreLeadingWhitespace { get; }
         public bool IgnoreNewlineStyle { get; }
@@ -947,7 +945,6 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNestedObjects() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
-        public TSelf IgnoringAllNewlines() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf IgnoringLeadingWhitespace() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -769,7 +769,6 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
-        bool IgnoreAllNewlines { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
         bool IgnoreNewlineStyle { get; }
@@ -935,7 +934,6 @@ namespace FluentAssertions.Equivalency
         protected SelfReferenceEquivalencyOptions(FluentAssertions.Equivalency.IEquivalencyOptions defaults) { }
         public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
-        public bool IgnoreAllNewlines { get; }
         public bool IgnoreCase { get; }
         public bool IgnoreLeadingWhitespace { get; }
         public bool IgnoreNewlineStyle { get; }
@@ -960,7 +958,6 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNestedObjects() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
-        public TSelf IgnoringAllNewlines() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf IgnoringLeadingWhitespace() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -769,8 +769,10 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
+        bool IgnoreAllNewlines { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
+        bool IgnoreNewlineStyle { get; }
         bool IgnoreNonBrowsableOnSubject { get; }
         bool IgnoreTrailingWhitespace { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
@@ -933,8 +935,10 @@ namespace FluentAssertions.Equivalency
         protected SelfReferenceEquivalencyOptions(FluentAssertions.Equivalency.IEquivalencyOptions defaults) { }
         public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        public bool IgnoreAllNewlines { get; }
         public bool IgnoreCase { get; }
         public bool IgnoreLeadingWhitespace { get; }
+        public bool IgnoreNewlineStyle { get; }
         public bool IgnoreTrailingWhitespace { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -956,9 +960,11 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNestedObjects() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
+        public TSelf IgnoringAllNewlines() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf IgnoringLeadingWhitespace() { }
+        public TSelf IgnoringNewlineStyle() { }
         public TSelf IgnoringNonBrowsableMembersOnSubject() { }
         public TSelf IgnoringTrailingWhitespace() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -749,8 +749,10 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
+        bool IgnoreAllNewlines { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
+        bool IgnoreNewlineStyle { get; }
         bool IgnoreNonBrowsableOnSubject { get; }
         bool IgnoreTrailingWhitespace { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
@@ -913,8 +915,10 @@ namespace FluentAssertions.Equivalency
         protected SelfReferenceEquivalencyOptions(FluentAssertions.Equivalency.IEquivalencyOptions defaults) { }
         public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        public bool IgnoreAllNewlines { get; }
         public bool IgnoreCase { get; }
         public bool IgnoreLeadingWhitespace { get; }
+        public bool IgnoreNewlineStyle { get; }
         public bool IgnoreTrailingWhitespace { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -936,9 +940,11 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNestedObjects() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
+        public TSelf IgnoringAllNewlines() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf IgnoringLeadingWhitespace() { }
+        public TSelf IgnoringNewlineStyle() { }
         public TSelf IgnoringNonBrowsableMembersOnSubject() { }
         public TSelf IgnoringTrailingWhitespace() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -749,7 +749,6 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
-        bool IgnoreAllNewlines { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
         bool IgnoreNewlineStyle { get; }
@@ -915,7 +914,6 @@ namespace FluentAssertions.Equivalency
         protected SelfReferenceEquivalencyOptions(FluentAssertions.Equivalency.IEquivalencyOptions defaults) { }
         public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
-        public bool IgnoreAllNewlines { get; }
         public bool IgnoreCase { get; }
         public bool IgnoreLeadingWhitespace { get; }
         public bool IgnoreNewlineStyle { get; }
@@ -940,7 +938,6 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNestedObjects() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
-        public TSelf IgnoringAllNewlines() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf IgnoringLeadingWhitespace() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -756,8 +756,10 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
+        bool IgnoreAllNewlines { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
+        bool IgnoreNewlineStyle { get; }
         bool IgnoreNonBrowsableOnSubject { get; }
         bool IgnoreTrailingWhitespace { get; }
         FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
@@ -920,8 +922,10 @@ namespace FluentAssertions.Equivalency
         protected SelfReferenceEquivalencyOptions(FluentAssertions.Equivalency.IEquivalencyOptions defaults) { }
         public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        public bool IgnoreAllNewlines { get; }
         public bool IgnoreCase { get; }
         public bool IgnoreLeadingWhitespace { get; }
+        public bool IgnoreNewlineStyle { get; }
         public bool IgnoreTrailingWhitespace { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -943,9 +947,11 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNestedObjects() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
+        public TSelf IgnoringAllNewlines() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf IgnoringLeadingWhitespace() { }
+        public TSelf IgnoringNewlineStyle() { }
         public TSelf IgnoringNonBrowsableMembersOnSubject() { }
         public TSelf IgnoringTrailingWhitespace() { }
         public TSelf Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -756,7 +756,6 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
-        bool IgnoreAllNewlines { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
         bool IgnoreNewlineStyle { get; }
@@ -922,7 +921,6 @@ namespace FluentAssertions.Equivalency
         protected SelfReferenceEquivalencyOptions(FluentAssertions.Equivalency.IEquivalencyOptions defaults) { }
         public bool? CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
-        public bool IgnoreAllNewlines { get; }
         public bool IgnoreCase { get; }
         public bool IgnoreLeadingWhitespace { get; }
         public bool IgnoreNewlineStyle { get; }
@@ -947,7 +945,6 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingNestedObjects() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
-        public TSelf IgnoringAllNewlines() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }
         public TSelf IgnoringLeadingWhitespace() { }

--- a/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
+++ b/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
@@ -82,11 +82,7 @@ public class UsersOfGetClosedGenericInterfaces
 
         public bool IgnoreTrailingWhitespace => throw new NotImplementedException();
 
-        public bool IgnoreNewlines => throw new NotImplementedException();
-
         public bool IgnoreCase => throw new NotImplementedException();
-
-        public bool IgnoreAllNewlines => throw new NotImplementedException();
 
         public bool IgnoreNewlineStyle => throw new NotImplementedException();
     }

--- a/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
+++ b/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
@@ -85,6 +85,10 @@ public class UsersOfGetClosedGenericInterfaces
         public bool IgnoreNewlines => throw new NotImplementedException();
 
         public bool IgnoreCase => throw new NotImplementedException();
+
+        public bool IgnoreAllNewlines => throw new NotImplementedException();
+
+        public bool IgnoreNewlineStyle => throw new NotImplementedException();
     }
 
     [Params(typeof(DBNull), typeof(bool), typeof(char), typeof(sbyte), typeof(byte), typeof(short), typeof(ushort),

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeEquivalentTo.cs
@@ -38,5 +38,27 @@ public partial class CollectionAssertionSpecs
             // Act / Assert
             actual.Should().AllBeEquivalentTo(expectation, o => o.IgnoringTrailingWhitespace());
         }
+
+        [Fact]
+        public void Can_ignore_all_newlines_while_comparing_collections_of_strings()
+        {
+            // Arrange
+            var actual = new[] { "ABC", "\nA\nBC", "A\nBC\n", "A\r\nB\r\nC", "\r\nA\r\nB\r\nC\r\n" };
+            var expectation = "ABC";
+
+            // Act / Assert
+            actual.Should().AllBeEquivalentTo(expectation, o => o.IgnoringAllNewlines());
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_comparing_collections_of_strings()
+        {
+            // Arrange
+            var actual = new[] { "A\nB\nC", "A\r\nB\r\nC", "A\r\nB\nC", "A\nB\r\nC" };
+            var expectation = "A\nB\nC";
+
+            // Act / Assert
+            actual.Should().AllBeEquivalentTo(expectation, o => o.IgnoringNewlineStyle());
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeEquivalentTo.cs
@@ -40,17 +40,6 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void Can_ignore_all_newlines_while_comparing_collections_of_strings()
-        {
-            // Arrange
-            var actual = new[] { "ABC", "\nA\nBC", "A\nBC\n", "A\r\nB\r\nC", "\r\nA\r\nB\r\nC\r\n" };
-            var expectation = "ABC";
-
-            // Act / Assert
-            actual.Should().AllBeEquivalentTo(expectation, o => o.IgnoringAllNewlines());
-        }
-
-        [Fact]
         public void Can_ignore_newline_style_while_comparing_collections_of_strings()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
@@ -193,17 +193,6 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
-        public void Can_ignore_all_newlines_while_comparing_collections_of_strings()
-        {
-            // Arrange
-            var actual = new[] { "first", "\rA\nB\r\nC\n", "last" };
-            var expectation = new[] { "first", "ABC", "last" };
-
-            // Act / Assert
-            actual.Should().BeEquivalentTo(expectation, o => o.IgnoringAllNewlines());
-        }
-
-        [Fact]
         public void Can_ignore_newline_style_while_comparing_collections_of_strings()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
@@ -191,6 +191,28 @@ public partial class CollectionAssertionSpecs
             // Act / Assert
             actual.Should().BeEquivalentTo(expectation, o => o.IgnoringTrailingWhitespace());
         }
+
+        [Fact]
+        public void Can_ignore_all_newlines_while_comparing_collections_of_strings()
+        {
+            // Arrange
+            var actual = new[] { "first", "\rA\nB\r\nC\n", "last" };
+            var expectation = new[] { "first", "ABC", "last" };
+
+            // Act / Assert
+            actual.Should().BeEquivalentTo(expectation, o => o.IgnoringAllNewlines());
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_comparing_collections_of_strings()
+        {
+            // Arrange
+            var actual = new[] { "first", "A\nB\r\nC", "last" };
+            var expectation = new[] { "first", "A\r\nB\nC", "last" };
+
+            // Act / Assert
+            actual.Should().BeEquivalentTo(expectation, o => o.IgnoringNewlineStyle());
+        }
     }
 
     public class NotBeEquivalentTo

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeEquivalentTo.cs
@@ -40,17 +40,6 @@ public partial class ObjectAssertionSpecs
         }
 
         [Fact]
-        public void Can_ignore_all_newlines_while_comparing_objects_with_string_properties()
-        {
-            // Arrange
-            var actual = new { foo = "\rA\nB\r\nC\n" };
-            var expectation = new { foo = "ABC" };
-
-            // Act / Assert
-            actual.Should().BeEquivalentTo(expectation, o => o.IgnoringAllNewlines());
-        }
-
-        [Fact]
         public void Can_ignore_newline_style_while_comparing_objects_with_string_properties()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeEquivalentTo.cs
@@ -38,5 +38,27 @@ public partial class ObjectAssertionSpecs
             // Act / Assert
             actual.Should().BeEquivalentTo(expectation, o => o.IgnoringTrailingWhitespace());
         }
+
+        [Fact]
+        public void Can_ignore_all_newlines_while_comparing_objects_with_string_properties()
+        {
+            // Arrange
+            var actual = new { foo = "\rA\nB\r\nC\n" };
+            var expectation = new { foo = "ABC" };
+
+            // Act / Assert
+            actual.Should().BeEquivalentTo(expectation, o => o.IgnoringAllNewlines());
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_comparing_objects_with_string_properties()
+        {
+            // Arrange
+            var actual = new { foo = "A\nB\r\nC" };
+            var expectation = new { foo = "A\r\nB\nC" };
+
+            // Act / Assert
+            actual.Should().BeEquivalentTo(expectation, o => o.IgnoringNewlineStyle());
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeEquivalentTo.cs
@@ -73,6 +73,28 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
+        public void Can_ignore_all_newlines_while_comparing_strings_to_be_equivalent()
+        {
+            // Arrange
+            string actual = "\rA\nB\r\nC\n";
+            string expect = "\r\nAB\nC";
+
+            // Act / Assert
+            actual.Should().BeEquivalentTo(expect, o => o.IgnoringAllNewlines());
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_comparing_strings_to_be_equivalent()
+        {
+            // Arrange
+            string actual = "A\nB\r\nC";
+            string expect = "A\r\nB\nC";
+
+            // Act / Assert
+            actual.Should().BeEquivalentTo(expect, o => o.IgnoringNewlineStyle());
+        }
+
+        [Fact]
         public void When_strings_are_the_same_while_ignoring_case_it_should_not_throw()
         {
             // Arrange
@@ -232,6 +254,34 @@ public partial class StringAssertionSpecs
 
             // Act
             Action act = () => actual.Should().NotBeEquivalentTo(expect, o => o.IgnoringTrailingWhitespace());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Can_ignore_all_newlines_while_comparing_strings_to_not_be_equivalent()
+        {
+            // Arrange
+            string actual = "\rA\nB\r\nC\n";
+            string expect = "\nA\r\nB\n\nC";
+
+            // Act
+            Action act = () => actual.Should().NotBeEquivalentTo(expect, o => o.IgnoringAllNewlines());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_comparing_strings_to_not_be_equivalent()
+        {
+            // Arrange
+            string actual = "\rA\nB\r\nC\n";
+            string expect = "\nA\r\nB\nC\r";
+
+            // Act
+            Action act = () => actual.Should().NotBeEquivalentTo(expect, o => o.IgnoringNewlineStyle());
 
             // Assert
             act.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeEquivalentTo.cs
@@ -73,17 +73,6 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void Can_ignore_all_newlines_while_comparing_strings_to_be_equivalent()
-        {
-            // Arrange
-            string actual = "\rA\nB\r\nC\n";
-            string expect = "\r\nAB\nC";
-
-            // Act / Assert
-            actual.Should().BeEquivalentTo(expect, o => o.IgnoringAllNewlines());
-        }
-
-        [Fact]
         public void Can_ignore_newline_style_while_comparing_strings_to_be_equivalent()
         {
             // Arrange
@@ -254,20 +243,6 @@ public partial class StringAssertionSpecs
 
             // Act
             Action act = () => actual.Should().NotBeEquivalentTo(expect, o => o.IgnoringTrailingWhitespace());
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void Can_ignore_all_newlines_while_comparing_strings_to_not_be_equivalent()
-        {
-            // Arrange
-            string actual = "\rA\nB\r\nC\n";
-            string expect = "\nA\r\nB\n\nC";
-
-            // Act
-            Action act = () => actual.Should().NotBeEquivalentTo(expect, o => o.IgnoringAllNewlines());
 
             // Assert
             act.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainEquivalentOf.cs
@@ -71,6 +71,28 @@ public partial class StringAssertionSpecs
             actual.Should().ContainEquivalentOf(expect, o => o.IgnoringTrailingWhitespace());
         }
 
+        [Fact]
+        public void Can_ignore_all_newlines_while_checking_a_string_to_contain_another()
+        {
+            // Arrange
+            string actual = "this is a string containing \rA\nB\r\nC.\n";
+            string expect = "\nA\rB\r\nC";
+
+            // Act / Assert
+            actual.Should().ContainEquivalentOf(expect, o => o.IgnoringAllNewlines());
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_checking_a_string_to_contain_another()
+        {
+            // Arrange
+            string actual = "this is a string containing \rA\nB\r\nC.\n";
+            string expect = "A\r\nB\nC";
+
+            // Act / Assert
+            actual.Should().ContainEquivalentOf(expect, o => o.IgnoringNewlineStyle());
+        }
+
         [InlineData("aa", "A")]
         [InlineData("aCCa", "acca")]
         [Theory]
@@ -548,6 +570,34 @@ public partial class StringAssertionSpecs
 
             // Act
             Action act = () => actual.Should().NotContainEquivalentOf(expect, o => o.IgnoringTrailingWhitespace());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Can_ignore_all_newlines_while_checking_a_string_to_not_contain_another()
+        {
+            // Arrange
+            string actual = "this is a string containing \rA\nB\r\nC.\n";
+            string expect = "AB\n\nC\r";
+
+            // Act
+            Action act = () => actual.Should().NotContainEquivalentOf(expect, o => o.IgnoringAllNewlines());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_checking_a_string_to_not_contain_another()
+        {
+            // Arrange
+            string actual = "this is a string containing \rA\nB\r\nC.\n";
+            string expect = "\nA\r\nB\rC";
+
+            // Act
+            Action act = () => actual.Should().NotContainEquivalentOf(expect, o => o.IgnoringNewlineStyle());
 
             // Assert
             act.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainEquivalentOf.cs
@@ -72,17 +72,6 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void Can_ignore_all_newlines_while_checking_a_string_to_contain_another()
-        {
-            // Arrange
-            string actual = "this is a string containing \rA\nB\r\nC.\n";
-            string expect = "\nA\rB\r\nC";
-
-            // Act / Assert
-            actual.Should().ContainEquivalentOf(expect, o => o.IgnoringAllNewlines());
-        }
-
-        [Fact]
         public void Can_ignore_newline_style_while_checking_a_string_to_contain_another()
         {
             // Arrange
@@ -570,20 +559,6 @@ public partial class StringAssertionSpecs
 
             // Act
             Action act = () => actual.Should().NotContainEquivalentOf(expect, o => o.IgnoringTrailingWhitespace());
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void Can_ignore_all_newlines_while_checking_a_string_to_not_contain_another()
-        {
-            // Arrange
-            string actual = "this is a string containing \rA\nB\r\nC.\n";
-            string expect = "AB\n\nC\r";
-
-            // Act
-            Action act = () => actual.Should().NotContainEquivalentOf(expect, o => o.IgnoringAllNewlines());
 
             // Assert
             act.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.EndWithEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.EndWithEquivalentOf.cs
@@ -73,6 +73,28 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
+        public void Can_ignore_all_newlines_while_checking_a_string_to_end_with_another()
+        {
+            // Arrange
+            string actual = "prefix for \rA\nB\r\nC\n";
+            string expect = "A\r\nB\nC";
+
+            // Act / Assert
+            actual.Should().EndWithEquivalentOf(expect, o => o.IgnoringAllNewlines());
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_checking_a_string_to_end_with_another()
+        {
+            // Arrange
+            string actual = "prefix for \rA\nB\r\nC";
+            string expect = "A\r\nB\nC";
+
+            // Act / Assert
+            actual.Should().EndWithEquivalentOf(expect, o => o.IgnoringNewlineStyle());
+        }
+
+        [Fact]
         public void When_suffix_of_string_differs_by_case_only_it_should_not_throw()
         {
             // Arrange
@@ -224,6 +246,34 @@ public partial class StringAssertionSpecs
 
             // Act
             Action act = () => actual.Should().NotEndWithEquivalentOf(expect, o => o.IgnoringTrailingWhitespace());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Can_ignore_all_newlines_while_checking_a_string_to_not_end_with_another()
+        {
+            // Arrange
+            string actual = "prefix for \rA\nB\r\nC\n";
+            string expect = "A\r\nB\n\nC";
+
+            // Act
+            Action act = () => actual.Should().NotEndWithEquivalentOf(expect, o => o.IgnoringAllNewlines());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_checking_a_string_to_not_end_with_another()
+        {
+            // Arrange
+            string actual = "prefix for \rA\nB\r\nC\n";
+            string expect = "A\r\nB\nC\r";
+
+            // Act
+            Action act = () => actual.Should().NotEndWithEquivalentOf(expect, o => o.IgnoringNewlineStyle());
 
             // Assert
             act.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.EndWithEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.EndWithEquivalentOf.cs
@@ -73,17 +73,6 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void Can_ignore_all_newlines_while_checking_a_string_to_end_with_another()
-        {
-            // Arrange
-            string actual = "prefix for \rA\nB\r\nC\n";
-            string expect = "A\r\nB\nC";
-
-            // Act / Assert
-            actual.Should().EndWithEquivalentOf(expect, o => o.IgnoringAllNewlines());
-        }
-
-        [Fact]
         public void Can_ignore_newline_style_while_checking_a_string_to_end_with_another()
         {
             // Arrange
@@ -246,20 +235,6 @@ public partial class StringAssertionSpecs
 
             // Act
             Action act = () => actual.Should().NotEndWithEquivalentOf(expect, o => o.IgnoringTrailingWhitespace());
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void Can_ignore_all_newlines_while_checking_a_string_to_not_end_with_another()
-        {
-            // Arrange
-            string actual = "prefix for \rA\nB\r\nC\n";
-            string expect = "A\r\nB\n\nC";
-
-            // Act
-            Action act = () => actual.Should().NotEndWithEquivalentOf(expect, o => o.IgnoringAllNewlines());
 
             // Assert
             act.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchEquivalentOf.cs
@@ -45,17 +45,6 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void Can_ignore_all_newlines_while_checking_a_string_to_match_another()
-        {
-            // Arrange
-            string actual = "\rA\nB\r\nC\n";
-            string expect = "A?C\r";
-
-            // Act / Assert
-            actual.Should().MatchEquivalentOf(expect, o => o.IgnoringAllNewlines());
-        }
-
-        [Fact]
         public void Can_ignore_newline_style_while_checking_a_string_to_match_another()
         {
             // Arrange
@@ -178,20 +167,6 @@ public partial class StringAssertionSpecs
 
             // Act
             Action act = () => actual.Should().NotMatchEquivalentOf(expect, o => o.IgnoringTrailingWhitespace());
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void Can_ignore_all_newlines_while_checking_a_string_to_not_match_another()
-        {
-            // Arrange
-            string actual = "\rA\nB\r\nC\n";
-            string expect = "\nA\r\n?\nC\r";
-
-            // Act
-            Action act = () => actual.Should().NotMatchEquivalentOf(expect, o => o.IgnoringAllNewlines());
 
             // Assert
             act.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchEquivalentOf.cs
@@ -202,7 +202,7 @@ public partial class StringAssertionSpecs
         {
             // Arrange
             string actual = "\rA\nB\r\nC\n";
-            string expect = "\nA\r\n?\n\nC\r";
+            string expect = "\nA\r\n?\nC\r";
 
             // Act
             Action act = () => actual.Should().NotMatchEquivalentOf(expect, o => o.IgnoringNewlineStyle());

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.MatchEquivalentOf.cs
@@ -45,6 +45,28 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
+        public void Can_ignore_all_newlines_while_checking_a_string_to_match_another()
+        {
+            // Arrange
+            string actual = "\rA\nB\r\nC\n";
+            string expect = "A?C\r";
+
+            // Act / Assert
+            actual.Should().MatchEquivalentOf(expect, o => o.IgnoringAllNewlines());
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_checking_a_string_to_match_another()
+        {
+            // Arrange
+            string actual = "\rA\nB\r\nC\n";
+            string expect = "\nA\r\n?\nC\r";
+
+            // Act / Assert
+            actual.Should().MatchEquivalentOf(expect, o => o.IgnoringNewlineStyle());
+        }
+
+        [Fact]
         public void When_a_string_does_not_match_the_equivalent_of_a_wildcard_pattern_it_should_throw()
         {
             // Arrange
@@ -156,6 +178,34 @@ public partial class StringAssertionSpecs
 
             // Act
             Action act = () => actual.Should().NotMatchEquivalentOf(expect, o => o.IgnoringTrailingWhitespace());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Can_ignore_all_newlines_while_checking_a_string_to_not_match_another()
+        {
+            // Arrange
+            string actual = "\rA\nB\r\nC\n";
+            string expect = "\nA\r\n?\nC\r";
+
+            // Act
+            Action act = () => actual.Should().NotMatchEquivalentOf(expect, o => o.IgnoringAllNewlines());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_checking_a_string_to_not_match_another()
+        {
+            // Arrange
+            string actual = "\rA\nB\r\nC\n";
+            string expect = "\nA\r\n?\n\nC\r";
+
+            // Act
+            Action act = () => actual.Should().NotMatchEquivalentOf(expect, o => o.IgnoringNewlineStyle());
 
             // Assert
             act.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.StartWithEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.StartWithEquivalentOf.cs
@@ -73,17 +73,6 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void Can_ignore_all_newlines_while_checking_a_string_to_start_with_another()
-        {
-            // Arrange
-            string actual = "\rA\nB\r\nC\n with suffix";
-            string expect = "\n\nABC";
-
-            // Act / Assert
-            actual.Should().StartWithEquivalentOf(expect, o => o.IgnoringAllNewlines());
-        }
-
-        [Fact]
         public void Can_ignore_newline_style_while_checking_a_string_to_start_with_another()
         {
             // Arrange
@@ -245,20 +234,6 @@ public partial class StringAssertionSpecs
 
             // Act
             Action act = () => actual.Should().NotStartWithEquivalentOf(expect, o => o.IgnoringTrailingWhitespace());
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void Can_ignore_all_newlines_while_checking_a_string_to_not_start_with_another()
-        {
-            // Arrange
-            string actual = "\rA\nB\r\nC\n with suffix";
-            string expect = "\n\nAB\rC";
-
-            // Act
-            Action act = () => actual.Should().NotStartWithEquivalentOf(expect, o => o.IgnoringAllNewlines());
 
             // Assert
             act.Should().Throw<XunitException>();

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.StartWithEquivalentOf.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.StartWithEquivalentOf.cs
@@ -73,6 +73,28 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
+        public void Can_ignore_all_newlines_while_checking_a_string_to_start_with_another()
+        {
+            // Arrange
+            string actual = "\rA\nB\r\nC\n with suffix";
+            string expect = "\n\nABC";
+
+            // Act / Assert
+            actual.Should().StartWithEquivalentOf(expect, o => o.IgnoringAllNewlines());
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_checking_a_string_to_start_with_another()
+        {
+            // Arrange
+            string actual = "\rA\nB\r\nC\n with suffix";
+            string expect = "\r\nA\rB\nC";
+
+            // Act / Assert
+            actual.Should().StartWithEquivalentOf(expect, o => o.IgnoringNewlineStyle());
+        }
+
+        [Fact]
         public void When_start_of_string_differs_by_case_only_it_should_not_throw()
         {
             // Arrange
@@ -223,6 +245,34 @@ public partial class StringAssertionSpecs
 
             // Act
             Action act = () => actual.Should().NotStartWithEquivalentOf(expect, o => o.IgnoringTrailingWhitespace());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Can_ignore_all_newlines_while_checking_a_string_to_not_start_with_another()
+        {
+            // Arrange
+            string actual = "\rA\nB\r\nC\n with suffix";
+            string expect = "\n\nAB\rC";
+
+            // Act
+            Action act = () => actual.Should().NotStartWithEquivalentOf(expect, o => o.IgnoringAllNewlines());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Can_ignore_newline_style_while_checking_a_string_to_not_start_with_another()
+        {
+            // Arrange
+            string actual = "\rA\nB\r\nC\n with suffix";
+            string expect = "\nA\r\nB\rC";
+
+            // Act
+            Action act = () => actual.Should().NotStartWithEquivalentOf(expect, o => o.IgnoringNewlineStyle());
 
             // Assert
             act.Should().Throw<XunitException>();

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -21,7 +21,7 @@ sidebar:
 * Improve failure message for string assertions when checking for equality - [#2307](https://github.com/fluentassertions/fluentassertions/pull/2307)
 * Allow specifying `EquivalencyOptions` in string assertions - [#2413](https://github.com/fluentassertions/fluentassertions/pull/2413)
   * This also adds the capability to ignore casing, leading or trailing whitespace on strings when using `BeEquivalentTo` on object graphs or collections.
-  * Also adds the capability to ignore all newlines or the newline style on strings - [#2565](https://github.com/fluentassertions/fluentassertions/pull/2565)
+  * Also adds the capability to ignore the newline style on strings - [#2565](https://github.com/fluentassertions/fluentassertions/pull/2565)
 * You can mark all assertions in an assembly as custom assertions using the `[CustomAssertionsAssembly]` attribute - [#2389](https://github.com/fluentassertions/fluentassertions/pull/2389)
 * Improve `BeEmpty()` and `BeNullOrEmpty()` performance for `IEnumerable<T>`, by materializing only the first item - [#2530](https://github.com/fluentassertions/fluentassertions/pull/2530)
 * All `Should()` methods on reference types are now annotated with the `[NotNull]` attribute for a better Fluent Assertions experience when nullable reference types are enabled - [#2380](https://github.com/fluentassertions/fluentassertions/pull/2380)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -21,6 +21,7 @@ sidebar:
 * Improve failure message for string assertions when checking for equality - [#2307](https://github.com/fluentassertions/fluentassertions/pull/2307)
 * Allow specifying `EquivalencyOptions` in string assertions - [#2413](https://github.com/fluentassertions/fluentassertions/pull/2413)
   * This also adds the capability to ignore casing, leading or trailing whitespace on strings when using `BeEquivalentTo` on object graphs or collections.
+  * Also adds the capability to ignore all newlines or the newline style on strings - [#2565](https://github.com/fluentassertions/fluentassertions/pull/2565)
 * You can mark all assertions in an assembly as custom assertions using the `[CustomAssertionsAssembly]` attribute - [#2389](https://github.com/fluentassertions/fluentassertions/pull/2389)
 * Improve `BeEmpty()` and `BeNullOrEmpty()` performance for `IEnumerable<T>`, by materializing only the first item - [#2530](https://github.com/fluentassertions/fluentassertions/pull/2530)
 * All `Should()` methods on reference types are now annotated with the `[NotNull]` attribute for a better Fluent Assertions experience when nullable reference types are enabled - [#2380](https://github.com/fluentassertions/fluentassertions/pull/2380)

--- a/docs/_pages/strings.md
+++ b/docs/_pages/strings.md
@@ -89,7 +89,6 @@ The supported options are:
 | `IgnoringLeadingWhitespace`  | Ignores leading whitespace in the subject and the expectation.                                    |
 | `IgnoringTrailingWhitespace` | Ignores trailing whitespace in the subject and the expectation.                                   |
 | `IgnoringCase`               | Compares the strings case-insensitive.                                                            |
-| `IgnoringAllNewlines`        | Removes all newlines in the subject and expectation.                                              |
 | `IgnoringNewlineStyle`       | Replaces `"\r\n"` and `"\r"` with `"\n"` before comparing the subject and expectation.            |
 
 You can also specify a custom string comparer via

--- a/docs/_pages/strings.md
+++ b/docs/_pages/strings.md
@@ -84,11 +84,13 @@ theString.Should().BeEquivalentTo("This is a string", o => o.IgnoringLeadingWhit
 
 The supported options are:
 
-| Option                       | Behavior                                                       |
-| ---------------------------- | --------------------------------------------------------------- |
-| `IgnoringLeadingWhitespace`  | Ignores leading whitespace in the subject and the expectation.  |
-| `IgnoringTrailingWhitespace` | Ignores trailing whitespace in the subject and the expectation. |
-| `IgnoringCase`               | Compares the strings case-insensitive.                          |
+| Option                       | Behavior                                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------------------------- |
+| `IgnoringLeadingWhitespace`  | Ignores leading whitespace in the subject and the expectation.                                    |
+| `IgnoringTrailingWhitespace` | Ignores trailing whitespace in the subject and the expectation.                                   |
+| `IgnoringCase`               | Compares the strings case-insensitive.                                                            |
+| `IgnoringAllNewlines`        | Removes all newlines in the subject and expectation.                                              |
+| `IgnoringNewlineStyle`       | Replaces `"\r\n"` and `"\r"` with `"\n"` before comparing the subject and expectation.            |
 
 You can also specify a custom string comparer via
 ```csharp


### PR DESCRIPTION
Add the following option to the `EquivalencyAssertionOptions<T>` for strings

```C#
public EquivalencyAssertionOptions<T> IgnoringNewlineStyle()
{
    // This will replace "\r\n" with "\n" in actual and expected before comparison
    return this;
}
```

This fixes #2612 and fixes #2566


## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
