### PR TITLE
Filter the list of events returned by RaisePropertyChangeFor

### DIFF
--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -147,16 +147,29 @@ public static class EventRaisingExtensions
         return new FilteredEventRecording(eventRecording, eventsWithMatchingPredicate);
     }
 
-    internal static IEventRecording WithPropertyChanged(this IEventRecording eventRecording, string propertyName)
+    /// <summary>
+    /// Asserts that all occurrences of the events has arguments of type <see cref="PropertyChangedEventArgs"/>
+    /// and are for property <paramref name="propertyName"/>.
+    /// </summary>
+    /// <param name="propertyName">
+    /// The property name for which the property changed events should have been raised.
+    /// </param>
+    /// <returns>
+    /// Returns only the property changed events affecting the particular property name.
+    /// </returns>
+    /// <remarks>
+    /// If a <see langword="null"/> or string.Empty is provided as property name, the events are return as-is.
+    /// </remarks>
+    internal static IEventRecording WithPropertyChangeFor(this IEventRecording eventRecording, string propertyName)
     {
         if (string.IsNullOrEmpty(propertyName))
         {
             return eventRecording;
         }
 
-        var eventsForPropertyName = eventRecording.Where(@event =>
-            @event.Parameters.OfType<PropertyChangedEventArgs>()
-                .Any(e => string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == propertyName)).ToList();
+        IEnumerable<OccurredEvent> eventsForPropertyName =
+            eventRecording.Where(@event => @event.IsAffectingPropertyName(propertyName))
+                          .ToList();
 
         return new FilteredEventRecording(eventRecording, eventsForPropertyName);
     }

--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -149,6 +149,11 @@ public static class EventRaisingExtensions
 
     internal static IEventRecording WithPropertyChanged(this IEventRecording eventRecording, string propertyName)
     {
+        if (string.IsNullOrEmpty(propertyName))
+        {
+            return eventRecording;
+        }
+
         var eventsForPropertyName = eventRecording.Where(@event =>
             @event.Parameters.OfType<PropertyChangedEventArgs>()
                 .Any(e => string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == propertyName)).ToList();

--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
@@ -144,5 +145,14 @@ public static class EventRaisingExtensions
         }
 
         return new FilteredEventRecording(eventRecording, eventsWithMatchingPredicate);
+    }
+
+    internal static IEventRecording WithPropertyChanged(this IEventRecording eventRecording, string propertyName)
+    {
+        var eventsForPropertyName = eventRecording.Where(@event =>
+            @event.Parameters.OfType<PropertyChangedEventArgs>()
+                .Any(e => string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == propertyName)).ToList();
+
+        return new FilteredEventRecording(eventRecording, eventsForPropertyName);
     }
 }

--- a/Src/FluentAssertions/Events/EventAssertions.cs
+++ b/Src/FluentAssertions/Events/EventAssertions.cs
@@ -123,7 +123,7 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
                     Monitor.Subject, PropertyChangedEventName, propertyName, actualPropertyNames);
         }
 
-        return recording;
+        return recording.WithPropertyChanged(propertyName);
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Events/OccurredEvent.cs
+++ b/Src/FluentAssertions/Events/OccurredEvent.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.ComponentModel;
+using System.Linq;
 
 namespace FluentAssertions.Events;
 
@@ -26,4 +28,19 @@ public class OccurredEvent
     /// The order in which this event was raised on the monitored object.
     /// </summary>
     public int Sequence { get; set; }
+
+    /// <summary>
+    /// Verifies if a property changed event is affecting a particular property.
+    /// </summary>
+    /// <param name="propertyName">
+    /// The property name for which the property changed event should have been raised.
+    /// </param>
+    /// <returns>
+    /// Returns <see langword="true"/> if the event is affecting the property specified, <see langword="false"/> otherwise.
+    /// </returns>
+    internal bool IsAffectingPropertyName(string propertyName)
+    {
+        return Parameters.OfType<PropertyChangedEventArgs>()
+                         .Any(e => string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == propertyName);
+    }
 }

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -543,7 +543,7 @@ public class EventAssertionSpecs
 
         [Fact]
         public void
-            The_number_of_property_changed_recorded_for_a_specific_property_matches_the_number_of_time_it_was_raised_specifically()
+            The_number_of_property_changed_recorded_for_a_specific_property_matches_the_number_of_times_it_was_raised_specifically()
         {
             // Arrange
             var subject = new EventRaisingClass();
@@ -553,12 +553,12 @@ public class EventAssertionSpecs
             subject.RaiseEventWithSenderAndPropertyName(nameof(EventRaisingClass.SomeOtherProperty));
 
             // Act
-            monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty).Count().Should().Be(2);
+            monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty).Should().HaveCount(2);
         }
 
         [Fact]
         public void
-            The_number_of_property_changed_recorded_for_a_specific_property_matches_the_number_of_time_it_was_raised_including_agnostic_property()
+            The_number_of_property_changed_recorded_for_a_specific_property_matches_the_number_of_times_it_was_raised_including_agnostic_property()
         {
             // Arrange
             var subject = new EventRaisingClass();
@@ -569,12 +569,12 @@ public class EventAssertionSpecs
             subject.RaiseEventWithSenderAndPropertyName(string.Empty);
 
             // Act
-            monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty).Count().Should().Be(3);
+            monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty).Should().HaveCount(3);
         }
 
         [Fact]
         public void
-            The_number_of_property_changed_recorded_matches_the_number_of_time_it_was_raised()
+            The_number_of_property_changed_recorded_matches_the_number_of_times_it_was_raised()
         {
             // Arrange
             var subject = new EventRaisingClass();
@@ -585,7 +585,7 @@ public class EventAssertionSpecs
             subject.RaiseEventWithSenderAndPropertyName(string.Empty);
 
             // Act
-            monitor.Should().RaisePropertyChangeFor(null).Count().Should().Be(4);
+            monitor.Should().RaisePropertyChangeFor(null).Should().HaveCount(4);
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -540,6 +540,37 @@ public class EventAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected*property*SomeProperty*but*OtherProperty1*OtherProperty2*");
         }
+
+        [Fact]
+        public void
+            The_number_of_property_changed_recorded_for_a_target_property_matches_the_number_of_time_it_was_raised_specifically()
+        {
+            // Arrange
+            var subject = new EventRaisingClass();
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithSenderAndPropertyName(nameof(EventRaisingClass.SomeProperty));
+            subject.RaiseEventWithSenderAndPropertyName(nameof(EventRaisingClass.SomeProperty));
+            subject.RaiseEventWithSenderAndPropertyName(nameof(EventRaisingClass.SomeOtherProperty));
+
+            // Act
+            monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty).Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void
+            The_number_of_property_changed_recorded_for_a_target_property_matches_the_number_of_time_it_was_raised_including_unspecified_property()
+        {
+            // Arrange
+            var subject = new EventRaisingClass();
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithSenderAndPropertyName(nameof(EventRaisingClass.SomeProperty));
+            subject.RaiseEventWithSenderAndPropertyName(nameof(EventRaisingClass.SomeOtherProperty));
+            subject.RaiseEventWithSenderAndPropertyName(null);
+            subject.RaiseEventWithSenderAndPropertyName(string.Empty);
+
+            // Act
+            monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty).Count().Should().Be(3);
+        }
     }
 
     public class ShouldNotRaisePropertyChanged

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -50,6 +50,7 @@ sidebar:
 * One overload of the `AssertionScope` constructor would not create an actual scope associated with the thread - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
 * Fixed `ThrowWithinAsync` not respecting `OperationCanceledException` - [#2614](https://github.com/fluentassertions/fluentassertions/pull/2614)
 * Fixed using `BeEquivalentTo` with an `IEqualityComparer` targeting nullable types - [#2648](https://github.com/fluentassertions/fluentassertions/pull/2648)
+* Fixed `RaisePropertyChangeFor` to return a filtered list of events - [#2677](https://github.com/fluentassertions/fluentassertions/pull/2677)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION
The call to `RaisePropertyChangeFor` on `EventAssertions<T>` now returns a filtered list of events related to the property given as parameter.  The `NotRaisePropertyChangeFor` function has been revised as well to match the behavior of `RaisePropertyChangeFor` especially when the parameter provided is `null`.

This fixes #393.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
