### PR TITLE
Improve code coverage in `...Formatter`s

### DIFF
--- a/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
@@ -92,14 +92,7 @@ public class DateTimeOffsetValueFormatter : IValueFormatter
 
         if (!hasDate && !hasTime)
         {
-            if (HasMilliSeconds(dateTimeOffset))
-            {
-                formattedGraph.AddFragment("0001-01-01 00:00:00." + dateTimeOffset.ToString("fff", CultureInfo.InvariantCulture));
-            }
-            else
-            {
-                formattedGraph.AddFragment("0001-01-01 00:00:00.000");
-            }
+            formattedGraph.AddFragment("0001-01-01 00:00:00.000");
         }
 
         formattedGraph.AddFragment(">");

--- a/Src/FluentAssertions/Formatting/FormattedObjectGraph.cs
+++ b/Src/FluentAssertions/Formatting/FormattedObjectGraph.cs
@@ -101,7 +101,7 @@ public class FormattedObjectGraph
     {
         if (lineBuilder.Length > 0)
         {
-            AppendSafely(lineBuilderWhitespace + lineBuilder);
+            AppendSafely($"{lineBuilderWhitespace}{lineBuilder}");
 
             lineBuilder.Clear();
             lineBuilderWhitespace = Whitespace;
@@ -247,24 +247,6 @@ public class FormattedObjectGraph
             else
             {
                 parentGraph.AddFragmentOnNewLine(fragment);
-            }
-        }
-
-        /// <summary>
-        /// Write the fragment.  If more lines have been added since this instance was
-        /// created then also flush the line and indent the next line.
-        /// </summary>
-        internal void AddEndingLineOrFragment(string fragment)
-        {
-            if (FormatOnSingleLine)
-            {
-                parentGraph.AddFragment(fragment);
-            }
-            else
-            {
-                parentGraph.AddFragment(fragment);
-                parentGraph.FlushCurrentLine();
-                parentGraph.lineBuilderWhitespace += MakeWhitespace(1);
             }
         }
 

--- a/Src/FluentAssertions/Formatting/GuidValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/GuidValueFormatter.cs
@@ -18,6 +18,6 @@ public class GuidValueFormatter : IValueFormatter
 
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
-        formattedGraph.AddFragment("{" + value + "}");
+        formattedGraph.AddFragment($"{{{value}}}");
     }
 }

--- a/Src/FluentAssertions/Formatting/StringValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/StringValueFormatter.cs
@@ -16,7 +16,9 @@ public class StringValueFormatter : IValueFormatter
 
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
-        string result = "\"" + value + "\"";
+        string result = $"""
+                         "{value}"
+                         """;
 
         formattedGraph.AddFragment(result);
     }

--- a/Src/FluentAssertions/Formatting/TaskFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TaskFormatter.cs
@@ -3,7 +3,7 @@
 namespace FluentAssertions.Formatting;
 
 /// <summary>
-/// Provides a human readable version of a generic or non-generic <see cref="Task"/>
+/// Provides a human-readable version of a generic or non-generic <see cref="Task"/>
 /// including its state.
 /// </summary>
 public class TaskFormatter : IValueFormatter
@@ -15,14 +15,8 @@ public class TaskFormatter : IValueFormatter
 
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
-        if (value is Task task)
-        {
-            formatChild("type", task.GetType(), formattedGraph);
-            formattedGraph.AddFragment($" {{Status={task.Status}}}");
-        }
-        else
-        {
-            formattedGraph.AddFragment("<null>");
-        }
+        var task = (Task)value;
+        formatChild("type", task.GetType(), formattedGraph);
+        formattedGraph.AddFragment($" {{Status={task.Status}}}");
     }
 }


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
### `TaskFormatter`
Removed unreachable path.
I think we can rely on the return value of `CanHandle()` that we are dealing with a `Task`.
I tried to get into the `Format` method using `Formatter.Format((Task)null)`, but I always ended up in the `NullFormatter`.

### `GuidValueFormatter` / `StringValueFormatter`
An interpolated string has no missed branches for whatever reason.

### `FormatterObjectGraph`
Removed an unused method, which was introduced in https://github.com/fluentassertions/fluentassertions/pull/2144

### `DateTimeOffsetValueFormatter`
Since we first check in `HasTime` that the value also could have milli seconds, the `if` branch can never be entered

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
