### PR TITLE
Fix `ArgumentOutOfRangeException` when using global tracing

### DIFF
--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -100,7 +100,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
         matchingRules.AddRange(defaults.MatchingRules);
         OrderingRules = new OrderingRuleCollection(defaults.OrderingRules);
 
-        TraceWriter = defaults.TraceWriter;
+        TraceWriter = defaults.TraceWriter?.NewInstance();
 
         RemoveSelectionRule<AllPropertiesSelectionRule>();
         RemoveSelectionRule<AllFieldsSelectionRule>();

--- a/Src/FluentAssertions/Equivalency/Tracing/ExtensionMethods.cs
+++ b/Src/FluentAssertions/Equivalency/Tracing/ExtensionMethods.cs
@@ -1,0 +1,6 @@
+namespace FluentAssertions.Equivalency.Tracing;
+
+internal static class ExtensionMethods
+{
+    internal static ITraceWriter NewInstance(this ITraceWriter _) => new StringBuilderTraceWriter();
+}

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -161,6 +161,35 @@ public class AssertionOptionsSpecs
     }
 
     [Collection("AssertionOptionsSpecs")]
+    public class When_using_global_tracing : Given_temporary_global_assertion_options
+    {
+        public When_using_global_tracing()
+        {
+            When(() => AssertionOptions.AssertEquivalencyUsing(e => e.WithTracing()));
+        }
+
+        [Fact]
+        public void It_does_not_throw_an_argument_out_of_rage_exception()
+        {
+            Action act = () =>
+            {
+                Parallel.For(1, 10_000, (_, _) =>
+                {
+                    try
+                    {
+                        new { A = "a" }.Should().BeEquivalentTo(new { A = "b" });
+                    }
+                    catch (XunitException)
+                    {
+                    }
+                });
+            };
+
+            act.Should().NotThrow<ArgumentOutOfRangeException>();
+        }
+    }
+
+    [Collection("AssertionOptionsSpecs")]
     public class When_assertion_doubles_should_always_allow_small_deviations : Given_temporary_global_assertion_options
     {
         public When_assertion_doubles_should_always_allow_small_deviations()

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -50,6 +50,7 @@ sidebar:
 * One overload of the `AssertionScope` constructor would not create an actual scope associated with the thread - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
 * Fixed `ThrowWithinAsync` not respecting `OperationCanceledException` - [#2614](https://github.com/fluentassertions/fluentassertions/pull/2614)
 * Fixed using `BeEquivalentTo` with an `IEqualityComparer` targeting nullable types - [#2648](https://github.com/fluentassertions/fluentassertions/pull/2648)
+* Fixed `ArgumentOutOfRangeException` when using globally enabled tracing - [#2721](https://github.com/fluentassertions/fluentassertions/pull/2721)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Closes #2619 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
