### PR TITLE
Added support for ignored members to `BeXmlSerializable`.

### DIFF
--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeXmlSerializable.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeXmlSerializable.cs
@@ -66,6 +66,20 @@ public partial class ObjectAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage("*to be serializable, but serialization failed with:*Name*to be*");
         }
+
+        [Fact]
+        public void When_an_object_is_xml_serializable_but_ignores_members_it_should_pass()
+        {
+            // Arrange
+            var subject = new ClassWithIgnoredMembers
+            {
+                IgnoredProperty = "ignored",
+                ObservedProperty = "observed"
+            };
+
+            // Act & Assert
+            subject.Should().BeXmlSerializable();
+        }
     }
 
     public class XmlSerializableClass
@@ -103,5 +117,13 @@ public partial class ObjectAssertionSpecs
     {
         [UsedImplicitly]
         public string Name { get; set; }
+    }
+
+    public class ClassWithIgnoredMembers
+    {
+        [XmlIgnore]
+        public string IgnoredProperty { get; set; }
+
+        public string ObservedProperty { get; set; }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeXmlSerializable.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.BeXmlSerializable.cs
@@ -77,8 +77,11 @@ public partial class ObjectAssertionSpecs
                 ObservedProperty = "observed"
             };
 
-            // Act & Assert
-            subject.Should().BeXmlSerializable();
+            // Act
+            Action act = () => subject.Should().BeXmlSerializable();
+
+            // Assert
+            act.Should().NotThrow();
         }
     }
 


### PR DESCRIPTION
# TL;DR

This PR resolves the following issues:

- #2626 

## Ignored XML Members (2626)

This issue is caused by the fact that ignored members are not serialized using `XmlSerializer`. The deserialization step utilized in `BeXmlSerializable` does not contain the data from ignored members, and as a result, the equivalency test fails.

## Remaining Work

- [ ] Design the changes needed to facilitate support for ignored members.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
