### PR TITLE
Make `ThrowWithinAsync` respect canceled tasks

### DIFF
--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -288,8 +288,8 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     {
         using var delayCancellationTokenSource = new CancellationTokenSource();
 
-        Task completedTask =
-            await Task.WhenAny(target, Clock.DelayAsync(remainingTime, delayCancellationTokenSource.Token));
+        Task delayTask = Clock.DelayAsync(remainingTime, delayCancellationTokenSource.Token);
+        Task completedTask = await Task.WhenAny(target, delayTask);
 
         if (completedTask.IsFaulted)
         {
@@ -301,6 +301,12 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         {
             // The monitored task did not complete.
             return false;
+        }
+
+        if (target.IsCanceled)
+        {
+            // Rethrow the exception causing the task be canceled.
+            await target;
         }
 
         // The monitored task is completed, we shall cancel the clock.

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -503,6 +503,52 @@ public static class TaskAssertionSpecs
                 "Expected a <System.InvalidOperationException> to be thrown within 1s,"
                 + " but found <System.NotSupportedException>:*foo*");
         }
+
+        [Fact]
+        public async Task When_task_is_canceled_before_timeout_it_succeeds()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
+
+            // Act
+            Func<Task> action = () =>
+            {
+                return Awaiting(() => (Task)taskFactory.Task)
+                    .Should(timer).ThrowWithinAsync<TaskCanceledException>(1.Seconds());
+            };
+
+            _ = action.Invoke();
+
+            taskFactory.SetCanceled();
+            timer.Complete();
+
+            // Assert
+            await action.Should().NotThrowAsync<XunitException>();
+        }
+
+        [Fact]
+        public async Task When_task_is_canceled_after_timeout_it_fails()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
+
+            // Act
+            Func<Task> action = () =>
+            {
+                return Awaiting(() => (Task)taskFactory.Task)
+                    .Should(timer).ThrowWithinAsync<TaskCanceledException>(1.Seconds());
+            };
+
+            _ = action.Invoke();
+
+            timer.Delay(1.Seconds());
+            taskFactory.SetCanceled();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>();
+        }
     }
 
     public class ThrowExactlyAsync

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -44,6 +44,7 @@ sidebar:
 * Fixed incorrect treatment of "\\r\\n" as new line - [#2569](https://github.com/fluentassertions/fluentassertions/pull/2569)
 * Ensured that nested calls to `AssertionScope(context)` create a chained context - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
 * One overload of the `AssertionScope` constructor would not create an actual scope associated with the thread - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
+* Fixed `ThrowWithinAsync` not respecting `OperationCanceledException` - [#2614](https://github.com/fluentassertions/fluentassertions/pull/2614)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION
When the subject `Task` was canceled we did not recognize that.
Instead we got a non-faulting (but canceled) task when awaiting `Task.WhenAny`.

This fixes #2444 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
