### PR TITLE
Add JsonElementEquivalencyStep

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/JsonElementEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/JsonElementEquivalencyStep.cs
@@ -1,0 +1,148 @@
+#if NET6_0_OR_GREATER
+namespace FluentAssertions.Equivalency.Steps;
+
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions.Execution;
+
+public class JsonElementEquivalencyStep : IEquivalencyStep
+{
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    {
+        JsonElement? subject = comparands.Subject switch
+        {
+            JsonElement s => s,
+            JsonDocument d => d.RootElement,
+            JsonNode n => NodeToElement(n),
+            _ => null,
+        };
+
+        JsonElement? expectation = comparands.Expectation switch
+        {
+            JsonElement s => s,
+            JsonDocument d => d.RootElement,
+            JsonNode n => NodeToElement(n),
+            _ => null,
+        };
+
+        if (subject is not null && expectation is not null)
+        {
+            HandleElementCompare(subject.Value, expectation.Value, context, nestedValidator);
+            return EquivalencyResult.AssertionCompleted;
+        }
+
+        return EquivalencyResult.ContinueWithNext;
+    }
+
+    private static JsonElement? NodeToElement(JsonNode jsonNode)
+    {
+        using var document = JsonDocument.Parse(jsonNode.ToJsonString());
+        return document.RootElement.Clone();
+    }
+
+    private static void HandleElementCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    {
+        AssertionScope.Current
+            .ForCondition(subject.ValueKind == expectation.ValueKind)
+            .FailWith("Expected type to be {0}, but found {1}", expectation.ValueKind, subject.ValueKind);
+
+        switch (subject.ValueKind)
+        {
+            case JsonValueKind.Array:
+                HandleArrayCompare(subject, expectation, context, nestedValidator);
+                break;
+            case JsonValueKind.Object:
+                HandleObjectCompare(subject, expectation, context, nestedValidator);
+                break;
+            case JsonValueKind.String:
+                HandleStringCompare(subject, expectation, context, nestedValidator);
+                break;
+            case JsonValueKind.Number:
+                HandleNumberCompare(subject, expectation, context, nestedValidator);
+                break;
+            default:
+                // true, false, null, undefined has no value to compare,
+                // so if both have the same ValueKind, the json are equal
+                break;
+        }
+    }
+
+    private static void HandleNumberCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    {
+        // Json does not specify a range for numbers, but allows scientific syntax
+        // (1E2 for 100), so we can't just compare strings.
+        // The solution here is to first check if the numbers are equal in 64bit floating point
+        // then compare the actual raw text to get a proper error message.
+        if (!NumbersEqualsIgnoreInfAndNan(subject.GetDouble(), expectation.GetDouble()))
+        {
+            var subjectString = subject.GetRawText();
+            var expectationString = expectation.GetRawText();
+            nestedValidator.RecursivelyAssertEquality(new Comparands(subjectString, expectationString, typeof(double)), context);
+        }
+    }
+
+    private static bool NumbersEqualsIgnoreInfAndNan(double actual, double expected)
+    {
+        if (
+            double.IsInfinity(actual) ||
+            double.IsInfinity(expected) ||
+            double.IsNaN(actual) ||
+            double.IsNaN(expected))
+        {
+            return false;
+        }
+
+        return actual.Equals(expected);
+    }
+
+    private static void HandleStringCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    {
+        var subjectString = subject.GetString();
+        var expectationString = expectation.GetString();
+        nestedValidator.RecursivelyAssertEquality(new Comparands(subjectString, expectationString, typeof(string)), context);
+    }
+
+    private static void HandleObjectCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    {
+        int expectedCount = 0;
+        foreach (var expectedProperty in expectation.EnumerateObject())
+        {
+            var expectedPropertyName = expectedProperty.Name;
+            expectedCount++;
+            if (!subject.TryGetProperty(expectedPropertyName, out var subjectElement))
+            {
+                AssertionScope.Current
+                    .ForCondition(true)
+                    .FailWith("Expected property {0} not found", expectedPropertyName);
+            }
+
+            nestedValidator.RecursivelyAssertEquality(
+                new Comparands(subjectElement, expectedProperty.Value, typeof(JsonElement)),
+                context.AsDictionaryItem<string, JsonElement>(expectedPropertyName));
+        }
+
+        // All expected properties are found, now check if there are any extra properties in the subject
+        var subjectCount = subject.EnumerateObject().Count();
+        AssertionScope.Current
+            .ForCondition(subjectCount == expectedCount)
+            .FailWith("Expected object to have length {0}, but found {0} properties", expectedCount, subjectCount);
+    }
+
+    private static void HandleArrayCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    {
+        AssertionScope.Current
+            .ForCondition(subject.GetArrayLength() == expectation.GetArrayLength())
+            .FailWith("Expected array length {0} but found {1}", expectation.GetArrayLength(), subject.GetArrayLength());
+
+        int index = 0;
+        foreach (var (expectedElement, subjectElement) in expectation.EnumerateArray().Zip(subject.EnumerateArray()))
+        {
+            index++;
+            nestedValidator.RecursivelyAssertEquality(
+                new Comparands(subjectElement, expectedElement, typeof(JsonElement)),
+                context.AsCollectionItem<JsonElement>(index));
+        }
+    }
+}
+#endif

--- a/Src/FluentAssertions/Equivalency/Steps/JsonElementEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/JsonElementEquivalencyStep.cs
@@ -1,65 +1,95 @@
 #if NET6_0_OR_GREATER
-namespace FluentAssertions.Equivalency.Steps;
+#nullable enable
 
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using FluentAssertions.Execution;
 
+namespace FluentAssertions.Equivalency.Steps;
+
 public class JsonElementEquivalencyStep : IEquivalencyStep
 {
-    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    public EquivalencyResult Handle(
+        Comparands comparands,
+        IEquivalencyValidationContext context,
+        IValidateChildNodeEquivalency valueChildNodes)
     {
-        JsonElement? subject = comparands.Subject switch
+        // We sometimes need to parse into JsonDocument, and those need to be disposed.
+        JsonDocument? subjectDocument = null;
+        JsonDocument? expectationDocument = null;
+        try
         {
-            JsonElement s => s,
-            JsonDocument d => d.RootElement,
-            JsonNode n => NodeToElement(n),
-            _ => null,
-        };
+            // Convert the subject and expectation to JsonElement from the supported types
+            JsonElement? subject = null;
+            switch (comparands.Subject)
+            {
+                case JsonElement jsonElement:
+                    subject = jsonElement;
+                    break;
+                case JsonDocument jsonDocument:
+                    subject = jsonDocument.RootElement;
+                    break;
+                case JsonNode jsonNode:
+                    // Ensure the document can be properly disposed
+                    subjectDocument = JsonDocument.Parse(jsonNode.ToJsonString());
+                    subject = subjectDocument.RootElement;
+                    break;
+            }
 
-        JsonElement? expectation = comparands.Expectation switch
-        {
-            JsonElement s => s,
-            JsonDocument d => d.RootElement,
-            JsonNode n => NodeToElement(n),
-            _ => null,
-        };
+            JsonElement? expectation = null;
+            switch (comparands.Expectation)
+            {
+                case JsonElement jsonElement:
+                    expectation = jsonElement;
+                    break;
+                case JsonDocument jsonDocument:
+                    expectation = jsonDocument.RootElement;
+                    break;
+                case JsonNode jsonNode:
+                    // Ensure the document can be properly disposed
+                    expectationDocument = JsonDocument.Parse(jsonNode.ToJsonString());
+                    expectation = expectationDocument.RootElement;
+                    break;
+            }
 
-        if (subject is not null && expectation is not null)
-        {
-            HandleElementCompare(subject.Value, expectation.Value, context, nestedValidator);
-            return EquivalencyResult.AssertionCompleted;
+            // Should we consider running JsonSerializer.SerializeToDocument(obj) on the other value if only one is a JsonElement like type?
+            if (subject.HasValue && expectation.HasValue)
+            {
+                HandleElementCompare(subject.Value, expectation.Value, context, valueChildNodes);
+                return EquivalencyResult.EquivalencyProven;
+            }
+
+            return EquivalencyResult.ContinueWithNext;
         }
-
-        return EquivalencyResult.ContinueWithNext;
+        finally
+        {
+            subjectDocument?.Dispose();
+            expectationDocument?.Dispose();
+        }
     }
 
-    private static JsonElement? NodeToElement(JsonNode jsonNode)
+    private static void HandleElementCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IValidateChildNodeEquivalency valueChildNodes)
     {
-        using var document = JsonDocument.Parse(jsonNode.ToJsonString());
-        return document.RootElement.Clone();
-    }
+        var assertionChain = AssertionChain.GetOrCreate().For(context);
 
-    private static void HandleElementCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
-    {
-        AssertionScope.Current
+        assertionChain
             .ForCondition(subject.ValueKind == expectation.ValueKind)
-            .FailWith("Expected type to be {0}, but found {1}", expectation.ValueKind, subject.ValueKind);
+            .FailWith("Expected JsonType to be {0}, but found {1}", expectation.ValueKind.ToString(), subject.ValueKind.ToString());
 
         switch (subject.ValueKind)
         {
             case JsonValueKind.Array:
-                HandleArrayCompare(subject, expectation, context, nestedValidator);
+                HandleArrayCompare(subject, expectation, context, valueChildNodes, assertionChain);
                 break;
             case JsonValueKind.Object:
-                HandleObjectCompare(subject, expectation, context, nestedValidator);
+                HandleObjectCompare(subject, expectation, context, valueChildNodes, assertionChain);
                 break;
             case JsonValueKind.String:
-                HandleStringCompare(subject, expectation, context, nestedValidator);
+                HandleStringCompare(subject, expectation, context, valueChildNodes);
                 break;
             case JsonValueKind.Number:
-                HandleNumberCompare(subject, expectation, context, nestedValidator);
+                HandleNumberCompare(subject, expectation, context, valueChildNodes);
                 break;
             default:
                 // true, false, null, undefined has no value to compare,
@@ -68,26 +98,26 @@ public class JsonElementEquivalencyStep : IEquivalencyStep
         }
     }
 
-    private static void HandleNumberCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    private static void HandleNumberCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IValidateChildNodeEquivalency valueChildNodes)
     {
         // Json does not specify a range for numbers, but allows scientific syntax
         // (1E2 for 100), so we can't just compare strings.
         // The solution here is to run multiple checks
-        // 1. Check if they are both representable as 64 bit integers and compare them
-        // 2. If not check if they are equal in 64bit floating point
+        // 1. Check if they are both representable as 64-bit integers and compare them
+        // 2. If not, check if they are equal in 64bit floating point
         // 3. Then compare the actual raw text to get a proper error message.
         if (!NumbersEqualsIgnoreInfAndNan(subject, expectation))
         {
             var subjectString = subject.GetRawText();
             var expectationString = expectation.GetRawText();
-            nestedValidator.RecursivelyAssertEquality(new Comparands(subjectString, expectationString, typeof(double)), context);
+            valueChildNodes.AssertEquivalencyOf(new Comparands(subjectString, expectationString, typeof(string)), context);
         }
     }
 
     private static bool NumbersEqualsIgnoreInfAndNan(JsonElement actual, JsonElement expected)
     {
         // This check ensures that integers between 2^53 and 2^61 are compared with full precision
-        if(actual.TryGetInt64(out var actualInt) && expected.TryGetInt64(out var expectedInt))
+        if (actual.TryGetInt64(out var actualInt) && expected.TryGetInt64(out var expectedInt))
         {
             return actualInt == expectedInt;
         }
@@ -106,42 +136,42 @@ public class JsonElementEquivalencyStep : IEquivalencyStep
         return actualDouble.Equals(expectedDouble);
     }
 
-    private static void HandleStringCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    private static void HandleStringCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IValidateChildNodeEquivalency valueChildNodes)
     {
         var subjectString = subject.GetString();
         var expectationString = expectation.GetString();
-        nestedValidator.RecursivelyAssertEquality(new Comparands(subjectString, expectationString, typeof(string)), context);
+        valueChildNodes.AssertEquivalencyOf(new Comparands(subjectString, expectationString, typeof(string)), context);
     }
 
-    private static void HandleObjectCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    private static void HandleObjectCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IValidateChildNodeEquivalency valueChildNodes, AssertionChain assertionChain)
     {
         int expectedCount = 0;
-        foreach (var expectedProperty in expectation.EnumerateObject())
+        foreach (JsonProperty expectedProperty in expectation.EnumerateObject())
         {
-            var expectedPropertyName = expectedProperty.Name;
-            expectedCount++;
-            if (!subject.TryGetProperty(expectedPropertyName, out var subjectElement))
+            // How would you configure the property matching to be case insensitive?
+            if (!subject.TryGetProperty(expectedProperty.Name, out JsonElement subjectElement))
             {
-                AssertionScope.Current
+                assertionChain
                     .ForCondition(true)
-                    .FailWith("Expected property {0} not found", expectedPropertyName);
+                    .FailWith("Expected property {0} not found", expectedProperty.Name);
             }
 
-            nestedValidator.RecursivelyAssertEquality(
+            valueChildNodes.AssertEquivalencyOf(
                 new Comparands(subjectElement, expectedProperty.Value, typeof(JsonElement)),
-                context.AsDictionaryItem<string, JsonElement>(expectedPropertyName));
+                context.AsDictionaryItem<string, JsonElement>(expectedProperty.Name));
+            expectedCount++;
         }
 
         // All expected properties are found, now check if there are any extra properties in the subject
         var subjectCount = subject.EnumerateObject().Count();
-        AssertionScope.Current
+        assertionChain
             .ForCondition(subjectCount == expectedCount)
             .FailWith("Expected object to have length {0}, but found {0} properties", expectedCount, subjectCount);
     }
 
-    private static void HandleArrayCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+    private static void HandleArrayCompare(JsonElement subject, JsonElement expectation, IEquivalencyValidationContext context, IValidateChildNodeEquivalency valueChildNodes, AssertionChain assertionChain)
     {
-        AssertionScope.Current
+        assertionChain
             .ForCondition(subject.GetArrayLength() == expectation.GetArrayLength())
             .FailWith("Expected array length {0} but found {1}", expectation.GetArrayLength(), subject.GetArrayLength());
 
@@ -149,7 +179,7 @@ public class JsonElementEquivalencyStep : IEquivalencyStep
         foreach (var (expectedElement, subjectElement) in expectation.EnumerateArray().Zip(subject.EnumerateArray()))
         {
             index++;
-            nestedValidator.RecursivelyAssertEquality(
+            valueChildNodes.AssertEquivalencyOf(
                 new Comparands(subjectElement, expectedElement, typeof(JsonElement)),
                 context.AsCollectionItem<JsonElement>(index));
         }

--- a/Src/FluentAssertions/EquivalencyPlan.cs
+++ b/Src/FluentAssertions/EquivalencyPlan.cs
@@ -148,6 +148,9 @@ public class EquivalencyPlan : IEnumerable<IEquivalencyStep>
             new XDocumentEquivalencyStep(),
             new XElementEquivalencyStep(),
             new XAttributeEquivalencyStep(),
+#if NET6_0_OR_GREATER
+            new JsonElementEquivalencyStep(),
+#endif
             new DictionaryEquivalencyStep(),
             new MultiDimensionalArrayEquivalencyStep(),
             new GenericEnumerableEquivalencyStep(),

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1004,6 +1004,11 @@ namespace FluentAssertions.Equivalency.Steps
         public GenericEnumerableEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    public class JsonElementEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public JsonElementEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
     public class ReferenceEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public ReferenceEqualityEquivalencyStep() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1007,7 +1007,7 @@ namespace FluentAssertions.Equivalency.Steps
     public class JsonElementEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public JsonElementEquivalencyStep() { }
-        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
     public class ReferenceEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/FluentAssertions.Equivalency.Specs/SystemTextJsonSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SystemTextJsonSpecs.cs
@@ -53,6 +53,26 @@ public class SystemTextJsonSpecs
     }
 
     [Fact]
+    public void DifferentOrderJsonObject_ShouldBeEquivalent()
+    {
+        using var expected = JsonDocument.Parse("""{"a":123,"b":234}""");
+        using var actual = JsonDocument.Parse("""{"b":234,"a":123}""");
+        actual.RootElement.Should().BeEquivalentTo(expected.RootElement);
+    }
+
+    [Fact]
+    public void DifferentOrderDifferentValueJsonObject_ShouldNotBeEquivalent()
+    {
+        var action = () =>
+        {
+            using var expected = JsonDocument.Parse("""{"a":123,"b":234}""");
+            using var actual = JsonDocument.Parse("""{"b":234,"a":1}""");
+            actual.RootElement.Should().BeEquivalentTo(expected.RootElement);
+        };
+        action.Should().Throw<XunitException>().WithMessage("""*actual.RootElement[a]*"123"*"1"*""");
+    }
+
+    [Fact]
     public void DifferentJsonElement_ShouldNotBeEquivalent()
     {
         var action = () =>
@@ -62,6 +82,62 @@ public class SystemTextJsonSpecs
             return actual.RootElement.Should().BeEquivalentTo(expected.RootElement);
         };
         action.Should().Throw<XunitException>().WithMessage("*234*44*");
+    }
+
+    [Fact]
+    public void DifferentJsonTypes_ShouldNotBeEquivalent()
+    {
+        var action = () =>
+        {
+            using var actual = JsonDocument.Parse("true");
+            using var expected = JsonDocument.Parse("\"true\"");
+            return actual.RootElement.Should().BeEquivalentTo(expected.RootElement);
+        };
+        action.Should().Throw<XunitException>().WithMessage("""*"String"*"True"*""");
+    }
+
+    [Fact]
+    public void DifferenceDeepRecursive_ShouldIncludePath()
+    {
+        var action = () =>
+        {
+            using var actual = JsonDocument.Parse("""
+                  {
+                    "list":[
+                      1,
+                      {
+                        "a":2,
+                        "b":3,
+                        "c":4,
+                        "d":{
+                          "e":true
+                        }
+                      },
+                      3,
+                      {"error":[{"a":1}]}
+                    ]
+                  }
+                  """);
+            using var expected = JsonDocument.Parse("""
+                {
+                  "list":[
+                    1,
+                    {
+                      "a":2,
+                      "c":4,
+                      "b":3,
+                      "d":{
+                        "e":true
+                      }
+                    },
+                    3,
+                    {"error":[{"a":2}]}
+                  ]
+                }
+                """);
+            return actual.RootElement.Should().BeEquivalentTo(expected.RootElement);
+        };
+        action.Should().Throw<XunitException>().WithMessage("*actual.RootElement[list][4][error][1][a]*");
     }
 
     [Theory]
@@ -82,6 +158,7 @@ public class SystemTextJsonSpecs
         "*4*3*"
         )]
     [InlineData("6","6.0000", null)]
+    [InlineData("\"6\"","\"6.0000\"", "*\"6.0000\"*\"6\"*")]
     [InlineData("[]","[]", null)]
     [InlineData("[]","[2]", "*array length*")]
     [InlineData("[2]","[]", "*array length*")]

--- a/Tests/FluentAssertions.Equivalency.Specs/SystemTextJsonSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SystemTextJsonSpecs.cs
@@ -1,0 +1,107 @@
+#if NET6_0_OR_GREATER
+#nullable enable
+using System.Text.Json;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Equivalency.Specs;
+
+public class SystemTextJsonSpecs
+{
+    [Fact]
+    public void EmptyJsonDocument_ShouldBeEquivalent()
+    {
+        using var expected = JsonDocument.Parse("{}");
+        using var actual = JsonDocument.Parse("{}");
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EqualJsonDocument_ShouldBeEquivalent()
+    {
+        using var expected = JsonDocument.Parse("""{"a":123}""");
+        using var actual = JsonDocument.Parse("""{"a":123}""");
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void DifferentJsonDocument_ShouldNotBeEquivalent()
+    {
+        var action = () =>
+        {
+            using var expected = JsonDocument.Parse("234");
+            using var actual = JsonDocument.Parse("44");
+            return actual.Should().BeEquivalentTo(expected);
+        };
+        action.Should().Throw<XunitException>().WithMessage("*234*44*");
+    }
+
+    [Fact]
+    public void EmptyJsonElement_ShouldBeEquivalent()
+    {
+        using var expected = JsonDocument.Parse("{}");
+        using var actual = JsonDocument.Parse("{}");
+        actual.RootElement.Should().BeEquivalentTo(expected.RootElement);
+    }
+
+    [Fact]
+    public void EqualJsonElement_ShouldBeEquivalent()
+    {
+        using var expected = JsonDocument.Parse("""{"a":123}""");
+        using var actual = JsonDocument.Parse("""{"a":123}""");
+        actual.RootElement.Should().BeEquivalentTo(expected.RootElement);
+    }
+
+    [Fact]
+    public void DifferentJsonElement_ShouldNotBeEquivalent()
+    {
+        var action = () =>
+        {
+            using var actual = JsonDocument.Parse("44");
+            using var expected = JsonDocument.Parse("234");
+            return actual.RootElement.Should().BeEquivalentTo(expected.RootElement);
+        };
+        action.Should().Throw<XunitException>().WithMessage("*234*44*");
+    }
+
+    [Theory]
+    [InlineData("""
+        {
+            "numbers": [1,2,3]
+        }
+        """,
+        """{"numbers":[1,2,3]}""",
+        null
+        )]
+    [InlineData("""
+        {
+            "numbers": [1,2,3]
+        }
+        """,
+        """{"numbers":[1,2,4]}""",
+        "*4*3*"
+        )]
+    [InlineData("6","6.0000", null)]
+    [InlineData("[]","[]", null)]
+    [InlineData("[]","[2]", "*array length*")]
+    [InlineData("[2]","[]", "*array length*")]
+    public void TestTheory(string actual, string expected, string? errorPattern)
+    {
+        using var expectedDoc = JsonDocument.Parse(expected);
+        using var actualDoc = JsonDocument.Parse(actual);
+
+        if (errorPattern is null)
+        {
+            actualDoc.Should().BeEquivalentTo(expectedDoc);
+        }
+        else
+        {
+            // ReSharper disable line AccessToDisposedClosure
+            Record.Exception(() => actualDoc.Should().BeEquivalentTo(expectedDoc))
+                .Should().BeOfType<XunitException>()
+                .Which
+                .Message.Should().Match(errorPattern);
+        }
+    }
+}
+#endif

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -28,6 +28,7 @@ sidebar:
 * Added a few more assertions on `XDocument` - [#2690](https://github.com/fluentassertions/fluentassertions/pull/2690)
     * `[Not]HaveElementWithValue`
     * `NotHaveElement`
+* Added `IEquivalencyStep` for `JsonElement`, `JsonDocument` and `JsonNode` so that parsed json can be compared with `BeEquivalentTo` - [#2576](https://github.com/fluentassertions/fluentassertions/pull/2576)
 
 ### Improvements
 * Improve failure message for string assertions when checking for equality - [#2307](https://github.com/fluentassertions/fluentassertions/pull/2307)


### PR DESCRIPTION
Taking some inspiration from https://github.com/fluentassertions/fluentassertions/issues/2374, I improved the implementation of `IEquivalencyStep` to actually keep the path when recursing into a json structure and added some tests.

I'm a little puzzled about how to compare json numbers. In JS they are 64 bit floating point, so I ended up using `GetDouble()` so that `100` and `1e2` is equivalent, but used the string for comparing `NaN`, `Inf` and for generating the error message.

As this is part of adding proper support for `System.Text.Json`, I'm not sure how the release notes should be written.

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
