### PR TITLE
Simplify FrameworkSpecs

### DIFF
--- a/Tests/TestFrameworks/MSTestV2.Specs/FrameworkSpecs.cs
+++ b/Tests/TestFrameworks/MSTestV2.Specs/FrameworkSpecs.cs
@@ -14,9 +14,6 @@ public class FrameworkSpecs
         Action act = () => 0.Should().Be(1);
 
         // Assert
-        Exception exception = act.Should().Throw<Exception>().Which;
-        exception.GetType()
-            .FullName.Should()
-            .ContainEquivalentOf("Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException");
+        act.Should().Throw<AssertFailedException>();
     }
 }

--- a/Tests/TestFrameworks/MSpec.Specs/FrameworkSpecs.cs
+++ b/Tests/TestFrameworks/MSpec.Specs/FrameworkSpecs.cs
@@ -9,8 +9,7 @@ public class When_mspec_is_used
 {
     Because of = () => Exception = Catch.Exception(() => 0.Should().Be(1));
 
-    It should_fail = () => Exception.Should().NotBeNull().And.BeAssignableTo<Exception>();
-    It should_have_a_specific_reason = () => Exception.GetType().FullName.Should().ContainEquivalentOf("Machine.Specifications.SpecificationException");
+    It should_fail_with_a_specification_exception = () => Exception.Should().BeOfType<SpecificationException>();
 
     private static Exception Exception;
 }

--- a/Tests/TestFrameworks/NUnit3.Specs/FrameworkSpecs.cs
+++ b/Tests/TestFrameworks/NUnit3.Specs/FrameworkSpecs.cs
@@ -14,9 +14,6 @@ public class FrameworkSpecs
         Action act = () => 0.Should().Be(1);
 
         // Assert
-        Exception exception = act.Should().Throw<Exception>().Which;
-        exception.GetType()
-            .FullName.Should()
-            .ContainEquivalentOf("NUnit.Framework.AssertionException");
+        act.Should().Throw<AssertionException>();
     }
 }

--- a/Tests/TestFrameworks/XUnit2.Specs/FrameworkSpecs.cs
+++ b/Tests/TestFrameworks/XUnit2.Specs/FrameworkSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentAssertions;
 using Xunit;
+using Xunit.Sdk;
 
 namespace XUnit2.Specs;
 
@@ -13,7 +14,6 @@ public class FrameworkSpecs
         Action act = () => 0.Should().Be(1);
 
         // Assert
-        Exception exception = act.Should().Throw<Exception>().Which;
-        exception.GetType().FullName.Should().ContainEquivalentOf("xunit");
+        act.Should().Throw<XunitException>();
     }
 }


### PR DESCRIPTION
## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Description

While it makes sense not to take hard dependencies on test frameworks in the FluentAssertions library, the TestFrameworks specs all have a dependency on the their respective test frameworks. Use them to simplify the assertion on the exceptions which should be thrown.

Note that the support for NUnit4 was introduced exactly like this in 2f56211b769b7a9a10b619d8f3a2d868dd473735.