### PR TITLE
Add support for `Satisfy` on `ReferenceTypeAssertions`

### DIFF
--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -423,15 +423,18 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
     }
 
     /// <summary>
-    /// Asserts that the criteria provided by the element inspector is satisfied.
+    /// Allows combining one or more assertions using the other assertion methods that this library offers on an instance of <typeparamref name="T"/>.
     /// </summary>
-    /// <param name="expected">The element inspector which must be satisfied by the <typeparamref name="TSubject" />.</param>
+    /// <remarks>
+    /// If multiple assertions executed by the <paramref name="assertion"/> fail, they will be raised as a single failure.
+    /// </remarks>
+    /// <param name="assertion">The element inspector which must be satisfied by the <typeparamref name="TSubject" />.</param>
     /// <returns>An <see cref="AndConstraint{T}" /> which can be used to chain assertions.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
-    public AndConstraint<TAssertions> Satisfy<T>(Action<T> expected)
+    /// <exception cref="ArgumentNullException"><paramref name="assertion"/> is <see langword="null"/>.</exception>
+    public AndConstraint<TAssertions> Satisfy<T>(Action<T> assertion)
         where T : TSubject
     {
-        Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify an object against a <null> inspector.");
+        Guard.ThrowIfArgumentIsNull(assertion, nameof(assertion), "Cannot verify an object against a <null> inspector.");
 
         Execute.Assertion
             .ForCondition(Subject is T)
@@ -442,7 +445,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
 
         using (var assertionScope = new AssertionScope())
         {
-            expected((T)Subject);
+            assertion((T)Subject);
             failuresFromInspector = assertionScope.Discard();
         }
 

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -443,7 +443,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
             .Then
             .ForCondition(Subject is T)
             .WithDefaultIdentifier(Identifier)
-            .FailWith("Expected {context:object} to be assignable to {0}{reason}, but {1} is not.", typeof(T), Subject!.GetType());
+            .FailWith("Expected {context:object} to be assignable to {0}{reason}, but {1} is not.", typeof(T), Subject?.GetType());
 
         if (success)
         {

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
@@ -417,6 +418,44 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
             .BecauseOf(because, becauseArgs)
             .WithDefaultIdentifier(Identifier)
             .FailWith("Expected {context:object} to match {1}{reason}, but found {0}.", Subject, predicate);
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
+    /// Asserts that the criteria provided by the element inspector is satisfied.
+    /// </summary>
+    /// <param name="expected">The element inspector which must be satisfied by the <typeparamref name="TSubject" />.</param>
+    /// <returns>An <see cref="AndConstraint{T}" /> which can be used to chain assertions.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
+    public AndConstraint<TAssertions> Satisfy<T>(Action<T> expected)
+        where T : TSubject
+    {
+        Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify an object against a <null> inspector.");
+
+        Execute.Assertion
+            .ForCondition(Subject is T)
+            .WithDefaultIdentifier(Identifier)
+            .FailWith("Expected {context:object} to be assignable to {0}{reason}, but {1} is not.", typeof(T), Subject.GetType());
+
+        string[] failuresFromInspector;
+
+        using (var assertionScope = new AssertionScope())
+        {
+            expected((T)Subject);
+            failuresFromInspector = assertionScope.Discard();
+        }
+
+        if (failuresFromInspector.Length > 0)
+        {
+            string failureMessage = Environment.NewLine
+                + string.Join(Environment.NewLine, failuresFromInspector.Select(x => x.IndentLines()));
+
+            Execute.Assertion
+                .WithDefaultIdentifier(Identifier)
+                .WithExpectation("Expected {context:object} to match inspector, but the inspector was not satisfied:", Subject)
+                .FailWithPreFormatted(failureMessage);
+        }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -437,9 +437,13 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
         Guard.ThrowIfArgumentIsNull(assertion, nameof(assertion), "Cannot verify an object against a <null> inspector.");
 
         Execute.Assertion
+            .ForCondition(Subject is not null)
+            .WithDefaultIdentifier(Identifier)
+            .FailWith("Expected {context:object} to be assignable to {0}{reason}, but found <null>.", typeof(T))
+            .Then
             .ForCondition(Subject is T)
             .WithDefaultIdentifier(Identifier)
-            .FailWith("Expected {context:object} to be assignable to {0}{reason}, but {1} is not.", typeof(T), Subject.GetType());
+            .FailWith("Expected {context:object} to be assignable to {0}{reason}, but {1} is not.", typeof(T), Subject!.GetType());
 
         string[] failuresFromInspector;
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2019,6 +2019,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Satisfy<T>(System.Action<T> expected)
+            where T : TSubject { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2019,7 +2019,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> Satisfy<T>(System.Action<T> expected)
+        public FluentAssertions.AndConstraint<TAssertions> Satisfy<T>(System.Action<T> assertion)
             where T : TSubject { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2103,7 +2103,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> Satisfy<T>(System.Action<T> expected)
+        public FluentAssertions.AndConstraint<TAssertions> Satisfy<T>(System.Action<T> assertion)
             where T : TSubject { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2103,6 +2103,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Satisfy<T>(System.Action<T> expected)
+            where T : TSubject { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1963,6 +1963,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Satisfy<T>(System.Action<T> expected)
+            where T : TSubject { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1963,7 +1963,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> Satisfy<T>(System.Action<T> expected)
+        public FluentAssertions.AndConstraint<TAssertions> Satisfy<T>(System.Action<T> assertion)
             where T : TSubject { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2019,6 +2019,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Satisfy<T>(System.Action<T> expected)
+            where T : TSubject { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2019,7 +2019,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> Satisfy<T>(System.Action<T> expected)
+        public FluentAssertions.AndConstraint<TAssertions> Satisfy<T>(System.Action<T> assertion)
             where T : TSubject { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
@@ -1,0 +1,220 @@
+﻿using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Primitives;
+
+public partial class ReferenceTypeAssertionsSpecs
+{
+    public class Satisfy
+    {
+        [Fact]
+        public void When_object_satisfies_inspector_it_should_not_throw()
+        {
+            // Arrange
+            var someObject = new object();
+
+            // Act
+            Action act = () => someObject.Should().Satisfy<object>(x => x.Should().NotBeNull());
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_typed_object_satisfies_inspector_it_should_not_throw()
+        {
+            // Arrange
+            var someObject = new PersonDto
+            {
+                Name = "Name Nameson",
+                Birthdate = new DateTime(2000, 1, 1),
+            };
+
+            // Act
+            Action act = () => someObject.Should().Satisfy<PersonDto>(o => o.Age.Should().BeGreaterThan(0));
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_object_does_not_satisfy_the_inspector_it_should_throw()
+        {
+            // Arrange
+            var someObject = new object();
+
+            // Act
+            Action act = () => someObject.Should().Satisfy<object>(o => o.Should().BeNull("it is not initialized yet"));
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                $"""
+                 Expected {nameof(someObject)} to match inspector, but the inspector was not satisfied:
+                 *Expected o to be <null> because it is not initialized yet, but found System.Object*
+                 """);
+        }
+
+        [Fact]
+        public void When_a_typed_object_does_not_satisfy_the_inspector_it_should_throw()
+        {
+            // Arrange
+            const string personName = "Name Nameson";
+
+            var somePerson = new PersonDto
+            {
+                Name = personName,
+                Birthdate = new DateTime(1973, 9, 20),
+            };
+
+            // Act
+            Action act = () =>
+                somePerson.Should().Satisfy<PersonDto>(d => d.Name.Should().HaveLength(0, "it is not initialized yet"));
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                $"""
+                 Expected {nameof(somePerson)} to match inspector, but the inspector was not satisfied:
+                 *Expected d.Name with length 0 because it is not initialized yet, but found string "{personName}" with length {personName.Length}.
+                 """);
+        }
+
+        [Fact]
+        public void When_a_complex_typed_object_does_not_satisfy_inspector_it_should_throw()
+        {
+            // Arrange
+            var someComplexDto = new PersonAndAddressDto
+            {
+                Person = new PersonDto
+                {
+                    Name = "Buford Howard Tannen",
+                    Birthdate = new DateTime(1937, 3, 26),
+                },
+                Address = new AddressDto
+                {
+                    Street = "Mason Street",
+                    Number = "1809",
+                    City = "Hill Valley",
+                    Country = "United States",
+                    PostalCode = "CA 91905",
+                },
+            };
+
+            // Act
+            Action act = () => someComplexDto.Should().Satisfy<PersonAndAddressDto>(dto =>
+            {
+                dto.Person.Should().Satisfy<PersonDto>(person =>
+                {
+                    person.Name.Should().Be("Biff Tannen");
+                    person.Age.Should().Be(48);
+                    person.Birthdate.Should().Be(new DateTime(1937, 3, 26));
+                });
+
+                dto.Address.Should().Satisfy<AddressDto>(address =>
+                {
+                    address.Street.Should().Be("Mason Street");
+                    address.Number.Should().Be("1809");
+                    address.City.Should().Be("Hill Valley, San Diego County, California");
+                    address.Country.Should().Be("United States");
+                    address.PostalCode.Should().Be("CA 91905");
+                });
+            });
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                $"""
+                 Expected {nameof(someComplexDto)} to match inspector, but the inspector was not satisfied:
+                 *Expected dto.Person to match inspector*
+                 *Expected person.Name*
+                 *Expected dto.Address to match inspector*
+                 *Expected address.City*
+                 """);
+        }
+
+        [Fact]
+        public void When_a_typed_object_is_satisfied_against_an_incorrect_type_it_should_throw()
+        {
+            // Arrange
+            var personDto = new PersonDto();
+
+            // Act
+            Action act = () => personDto.Should().Satisfy<AddressDto>(dto => dto.Should().NotBeNull());
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    $"Expected {nameof(personDto)} to be assignable to {typeof(AddressDto)}, but {typeof(PersonDto)} is not.");
+        }
+
+        [Fact]
+        public void When_a_typed_object_does_not_match_multiple_inspectors_it_should_throw()
+        {
+            // Arrange
+            var somePerson = new PersonDto
+            {
+                Name = "Name Nameson",
+                Birthdate = new DateTime(2000, 1, 1),
+            };
+
+            // Act
+            Action act = () => somePerson.Should().Satisfy<PersonDto>(d =>
+            {
+                d.Name.Should().Be("Someone Else");
+                d.Age.Should().BeLessThan(20);
+                d.Birthdate.Should().BeAfter(new DateTime(2001, 1, 1));
+            });
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                $"""
+                 Expected {nameof(somePerson)} to match inspector, but the inspector was not satisfied:
+                 *Expected d.Name*
+                 *Expected d.Age*
+                 *Expected d.Birthdate*
+                 """);
+        }
+
+        [Fact]
+        public void When_object_is_satisfied_against_a_null_inspector_it_should_throw()
+        {
+            // Arrange
+            var someObject = new object();
+
+            // Act
+            Action act = () => someObject.Should().Satisfy<object>(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .WithMessage("Cannot verify an object against a <null> inspector.*");
+        }
+
+        private class PersonDto
+        {
+            public string Name { get; init; }
+
+            public DateTime Birthdate { get; init; }
+
+            public int Age => DateTime.UtcNow.Subtract(Birthdate).Days / 365;
+        }
+
+        private class PersonAndAddressDto
+        {
+            public PersonDto Person { get; init; }
+
+            public AddressDto Address { get; init; }
+        }
+
+        private class AddressDto
+        {
+            public string Street { get; init; }
+
+            public string Number { get; init; }
+
+            public string City { get; init; }
+
+            public string PostalCode { get; init; }
+
+            public string Country { get; init; }
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
@@ -200,6 +200,49 @@ public partial class ReferenceTypeAssertionsSpecs
                     $"Expected {nameof(personDto)} to be assignable to {typeof(AddressDto)}, but {typeof(PersonDto)} is not.");
         }
 
+        [Fact]
+        public void Sub_class_satisfied_against_base_class_does_not_throw()
+        {
+            // Arrange
+            var subClass = new SubClass
+            {
+                Number = 42,
+                Date = new DateTime(2021, 1, 1),
+                Text = "Some text"
+            };
+
+            // Act / Assert
+            subClass.Should().Satisfy<BaseClass>(x =>
+            {
+                x.Number.Should().Be(42);
+                x.Date.Should().Be(new DateTime(2021, 1, 1));
+            });
+        }
+
+        [Fact]
+        public void Base_class_satisfied_against_sub_class_throws()
+        {
+            // Arrange
+            var baseClass = new BaseClass
+            {
+                Number = 42,
+                Date = new DateTime(2021, 1, 1),
+            };
+
+            // Act
+            Action act = () => baseClass.Should().Satisfy<SubClass>(x =>
+            {
+                x.Number.Should().Be(42);
+                x.Date.Should().Be(new DateTime(2021, 1, 1));
+                x.Text.Should().Be("Some text");
+            });
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    $"Expected {nameof(baseClass)} to be assignable to {typeof(SubClass)}, but {typeof(BaseClass)} is not.");
+        }
+
         private class PersonDto
         {
             public string Name { get; init; }
@@ -227,6 +270,18 @@ public partial class ReferenceTypeAssertionsSpecs
             public string PostalCode { get; init; }
 
             public string Country { get; init; }
+        }
+
+        private class BaseClass
+        {
+            public int Number { get; init; }
+
+            public DateTime Date { get; init; }
+        }
+
+        private sealed class SubClass : BaseClass
+        {
+            public string Text { get; init; }
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
@@ -91,7 +92,7 @@ public partial class ReferenceTypeAssertionsSpecs
                 {
                     person.Name.Should().Be("Name Nameson");
                     person.Age.Should().BeGreaterThan(0);
-                    person.Birthdate.Should().Be(new DateTime(2000, 1, 1));
+                    person.Birthdate.Should().Be(1.January(2000));
                 });
 
                 dto.Address.Should().Satisfy<AddressDto>(address =>
@@ -120,7 +121,7 @@ public partial class ReferenceTypeAssertionsSpecs
             {
                 d.Name.Should().Be("Someone Else");
                 d.Age.Should().BeLessThan(20);
-                d.Birthdate.Should().BeAfter(new DateTime(2001, 1, 1));
+                d.Birthdate.Should().BeAfter(1.January(2001));
             });
 
             // Assert
@@ -161,7 +162,7 @@ public partial class ReferenceTypeAssertionsSpecs
                 {
                     person.Name.Should().Be("Biff Tannen");
                     person.Age.Should().Be(48);
-                    person.Birthdate.Should().Be(new DateTime(1937, 3, 26));
+                    person.Birthdate.Should().Be(26.March(1937));
                 });
 
                 dto.Address.Should().Satisfy<AddressDto>(address =>
@@ -215,7 +216,7 @@ public partial class ReferenceTypeAssertionsSpecs
             subClass.Should().Satisfy<BaseClass>(x =>
             {
                 x.Number.Should().Be(42);
-                x.Date.Should().Be(new DateTime(2021, 1, 1));
+                x.Date.Should().Be(1.January(2021));
             });
         }
 
@@ -233,7 +234,7 @@ public partial class ReferenceTypeAssertionsSpecs
             Action act = () => baseClass.Should().Satisfy<SubClass>(x =>
             {
                 x.Number.Should().Be(42);
-                x.Date.Should().Be(new DateTime(2021, 1, 1));
+                x.Date.Should().Be(1.January(2021));
                 x.Text.Should().Be("Some text");
             });
 

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
@@ -267,7 +267,11 @@ public partial class ReferenceTypeAssertionsSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected dto.Address to be assignable to *AddressDto, but found <null>.");
+                .WithMessage(
+                    $"""
+                    Expected {nameof(complexDto)} to match inspector, but the inspector was not satisfied:
+                    *Expected dto.Address to be assignable to {typeof(AddressDto)}, but found <null>.
+                    """);
         }
 
         [Fact]
@@ -296,7 +300,11 @@ public partial class ReferenceTypeAssertionsSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected dto.Address to be assignable to *AddressDto, but found <null>.");
+                .WithMessage(
+                    $"""
+                     Expected {nameof(complexDto)} to match inspector, but the inspector was not satisfied:
+                     *Expected dto.Address to be assignable to {typeof(AddressDto)}, but found <null>.
+                     """);
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
@@ -9,7 +9,7 @@ public partial class ReferenceTypeAssertionsSpecs
     public class Satisfy
     {
         [Fact]
-        public void When_object_satisfies_inspector_it_should_not_throw()
+        public void Object_satisfying_inspector_does_not_throw()
         {
             // Arrange
             var someObject = new object();
@@ -19,7 +19,7 @@ public partial class ReferenceTypeAssertionsSpecs
         }
 
         [Fact]
-        public void When_object_does_not_satisfy_the_inspector_it_should_throw()
+        public void Object_not_satisfying_inspector_throws()
         {
             // Arrange
             var someObject = new object();
@@ -36,7 +36,7 @@ public partial class ReferenceTypeAssertionsSpecs
         }
 
         [Fact]
-        public void When_object_is_satisfied_against_a_null_inspector_it_should_throw()
+        public void Object_satisfied_against_null_throws()
         {
             // Arrange
             var someObject = new object();
@@ -50,7 +50,7 @@ public partial class ReferenceTypeAssertionsSpecs
         }
 
         [Fact]
-        public void When_typed_object_satisfies_inspector_it_should_not_throw()
+        public void Typed_object_satisfying_inspector_does_not_throw()
         {
             // Arrange
             var personDto = new PersonDto
@@ -64,7 +64,7 @@ public partial class ReferenceTypeAssertionsSpecs
         }
 
         [Fact]
-        public void When_complex_typed_object_satisfies_inspector_it_should_not_throw()
+        public void Complex_typed_object_satisfying_inspector_does_not_throw()
         {
             // Arrange
             var complexDto = new PersonAndAddressDto
@@ -106,31 +106,7 @@ public partial class ReferenceTypeAssertionsSpecs
         }
 
         [Fact]
-        public void When_a_typed_object_does_not_satisfy_the_inspector_it_should_throw()
-        {
-            // Arrange
-            const string personName = "Name Nameson";
-
-            var personDto = new PersonDto
-            {
-                Name = personName,
-                Birthdate = new DateTime(1973, 9, 20),
-            };
-
-            // Act
-            Action act = () =>
-                personDto.Should().Satisfy<PersonDto>(d => d.Name.Should().HaveLength(0, "it is not initialized yet"));
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                $"""
-                 Expected {nameof(personDto)} to match inspector, but the inspector was not satisfied:
-                 *Expected d.Name with length 0 because it is not initialized yet, but found string "{personName}" with length {personName.Length}.
-                 """);
-        }
-
-        [Fact]
-        public void When_a_typed_object_does_not_satisfy_inspector_it_should_throw()
+        public void Typed_object_not_satisfying_inspector_throws()
         {
             // Arrange
             var personDto = new PersonDto
@@ -158,7 +134,7 @@ public partial class ReferenceTypeAssertionsSpecs
         }
 
         [Fact]
-        public void When_a_complex_typed_object_does_not_satisfy_inspector_it_should_throw()
+        public void Complex_typed_object_not_satisfying_inspector_throws()
         {
             // Arrange
             var complexDto = new PersonAndAddressDto
@@ -210,7 +186,7 @@ public partial class ReferenceTypeAssertionsSpecs
         }
 
         [Fact]
-        public void When_a_typed_object_is_satisfied_against_an_incorrect_type_it_should_throw()
+        public void Typed_object_satisfied_against_incorrect_type_throws()
         {
             // Arrange
             var personDto = new PersonDto();

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
@@ -14,11 +14,8 @@ public partial class ReferenceTypeAssertionsSpecs
             // Arrange
             var someObject = new object();
 
-            // Act
-            Action act = () => someObject.Should().Satisfy<object>(x => x.Should().NotBeNull());
-
-            // Assert
-            act.Should().NotThrow();
+            // Act / Assert
+            someObject.Should().Satisfy<object>(x => x.Should().NotBeNull());
         }
 
         [Fact]
@@ -31,11 +28,8 @@ public partial class ReferenceTypeAssertionsSpecs
                 Birthdate = new DateTime(2000, 1, 1),
             };
 
-            // Act
-            Action act = () => someObject.Should().Satisfy<PersonDto>(o => o.Age.Should().BeGreaterThan(0));
-
-            // Assert
-            act.Should().NotThrow();
+            // Act / Assert
+            someObject.Should().Satisfy<PersonDto>(o => o.Age.Should().BeGreaterThan(0));
         }
 
         [Fact]
@@ -147,7 +141,7 @@ public partial class ReferenceTypeAssertionsSpecs
         }
 
         [Fact]
-        public void When_a_typed_object_does_not_match_multiple_inspectors_it_should_throw()
+        public void When_a_typed_object_does_not_satisfy_multiple_inspectors_it_should_throw()
         {
             // Arrange
             var somePerson = new PersonDto

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
@@ -244,6 +244,31 @@ public partial class ReferenceTypeAssertionsSpecs
                     $"Expected {nameof(baseClass)} to be assignable to {typeof(SubClass)}, but {typeof(BaseClass)} is not.");
         }
 
+        [Fact]
+        public void Nested_assertion_on_null_throws()
+        {
+            // Arrange
+            var complexDto = new PersonAndAddressDto
+            {
+                Person = new PersonDto
+                {
+                    Name = "Buford Howard Tannen",
+                },
+                Address = null,
+            };
+
+            // Act
+            Action act = () => complexDto.Should().Satisfy<PersonAndAddressDto>(dto =>
+            {
+                dto.Person.Name.Should().Be("Buford Howard Tannen");
+                dto.Address.Should().Satisfy<AddressDto>(address => address.City.Should().Be("Hill Valley"));
+            });
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected dto.Address to be assignable to *AddressDto, but found <null>.");
+        }
+
         private class PersonDto
         {
             public string Name { get; init; }

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -8,7 +8,7 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.Primitives;
 
-public class ReferenceTypeAssertionsSpecs
+public partial class ReferenceTypeAssertionsSpecs
 {
     [Fact]
     public void When_the_same_objects_are_expected_to_be_the_same_it_should_not_fail()

--- a/docs/_pages/basicassertions.md
+++ b/docs/_pages/basicassertions.md
@@ -74,29 +74,28 @@ As an alternative to using predicate matching, it is also possible to use elemen
 
 ```csharp
 var productDto = new ProductDto
+{
+    Name = "Some product name",
+    Price = 19.95,
+    SKU = "ABC12345",
+    Store = new Store
     {
-        Name = "Some product name",
-        Price = 19.95,
-        SKU = "ABC12345",
-        Store = new Store
-            {
-                Country = "Germany",
-                Quantity = 42
-            }
-    };
-productDto.Should().Satisfy<ProductDto>(dto =>
-    {
-        dto.Name.Should().Be("Some product name");
-        dto.Price.Should().Be(19.95);
-        dto.SKU.Should().EndWith("12345");
-        dto.Store.Should().Satisfy<Store>(store =>
-            {
-                store.Country.Should().Be("Germany");
-                store.Quantity.Should().BeGreaterThan(40);
-            }
-        );
+        Country = "Germany",
+        Quantity = 42
     }
-);
+};
+
+productDto.Should().Satisfy<ProductDto>(dto =>
+{
+    dto.Name.Should().Be("Some product name");
+    dto.Price.Should().Be(19.95);
+    dto.SKU.Should().EndWith("12345");
+    dto.Store.Should().Satisfy<Store>(store =>
+    {
+        store.Country.Should().Be("Germany");
+        store.Quantity.Should().BeGreaterThan(40);
+    });
+});
 ```
 
 Some users requested the ability to easily downcast an object to one of its derived classes in a fluent way.

--- a/docs/_pages/basicassertions.md
+++ b/docs/_pages/basicassertions.md
@@ -70,6 +70,35 @@ dummy.Should().Match<string>(d => (d == "System.Object"));
 dummy.Should().Match((string d) => (d == "System.Object"));
 ```
 
+As an alternative to using predicate matching, it is also possible to use element inspectors to do nested assertions in a fluent way.
+
+```csharp
+var productDto = new ProductDto
+    {
+        Name = "Some product name",
+        Price = 19.95,
+        SKU = "ABC12345",
+        Store = new Store
+            {
+                Country = "Germany",
+                Quantity = 42
+            }
+    };
+productDto.Should().Satisfy<ProductDto>(dto =>
+    {
+        dto.Name.Should().Be("Some product name");
+        dto.Price.Should().Be(19.95);
+        dto.SKU.Should().EndWith("12345");
+        dto.Store.Should().Satisfy<Store>(store =>
+            {
+                store.Country.Should().Be("Germany");
+                store.Quantity.Should().BeGreaterThan(40);
+            }
+        );
+    }
+);
+```
+
 Some users requested the ability to easily downcast an object to one of its derived classes in a fluent way.
 
 ```csharp

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -15,7 +15,7 @@ sidebar:
 * Ensure compatibility with .NET 8 - [#2466](https://github.com/fluentassertions/fluentassertions/pull/2466)
 * Add support for NUnit 4 - [#2483](https://github.com/fluentassertions/fluentassertions/pull/2483)
 * Added `NotBeIn` to check if a `DateTime` is not in a given `DateTimeKind` - [#2536](https://github.com/fluentassertions/fluentassertions/pull/2536)
-* Introduced a new `Satisfy` method to `ReferenceTypeAssertions` to allow for custom assertions - [#2597](https://github.com/fluentassertions/fluentassertions/pull/2597)
+* Introduced a new `Satisfy` method available to all reference types to allow for nested assertions - [#2597](https://github.com/fluentassertions/fluentassertions/pull/2597)
 * Added `BeNaN` and `NotBeNaN` for assertions on `float` and `double` - [#2606](https://github.com/fluentassertions/fluentassertions/pull/2606)
 * Added option for event monitoring to ignore failing event accessors - [#2629](https://github.com/fluentassertions/fluentassertions/pull/2629)
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -15,6 +15,7 @@ sidebar:
 * Ensure compatibility with .NET 8 - [#2466](https://github.com/fluentassertions/fluentassertions/pull/2466)
 * Add support for NUnit 4 - [#2483](https://github.com/fluentassertions/fluentassertions/pull/2483)
 * Added `NotBeIn` to check if a `DateTime` is not in a given `DateTimeKind` - [#2536](https://github.com/fluentassertions/fluentassertions/pull/2536)
+* Introduced a new `Satisfy` method to `ReferenceTypeAssertions` to allow for custom assertions - [#2597](https://github.com/fluentassertions/fluentassertions/pull/2597)
 * Added `BeNaN` and `NotBeNaN` for assertions on `float` and `double` - [#2606](https://github.com/fluentassertions/fluentassertions/pull/2606)
 * Added option for event monitoring to ignore failing event accessors - [#2629](https://github.com/fluentassertions/fluentassertions/pull/2629)
 


### PR DESCRIPTION
Added support for `Satisfy` on `ReferenceTypeAssertions` allowing to use element inspectors as an alternative to using predicates on Match.

Example:
```cs
var myDto = new Dto { Name = "Some Name" };

myDto.Should().Satisfy<Dto>(dto => dto.Name.Should().Be("Some Name"));
```

Fixed #2516

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
