### PR TITLE
Fixed `BeEquivalentTo` when using a custom comparer targeting nullable types

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
@@ -16,7 +16,9 @@ public class EqualityComparerEquivalencyStep<T> : IEquivalencyStep
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IEquivalencyValidator nestedValidator)
     {
-        if (comparands.GetExpectedType(context.Options) != typeof(T))
+        var expectedType = context.Options.UseRuntimeTyping ? comparands.RuntimeType : comparands.CompileTimeType;
+
+        if (expectedType != typeof(T))
         {
             return EquivalencyResult.ContinueWithNext;
         }

--- a/Tests/FluentAssertions.Equivalency.Specs/AssertionRuleSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/AssertionRuleSpecs.cs
@@ -246,7 +246,7 @@ public class AssertionRuleSpecs
     }
 
     [Fact]
-    public void When_the_compile_time_type_is_nullable_but_the_equality_comparer_type_is_not_it_should_use_the_default_mechanics()
+    public void An_equality_comparer_of_non_nullable_type_is_not_invoked_on_nullable_member()
     {
         // Arrange
         var subject = new { Timestamp = (DateTime?)22.March(2020) };
@@ -262,7 +262,7 @@ public class AssertionRuleSpecs
     }
 
     [Fact]
-    public void When_the_compile_time_type_is_not_nullable_but_the_equality_comparer_type_is_it_should_use_the_default_mechanics()
+    public void An_equality_comparer_of_nullable_type_is_not_invoked_on_non_nullable_member()
     {
         // Arrange
         var subject = new { Timestamp = 22.March(2020) };
@@ -278,7 +278,7 @@ public class AssertionRuleSpecs
     }
 
     [Fact]
-    public void When_the_runtime_time_type_match_the_equality_comparer_type_it_should_use_the_comparer()
+    public void An_equality_comparer_of_non_nullable_type_is_invoked_on_non_nullable_data()
     {
         // Arrange
         var subject = new { Timestamp = (DateTime?)22.March(2020) };
@@ -286,16 +286,13 @@ public class AssertionRuleSpecs
         var expectation = new { Timestamp = (DateTime?)1.January(2020) };
 
         // Act
-        Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt
+        subject.Should().BeEquivalentTo(expectation, opt => opt
             .RespectingRuntimeTypes()
             .Using(new DateTimeByYearComparer()));
-
-        // Assert
-        act.Should().NotThrow();
     }
 
     [Fact]
-    public void When_the_runtime_type_differs_from_the_equality_comparer_type_because_of_nullability_it_should_use_the_default_mechanics()
+    public void An_equality_comparer_of_nullable_type_is_not_invoked_on_non_nullable_data()
     {
         // Arrange
         var subject = new { Timestamp = (DateTime?)22.March(2020) };

--- a/Tests/FluentAssertions.Equivalency.Specs/AssertionRuleSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/AssertionRuleSpecs.cs
@@ -245,67 +245,70 @@ public class AssertionRuleSpecs
         act.Should().Throw<XunitException>().WithMessage("*ConcreteClassEqualityComparer*");
     }
 
-    [Fact]
-    public void An_equality_comparer_of_non_nullable_type_is_not_invoked_on_nullable_member()
+    public class BeEquivalentTo
     {
-        // Arrange
-        var subject = new { Timestamp = (DateTime?)22.March(2020) };
+        [Fact]
+        public void An_equality_comparer_of_non_nullable_type_is_not_invoked_on_nullable_member()
+        {
+            // Arrange
+            var subject = new { Timestamp = (DateTime?)22.March(2020) };
 
-        var expectation = new { Timestamp = (DateTime?)1.January(2020) };
+            var expectation = new { Timestamp = (DateTime?)1.January(2020) };
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expectation,
-            opt => opt.Using(new DateTimeByYearComparer()));
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation,
+                opt => opt.Using(new DateTimeByYearComparer()));
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*2020*");
-    }
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*2020*");
+        }
 
-    [Fact]
-    public void An_equality_comparer_of_nullable_type_is_not_invoked_on_non_nullable_member()
-    {
-        // Arrange
-        var subject = new { Timestamp = 22.March(2020) };
+        [Fact]
+        public void An_equality_comparer_of_nullable_type_is_not_invoked_on_non_nullable_member()
+        {
+            // Arrange
+            var subject = new { Timestamp = 22.March(2020) };
 
-        var expectation = new { Timestamp = 1.January(2020) };
+            var expectation = new { Timestamp = 1.January(2020) };
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expectation,
-            opt => opt.Using(new NullableDateTimeByYearComparer()));
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation,
+                opt => opt.Using(new NullableDateTimeByYearComparer()));
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*2020*");
-    }
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*2020*");
+        }
 
-    [Fact]
-    public void An_equality_comparer_of_non_nullable_type_is_invoked_on_non_nullable_data()
-    {
-        // Arrange
-        var subject = new { Timestamp = (DateTime?)22.March(2020) };
+        [Fact]
+        public void An_equality_comparer_of_non_nullable_type_is_invoked_on_non_nullable_data()
+        {
+            // Arrange
+            var subject = new { Timestamp = (DateTime?)22.March(2020) };
 
-        var expectation = new { Timestamp = (DateTime?)1.January(2020) };
+            var expectation = new { Timestamp = (DateTime?)1.January(2020) };
 
-        // Act
-        subject.Should().BeEquivalentTo(expectation, opt => opt
-            .RespectingRuntimeTypes()
-            .Using(new DateTimeByYearComparer()));
-    }
+            // Act
+            subject.Should().BeEquivalentTo(expectation, opt => opt
+                .RespectingRuntimeTypes()
+                .Using(new DateTimeByYearComparer()));
+        }
 
-    [Fact]
-    public void An_equality_comparer_of_nullable_type_is_not_invoked_on_non_nullable_data()
-    {
-        // Arrange
-        var subject = new { Timestamp = (DateTime?)22.March(2020) };
+        [Fact]
+        public void An_equality_comparer_of_nullable_type_is_not_invoked_on_non_nullable_data()
+        {
+            // Arrange
+            var subject = new { Timestamp = (DateTime?)22.March(2020) };
 
-        var expectation = new { Timestamp = (DateTime?)1.January(2020) };
+            var expectation = new { Timestamp = (DateTime?)1.January(2020) };
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt
-            .RespectingRuntimeTypes()
-            .Using(new NullableDateTimeByYearComparer()));
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt
+                .RespectingRuntimeTypes()
+                .Using(new NullableDateTimeByYearComparer()));
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*2020*");
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*2020*");
+        }
     }
 
     private interface IInterface;

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -47,7 +47,7 @@ sidebar:
 * Ensured that nested calls to `AssertionScope(context)` create a chained context - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
 * One overload of the `AssertionScope` constructor would not create an actual scope associated with the thread - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
 * Fixed `ThrowWithinAsync` not respecting `OperationCanceledException` - [#2614](https://github.com/fluentassertions/fluentassertions/pull/2614)
-* Fixed using `BeEquivalentTo` with a custom comparer targeting nullable types - [#2648](https://github.com/fluentassertions/fluentassertions/pull/2648)
+* Fixed using `BeEquivalentTo` with an `IEqualityComparer` targeting nullable types - [#2648](https://github.com/fluentassertions/fluentassertions/pull/2648)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -47,6 +47,7 @@ sidebar:
 * Ensured that nested calls to `AssertionScope(context)` create a chained context - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
 * One overload of the `AssertionScope` constructor would not create an actual scope associated with the thread - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
 * Fixed `ThrowWithinAsync` not respecting `OperationCanceledException` - [#2614](https://github.com/fluentassertions/fluentassertions/pull/2614)
+* Fixed using `BeEquivalentTo` with a custom comparer targeting nullable types - [#2648](https://github.com/fluentassertions/fluentassertions/pull/2648)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION
The way the `EqualityComparerEquivalencyStep<T>` step is comparing the comparand's type against the equality comparer's type has been reviewed to take into account nullables.  

This fixes #2595.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [X] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [X] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [X] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
