### PR TITLE
Add missing tests for several `NumericAssertions`

### DIFF
--- a/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.BeGreaterThan.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.BeGreaterThan.cs
@@ -67,5 +67,135 @@ public partial class NullableNumericAssertionSpecs
                 .Should().Throw<XunitException>()
                 .WithMessage("*NaN*");
         }
+
+        [Theory]
+        [InlineData(5, 5)]
+        [InlineData(1, 10)]
+        [InlineData(0, 5)]
+        [InlineData(0, 0)]
+        [InlineData(-1, 5)]
+        [InlineData(-1, -1)]
+        [InlineData(10, 10)]
+        public void To_test_the_null_path_for_difference_on_nullable_int(int? subject, int expectation)
+        {
+            // Arrange
+            // Act
+            Action act = () => subject.Should().BeGreaterThan(expectation);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Fact]
+        public void To_test_the_null_path_for_difference_on_nullable_byte()
+        {
+            // Arrange
+            var value = (byte?)1;
+
+            // Act
+            Action act = () => value.Should().BeGreaterThan(1);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Fact]
+        public void To_test_the_non_null_path_for_difference_on_nullable_byte()
+        {
+            // Arrange
+            var value = (byte?)1;
+
+            // Act
+            Action act = () => value.Should().BeGreaterThan(2);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Fact]
+        public void To_test_the_null_path_for_difference_on_nullable_decimal()
+        {
+            // Arrange
+            var value = (decimal?)11.0;
+
+            // Act
+            Action act = () => value.Should().BeGreaterThan(11M);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Fact]
+        public void To_test_the_null_path_for_difference_on_short()
+        {
+            // Arrange
+            var value = (short?)11;
+
+            // Act
+            Action act = () => value.Should().BeGreaterThan(11);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Fact]
+        public void To_test_the_null_path_for_difference_on_nullable_short()
+        {
+            // Arrange
+            var value = (short?)11;
+
+            // Act
+            Action act = () => value.Should().BeGreaterThan(11);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Fact]
+        public void To_test_the_null_path_for_difference_on_nullable_ushort()
+        {
+            // Arrange
+            var value = (ushort?)11;
+
+            // Act
+            Action act = () => value.Should().BeGreaterThan(11);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Theory]
+        [InlineData(5L, 5L)]
+        [InlineData(1L, 10L)]
+        [InlineData(0L, 5L)]
+        [InlineData(0L, 0L)]
+        [InlineData(-1L, 5L)]
+        [InlineData(-1L, -1L)]
+        [InlineData(10L, 10L)]
+        public void To_test_the_null_path_for_difference_on_nullable_long(long? subject, long expectation)
+        {
+            // Arrange
+            // Act
+            Action act = () => subject.Should().BeGreaterThan(expectation);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.BeLessThan.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.BeLessThan.cs
@@ -67,5 +67,37 @@ public partial class NullableNumericAssertionSpecs
                 .Should().Throw<XunitException>()
                 .WithMessage("*NaN*");
         }
+
+        [Theory]
+        [InlineData(5, -1)]
+        [InlineData(10, 5)]
+        [InlineData(10, -1)]
+        public void To_test_the_remaining_paths_for_difference_on_nullable_int(int? subject, int expectation)
+        {
+            // Arrange
+            // Act
+            Action act = () => subject.Should().BeLessThan(expectation);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Theory]
+        [InlineData(5L, -1L)]
+        [InlineData(10L, 5L)]
+        [InlineData(10L, -1L)]
+        public void To_test_the_remaining_paths_for_difference_on_nullable_long(long? subject, long expectation)
+        {
+            // Arrange
+            // Act
+            Action act = () => subject.Should().BeLessThan(expectation);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.BeGreaterThan.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.BeGreaterThan.cs
@@ -129,5 +129,91 @@ public partial class NumericAssertionSpecs
                 .Should().Throw<XunitException>()
                 .WithMessage("*null*");
         }
+
+        [Fact]
+        public void To_test_the_null_path_for_difference_on_byte()
+        {
+            // Arrange
+            var value = (byte)1;
+
+            // Act
+            Action act = () => value.Should().BeGreaterThan(1);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Fact]
+        public void To_test_the_non_null_path_for_difference_on_byte()
+        {
+            // Arrange
+            var value = (byte)1;
+
+            // Act
+            Action act = () => value.Should().BeGreaterThan(2);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Theory]
+        [InlineData(5, 5)]
+        [InlineData(1, 10)]
+        [InlineData(0, 5)]
+        [InlineData(0, 0)]
+        [InlineData(-1, 5)]
+        [InlineData(-1, -1)]
+        [InlineData(10, 10)]
+        public void To_test_the_null_path_for_difference_on_int(int subject, int expectation)
+        {
+            // Arrange
+            // Act
+            Action act = () => subject.Should().BeGreaterThan(expectation);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Theory]
+        [InlineData(5L, 5L)]
+        [InlineData(1L, 10L)]
+        [InlineData(0L, 5L)]
+        [InlineData(0L, 0L)]
+        [InlineData(-1L, 5L)]
+        [InlineData(-1L, -1L)]
+        [InlineData(10L, 10L)]
+        public void To_test_the_null_path_for_difference_on_long(long subject, long expectation)
+        {
+            // Arrange
+            // Act
+            Action act = () => subject.Should().BeGreaterThan(expectation);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(10, 10)]
+        [InlineData(10, 11)]
+        public void To_test_the_null_path_for_difference_on_ushort(ushort subject, ushort expectation)
+        {
+            // Arrange
+            // Act
+            Action act = () => subject.Should().BeGreaterThan(expectation);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.BeLessThan.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.BeLessThan.cs
@@ -128,5 +128,37 @@ public partial class NumericAssertionSpecs
                 .Should().Throw<XunitException>()
                 .WithMessage("*null*");
         }
+
+        [Theory]
+        [InlineData(5, -1)]
+        [InlineData(10, 5)]
+        [InlineData(10, -1)]
+        public void To_test_the_remaining_paths_for_difference_on_int(int subject, int expectation)
+        {
+            // Arrange
+            // Act
+            Action act = () => subject.Should().BeLessThan(expectation);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
+
+        [Theory]
+        [InlineData(5L, -1L)]
+        [InlineData(10L, 5L)]
+        [InlineData(10L, -1L)]
+        public void To_test_the_remaining_paths_for_difference_on_long(long subject, long expectation)
+        {
+            // Arrange
+            // Act
+            Action act = () => subject.Should().BeLessThan(expectation);
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .Which.Message.Should().NotMatch("*(difference of 0)*");
+        }
     }
 }


### PR DESCRIPTION
`ByteAssertions`
`NullableByteAssertions`
`NullableInt*Assertions`
`NullableUInt*Assertions`

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
