### PR TITLE
Add `[CustomAssertion]` attribute to extensibility docs

### DIFF
--- a/docs/_pages/extensibility.md
+++ b/docs/_pages/extensibility.md
@@ -36,6 +36,7 @@ public class DirectoryInfoAssertions :
 
     protected override string Identifier => "directory";
 
+    [CustomAssertion]
     public AndConstraint<DirectoryInfoAssertions> ContainFile(
         string filename, string because = "", params object[] becauseArgs)
     {

--- a/docs/_pages/extensibility.md
+++ b/docs/_pages/extensibility.md
@@ -58,6 +58,7 @@ public class DirectoryInfoAssertions :
 This is quite an elaborate example which shows some of the more advanced extensibility features. Let me highlight some things:
 
 * The `Subject` property is used to give the base-class extensions access to the current `DirectoryInfo` object.
+* `[CustomAssertion]` attribute enables correct subject identification, allowing Fluent Assertions to render more meaningful test fail messages
 * `Execute.Assertion` is the point of entrance into the internal fluent assertion API.
 * The optional `because` parameter can contain `string.Format` style place holders which will be filled using the values provided to the `becauseArgs`. They can be used by the caller to provide a reason why the assertion should succeed. By passing those into the `BecauseOf` method, you can refer to the expanded result using the `{reason}` tag in the `FailWith` method.
 * The `Then` property is just there to chain multiple assertions together. You can have more than one.


### PR DESCRIPTION
Continuing https://github.com/fluentassertions/fluentassertions/pull/2685 in a separate PR, due to my wrong branching choice

Description from original PR:

> There are (at least) two pages in the docs, that describe creating custom assertion methods - [Introduction](https://fluentassertions.com/introduction#subject-identification) and [Extensibility](https://fluentassertions.com/extensibility/#building-your-own-extensions)
> 
> `[CustomAssertion]` attribute is only mentioned in _Introduction_, along with a description of why including it is important, whereas in _Extensibility_ there is no mention of that attribute, and people googling https://www.google.com/search?q=fluent+assertions+how+to+create+custom+assertion will more likely land on _Extensibility_ rather than _Introduction_
> 
> This leads to confusion.
> 
> This PR adds a mention of `[CustomAssertion]` attribute to _Extensibility_ page

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
