### PR TITLE
Backport fixes from develop to v6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <LangVersion>11.0</LangVersion>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902;NU1903</WarningsNotAsErrors> <!-- disable EOL warnings -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisLevel>7.0</AnalysisLevel>
     <AnalysisMode>All</AnalysisMode>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -55,7 +55,8 @@ public static class CallerIdentifier
                 if (frame.GetMethod() is not null
                     && !IsDynamic(frame)
                     && !IsDotNet(frame)
-                    && !IsCustomAssertion(frame))
+                    && !IsCustomAssertion(frame)
+                    && !IsCurrentAssembly(frame))
                 {
                     caller = ExtractVariableNameFrom(frame);
                     break;

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -26,9 +26,7 @@ public static class CallerIdentifier
         {
             var stack = new StackTrace(fNeedFileInfo: true);
 
-            var allStackFrames = stack.GetFrames()
-                .Where(frame => frame is not null && !IsCompilerServices(frame))
-                .ToArray();
+            var allStackFrames = GetFrames(stack);
 
             int searchStart = allStackFrames.Length - 1;
 
@@ -82,9 +80,7 @@ public static class CallerIdentifier
         {
             var stack = new StackTrace();
 
-            var allStackFrames = stack.GetFrames()
-                .Where(frame => frame is not null && !IsCompilerServices(frame))
-                .ToArray();
+            var allStackFrames = GetFrames(stack);
 
             int firstUserCodeFrameIndex = 0;
 
@@ -115,9 +111,7 @@ public static class CallerIdentifier
 
     internal static bool OnlyOneFluentAssertionScopeOnCallStack()
     {
-        var allStackFrames = new StackTrace().GetFrames()
-            .Where(frame => frame is not null && !IsCompilerServices(frame))
-            .ToArray();
+        var allStackFrames = GetFrames(new StackTrace());
 
         int firstNonFluentAssertionsStackFrameIndex = Array.FindIndex(
             allStackFrames,
@@ -256,5 +250,19 @@ public static class CallerIdentifier
     private static bool IsBooleanLiteral(string candidate)
     {
         return candidate is "true" or "false";
+    }
+
+    private static StackFrame[] GetFrames(StackTrace stack)
+    {
+        var frames = stack.GetFrames();
+#if !NETCOREAPP2_1_OR_GREATER
+        if (frames == null)
+        {
+            return Array.Empty<StackFrame>();
+        }
+#endif
+        return frames
+            .Where(frame => !IsCompilerServices(frame))
+            .ToArray();
     }
 }

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -286,15 +286,16 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// </param>
     public AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs)
     {
+        var singleItemArray = Subject?.Take(1).ToArray();
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:collection} to be empty{reason}, ")
-            .Given(() => Subject)
+            .Given(() => singleItemArray)
             .ForCondition(subject => subject is not null)
             .FailWith("but found <null>.")
             .Then
-            .ForCondition(subject => !subject.Any())
-            .FailWith("but found {0}.", Subject)
+            .ForCondition(subject => subject.Length == 0)
+            .FailWith("but found at least one item {0}.", singleItemArray)
             .Then
             .ClearExpectation();
 
@@ -639,13 +640,14 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// </param>
     public AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs)
     {
-        var nullOrEmpty = Subject is null || !Subject.Any();
+        var singleItemArray = Subject?.Take(1).ToArray();
+        var nullOrEmpty = singleItemArray is null || singleItemArray.Length == 0;
 
         Execute.Assertion.ForCondition(nullOrEmpty)
             .BecauseOf(because, becauseArgs)
             .FailWith(
-                "Expected {context:collection} to be null or empty{reason}, but found {0}.",
-                Subject);
+                "Expected {context:collection} to be null or empty{reason}, but found at least one item {0}.",
+                singleItemArray);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -811,13 +811,18 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that a collection of objects contains at least one object equivalent to another object.
+    /// Asserts that at least one element in the collection is equivalent to <paramref name="expectation"/>.
     /// </summary>
     /// <remarks>
-    /// Objects within the collection are equivalent to the expected object when both object graphs have equally named properties with the same
-    /// value, irrespective of the type of those objects. Two properties are also equal if one type can be converted to another
-    /// and the result is equal.
+    /// <para>
+    /// <b>Important:</b> You cannot use this method to assert whether a subset of the collection is equivalent to the <paramref name="expectation"/>.
+    /// This usually means that the expectation is meant to be a <i>single</i> item.
+    /// </para>
+    /// <para>
+    /// By default, objects within the collection are seen as equivalent to the expected object when both object graphs have equally named properties with the same
+    /// value, irrespective of the type of those objects.
     /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
+    /// </para>
     /// </remarks>
     /// <param name="expectation">The expected element.</param>
     /// <param name="because">
@@ -834,13 +839,18 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that a collection of objects contains at least one object equivalent to another object.
+    /// Asserts that at least one element in the collection is equivalent to <paramref name="expectation"/>.
     /// </summary>
     /// <remarks>
-    /// Objects within the collection are equivalent to the expected object when both object graphs have equally named properties with the same
-    /// value, irrespective of the type of those objects. Two properties are also equal if one type can be converted to another
-    /// and the result is equal.
+    /// <para>
+    /// <b>Important:</b> You cannot use this method to assert whether a subset of the collection is equivalent to the <paramref name="expectation"/>.
+    /// This usually means that the expectation is meant to be a <i>single</i> item.
+    /// </para>
+    /// <para>
+    /// By default, objects within the collection are seen as equivalent to the expected object when both object graphs have equally named properties with the same
+    /// value, irrespective of the type of those objects.
     /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
+    /// </para>
     /// </remarks>
     /// <param name="expectation">The expected element.</param>
     /// <param name="config">
@@ -2292,13 +2302,18 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that a collection of objects does not contain any object equivalent to another object.
+    /// Asserts that no element in the collection is equivalent to <paramref name="unexpected"/>.
     /// </summary>
     /// <remarks>
-    /// Objects within the collection are equivalent to the expected object when both object graphs have equally named properties with the same
-    /// value, irrespective of the type of those objects. Two properties are also equal if one type can be converted to another
-    /// and the result is equal.
+    /// <para>
+    /// <b>Important:</b> You cannot use this method to assert whether a subset of the collection is not equivalent to the <paramref name="unexpected"/>.
+    /// This usually means that the expectation is meant to be a <i>single</i> item.
+    /// </para>
+    /// <para>
+    /// By default, objects within the collection are seen as not equivalent to the expected object when both object graphs have unequally named properties with the same
+    /// value, irrespective of the type of those objects.
     /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
+    /// </para>
     /// </remarks>
     /// <param name="unexpected">The unexpected element.</param>
     /// <param name="because">
@@ -2315,13 +2330,18 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that a collection of objects does not contain any object equivalent to another object.
+    /// Asserts that no element in the collection is equivalent to <paramref name="unexpected"/>.
     /// </summary>
     /// <remarks>
-    /// Objects within the collection are equivalent to the expected object when both object graphs have equally named properties with the same
-    /// value, irrespective of the type of those objects. Two properties are also equal if one type can be converted to another
-    /// and the result is equal.
+    /// <para>
+    /// <b>Important:</b> You cannot use this method to assert whether a subset of the collection is not equivalent to the <paramref name="unexpected"/>.
+    /// This usually means that the expectation is meant to be a <i>single</i> item.
+    /// </para>
+    /// <para>
+    /// By default, objects within the collection are seen as not equivalent to the expected object when both object graphs have unequally named properties with the same
+    /// value, irrespective of the type of those objects.
     /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
+    /// </para>
     /// </remarks>
     /// <param name="unexpected">The unexpected element.</param>
     /// <param name="config">

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1854,7 +1854,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
 
         using (var scope = new AssertionScope())
         {
-            Subject.Should().BeEquivalentTo(unexpected, config);
+            BeEquivalentTo(unexpected, config);
 
             failures = scope.Discard();
         }

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -184,10 +184,10 @@ internal static class TypeExtensions
     /// </returns>
     public static PropertyInfo FindProperty(this Type type, string propertyName, MemberVisibility memberVisibility)
     {
-        var properties = type.GetNonPrivateProperties(memberVisibility);
+        var properties = type.GetProperties(memberVisibility);
 
         return Array.Find(properties, p =>
-            p.Name == propertyName || p.Name.EndsWith("." + propertyName, StringComparison.OrdinalIgnoreCase));
+            p.Name == propertyName || p.Name.EndsWith("." + propertyName, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -198,24 +198,24 @@ internal static class TypeExtensions
     /// </returns>
     public static FieldInfo FindField(this Type type, string fieldName, MemberVisibility memberVisibility)
     {
-        var fields = type.GetNonPrivateFields(memberVisibility);
+        var fields = type.GetFields(memberVisibility);
 
         return Array.Find(fields, p => p.Name == fieldName);
     }
 
-    public static MemberInfo[] GetNonPrivateMembers(this Type typeToReflect, MemberVisibility visibility)
+    public static MemberInfo[] GetMembers(this Type typeToReflect, MemberVisibility visibility)
     {
-        return GetTypeReflectorFor(typeToReflect, visibility).NonPrivateMembers;
+        return GetTypeReflectorFor(typeToReflect, visibility).Members;
     }
 
-    public static PropertyInfo[] GetNonPrivateProperties(this Type typeToReflect, MemberVisibility visibility)
+    public static PropertyInfo[] GetProperties(this Type typeToReflect, MemberVisibility visibility)
     {
-        return GetTypeReflectorFor(typeToReflect, visibility).NonPrivateProperties;
+        return GetTypeReflectorFor(typeToReflect, visibility).Properties;
     }
 
-    public static FieldInfo[] GetNonPrivateFields(this Type typeToReflect, MemberVisibility visibility)
+    public static FieldInfo[] GetFields(this Type typeToReflect, MemberVisibility visibility)
     {
-        return GetTypeReflectorFor(typeToReflect, visibility).NonPrivateFields;
+        return GetTypeReflectorFor(typeToReflect, visibility).Fields;
     }
 
     private static TypeMemberReflector GetTypeReflectorFor(Type typeToReflect, MemberVisibility visibility)

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -351,9 +351,7 @@ internal static class TypeExtensions
 
         // check subject's interfaces against definition
         return type.GetInterfaces()
-            .Where(i => i.IsGenericType)
-            .Select(i => i.GetGenericTypeDefinition())
-            .Contains(definition);
+            .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == definition);
     }
 
     public static bool IsDerivedFromOpenGeneric(this Type type, Type definition)

--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -52,13 +52,13 @@ internal sealed class TypeMemberReflector
         });
     }
 
-    private static bool IsPublic(MethodInfo getMethod) =>
+    private static bool IsPublic(MethodBase getMethod) =>
         !getMethod.IsPrivate && !getMethod.IsFamily;
 
-    private static bool IsExplicitlyImplemented(MethodInfo getMethod) =>
+    private static bool IsExplicitlyImplemented(MethodBase getMethod) =>
         getMethod.IsPrivate && getMethod.IsFinal;
 
-    private static bool IsInternal(MethodInfo getMethod) =>
+    private static bool IsInternal(MethodBase getMethod) =>
         getMethod.IsAssembly || getMethod.IsFamilyOrAssembly;
 
     private static bool IsExplicitImplementation(PropertyInfo property)

--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -16,22 +16,22 @@ internal sealed class TypeMemberReflector
 
     public TypeMemberReflector(Type typeToReflect, MemberVisibility visibility)
     {
-        NonPrivateProperties = LoadNonPrivateProperties(typeToReflect, visibility);
-        NonPrivateFields = LoadNonPrivateFields(typeToReflect, visibility);
-        NonPrivateMembers = NonPrivateProperties.Concat<MemberInfo>(NonPrivateFields).ToArray();
+        Properties = LoadProperties(typeToReflect, visibility);
+        Fields = LoadFields(typeToReflect, visibility);
+        Members = Properties.Concat<MemberInfo>(Fields).ToArray();
     }
 
-    public MemberInfo[] NonPrivateMembers { get; }
+    public MemberInfo[] Members { get; }
 
-    public PropertyInfo[] NonPrivateProperties { get; }
+    public PropertyInfo[] Properties { get; }
 
-    public FieldInfo[] NonPrivateFields { get; }
+    public FieldInfo[] Fields { get; }
 
-    private static PropertyInfo[] LoadNonPrivateProperties(Type typeToReflect, MemberVisibility visibility)
+    private static PropertyInfo[] LoadProperties(Type typeToReflect, MemberVisibility visibility)
     {
         IEnumerable<PropertyInfo> query =
             from propertyInfo in GetPropertiesFromHierarchy(typeToReflect, visibility)
-            where HasNonPrivateGetter(propertyInfo, visibility)
+            where HasGetter(propertyInfo, visibility)
             where !propertyInfo.IsIndexer()
             select propertyInfo;
 
@@ -64,7 +64,7 @@ internal sealed class TypeMemberReflector
             property.Name.Contains('.', StringComparison.Ordinal);
     }
 
-    private static FieldInfo[] LoadNonPrivateFields(Type typeToReflect, MemberVisibility visibility)
+    private static FieldInfo[] LoadFields(Type typeToReflect, MemberVisibility visibility)
     {
         IEnumerable<FieldInfo> query =
             from fieldInfo in GetFieldsFromHierarchy(typeToReflect, visibility)
@@ -165,7 +165,7 @@ internal sealed class TypeMemberReflector
         return members;
     }
 
-    private static bool HasNonPrivateGetter(PropertyInfo propertyInfo, MemberVisibility visibility)
+    private static bool HasGetter(PropertyInfo propertyInfo, MemberVisibility visibility)
     {
         MethodInfo getMethod = propertyInfo.GetGetMethod(nonPublic: true);
 

--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -29,12 +29,12 @@ internal sealed class TypeMemberReflector
 
     private static PropertyInfo[] LoadProperties(Type typeToReflect, MemberVisibility visibility)
     {
-        IEnumerable<PropertyInfo> query = GetPropertiesFromHierarchy(typeToReflect, visibility);
+        List<PropertyInfo> query = GetPropertiesFromHierarchy(typeToReflect, visibility);
 
         return query.ToArray();
     }
 
-    private static IEnumerable<PropertyInfo> GetPropertiesFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
+    private static List<PropertyInfo> GetPropertiesFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
     {
         bool includeInternal = memberVisibility.HasFlag(MemberVisibility.Internal);
 
@@ -63,12 +63,12 @@ internal sealed class TypeMemberReflector
 
     private static FieldInfo[] LoadFields(Type typeToReflect, MemberVisibility visibility)
     {
-        IEnumerable<FieldInfo> query = GetFieldsFromHierarchy(typeToReflect, visibility);
+        List<FieldInfo> query = GetFieldsFromHierarchy(typeToReflect, visibility);
 
         return query.ToArray();
     }
 
-    private static IEnumerable<FieldInfo> GetFieldsFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
+    private static List<FieldInfo> GetFieldsFromHierarchy(Type typeToReflect, MemberVisibility memberVisibility)
     {
         bool includeInternal = memberVisibility.HasFlag(MemberVisibility.Internal);
 
@@ -87,7 +87,7 @@ internal sealed class TypeMemberReflector
         return field.IsAssembly || field.IsFamilyOrAssembly;
     }
 
-    private static IEnumerable<TMemberInfo> GetMembersFromHierarchy<TMemberInfo>(
+    private static List<TMemberInfo> GetMembersFromHierarchy<TMemberInfo>(
         Type typeToReflect,
         Func<Type, IEnumerable<TMemberInfo>> getMembers)
         where TMemberInfo : MemberInfo
@@ -100,7 +100,7 @@ internal sealed class TypeMemberReflector
         return GetClassMembers(typeToReflect, getMembers);
     }
 
-    private static IEnumerable<TMemberInfo> GetInterfaceMembers<TMemberInfo>(Type typeToReflect,
+    private static List<TMemberInfo> GetInterfaceMembers<TMemberInfo>(Type typeToReflect,
         Func<Type, IEnumerable<TMemberInfo>> getMembers)
         where TMemberInfo : MemberInfo
     {
@@ -136,7 +136,7 @@ internal sealed class TypeMemberReflector
         return members;
     }
 
-    private static IEnumerable<TMemberInfo> GetClassMembers<TMemberInfo>(Type typeToReflect,
+    private static List<TMemberInfo> GetClassMembers<TMemberInfo>(Type typeToReflect,
         Func<Type, IEnumerable<TMemberInfo>> getMembers)
         where TMemberInfo : MemberInfo
     {

--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -44,8 +44,7 @@ internal sealed class TypeMemberReflector
                 .GetProperties(AllInstanceMembersFlag | BindingFlags.DeclaredOnly)
                 .Where(p => HasGetter(p, memberVisibility) && !p.IsIndexer())
                 .Where(property => includeInternal || !IsInternal(property))
-                .OrderBy(property => IsExplicitImplementation(property))
-                .ToArray();
+                .OrderBy(property => IsExplicitImplementation(property));
         });
     }
 
@@ -77,8 +76,7 @@ internal sealed class TypeMemberReflector
             return type
                 .GetFields(AllInstanceMembersFlag)
                 .Where(field => !field.IsPrivate && !field.IsFamily)
-                .Where(field => includeInternal || !IsInternal(field))
-                .ToArray();
+                .Where(field => includeInternal || !IsInternal(field));
         });
     }
 

--- a/Src/FluentAssertions/Common/TypeMemberReflector.cs
+++ b/Src/FluentAssertions/Common/TypeMemberReflector.cs
@@ -53,7 +53,7 @@ internal sealed class TypeMemberReflector
     }
 
     private static bool IsPublic(MethodBase getMethod) =>
-        !getMethod.IsPrivate && !getMethod.IsFamily;
+        !getMethod.IsPrivate && !getMethod.IsFamily && !getMethod.IsFamilyAndAssembly;
 
     private static bool IsExplicitlyImplemented(MethodBase getMethod) =>
         getMethod.IsPrivate && getMethod.IsFinal;
@@ -83,10 +83,13 @@ internal sealed class TypeMemberReflector
         {
             return type
                 .GetFields(AllInstanceMembersFlag)
-                .Where(field => !field.IsPrivate && !field.IsFamily)
+                .Where(field => IsPublic(field))
                 .Where(field => includeInternal || !IsInternal(field));
         });
     }
+
+    private static bool IsPublic(FieldInfo field) =>
+        !field.IsPrivate && !field.IsFamily && !field.IsFamilyAndAssembly;
 
     private static bool IsInternal(FieldInfo field)
     {

--- a/Src/FluentAssertions/Equivalency/EqualityStrategyProvider.cs
+++ b/Src/FluentAssertions/Equivalency/EqualityStrategyProvider.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using FluentAssertions.Common;
+using JetBrains.Annotations;
+
+namespace FluentAssertions.Equivalency;
+
+internal sealed class EqualityStrategyProvider
+{
+    private readonly List<Type> referenceTypes = new();
+    private readonly List<Type> valueTypes = new();
+    private readonly ConcurrentDictionary<Type, EqualityStrategy> typeCache = new();
+
+    [CanBeNull]
+    private readonly Func<Type, EqualityStrategy> defaultStrategy;
+
+    private bool? compareRecordsByValue;
+
+    public EqualityStrategyProvider()
+    {
+    }
+
+    public EqualityStrategyProvider(Func<Type, EqualityStrategy> defaultStrategy)
+    {
+        this.defaultStrategy = defaultStrategy;
+    }
+
+    public bool? CompareRecordsByValue
+    {
+        get => compareRecordsByValue;
+        set
+        {
+            compareRecordsByValue = value;
+            typeCache.Clear();
+        }
+    }
+
+    public EqualityStrategy GetEqualityStrategy(Type type)
+    {
+        // As the valueFactory parameter captures instance members,
+        // be aware if the cache must be cleared on mutating the members.
+        return typeCache.GetOrAdd(type, typeKey =>
+        {
+            if (!typeKey.IsPrimitive && referenceTypes.Count > 0 && referenceTypes.Exists(t => typeKey.IsSameOrInherits(t)))
+            {
+                return EqualityStrategy.ForceMembers;
+            }
+            else if (valueTypes.Count > 0 && valueTypes.Exists(t => typeKey.IsSameOrInherits(t)))
+            {
+                return EqualityStrategy.ForceEquals;
+            }
+            else if (!typeKey.IsPrimitive && referenceTypes.Count > 0 &&
+                     referenceTypes.Exists(t => typeKey.IsAssignableToOpenGeneric(t)))
+            {
+                return EqualityStrategy.ForceMembers;
+            }
+            else if (valueTypes.Count > 0 && valueTypes.Exists(t => typeKey.IsAssignableToOpenGeneric(t)))
+            {
+                return EqualityStrategy.ForceEquals;
+            }
+            else if ((compareRecordsByValue.HasValue || defaultStrategy is null) && typeKey.IsRecord())
+            {
+                return compareRecordsByValue is true ? EqualityStrategy.ForceEquals : EqualityStrategy.ForceMembers;
+            }
+            else if (defaultStrategy is not null)
+            {
+                return defaultStrategy(typeKey);
+            }
+
+            return typeKey.HasValueSemantics() ? EqualityStrategy.Equals : EqualityStrategy.Members;
+        });
+    }
+
+    public bool AddReferenceType(Type type)
+    {
+        if (valueTypes.Exists(t => type.IsSameOrInherits(t)))
+        {
+            return false;
+        }
+
+        referenceTypes.Add(type);
+        typeCache.Clear();
+        return true;
+    }
+
+    public bool AddValueType(Type type)
+    {
+        if (referenceTypes.Exists(t => type.IsSameOrInherits(t)))
+        {
+            return false;
+        }
+
+        valueTypes.Add(type);
+        typeCache.Clear();
+        return true;
+    }
+
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+
+        if (compareRecordsByValue is true)
+        {
+            builder.AppendLine("- Compare records by value");
+        }
+        else
+        {
+            builder.AppendLine("- Compare records by their members");
+        }
+
+        foreach (Type valueType in valueTypes)
+        {
+            builder.AppendLine(CultureInfo.InvariantCulture, $"- Compare {valueType} by value");
+        }
+
+        foreach (Type type in referenceTypes)
+        {
+            builder.AppendLine(CultureInfo.InvariantCulture, $"- Compare {type} by its members");
+        }
+
+        return builder.ToString();
+    }
+}

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -66,14 +66,16 @@ public class EquivalencyValidator : IEquivalencyValidator
     {
         using var _ = context.Tracer.WriteBlock(node => node.Description);
 
-        Func<IEquivalencyStep, GetTraceMessage> getMessage = step => _ => $"Equivalency was proven by {step.GetType().Name}";
-
         foreach (IEquivalencyStep step in AssertionOptions.EquivalencyPlan)
         {
             var result = step.Handle(comparands, context, this);
             if (result == EquivalencyResult.AssertionCompleted)
             {
-                context.Tracer.WriteLine(getMessage(step));
+                context.Tracer.WriteLine(GetMessage(step));
+
+                static GetTraceMessage GetMessage(IEquivalencyStep step) =>
+                    _ => $"Equivalency was proven by {step.GetType().Name}";
+
                 return;
             }
         }

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -15,19 +15,20 @@ internal class MustMatchByNameRule : IMemberMatchingRule
 
         if (options.IncludedProperties != MemberVisibility.None)
         {
-            PropertyInfo propertyInfo = subject.GetType().FindProperty(expectedMember.Name);
+            PropertyInfo propertyInfo = subject.GetType().FindProperty(
+                expectedMember.Name,
+                options.IncludedProperties | MemberVisibility.ExplicitlyImplemented);
+
             subjectMember = propertyInfo is not null && !propertyInfo.IsIndexer() ? new Property(propertyInfo, parent) : null;
         }
 
         if (subjectMember is null && options.IncludedFields != MemberVisibility.None)
         {
-            FieldInfo fieldInfo = subject.GetType().FindField(expectedMember.Name);
-            subjectMember = fieldInfo is not null ? new Field(fieldInfo, parent) : null;
-        }
+            FieldInfo fieldInfo = subject.GetType().FindField(
+                expectedMember.Name,
+                options.IncludedFields);
 
-        if ((subjectMember is null || !options.UseRuntimeTyping) && ExpectationImplementsMemberExplicitly(subject, expectedMember))
-        {
-            subjectMember = expectedMember;
+            subjectMember = fieldInfo is not null ? new Field(fieldInfo, parent) : null;
         }
 
         if (subjectMember is null)
@@ -47,11 +48,6 @@ internal class MustMatchByNameRule : IMemberMatchingRule
         }
 
         return subjectMember;
-    }
-
-    private static bool ExpectationImplementsMemberExplicitly(object expectation, IMember subjectMember)
-    {
-        return subjectMember.DeclaringType.IsInstanceOfType(expectation);
     }
 
     /// <inheritdoc />

--- a/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
@@ -10,14 +10,20 @@ internal class TryMatchByNameRule : IMemberMatchingRule
 {
     public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions options)
     {
-        PropertyInfo property = subject.GetType().FindProperty(expectedMember.Name);
-
-        if (property is not null && !property.IsIndexer())
+        if (options.IncludedProperties != MemberVisibility.None)
         {
-            return new Property(property, parent);
+            PropertyInfo property = subject.GetType().FindProperty(expectedMember.Name,
+                options.IncludedProperties | MemberVisibility.ExplicitlyImplemented);
+
+            if (property is not null && !property.IsIndexer())
+            {
+                return new Property(property, parent);
+            }
         }
 
-        FieldInfo field = subject.GetType().FindField(expectedMember.Name);
+        FieldInfo field = subject.GetType()
+            .FindField(expectedMember.Name, options.IncludedFields);
+
         return field is not null ? new Field(field, parent) : null;
     }
 

--- a/Src/FluentAssertions/Equivalency/MemberFactory.cs
+++ b/Src/FluentAssertions/Equivalency/MemberFactory.cs
@@ -18,14 +18,14 @@ public static class MemberFactory
 
     internal static IMember Find(object target, string memberName, INode parent)
     {
-        PropertyInfo property = target.GetType().FindProperty(memberName);
+        PropertyInfo property = target.GetType().FindProperty(memberName, MemberVisibility.Public | MemberVisibility.ExplicitlyImplemented);
 
         if (property is not null && !property.IsIndexer())
         {
             return new Property(property, parent);
         }
 
-        FieldInfo field = target.GetType().FindField(memberName);
+        FieldInfo field = target.GetType().FindField(memberName, MemberVisibility.Public);
         return field is not null ? new Field(field, parent) : null;
     }
 }

--- a/Src/FluentAssertions/Equivalency/MemberVisibility.cs
+++ b/Src/FluentAssertions/Equivalency/MemberVisibility.cs
@@ -11,5 +11,6 @@ public enum MemberVisibility
 {
     None = 0,
     Internal = 1,
-    Public = 2
+    Public = 2,
+    ExplicitlyImplemented = 4
 }

--- a/Src/FluentAssertions/Equivalency/Selection/AllFieldsSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/AllFieldsSelectionRule.cs
@@ -14,11 +14,11 @@ internal class AllFieldsSelectionRule : IMemberSelectionRule
     public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
         MemberSelectionContext context)
     {
-        IEnumerable<IMember> selectedNonPrivateFields = context.Type
-            .GetNonPrivateFields(context.IncludedFields)
+        IEnumerable<IMember> selectedFields = context.Type
+            .GetFields(context.IncludedFields)
             .Select(info => new Field(info, currentNode));
 
-        return selectedMembers.Union(selectedNonPrivateFields).ToList();
+        return selectedMembers.Union(selectedFields).ToList();
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/Selection/AllPropertiesSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/AllPropertiesSelectionRule.cs
@@ -14,11 +14,11 @@ internal class AllPropertiesSelectionRule : IMemberSelectionRule
     public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
         MemberSelectionContext context)
     {
-        IEnumerable<IMember> selectedNonPrivateProperties = context.Type
-            .GetNonPrivateProperties(context.IncludedProperties)
+        IEnumerable<IMember> selectedProperties = context.Type
+            .GetProperties(context.IncludedProperties)
             .Select(info => new Property(context.Type, info, currentNode));
 
-        return selectedMembers.Union(selectedNonPrivateProperties).ToList();
+        return selectedMembers.Union(selectedProperties).ToList();
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
@@ -21,7 +21,7 @@ internal class IncludeMemberByPathSelectionRule : SelectMemberByPathSelectionRul
     protected override void AddOrRemoveMembersFrom(List<IMember> selectedMembers, INode parent, string parentPath,
         MemberSelectionContext context)
     {
-        foreach (MemberInfo memberInfo in context.Type.GetNonPrivateMembers(MemberVisibility.Public | MemberVisibility.Internal))
+        foreach (MemberInfo memberInfo in context.Type.GetMembers(MemberVisibility.Public | MemberVisibility.Internal))
         {
             var memberPath = new MemberPath(context.Type, memberInfo.DeclaringType, parentPath.Combine(memberInfo.Name));
 

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPredicateSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPredicateSelectionRule.cs
@@ -27,7 +27,7 @@ internal class IncludeMemberByPredicateSelectionRule : IMemberSelectionRule
     {
         var members = new List<IMember>(selectedMembers);
 
-        foreach (MemberInfo memberInfo in currentNode.Type.GetNonPrivateMembers(MemberVisibility.Public |
+        foreach (MemberInfo memberInfo in currentNode.Type.GetMembers(MemberVisibility.Public |
                      MemberVisibility.Internal))
         {
             IMember member = MemberFactory.Create(memberInfo, currentNode);

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -61,10 +61,17 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
         {
             return ((IEnumerable)value).Cast<object>().ToArray();
         }
-        catch (InvalidOperationException) when (value.GetType().Name.Equals("ImmutableArray`1", StringComparison.Ordinal))
+        catch (InvalidOperationException) when (IsIgnorableArrayLikeType(value))
         {
-            // This is probably a default ImmutableArray<T>
+            // This is probably a default ImmutableArray<T> or an empty ArraySegment.
             return Array.Empty<object>();
         }
+    }
+
+    private static bool IsIgnorableArrayLikeType(object value)
+    {
+        var type = value.GetType();
+        return type.Name.Equals("ImmutableArray`1", StringComparison.Ordinal) ||
+            (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>));
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
@@ -16,7 +16,9 @@ public class EqualityComparerEquivalencyStep<T> : IEquivalencyStep
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IEquivalencyValidator nestedValidator)
     {
-        if (comparands.GetExpectedType(context.Options) != typeof(T))
+        var expectedType = context.Options.UseRuntimeTyping ? comparands.RuntimeType : comparands.CompileTimeType;
+
+        if (expectedType != typeof(T))
         {
             return EquivalencyResult.ContinueWithNext;
         }

--- a/Src/FluentAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
@@ -21,6 +21,12 @@ public class EqualityComparerEquivalencyStep<T> : IEquivalencyStep
             return EquivalencyResult.ContinueWithNext;
         }
 
+        if (comparands.Subject is null || comparands.Expectation is null)
+        {
+            // The later check for `comparands.Subject is T` leads to a failure even if the expectation is null.
+            return EquivalencyResult.ContinueWithNext;
+        }
+
         Execute.Assertion
             .BecauseOf(context.Reason.FormattedMessage, context.Reason.Arguments)
             .ForCondition(comparands.Subject is T)

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -108,7 +108,7 @@ public sealed class AssertionScope : IAssertionScope
             reason = parent.reason;
             callerIdentityProvider = parent.callerIdentityProvider;
             FormattingOptions = parent.FormattingOptions.Clone();
-            Context = new Lazy<string>(() => JoinContext(parent.Context, context));
+            Context = JoinContexts(parent.Context, context);
         }
         else
         {
@@ -116,9 +116,18 @@ public sealed class AssertionScope : IAssertionScope
         }
     }
 
-    private static string JoinContext(params Lazy<string>[] contexts)
+    private static Lazy<string> JoinContexts(Lazy<string> outer, Lazy<string> inner)
     {
-        return string.Join("/", contexts.Where(ctx => ctx is not null).Select(x => x.Value));
+        return (outer, inner) switch
+        {
+            (null, null) => null,
+            ({ } a, null) => a,
+            (null, { } b) => b,
+            ({ } a, { } b) => Join(a, b)
+        };
+
+        static Lazy<string> Join(Lazy<string> outer, Lazy<string> inner) =>
+            new(() => outer.Value + "/" + inner.Value);
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -107,6 +107,7 @@ public sealed class AssertionScope : IAssertionScope
         {
             contextData.Add(parent.contextData);
             Context = parent.Context;
+            reason = parent.reason;
             callerIdentityProvider = parent.callerIdentityProvider;
         }
     }
@@ -147,10 +148,7 @@ public sealed class AssertionScope : IAssertionScope
     /// </summary>
     public FormattingOptions FormattingOptions { get; } = AssertionOptions.FormattingOptions.Clone();
 
-    internal bool Succeeded
-    {
-        get => succeeded == true;
-    }
+    internal bool Succeeded => succeeded == true;
 
     /// <summary>
     /// Adds an explanation of why the assertion is supposed to succeed to the scope.

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -109,6 +109,7 @@ public sealed class AssertionScope : IAssertionScope
             Context = parent.Context;
             reason = parent.reason;
             callerIdentityProvider = parent.callerIdentityProvider;
+            FormattingOptions = parent.FormattingOptions.Clone();
         }
     }
 

--- a/Src/FluentAssertions/Execution/Continuation.cs
+++ b/Src/FluentAssertions/Execution/Continuation.cs
@@ -15,7 +15,7 @@ public class Continuation
     }
 
     /// <summary>
-    /// Continuous the assertion chain if the previous assertion was successful.
+    /// Continues the assertion chain if the previous assertion was successful.
     /// </summary>
     public IAssertionScope Then
     {

--- a/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
+++ b/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
@@ -14,7 +14,7 @@ public class ContinuationOfGiven<TSubject>
     }
 
     /// <summary>
-    /// Continuous the assertion chain if the previous assertion was successful.
+    /// Continues the assertion chain if the previous assertion was successful.
     /// </summary>
     public GivenSelector<TSubject> Then { get; }
 

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -56,7 +56,7 @@ public class DefaultValueFormatter : IValueFormatter
     /// <remarks>The default is all non-private members.</remarks>
     protected virtual MemberInfo[] GetMembers(Type type)
     {
-        return type.GetNonPrivateMembers(MemberVisibility.Public);
+        return type.GetMembers(MemberVisibility.Public);
     }
 
     private static bool HasCompilerGeneratedToStringImplementation(object value)

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -449,12 +449,15 @@ public class NumericAssertions<T, TAssertions>
     {
         Guard.ThrowIfArgumentIsNull(unexpectedType);
 
-        Execute.Assertion
+        bool success = Execute.Assertion
             .ForCondition(Subject.HasValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected type not to be " + unexpectedType + "{reason}, but found <null>.");
 
-        Subject.GetType().Should().NotBe(unexpectedType, because, becauseArgs);
+        if (success)
+        {
+            Subject.GetType().Should().NotBe(unexpectedType, because, becauseArgs);
+        }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -51,7 +51,7 @@ public class BooleanAssertions<TAssertions>
         Execute.Assertion
             .ForCondition(Subject == false)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:boolean} to be false{reason}, but found {0}.", Subject);
+            .FailWith("Expected {context:boolean} to be False{reason}, but found {0}.", Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -71,7 +71,7 @@ public class BooleanAssertions<TAssertions>
         Execute.Assertion
             .ForCondition(Subject == true)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:boolean} to be true{reason}, but found {0}.", Subject);
+            .FailWith("Expected {context:boolean} to be True{reason}, but found {0}.", Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -32,7 +32,7 @@ public class BooleanAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public bool? Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -51,7 +51,7 @@ public class BooleanAssertions<TAssertions>
         Execute.Assertion
             .ForCondition(Subject == false)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:boolean} to be False{reason}, but found {0}.", Subject);
+            .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", false, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -71,7 +71,7 @@ public class BooleanAssertions<TAssertions>
         Execute.Assertion
             .ForCondition(Subject == true)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:boolean} to be True{reason}, but found {0}.", Subject);
+            .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", true, Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
@@ -34,7 +34,7 @@ public class DateOnlyAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public DateOnly? Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -42,7 +42,7 @@ public class DateTimeAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public DateTime? Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -43,7 +43,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public DateTimeOffset? Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
@@ -68,7 +68,7 @@ public class DateTimeOffsetRangeAssertions<TAssertions>
         bool success = Execute.Assertion
             .ForCondition(subject.HasValue)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:the date and time) to be " + predicate.DisplayText +
+            .FailWith("Expected {context:the date and time} to be " + predicate.DisplayText +
                 " {0} before {1}{reason}, but found a <null> DateTime.", timeSpan, target);
 
         if (success)

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -31,7 +31,7 @@ public class GuidAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public Guid? Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ObjectAssertions.cs
@@ -361,7 +361,7 @@ public class ObjectAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
 
         using (var scope = new AssertionScope())
         {
-            Subject.Should().BeEquivalentTo(unexpected, config);
+            BeEquivalentTo(unexpected, config);
             hasMismatches = scope.Discard().Length > 0;
         }
 

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -21,7 +21,7 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public TSubject Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -81,7 +81,6 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
     public AndConstraint<TAssertions> BeSameAs(TSubject expected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .UsingLineBreaks
             .ForCondition(ReferenceEquals(Subject, expected))
             .BecauseOf(because, becauseArgs)
             .WithDefaultIdentifier(Identifier)
@@ -104,7 +103,6 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
     public AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs)
     {
         Execute.Assertion
-            .UsingLineBreaks
             .ForCondition(!ReferenceEquals(Subject, unexpected))
             .BecauseOf(because, becauseArgs)
             .WithDefaultIdentifier(Identifier)

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -33,7 +33,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public TimeSpan? Subject { get; }
 

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -141,7 +141,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
 
         using (var scope = new AssertionScope())
         {
-            Subject.Should().BeEquivalentTo(unexpected);
+            BeEquivalentTo(unexpected);
             notEquivalent = scope.Discard().Length > 0;
         }
 

--- a/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
@@ -35,7 +35,7 @@ public class TimeOnlyAssertions<TAssertions>
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public TimeOnly? Subject { get; }
 

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -435,8 +435,8 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     {
         using var delayCancellationTokenSource = new CancellationTokenSource();
 
-        Task completedTask =
-            await Task.WhenAny(target, Clock.DelayAsync(remainingTime, delayCancellationTokenSource.Token));
+        Task delayTask = Clock.DelayAsync(remainingTime, delayCancellationTokenSource.Token);
+        Task completedTask = await Task.WhenAny(target, delayTask);
 
         if (completedTask.IsFaulted)
         {
@@ -448,6 +448,12 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         {
             // The monitored task did not complete.
             return false;
+        }
+
+        if (target.IsCanceled)
+        {
+            // Rethrow the exception causing the task be canceled.
+            await target;
         }
 
         // The monitored task is completed, we shall cancel the clock.

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -138,12 +138,15 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         {
             Exception exception = await InvokeWithInterceptionAsync(Subject);
 
-            Execute.Assertion
+            success = Execute.Assertion
                 .ForCondition(exception is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but no exception was thrown.", expectedType);
 
-            exception.Should().BeOfType(expectedType, because, becauseArgs);
+            if (success)
+            {
+                exception.Should().BeOfType(expectedType, because, becauseArgs);
+            }
 
             return new ExceptionAssertions<TException>(new[] { exception as TException });
         }

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -140,12 +140,15 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
 
             Type expectedType = typeof(TException);
 
-            Execute.Assertion
+            success = Execute.Assertion
                 .ForCondition(exception is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but no exception was thrown.", expectedType);
 
-            exception.Should().BeOfType(expectedType, because, becauseArgs);
+            if (success)
+            {
+                exception.Should().BeOfType(expectedType, because, becauseArgs);
+            }
 
             return new ExceptionAssertions<TException>(new[] { exception as TException });
         }

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -193,7 +193,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
         return this;
     }
 
-    private Exception[] AssertInnerExceptionExactly(Type innerException, string because = "",
+    private IEnumerable<Exception> AssertInnerExceptionExactly(Type innerException, string because = "",
         params object[] becauseArgs)
     {
         Execute.Assertion
@@ -213,7 +213,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
         return expectedExceptions;
     }
 
-    private Exception[] AssertInnerExceptions(Type innerException, string because = "",
+    private IEnumerable<Exception> AssertInnerExceptions(Type innerException, string because = "",
         params object[] becauseArgs)
     {
         Execute.Assertion

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -30,7 +30,7 @@ public class MethodInfoSelectorAssertions
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public IEnumerable<MethodInfo> SubjectMethods { get; }
 

--- a/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
@@ -130,9 +130,17 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
 
         if (success)
         {
-            Subject.Should().BeWritable(because, becauseArgs);
+            success = Execute.Assertion
+                .ForCondition(Subject!.CanWrite)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected {context:property} {0} to have a setter{reason}.",
+                    Subject);
 
-            Subject.GetSetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            if (success)
+            {
+                Subject.GetSetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            }
         }
 
         return new AndConstraint<PropertyInfoAssertions>(this);
@@ -221,9 +229,14 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
 
         if (success)
         {
-            Subject.Should().BeReadable(because, becauseArgs);
+            success = Execute.Assertion.ForCondition(Subject!.CanRead)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected property " + Subject.Name + " to have a getter{reason}, but it does not.");
 
-            Subject.GetGetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            if (success)
+            {
+                Subject.GetGetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            }
         }
 
         return new AndConstraint<PropertyInfoAssertions>(this);

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Types;
 public class PropertyInfoSelectorAssertions
 {
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public IEnumerable<PropertyInfo> SubjectProperties { get; }
 

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -462,7 +462,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     {
         Guard.ThrowIfArgumentIsNull(interfaceType);
 
-        bool containsInterface = Subject.GetInterfaces().Contains(interfaceType);
+        bool containsInterface = interfaceType.IsAssignableFrom(Subject) && interfaceType != Subject;
 
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -511,7 +511,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     {
         Guard.ThrowIfArgumentIsNull(interfaceType);
 
-        bool containsInterface = Subject.GetInterfaces().Contains(interfaceType);
+        bool containsInterface = interfaceType.IsAssignableFrom(Subject) && interfaceType != Subject;
 
         Execute.Assertion
             .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -462,20 +462,25 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     {
         Guard.ThrowIfArgumentIsNull(interfaceType);
 
-        bool containsInterface = interfaceType.IsAssignableFrom(Subject) && interfaceType != Subject;
-
-        Execute.Assertion
-            .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected type {0} to implement interface {1}{reason}", Subject, interfaceType)
-            .ForCondition(interfaceType.IsInterface)
-            .FailWith(", but {0} is not an interface.", interfaceType)
-            .Then
-            .ForCondition(containsInterface)
-            .FailWith(", but it does not.")
-            .Then
-            .ClearExpectation();
+        AssertSubjectImplements(interfaceType, because, becauseArgs);
 
         return new AndConstraint<TypeAssertions>(this);
+    }
+
+    private bool AssertSubjectImplements(Type interfaceType, string because = "", params object[] becauseArgs)
+    {
+        bool containsInterface = interfaceType.IsAssignableFrom(Subject) && interfaceType != Subject;
+
+        return Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected type {0} to implement interface {1}{reason}", Subject, interfaceType)
+                .ForCondition(interfaceType.IsInterface)
+                .FailWith(", but {0} is not an interface.", interfaceType)
+                .Then
+                .ForCondition(containsInterface)
+                .FailWith(", but it does not.")
+                .Then
+                .ClearExpectation();
     }
 
     /// <summary>
@@ -973,15 +978,18 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
 
         if (success)
         {
-            Subject.Should().Implement(interfaceType, because, becauseArgs);
+            success = AssertSubjectImplements(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
+            if (success)
+            {
+                var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(explicitlyImplementsProperty)
-                .FailWith(
-                    $"Expected {Subject} to explicitly implement {interfaceType}.{name}{{reason}}, but it does not.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(explicitlyImplementsProperty)
+                    .FailWith(
+                        $"Expected {Subject} to explicitly implement {interfaceType}.{name}{{reason}}, but it does not.");
+            }
         }
 
         return new AndConstraint<TypeAssertions>(this);
@@ -1040,16 +1048,19 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
 
         if (success)
         {
-            Subject.Should().Implement(interfaceType, because, becauseArgs);
+            success = AssertSubjectImplements(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
+            if (success)
+            {
+                var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(!explicitlyImplementsProperty)
-                .FailWith(
-                    $"Expected {Subject} to not explicitly implement {interfaceType}.{name}{{reason}}" +
-                    ", but it does.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!explicitlyImplementsProperty)
+                    .FailWith(
+                        $"Expected {Subject} to not explicitly implement {interfaceType}.{name}{{reason}}" +
+                        ", but it does.");
+            }
         }
 
         return new AndConstraint<TypeAssertions>(this);
@@ -1111,16 +1122,19 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
 
         if (success)
         {
-            Subject.Should().Implement(interfaceType, because, becauseArgs);
+            success = AssertSubjectImplements(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType}.{name}", parameterTypes);
+            if (success)
+            {
+                var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType}.{name}", parameterTypes);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(explicitlyImplementsMethod)
-                .FailWith(
-                    $"Expected {Subject} to explicitly implement {interfaceType}.{name}" +
-                    $"({GetParameterString(parameterTypes)}){{reason}}, but it does not.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(explicitlyImplementsMethod)
+                    .FailWith(
+                        $"Expected {Subject} to explicitly implement {interfaceType}.{name}" +
+                        $"({GetParameterString(parameterTypes)}){{reason}}, but it does not.");
+            }
         }
 
         return new AndConstraint<TypeAssertions>(this);
@@ -1184,16 +1198,19 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
 
         if (success)
         {
-            Subject.Should().Implement(interfaceType, because, becauseArgs);
+            success = AssertSubjectImplements(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType}.{name}", parameterTypes);
+            if (success)
+            {
+                var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType}.{name}", parameterTypes);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(!explicitlyImplementsMethod)
-                .FailWith(
-                    $"Expected {Subject} to not explicitly implement {interfaceType}.{name}" +
-                    $"({GetParameterString(parameterTypes)}){{reason}}, but it does.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!explicitlyImplementsMethod)
+                    .FailWith(
+                        $"Expected {Subject} to not explicitly implement {interfaceType}.{name}" +
+                        $"({GetParameterString(parameterTypes)}){{reason}}, but it does.");
+            }
         }
 
         return new AndConstraint<TypeAssertions>(this);

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -30,7 +30,7 @@ public class TypeSelectorAssertions
     }
 
     /// <summary>
-    /// Gets the object which value is being asserted.
+    /// Gets the object whose value is being asserted.
     /// </summary>
     public IEnumerable<Type> Subject { get; }
 

--- a/Tests/Approval.Tests/ApiApproval.cs
+++ b/Tests/Approval.Tests/ApiApproval.cs
@@ -28,10 +28,12 @@ public class ApiApproval
         string assemblyPath = Uri.UnescapeDataString(uri.Path);
         var containingDirectory = Path.GetDirectoryName(assemblyPath);
         var configurationName = new DirectoryInfo(containingDirectory).Parent.Name;
+
         var assemblyFile = Path.GetFullPath(
             Path.Combine(
                 GetSourceDirectory(),
-                Path.Combine("..", "..", "Src", "FluentAssertions", "bin", configurationName, frameworkVersion, "FluentAssertions.dll")));
+                Path.Combine("..", "..", "Src", "FluentAssertions", "bin", configurationName, frameworkVersion,
+                    "FluentAssertions.dll")));
 
         var assembly = Assembly.LoadFile(Path.GetFullPath(assemblyFile));
         var publicApi = assembly.GeneratePublicApi(options: null);
@@ -53,6 +55,7 @@ public class ApiApproval
         var diff = InlineDiffBuilder.Diff(verified, received);
 
         var builder = new StringBuilder();
+
         foreach (var line in diff.Lines)
         {
             switch (line.Type)
@@ -79,9 +82,12 @@ public class ApiApproval
     {
         public TargetFrameworksTheoryData()
         {
-            var csproj = Path.Combine(GetSourceDirectory(), Path.Combine("..", "..", "Src", "FluentAssertions", "FluentAssertions.csproj"));
+            var csproj = Path.Combine(GetSourceDirectory(),
+                Path.Combine("..", "..", "Src", "FluentAssertions", "FluentAssertions.csproj"));
+
             var project = XDocument.Load(csproj);
             var targetFrameworks = project.XPathSelectElement("/Project/PropertyGroup/TargetFrameworks");
+
             foreach (string targetFramework in targetFrameworks!.Value.Split(';'))
             {
                 Add(targetFramework);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -974,6 +974,7 @@ namespace FluentAssertions.Equivalency
         None = 0,
         Internal = 1,
         Public = 2,
+        ExplicitlyImplemented = 4,
     }
     public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -987,6 +987,7 @@ namespace FluentAssertions.Equivalency
         None = 0,
         Internal = 1,
         Public = 2,
+        ExplicitlyImplemented = 4,
     }
     public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -974,6 +974,7 @@ namespace FluentAssertions.Equivalency
         None = 0,
         Internal = 1,
         Public = 2,
+        ExplicitlyImplemented = 4,
     }
     public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -974,6 +974,7 @@ namespace FluentAssertions.Equivalency
         None = 0,
         Internal = 1,
         Public = 2,
+        ExplicitlyImplemented = 4,
     }
     public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -967,6 +967,7 @@ namespace FluentAssertions.Equivalency
         None = 0,
         Internal = 1,
         Public = 2,
+        ExplicitlyImplemented = 4,
     }
     public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -974,6 +974,7 @@ namespace FluentAssertions.Equivalency
         None = 0,
         Internal = 1,
         Public = 2,
+        ExplicitlyImplemented = 4,
     }
     public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
     {

--- a/Tests/FluentAssertions.Equivalency.Specs/AssertionRuleSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/AssertionRuleSpecs.cs
@@ -245,6 +245,72 @@ public class AssertionRuleSpecs
         act.Should().Throw<XunitException>().WithMessage("*ConcreteClassEqualityComparer*");
     }
 
+    public class BeEquivalentTo
+    {
+        [Fact]
+        public void An_equality_comparer_of_non_nullable_type_is_not_invoked_on_nullable_member()
+        {
+            // Arrange
+            var subject = new { Timestamp = (DateTime?)22.March(2020) };
+
+            var expectation = new { Timestamp = (DateTime?)1.January(2020) };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation,
+                opt => opt.Using(new DateTimeByYearComparer()));
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*2020*");
+        }
+
+        [Fact]
+        public void An_equality_comparer_of_nullable_type_is_not_invoked_on_non_nullable_member()
+        {
+            // Arrange
+            var subject = new { Timestamp = 22.March(2020) };
+
+            var expectation = new { Timestamp = 1.January(2020) };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation,
+                opt => opt.Using(new NullableDateTimeByYearComparer()));
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*2020*");
+        }
+
+        [Fact]
+        public void An_equality_comparer_of_non_nullable_type_is_invoked_on_non_nullable_data()
+        {
+            // Arrange
+            var subject = new { Timestamp = (DateTime?)22.March(2020) };
+
+            var expectation = new { Timestamp = (DateTime?)1.January(2020) };
+
+            // Act
+            subject.Should().BeEquivalentTo(expectation, opt => opt
+                .RespectingRuntimeTypes()
+                .Using(new DateTimeByYearComparer()));
+        }
+
+        [Fact]
+        public void An_equality_comparer_of_nullable_type_is_not_invoked_on_non_nullable_data()
+        {
+            // Arrange
+            var subject = new { Timestamp = (DateTime?)22.March(2020) };
+
+            var expectation = new { Timestamp = (DateTime?)1.January(2020) };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt
+                .RespectingRuntimeTypes()
+                .Using(new NullableDateTimeByYearComparer()));
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*2020*");
+        }
+    }
+
     private interface IInterface
     {
     }
@@ -269,5 +335,15 @@ public class AssertionRuleSpecs
         }
 
         public int GetHashCode(ConcreteClass obj) => obj.GetProperty().GetHashCode();
+    }
+
+    private class NullableDateTimeByYearComparer : IEqualityComparer<DateTime?>
+    {
+        public bool Equals(DateTime? x, DateTime? y)
+        {
+            return x?.Year == y?.Year;
+        }
+
+        public int GetHashCode(DateTime? obj) => obj?.GetHashCode() ?? 0;
     }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -645,4 +645,20 @@ public class BasicSpecs
         // Assert
         act.Should().Throw<XunitException>().WithMessage("Expected property actual[0].Id*to be *-*, but found *-*");
     }
+
+    [Fact]
+    public void Empty_array_segments_can_be_compared_for_equivalency()
+    {
+        // Arrange
+        var actual = new ClassWithArraySegment();
+        var expected = new ClassWithArraySegment();
+
+        // Act / Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    private class ClassWithArraySegment
+    {
+        public ArraySegment<byte> Segment { get; set; }
+    }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
@@ -1171,4 +1171,22 @@ public class DictionarySpecs
             .WhenTypeIs<double>()
         );
     }
+
+    [Fact]
+    public void Passing_the_reason_to_the_inner_equivalency_assertion_works()
+    {
+        var subject = new Dictionary<string, object>
+        {
+            ["a"] = new List<int>()
+        };
+
+        var expected = new Dictionary<string, object>
+        {
+            ["a"] = new List<int> { 42 }
+        };
+
+        Action act = () => subject.Should().BeEquivalentTo(expected, "FOO {0}", "BAR");
+
+        act.Should().Throw<XunitException>().WithMessage("*FOO BAR*");
+    }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
@@ -862,5 +862,267 @@ public class ExtensibilitySpecs
         }
     }
 
+    [Fact]
+    public void Can_compare_null_against_null_with_custom_comparer_for_nullable_property()
+    {
+        // Arrange
+        var subject = new ClassWithNullableStructProperty();
+
+        // Act / Assert
+        subject.Should().BeEquivalentTo(new ClassWithNullableStructProperty(), o => o
+            .Using<StructWithProperties, StructWithPropertiesComparer>()
+        );
+    }
+
+    [Fact]
+    public void Can_compare_null_against_not_null_with_custom_comparer_for_nullable_property()
+    {
+        // Arrange
+        var subject = new ClassWithNullableStructProperty();
+        var unexpected = new ClassWithNullableStructProperty
+        {
+            Value = new StructWithProperties
+            {
+                Value = 42
+            },
+        };
+
+        // Act / Assert
+        subject.Should().NotBeEquivalentTo(unexpected, o => o
+            .Using<StructWithProperties, StructWithPropertiesComparer>()
+        );
+    }
+
+    [Fact]
+    public void Can_compare_not_null_against_null_with_custom_comparer_for_nullable_property()
+    {
+        // Arrange
+        var subject = new ClassWithNullableStructProperty
+        {
+            Value = new StructWithProperties
+            {
+                Value = 42
+            },
+        };
+
+        // Act / Assert
+        subject.Should().NotBeEquivalentTo(new ClassWithNullableStructProperty(), o => o
+            .Using<StructWithProperties, StructWithPropertiesComparer>()
+        );
+    }
+
+    [Fact]
+    public void Can_compare_not_null_against_not_null_with_custom_comparer_for_nullable_property()
+    {
+        // Arrange
+        var subject = new ClassWithNullableStructProperty
+        {
+            Value = new StructWithProperties
+            {
+                Value = 42
+            },
+        };
+        var expected = new ClassWithNullableStructProperty
+        {
+            Value = new StructWithProperties
+            {
+                Value = 42
+            },
+        };
+
+        // Act / Assert
+        subject.Should().BeEquivalentTo(expected, o => o
+            .Using<StructWithProperties, StructWithPropertiesComparer>()
+        );
+    }
+
+    [Fact]
+    public void Can_compare_null_against_null_with_custom_nullable_comparer_for_nullable_property()
+    {
+        // Arrange
+        var subject = new ClassWithNullableStructProperty();
+
+        // Act / Assert
+        subject.Should().BeEquivalentTo(new ClassWithNullableStructProperty(), o => o
+            .Using<StructWithProperties?, StructWithPropertiesComparer>()
+        );
+    }
+
+    [Fact]
+    public void Can_compare_null_against_not_null_with_custom_nullable_comparer_for_nullable_property()
+    {
+        // Arrange
+        var subject = new ClassWithNullableStructProperty();
+        var unexpected = new ClassWithNullableStructProperty
+        {
+            Value = new StructWithProperties
+            {
+                Value = 42
+            },
+        };
+
+        // Act / Assert
+        subject.Should().NotBeEquivalentTo(unexpected, o => o
+            .Using<StructWithProperties?, StructWithPropertiesComparer>()
+        );
+    }
+
+    [Fact]
+    public void Can_compare_not_null_against_null_with_custom_nullable_comparer_for_nullable_property()
+    {
+        // Arrange
+        var subject = new ClassWithNullableStructProperty
+        {
+            Value = new StructWithProperties
+            {
+                Value = 42
+            },
+        };
+
+        // Act / Assert
+        subject.Should().NotBeEquivalentTo(new ClassWithNullableStructProperty(), o => o
+            .Using<StructWithProperties?, StructWithPropertiesComparer>()
+        );
+    }
+
+    [Fact]
+    public void Can_compare_not_null_against_not_null_with_custom_nullable_comparer_for_nullable_property()
+    {
+        // Arrange
+        var subject = new ClassWithNullableStructProperty
+        {
+            Value = new StructWithProperties
+            {
+                Value = 42
+            },
+        };
+        var expected = new ClassWithNullableStructProperty
+        {
+            Value = new StructWithProperties
+            {
+                Value = 42
+            },
+        };
+
+        // Act / Assert
+        subject.Should().BeEquivalentTo(expected, o => o
+            .Using<StructWithProperties?, StructWithPropertiesComparer>()
+        );
+    }
+
+    private class ClassWithNullableStructProperty
+    {
+        public StructWithProperties? Value { get; set; }
+    }
+
+    private struct StructWithProperties
+    {
+        // ReSharper disable once UnusedAutoPropertyAccessor.Local
+        public int Value { get; set; }
+    }
+
+    private class StructWithPropertiesComparer : IEqualityComparer<StructWithProperties>, IEqualityComparer<StructWithProperties?>
+    {
+        public bool Equals(StructWithProperties x, StructWithProperties y) => Equals(x.Value, y.Value);
+
+        public int GetHashCode(StructWithProperties obj) => obj.Value;
+
+        public bool Equals(StructWithProperties? x, StructWithProperties? y) => Equals(x?.Value, y?.Value);
+
+        public int GetHashCode(StructWithProperties? obj) => obj?.Value ?? 0;
+    }
+
+    [Fact]
+    public void Can_compare_null_against_null_with_custom_comparer_for_property()
+    {
+        // Arrange
+        var subject = new ClassWithClassProperty();
+
+        // Act / Assert
+        subject.Should().BeEquivalentTo(new ClassWithClassProperty(), o => o
+            .Using<ClassProperty, ClassPropertyComparer>()
+        );
+    }
+
+    [Fact]
+    public void Can_compare_null_against_not_null_with_custom_comparer_for_property()
+    {
+        // Arrange
+        var subject = new ClassWithClassProperty();
+        var unexpected = new ClassWithClassProperty
+        {
+            Value = new ClassProperty
+            {
+                Value = 42
+            },
+        };
+
+        // Act / Assert
+        subject.Should().NotBeEquivalentTo(unexpected, o => o
+            .Using<ClassProperty, ClassPropertyComparer>()
+        );
+    }
+
+    [Fact]
+    public void Can_compare_not_null_against_null_with_custom_comparer_for_property()
+    {
+        // Arrange
+        var subject = new ClassWithClassProperty
+        {
+            Value = new ClassProperty
+            {
+                Value = 42
+            },
+        };
+
+        // Act / Assert
+        subject.Should().NotBeEquivalentTo(new ClassWithClassProperty(), o => o
+            .Using<ClassProperty, ClassPropertyComparer>()
+        );
+    }
+
+    [Fact]
+    public void Can_compare_not_null_against_not_null_with_custom_comparer_for_property()
+    {
+        // Arrange
+        var subject = new ClassWithClassProperty
+        {
+            Value = new ClassProperty
+            {
+                Value = 42
+            },
+        };
+        var expected = new ClassWithClassProperty
+        {
+            Value = new ClassProperty
+            {
+                Value = 42
+            },
+        };
+
+        // Act / Assert
+        subject.Should().BeEquivalentTo(expected, o => o
+            .Using<ClassProperty, ClassPropertyComparer>()
+        );
+    }
+
+    private class ClassWithClassProperty
+    {
+        // ReSharper disable once UnusedAutoPropertyAccessor.Local
+        public ClassProperty Value { get; set; }
+    }
+
+    public class ClassProperty
+    {
+        public int Value { get; set; }
+    }
+
+    private class ClassPropertyComparer : IEqualityComparer<ClassProperty>
+    {
+        public bool Equals(ClassProperty x, ClassProperty y) => Equals(x?.Value, y?.Value);
+
+        public int GetHashCode(ClassProperty obj) => obj.Value;
+    }
+
     #endregion
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Extensions;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
 
@@ -1012,6 +1013,7 @@ public class ExtensibilitySpecs
 
     private class ClassWithNullableStructProperty
     {
+        [UsedImplicitly]
         public StructWithProperties? Value { get; set; }
     }
 

--- a/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
+++ b/Tests/FluentAssertions.Equivalency.Specs/FluentAssertions.Equivalency.Specs.csproj
@@ -57,6 +57,7 @@
 
   <ItemGroup>
     <PackageReference Include="Chill" Version="4.1.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="Xunit.StaFact" Version="1.1.11" />

--- a/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
@@ -62,8 +62,8 @@ public class MemberMatchingSpecs
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ParentOfSubjectWithProperty1>(
-                    e => e.Parent[0].Property2,
-                    s => s.Parent[0].Property1));
+                    e => e.Children[0].Property2,
+                    s => s.Children[0].Property1));
     }
 
     [Fact]
@@ -81,6 +81,25 @@ public class MemberMatchingSpecs
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ExpectationWithProperty2, SubjectWithProperty1>("Property2", "Property1"));
+    }
+
+    [Fact]
+    public void Nested_explicitly_implemented_properties_can_be_mapped_using_a_nested_type_and_property_names()
+    {
+        // Arrange
+        var subject = new ParentOfSubjectWithExplicitlyImplementedProperty(new[] { new SubjectWithExplicitImplementedProperty() });
+
+        ((IProperty)subject.Children[0]).Property = "Hello";
+
+        var expectation = new ParentOfExpectationWithProperty2(new[]
+        {
+            new ExpectationWithProperty2 { Property2 = "Hello" }
+        });
+
+        // Act / Assert
+        subject.Should()
+            .BeEquivalentTo(expectation, opt => opt
+                .WithMapping<ExpectationWithProperty2, SubjectWithExplicitImplementedProperty>("Property2", "Property"));
     }
 
     [Fact]
@@ -142,6 +161,25 @@ public class MemberMatchingSpecs
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Property2", "Property1"));
+    }
+
+    [Fact]
+    public void Properties_can_be_mapped_by_name_to_an_explicitly_implemented_property()
+    {
+        // Arrange
+        var subject = new SubjectWithExplicitImplementedProperty();
+
+        ((IProperty)subject).Property = "Hello";
+
+        var expectation = new ExpectationWithProperty2
+        {
+            Property2 = "Hello"
+        };
+
+        // Act / Assert
+        subject.Should()
+            .BeEquivalentTo(expectation, opt => opt
+                .WithMapping("Property2", "Property"));
     }
 
     [Fact]
@@ -515,27 +553,47 @@ public class MemberMatchingSpecs
 
     internal class ParentOfExpectationWithProperty2
     {
-        public ExpectationWithProperty2[] Parent { get; }
+        public ExpectationWithProperty2[] Children { get; }
 
-        public ParentOfExpectationWithProperty2(ExpectationWithProperty2[] parent)
+        public ParentOfExpectationWithProperty2(ExpectationWithProperty2[] children)
         {
-            Parent = parent;
+            Children = children;
         }
     }
 
     internal class ParentOfSubjectWithProperty1
     {
-        public SubjectWithProperty1[] Parent { get; }
+        public SubjectWithProperty1[] Children { get; }
 
-        public ParentOfSubjectWithProperty1(SubjectWithProperty1[] parent)
+        public ParentOfSubjectWithProperty1(SubjectWithProperty1[] children)
         {
-            Parent = parent;
+            Children = children;
+        }
+    }
+
+    internal class ParentOfSubjectWithExplicitlyImplementedProperty
+    {
+        public SubjectWithExplicitImplementedProperty[] Children { get; }
+
+        public ParentOfSubjectWithExplicitlyImplementedProperty(SubjectWithExplicitImplementedProperty[] children)
+        {
+            Children = children;
         }
     }
 
     internal class SubjectWithProperty1
     {
         public string Property1 { get; set; }
+    }
+
+    internal class SubjectWithExplicitImplementedProperty : IProperty
+    {
+        string IProperty.Property { get; set; }
+    }
+
+    internal interface IProperty
+    {
+        string Property { get; set; }
     }
 
     internal class ExpectationWithProperty2

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -1442,6 +1442,54 @@ public class SelectionRulesSpecs
             // Act / Assert
             actual.Should().BeEquivalentTo(expected);
         }
+
+        [Fact]
+        public void Private_protected_properties_are_ignored()
+        {
+            // Arrange
+            var subject = new ClassWithPrivateProtectedProperty("Name", 13);
+            var other = new ClassWithPrivateProtectedProperty("Name", 37);
+
+            // Act/Assert
+            subject.Should().BeEquivalentTo(other);
+        }
+
+        private class ClassWithPrivateProtectedProperty
+        {
+            public ClassWithPrivateProtectedProperty(string name, int value)
+            {
+                Name = name;
+                Value = value;
+            }
+
+            public string Name { get; }
+
+            private protected int Value { get; }
+        }
+
+        [Fact]
+        public void Private_protected_fields_are_ignored()
+        {
+            // Arrange
+            var subject = new ClassWithPrivateProtectedField("Name", 13);
+            var other = new ClassWithPrivateProtectedField("Name", 37);
+
+            // Act/Assert
+            subject.Should().BeEquivalentTo(other);
+        }
+
+        private class ClassWithPrivateProtectedField
+        {
+            public ClassWithPrivateProtectedField(string name, int value)
+            {
+                Name = name;
+                this.value = value;
+            }
+
+            public string Name;
+
+            private protected int value;
+        }
     }
 
     public class MemberHiding

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -905,13 +905,14 @@ public class SelectionRulesSpecs
                 "internal", "protected-internal", "private", "private-protected");
 
             var expected = new ClassWithAllAccessModifiersForMembers("public", "protected",
-                "ignored-internal", "ignored-protected-internal", "private", "ignore-private-protected");
+                "ignored-internal", "ignored-protected-internal", "private", "private-protected");
 
             // Act
-            Action act = () => subject.Should().BeEquivalentTo(expected, config =>
-                config.Excluding(ctx => ctx.WhichGetterHas(CSharpAccessModifier.Internal) ||
-                    ctx.WhichGetterHas(CSharpAccessModifier.ProtectedInternal) ||
-                    ctx.WhichGetterHas(CSharpAccessModifier.PrivateProtected)));
+            Action act = () => subject.Should().BeEquivalentTo(expected, config => config
+                .IncludingInternalFields()
+                .Excluding(ctx =>
+                    ctx.WhichGetterHas(CSharpAccessModifier.Internal) ||
+                    ctx.WhichGetterHas(CSharpAccessModifier.ProtectedInternal)));
 
             // Assert
             act.Should().NotThrow();
@@ -925,14 +926,15 @@ public class SelectionRulesSpecs
                 "internal", "protected-internal", "private", "private-protected");
 
             var expected = new ClassWithAllAccessModifiersForMembers("public", "protected",
-                "ignored-internal", "ignored-protected-internal", "ignored-private", "ignore-private-protected");
+                "ignored-internal", "ignored-protected-internal", "ignored-private", "private-protected");
 
             // Act
-            Action act = () => subject.Should().BeEquivalentTo(expected, config =>
-                config.Excluding(ctx => ctx.WhichSetterHas(CSharpAccessModifier.Internal) ||
+            Action act = () => subject.Should().BeEquivalentTo(expected, config => config
+                .IncludingInternalFields()
+                .Excluding(ctx =>
+                    ctx.WhichSetterHas(CSharpAccessModifier.Internal) ||
                     ctx.WhichSetterHas(CSharpAccessModifier.ProtectedInternal) ||
-                    ctx.WhichSetterHas(CSharpAccessModifier.Private) ||
-                    ctx.WhichSetterHas(CSharpAccessModifier.PrivateProtected)));
+                    ctx.WhichSetterHas(CSharpAccessModifier.Private)));
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using FluentAssertions.Common;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
 
@@ -60,7 +61,7 @@ public class SelectionRulesSpecs
 
         private class ClassWithFieldInLowerCase
         {
-            [JetBrains.Annotations.UsedImplicitly]
+            [UsedImplicitly]
 #pragma warning disable SA1307
             public string name;
 #pragma warning restore SA1307
@@ -68,7 +69,7 @@ public class SelectionRulesSpecs
 
         private class ClassWithFieldInUpperCase
         {
-            [JetBrains.Annotations.UsedImplicitly]
+            [UsedImplicitly]
             public string Name;
         }
 
@@ -95,6 +96,7 @@ public class SelectionRulesSpecs
 
         public class ClassWithIndexer
         {
+            [UsedImplicitly]
             public object Foo { get; set; }
 
             public string this[int n] =>
@@ -289,8 +291,10 @@ public class SelectionRulesSpecs
 
         internal class BaseClassPointingToClassWithoutProperties
         {
+            [UsedImplicitly]
             public string Name { get; set; }
 
+            [UsedImplicitly]
             public ClassWithoutProperty ClassWithoutProperty { get; } = new();
         }
 
@@ -453,6 +457,7 @@ public class SelectionRulesSpecs
 
         public class CustomType
         {
+            [UsedImplicitly]
             public string Name { get; set; }
         }
 
@@ -1360,10 +1365,13 @@ public class SelectionRulesSpecs
 
         private class ClassWithInternalProperty
         {
+            [UsedImplicitly]
             public string PublicProperty { get; set; }
 
+            [UsedImplicitly]
             internal string InternalProperty { get; set; }
 
+            [UsedImplicitly]
             protected internal string ProtectedInternalProperty { get; set; }
         }
 
@@ -1416,10 +1424,13 @@ public class SelectionRulesSpecs
 
         private class ClassWithInternalField
         {
+            [UsedImplicitly]
             public string PublicField;
 
+            [UsedImplicitly]
             internal string InternalField;
 
+            [UsedImplicitly]
             protected internal string ProtectedInternalField;
         }
 
@@ -1464,8 +1475,10 @@ public class SelectionRulesSpecs
                 Value = value;
             }
 
+            [UsedImplicitly]
             public string Name { get; }
 
+            [UsedImplicitly]
             private protected int Value { get; }
         }
 
@@ -1488,8 +1501,10 @@ public class SelectionRulesSpecs
                 this.value = value;
             }
 
+            [UsedImplicitly]
             public string Name;
 
+            [UsedImplicitly]
             private protected int value;
         }
     }
@@ -1632,26 +1647,31 @@ public class SelectionRulesSpecs
 
         private class BaseWithProperty
         {
+            [UsedImplicitly]
             public object Property { get; set; }
         }
 
         private class SubclassAHidingProperty<T> : BaseWithProperty
         {
+            [UsedImplicitly]
             public new T Property { get; set; }
         }
 
         private class BaseWithStringProperty
         {
+            [UsedImplicitly]
             public string Property { get; set; }
         }
 
         private class SubclassHidingStringProperty : BaseWithStringProperty
         {
+            [UsedImplicitly]
             public new string Property { get; set; }
         }
 
         private class AnotherBaseWithProperty
         {
+            [UsedImplicitly]
             public object Property { get; set; }
         }
 
@@ -1780,21 +1800,25 @@ public class SelectionRulesSpecs
 
         private class BaseWithField
         {
+            [UsedImplicitly]
             public string Field;
         }
 
         private class SubclassAHidingField : BaseWithField
         {
+            [UsedImplicitly]
             public new string Field;
         }
 
         private class AnotherBaseWithField
         {
+            [UsedImplicitly]
             public string Field;
         }
 
         private class SubclassBHidingField : AnotherBaseWithField
         {
+            [UsedImplicitly]
             public new string Field;
         }
     }
@@ -2233,11 +2257,13 @@ public class SelectionRulesSpecs
 
         private class BaseWithProperty
         {
+            [UsedImplicitly]
             public string BaseProperty { get; set; }
         }
 
         private class DerivedWithProperty : BaseWithProperty
         {
+            [UsedImplicitly]
             public string DerivedProperty { get; set; }
         }
 
@@ -2250,6 +2276,7 @@ public class SelectionRulesSpecs
         {
             public override DerivedWithProperty Property { get; }
 
+            [UsedImplicitly]
             public string OtherProp { get; set; }
 
             public DerivedWithCovariantOverride(DerivedWithProperty prop)
@@ -2797,45 +2824,59 @@ public class SelectionRulesSpecs
 
         private class ClassWithNonBrowsableMembers
         {
+            [UsedImplicitly]
             public int BrowsableField = -1;
 
+            [UsedImplicitly]
             public int BrowsableProperty { get; set; }
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Always)]
             public int ExplicitlyBrowsableField = -1;
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Always)]
             public int ExplicitlyBrowsableProperty { get; set; }
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Advanced)]
             public int AdvancedBrowsableField = -1;
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Advanced)]
             public int AdvancedBrowsableProperty { get; set; }
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Never)]
             public int NonBrowsableField = -1;
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Never)]
             public int NonBrowsableProperty { get; set; }
         }
 
         private class ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable
         {
+            [UsedImplicitly]
             public int BrowsableProperty { get; set; }
 
+            [UsedImplicitly]
             public int FieldThatMightBeNonBrowsable = -1;
 
+            [UsedImplicitly]
             public int PropertyThatMightBeNonBrowsable { get; set; }
         }
 
         private class ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable
         {
+            [UsedImplicitly]
             public int BrowsableProperty { get; set; }
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Never)]
             public int FieldThatMightBeNonBrowsable = -1;
 
+            [UsedImplicitly]
             [EditorBrowsable(EditorBrowsableState.Never)]
             public int PropertyThatMightBeNonBrowsable { get; set; }
         }

--- a/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/TestTypes.cs
@@ -43,7 +43,7 @@ public class ClassWithWriteOnlyProperty
 
     public int WriteOnlyProperty
     {
-        set { writeOnlyPropertyValue = value; }
+        set => writeOnlyPropertyValue = value;
     }
 
     public string SomeOtherProperty { get; set; }
@@ -616,9 +616,33 @@ public class Vehicle : IVehicle
     public int VehicleId { get; set; }
 }
 
+public class VehicleWithField
+{
+    public int VehicleId;
+}
+
 public class ExplicitVehicle : IVehicle
 {
     int IVehicle.VehicleId { get; set; }
+
+    public int VehicleId { get; set; }
+}
+
+public interface IReadOnlyVehicle
+{
+    int VehicleId { get; }
+}
+
+public class ExplicitReadOnlyVehicle : IReadOnlyVehicle
+{
+    private readonly int explicitValue;
+
+    public ExplicitReadOnlyVehicle(int explicitValue)
+    {
+        this.explicitValue = explicitValue;
+    }
+
+    int IReadOnlyVehicle.VehicleId => explicitValue;
 
     public int VehicleId { get; set; }
 }

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -6,6 +6,7 @@ using Chill;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Equivalency.Steps;
 using FluentAssertions.Execution;
+using FluentAssertions.Extensions;
 using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -6,7 +6,6 @@ using Chill;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Equivalency.Steps;
 using FluentAssertions.Execution;
-using FluentAssertions.Extensions;
 using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -35,7 +35,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty because that's what we expect, but found*1*2*3*");
+                .WithMessage("*to be empty because that's what we expect, but found at least one item*1*");
         }
 
         [Fact]
@@ -116,6 +116,21 @@ public partial class CollectionAssertionSpecs
             collection.Should().BeEmpty();
 
             // Assert
+            collection.GetEnumeratorCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void When_asserting_non_empty_collection_is_empty_it_should_enumerate_only_once()
+        {
+            // Arrange
+            var collection = new CountingGenericEnumerable<int>([1, 2, 3]);
+
+            // Act
+            Action act = () => collection.Should().BeEmpty();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*to be empty, but found at least one item {1}.");
             collection.GetEnumeratorCallCount.Should().Be(1);
         }
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -123,7 +123,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_non_empty_collection_is_empty_it_should_enumerate_only_once()
         {
             // Arrange
-            var collection = new CountingGenericEnumerable<int>([1, 2, 3]);
+            var collection = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
 
             // Act
             Action act = () => collection.Should().BeEmpty();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
@@ -66,7 +66,7 @@ public partial class CollectionAssertionSpecs
         public void When_asserting_non_empty_collection_is_null_or_empty_it_should_enumerate_only_once()
         {
             // Arrange
-            var collection = new CountingGenericEnumerable<int>([1, 2, 3]);
+            var collection = new CountingGenericEnumerable<int>(new[] { 1, 2, 3 });
 
             // Act
             Action act = () => collection.Should().BeNullOrEmpty();

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
@@ -46,7 +46,7 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to be null or empty because we want to test the failure message, but found {1, 2, 3}.");
+                    "Expected collection to be null or empty because we want to test the failure message, but found at least one item {1}.");
         }
 
         [Fact]
@@ -59,6 +59,21 @@ public partial class CollectionAssertionSpecs
             collection.Should().BeNullOrEmpty();
 
             // Assert
+            collection.GetEnumeratorCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void When_asserting_non_empty_collection_is_null_or_empty_it_should_enumerate_only_once()
+        {
+            // Arrange
+            var collection = new CountingGenericEnumerable<int>([1, 2, 3]);
+
+            // Act
+            Action act = () => collection.Should().BeNullOrEmpty();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*to be null or empty, but found at least one item {1}.");
             collection.GetEnumeratorCallCount.Should().Be(1);
         }
     }

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1339,7 +1339,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
         act
             .Should().Throw<XunitException>()
             .WithMessage(
-                "Expected collection to be empty because we want to test the failure message, but found*one*two*three*");
+                "Expected collection to be empty because we want to test the failure message, but found at least one item*one*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -877,7 +877,7 @@ public class GenericDictionaryAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected dictionary to be empty because we want to test the failure message, but found {[1] = \"One\"}.");
+                    "Expected dictionary to be empty because we want to test the failure message, but found at least one item {[1, One]}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScope.MessageFormatingSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScope.MessageFormatingSpecs.cs
@@ -83,6 +83,22 @@ public partial class AssertionScopeSpecs
     }
 
     [Fact]
+    public void The_inner_scope_is_used_when_the_outer_scope_does_not_have_a_context()
+    {
+        // Act
+        Action act = () =>
+        {
+            using var outerScope = new AssertionScope();
+            using var innerScope = new AssertionScope("inner");
+            new[] { 1, 2, 3 }.Should().Equal(3, 2, 1);
+        };
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected inner to be equal to*");
+    }
+
+    [Fact]
     public void Message_should_contain_each_unique_failed_assertion_seperately()
     {
         // Act

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScope.MessageFormatingSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScope.MessageFormatingSpecs.cs
@@ -67,6 +67,22 @@ public partial class AssertionScopeSpecs
     }
 
     [Fact]
+    public void Nested_scopes_use_the_name_of_their_outer_scope_as_context()
+    {
+        // Act
+        Action act = () =>
+        {
+            using var outerScope = new AssertionScope("outer");
+            using var innerScope = new AssertionScope("inner");
+            new[] { 1, 2, 3 }.Should().Equal(3, 2, 1);
+        };
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected outer/inner to be equal to*");
+    }
+
+    [Fact]
     public void Message_should_contain_each_unique_failed_assertion_seperately()
     {
         // Act

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -252,6 +252,40 @@ namespace FluentAssertions.Specs.Execution
             outerScope.Get<string>("innerReportable").Should().Be("bar");
         }
 
+        [Fact]
+        public void Formatting_options_passed_to_inner_assertion_scopes()
+        {
+            // Arrange
+            var subject = new[]
+            {
+                new
+                {
+                    Value = 42
+                }
+            };
+
+            var expected = new[]
+            {
+                new
+                {
+                    Value = 42
+                },
+                new
+                {
+                    Value = 42
+                }
+            };
+
+            // Act
+            using var scope = new AssertionScope();
+            scope.FormattingOptions.MaxDepth = 1;
+            subject.Should().BeEquivalentTo(expected);
+
+            // Assert
+            scope.Discard().Should().ContainSingle()
+                .Which.Should().Contain("Maximum recursion depth of 1 was reached");
+        }
+
         public class CustomAssertionStrategy : IAssertionStrategy
         {
             private readonly List<string> failureMessages = new();

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -7,7 +7,6 @@ using FluentAssertions;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
-using FluentAssertions.Primitives;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -61,6 +61,7 @@
 
   <ItemGroup>
     <PackageReference Include="Chill" Version="4.1.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="Xunit.StaFact" Version="1.1.11" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -41,7 +41,7 @@ public class BooleanAssertionSpecs
             // Assert
             action
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected boolean to be true because we want to test the failure message, but found False.");
+                .WithMessage("Expected boolean to be True because we want to test the failure message, but found False.");
         }
     }
 
@@ -78,7 +78,7 @@ public class BooleanAssertionSpecs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected boolean to be false because we want to test the failure message, but found True.");
+                .WithMessage("Expected boolean to be False because we want to test the failure message, but found True.");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
@@ -2245,6 +2245,44 @@ public class DateTimeAssertionSpecs
             // Assert
             action.Should().NotThrow();
         }
+
+        [Fact]
+        public void Should_throw_because_of_assertion_failure_when_asserting_null_is_within_second_before_specific_date()
+        {
+            // Arrange
+            DateTimeOffset? nullDateTime = null;
+            DateTimeOffset target = new DateTimeOffset(2000, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+            // Act
+            Action action = () =>
+                nullDateTime.Should()
+                    .BeWithin(TimeSpan.FromSeconds(1))
+                    .Before(target);
+
+            // Assert
+            action.Should().Throw<Exception>()
+                .Which.Message
+                .Should().StartWith("Expected nullDateTime to be within 1s before <2000-01-01 12:00:00 +0h>, but found a <null> DateTime");
+        }
+
+        [Fact]
+        public void Should_throw_because_of_assertion_failure_when_asserting_null_is_within_second_after_specific_date()
+        {
+            // Arrange
+            DateTimeOffset? nullDateTime = null;
+            DateTimeOffset target = new DateTimeOffset(2000, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+            // Act
+            Action action = () =>
+                nullDateTime.Should()
+                    .BeWithin(TimeSpan.FromSeconds(1))
+                    .After(target);
+
+            // Assert
+            action.Should().Throw<Exception>()
+                .Which.Message
+                .Should().StartWith("Expected nullDateTime to be within 1s after <2000-01-01 12:00:00 +0h>, but found a <null> DateTime");
+        }
     }
 
     public class BeOneOf

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -815,7 +815,10 @@ public class ObjectAssertionSpecs
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 valueTypeObject.Should().NotBeOfType(typeof(int), "because we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -10,6 +10,7 @@ using AssemblyB;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using FluentAssertions.Primitives;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
 
@@ -1494,11 +1495,13 @@ public class ObjectAssertionSpecs
 
     internal class NonPublicClass
     {
+        [UsedImplicitly]
         public string Name { get; set; }
     }
 
     public class XmlSerializableClass
     {
+        [UsedImplicitly]
         public string Name { get; set; }
 
         public int Id;
@@ -1506,6 +1509,7 @@ public class ObjectAssertionSpecs
 
     public class XmlSerializableClassNotRestoringAllProperties : IXmlSerializable
     {
+        [UsedImplicitly]
         public string Name { get; set; }
 
         public DateTime BirthDay { get; set; }
@@ -1627,6 +1631,7 @@ public class ObjectAssertionSpecs
 
     public class DataContractSerializableClass
     {
+        [UsedImplicitly]
         public string Name { get; set; }
 
         public int Id;

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -56,14 +56,13 @@ public class ReferenceTypeAssertionsSpecs
     [Fact]
     public void When_a_derived_class_has_longer_formatting_than_the_base_class()
     {
-        var subject = new SimpleComplexBase[] { new Simple(), new Complex("goodbye") };
+        var subject = new SimpleComplexBase[] { new Complex("goodbye"), new Simple() };
         Action act = () => subject.Should().BeEmpty();
         act.Should().Throw<XunitException>()
             .WithMessage(
             """
-            Expected subject to be empty, but found 
+            Expected subject to be empty, but found at least one item 
             {
-                Simple(Hello), 
                 FluentAssertions.Specs.Primitives.Complex
                 {
                     Statement = "goodbye"

--- a/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions.Execution;
 using FluentAssertions.Specialized;
 using Xunit;
 
@@ -33,5 +35,23 @@ public class DelegateAssertionSpecs
         // Act
         act.Should().ThrowExactly<ArgumentNullException>()
             .WithParameterName("clock");
+    }
+
+    public class ThrowExactly
+    {
+        [Fact]
+        public void Does_not_continue_assertion_on_exact_exception_type()
+        {
+            // Arrange
+            var a = () => { };
+
+            // Act
+            using var scope = new AssertionScope();
+            a.Should().ThrowExactly<InvalidOperationException>();
+
+            // Assert
+            scope.Discard().Should().ContainSingle()
+                .Which.Should().Match("*InvalidOperationException*no exception*");
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Specialized;
 using Xunit;

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
+using FluentAssertions.Specialized;
 using Xunit;
 using Xunit.Sdk;
 
@@ -463,6 +464,24 @@ public static class TaskAssertionSpecs
             await action.Should().ThrowAsync<XunitException>().WithMessage(
                 "Expected a <System.InvalidOperationException> to be thrown within 1s,"
                 + " but found <System.NotSupportedException>:*foo*");
+        }
+    }
+
+    public class ThrowExactlyAsync
+    {
+        [Fact]
+        public async Task Does_not_continue_assertion_on_exact_exception_type()
+        {
+            // Arrange
+            var a = () => Task.Delay(1);
+
+            // Act
+            using var scope = new AssertionScope();
+            await a.Should().ThrowExactlyAsync<InvalidOperationException>();
+
+            // Assert
+            scope.Discard().Should().ContainSingle()
+                .Which.Should().Match("*InvalidOperationException*no exception*");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
-using FluentAssertions.Specialized;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
@@ -2,6 +2,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using FluentAssertions.Common;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -557,6 +558,24 @@ public class PropertyInfoAssertionSpecs
         }
 
         [Fact]
+        public void Do_not_the_check_access_modifier_when_the_property_is_not_readable()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WriteOnlyProperty");
+
+            // Act
+            Action action = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().BeReadable(CSharpAccessModifier.Private);
+            };
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected property WriteOnlyProperty to have a getter, but it does not.");
+        }
+
+        [Fact]
         public void When_subject_is_null_be_readable_with_accessmodifier_should_fail()
         {
             // Arrange
@@ -616,6 +635,24 @@ public class PropertyInfoAssertionSpecs
             action.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method set_ReadPrivateWriteProperty to be Public because we want to test the error message, but it is Private.");
+        }
+
+        [Fact]
+        public void Do_not_the_check_access_modifier_when_the_property_is_not_writable()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadOnlyProperty");
+
+            // Act
+            Action action = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().BeWritable(CSharpAccessModifier.Private);
+            };
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected propertyInfo ReadOnlyProperty to have a setter.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitMethod.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitMethod.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -182,6 +183,19 @@ public partial class TypeAssertionSpecs
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
                 .WithParameterName("name");
+        }
+
+        [Fact]
+        public void Does_not_continue_assertion_on_explicit_interface_implementation_if_not_implemented_at_all()
+        {
+            var act = () =>
+            {
+                using var _ = new AssertionScope();
+                typeof(ClassWithMembers).Should().HaveExplicitMethod(typeof(IExplicitInterface), "Foo", new Type[0]);
+            };
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type *ClassWithMembers* to*implement *IExplicitInterface, but it does not.");
         }
     }
 
@@ -439,6 +453,21 @@ public partial class TypeAssertionSpecs
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
                 .WithParameterName("name");
+        }
+
+        [Fact]
+        public void Does_not_continue_assertion_on_explicit_interface_implementation_if_implemented()
+        {
+            var act = () =>
+            {
+                using var _ = new AssertionScope();
+                typeof(ClassExplicitlyImplementingInterface)
+                    .Should().NotHaveExplicitMethod(typeof(IExplicitInterface), "ExplicitMethod", new Type[0]);
+            };
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected *ClassExplicitlyImplementingInterface* to not*implement " +
+                    "*IExplicitInterface.ExplicitMethod(), but it does.");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitProperty.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitProperty.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -167,6 +168,19 @@ public partial class TypeAssertionSpecs
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
                 .WithParameterName("name");
+        }
+
+        [Fact]
+        public void Does_not_continue_assertion_on_explicit_interface_implementation_if_not_implemented_at_all()
+        {
+            var act = () =>
+            {
+                using var _ = new AssertionScope();
+                typeof(int).Should().HaveExplicitProperty(typeof(IExplicitInterface), "Foo");
+            };
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type System.Int32 to*implement *IExplicitInterface, but it does not.");
         }
     }
 
@@ -394,6 +408,21 @@ public partial class TypeAssertionSpecs
             // Assert
             act.Should().ThrowExactly<ArgumentException>()
                 .WithParameterName("name");
+        }
+
+        [Fact]
+        public void Does_not_continue_assertion_on_explicit_interface_implementation_if_implemented()
+        {
+            var act = () =>
+            {
+                using var _ = new AssertionScope();
+                typeof(ClassExplicitlyImplementingInterface)
+                    .Should().NotHaveExplicitProperty(typeof(IExplicitInterface), "ExplicitStringProperty");
+            };
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected *ClassExplicitlyImplementingInterface* to*implement " +
+                    "*IExplicitInterface.ExplicitStringProperty, but it does.");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.Implement.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.Implement.cs
@@ -73,6 +73,20 @@ public partial class TypeAssertionSpecs
             act.Should().ThrowExactly<ArgumentNullException>()
                 .WithParameterName("interfaceType");
         }
+
+        [Fact]
+        public void An_interface_does_not_implement_itself()
+        {
+            // Arrange
+            var type = typeof(IDummyInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().Implement(typeof(IDummyInterface));
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
     }
 
     public class ImplementOfT
@@ -155,6 +169,16 @@ public partial class TypeAssertionSpecs
             // Assert
             act.Should().ThrowExactly<ArgumentNullException>()
                 .WithParameterName("interfaceType");
+        }
+
+        [Fact]
+        public void An_interface_does_not_implement_itself()
+        {
+            // Arrange
+            var type = typeof(IDummyInterface);
+
+            // Act / Assert
+            type.Should().NotImplement(typeof(IDummyInterface));
         }
     }
 

--- a/docs/_data/tips/datetimes.yml
+++ b/docs/_data/tips/datetimes.yml
@@ -1,0 +1,23 @@
+- old: |
+    actual.Date.Should().Be(expected.Date);
+
+  new: |
+    actual.Should().BeSameDateAs(expected);
+
+  old-message: |
+    Expected date and time to be <2017-01-01>, but found <2017-01-02>.
+
+  new-message: |
+    Expected a date and time with date <2017-01-01>, but found <2017-01-02 21:00:00>.
+
+- old: |
+    actual.Date.Should().NotBe(unexpected.Date);
+
+  new: |
+    actual.Should().NotBeSameDateAs(unexpected);
+
+  old-message: |
+    Expected date and time not to be <2017-01-01>, but it is.
+
+  new-message: |
+    Expected a date and time that does not have date <2017-01-01>, but found it does.

--- a/docs/_data/tips/datetimes.yml
+++ b/docs/_data/tips/datetimes.yml
@@ -21,3 +21,147 @@
 
   new-message: |
     Expected a date and time that does not have date <2017-01-01>, but found it does.
+
+- old: | 
+    actual.Year.Should().Be(expected.Year);
+
+  new: |
+    actual.Should().HaveYear(expected.Year);
+
+  old-message: |
+    Expected actual.Year to be 2018, but found 2017 (difference of -1).
+
+  new-message: |
+    Expected the year part of actual to be 2018, but found 2017.
+
+- old: |
+    actual.Year.Should().NotBe(unexpected.Year);
+
+  new: |
+    actual.Should().NotHaveYear(unexpected.Year);
+
+  old-message: |
+    Did not expect the year part of actual to be 2017, but it was.
+
+  new-message: |
+    Did not expect actual.Year to be 2017.
+
+- old: |
+    actual.Month.Should().Be(expected.Month);
+
+  new: |
+    actual.Should().HaveMonth(expected.Month);
+
+  old-message: |
+    Expected actual.Month to be 2, but found 1.
+
+  new-message: |
+    Expected the month part of actual to be 2, but found 1.
+
+- old: |
+    actual.Month.Should().NotBe(unexpected.Month);
+
+  new: |
+    actual.Should().NotHaveMonth(unexpected.Month);
+
+  old-message: |
+    Did not expect actual.Month to be 1.
+
+  new-message: |
+    Did not expect the month part of actual to be 1, but it was.
+
+- old: |
+    actual.Day.Should().Be(expected.Day);
+
+  new: |
+    actual.Should().HaveDay(expected.Day);
+
+  old-message: |
+    Expected actual.Day to be 2, but found 1.
+
+  new-message: |
+    Expected the day part of actual to be 2, but found 1.
+
+- old: |
+    actual.Day.Should().NotBe(unexpected.Day);
+
+  new: |
+    actual.Should().NotHaveDay(unexpected.Day);
+
+  old-message: |
+    Did not expect actual.Day to be 1.
+
+  new-message: |
+    Did not expect the day part of actual to be 1, but it was.
+
+- old: |
+    actual.Hour.Should().Be(expected.Hour);
+
+  new: |
+    actual.Should().HaveHour(expected.Hour);
+
+  old-message: |
+    Expected actual.Hour to be 19, but found 16 (difference of -3).
+
+  new-message: |
+    Expected the hour part of actual to be 19, but found 16.
+
+- old: |
+    actual.Hour.Should().NotBe(unexpected.Hour);
+
+  new: |
+    actual.Should().NotHaveHour(unexpected.Hour);
+
+  old-message: |
+    Did not expect actual.Hour to be 16.
+
+  new-message: |
+    Did not expect the hour part of actual to be 16, but it was.
+
+- old: |
+    actual.Minute.Should().Be(expected.Minute);
+
+  new: |
+    actual.Should().HaveMinute(expected.Minute);
+
+  old-message: |
+    Expected actual.Minute to be 31, but found 30 (difference of -1).
+
+  new-message: |
+    Expected the minute part of actual to be 31, but found 30.
+
+- old: |
+    actual.Minute.Should().NotBe(unexpected.Minute);
+
+  new: |
+    actual.Should().NotHaveMinute(unexpected.Minute);
+
+  old-message: |
+    Did not expect actual.Minute to be 30.
+
+  new-message: |
+    Did not expect the minute part of actual to be 30, but it was.
+
+- old: |
+    actual.Second.Should().Be(expected.Second);
+
+  new: |
+    actual.Should().HaveSecond(expected.Second);
+
+  old-message: |
+    Expected actual.Second to be 18, but found 17 (difference of -1).
+
+  new-message: |
+    Expected the seconds part of actual to be 18, but found 17.
+
+- old: |
+    actual.Second.Should().NotBe(unexpected.Second);
+
+  new: |
+    actual.Should().NotHaveSecond(unexpected.Second);
+
+  old-message: |
+    Did not expect actual.Second to be 17.
+
+  new-message: |
+    Did not expect the seconds part of actual to be 17, but it was.

--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -162,9 +162,9 @@ Consider for instance two collections that contain some kind of domain entity pe
 Since the actual object instance is different, if you want to make sure a particular property was properly persisted, you usually do something like this:
 
 ```csharp
-persistedCustomers.Select(c => c.Name).Should().Equal(customers.Select(c => c.Name);
-persistedCustomers.Select(c => c.Name).Should().StartWith(customers.Select(c => c.Name);
-persistedCustomers.Select(c => c.Name).Should().EndWith(customers.Select(c => c.Name);
+persistedCustomers.Select(c => c.Name).Should().Equal(customers.Select(c => c.Name));
+persistedCustomers.Select(c => c.Name).Should().StartWith(customers.Select(c => c.Name));
+persistedCustomers.Select(c => c.Name).Should().EndWith(customers.Select(c => c.Name));
 ```
 
 With these new overloads, you can rewrite them into:

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,6 +16,7 @@ sidebar:
 `BeWithin(...).Before(...)` - [#2312](https://github.com/fluentassertions/fluentassertions/pull/2312)
 * `BeEquivalentTo` will now find and can map subject properties that are implemented through an explicitly-implemented interface - [#2152](https://github.com/fluentassertions/fluentassertions/pull/2152)
 * Fixed that the `because` and `becauseArgs` were not passed down the equivalency tree - [#2318](https://github.com/fluentassertions/fluentassertions/pull/2318)
+* `BeEquivalentTo` can again compare a non-generic `IDictionary` with a generic one - [#2358](https://github.com/fluentassertions/fluentassertions/pull/23158)
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -31,6 +31,7 @@ sidebar:
 * Ensured that nested calls to `AssertionScope(context)` create a chained context - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
 * One overload of the `AssertionScope` constructor would not create an actual scope associated with the thread - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
 * Fixed `ThrowWithinAsync` not respecting `OperationCanceledException` - [#2614](https://github.com/fluentassertions/fluentassertions/pull/2614)
+* Fixed using `BeEquivalentTo` with an `IEqualityComparer` targeting nullable types - [#2648](https://github.com/fluentassertions/fluentassertions/pull/2648)
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,7 +16,7 @@ sidebar:
 `BeWithin(...).Before(...)` - [#2312](https://github.com/fluentassertions/fluentassertions/pull/2312)
 * `BeEquivalentTo` will now find and can map subject properties that are implemented through an explicitly-implemented interface - [#2152](https://github.com/fluentassertions/fluentassertions/pull/2152)
 * Fixed that the `because` and `becauseArgs` were not passed down the equivalency tree - [#2318](https://github.com/fluentassertions/fluentassertions/pull/2318)
-* `BeEquivalentTo` can again compare a non-generic `IDictionary` with a generic one - [#2358](https://github.com/fluentassertions/fluentassertions/pull/23158)
+* `BeEquivalentTo` can again compare a non-generic `IDictionary` with a generic one - [#2358](https://github.com/fluentassertions/fluentassertions/pull/2358)
 * Fixed that the `FormattingOptions` were not respected in inner `AssertionScope` - [#2328](https://github.com/fluentassertions/fluentassertions/pull/2328)
 * Capitalize `true` and `false` in failure messages and make them formattable to a custom `BooleanFormatter` - [#2390](https://github.com/fluentassertions/fluentassertions/pull/2390), [#2393](https://github.com/fluentassertions/fluentassertions/pull/2393)
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -26,6 +26,7 @@ sidebar:
 * Improved the failure message for `[Not]HaveExplicitMethod` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
 * Changed `BeEquivalentTo` to exclude `private protected` members from the comparison - [#2417](https://github.com/fluentassertions/fluentassertions/pull/2417)
 * Fixed using `BeEquivalentTo` on an empty `ArraySegment` - [#2445](https://github.com/fluentassertions/fluentassertions/pull/2445), [#2511](https://github.com/fluentassertions/fluentassertions/pull/2511)
+* `BeEquivalentTo` with a custom comparer can now handle null values - [#2489](https://github.com/fluentassertions/fluentassertions/pull/2489)
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -15,6 +15,7 @@ sidebar:
 * Fixed formatting error when checking nullable `DateTimeOffset` with 
 `BeWithin(...).Before(...)` - [#2312](https://github.com/fluentassertions/fluentassertions/pull/2312)
 * `BeEquivalentTo` will now find and can map subject properties that are implemented through an explicitly-implemented interface - [#2152](https://github.com/fluentassertions/fluentassertions/pull/2152)
+* Fixed that the `because` and `becauseArgs` were not passed down the equivalency tree - [#2318](https://github.com/fluentassertions/fluentassertions/pull/2318)
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -22,6 +22,8 @@ sidebar:
 * Improved the failure message for `NotBeOfType` when wrapped in an `AssertionScope` and the subject is null  - [#2399](https://github.com/fluentassertions/fluentassertions/pull/2399)
 * Improved the failure message for `BeWritable`/`BeReadable` when wrapped in an `AssertionScope` and the subject is read-only/write-only - [#2399](https://github.com/fluentassertions/fluentassertions/pull/2399)
 * Improved the failure message for `ThrowExactly[Async]` when wrapped in an `AssertionScope` and no exception is thrown - [#2398](https://github.com/fluentassertions/fluentassertions/pull/2398)
+* Improved the failure message for `[Not]HaveExplicitProperty` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
+* Improved the failure message for `[Not]HaveExplicitMethod` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
 
 
 ## 6.12.0

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -28,6 +28,8 @@ sidebar:
 * Changed `BeEquivalentTo` to exclude `private protected` members from the comparison - [#2417](https://github.com/fluentassertions/fluentassertions/pull/2417)
 * Fixed using `BeEquivalentTo` on an empty `ArraySegment` - [#2445](https://github.com/fluentassertions/fluentassertions/pull/2445), [#2511](https://github.com/fluentassertions/fluentassertions/pull/2511)
 * `BeEquivalentTo` with a custom comparer can now handle null values - [#2489](https://github.com/fluentassertions/fluentassertions/pull/2489)
+* Ensured that nested calls to `AssertionScope(context)` create a chained context - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
+* One overload of the `AssertionScope` constructor would not create an actual scope associated with the thread - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -25,7 +25,7 @@ sidebar:
 * Improved the failure message for `[Not]HaveExplicitProperty` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
 * Improved the failure message for `[Not]HaveExplicitMethod` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
 * Changed `BeEquivalentTo` to exclude `private protected` members from the comparison - [#2417](https://github.com/fluentassertions/fluentassertions/pull/2417)
-
+* Fixed using `BeEquivalentTo` on an empty `ArraySegment` - [#2445](https://github.com/fluentassertions/fluentassertions/pull/2445), [#2511](https://github.com/fluentassertions/fluentassertions/pull/2511)
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,8 @@ sidebar:
 ### Improvements
 
 ### Fixes
+* Fixed formatting error when checking nullable `DateTimeOffset` with 
+`BeWithin(...).Before(...)` - [#2312](https://github.com/fluentassertions/fluentassertions/pull/2312)
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -30,6 +30,7 @@ sidebar:
 * `BeEquivalentTo` with a custom comparer can now handle null values - [#2489](https://github.com/fluentassertions/fluentassertions/pull/2489)
 * Ensured that nested calls to `AssertionScope(context)` create a chained context - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
 * One overload of the `AssertionScope` constructor would not create an actual scope associated with the thread - [#2607](https://github.com/fluentassertions/fluentassertions/pull/2607)
+* Fixed `ThrowWithinAsync` not respecting `OperationCanceledException` - [#2614](https://github.com/fluentassertions/fluentassertions/pull/2614)
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,7 +18,7 @@ sidebar:
 * Fixed that the `because` and `becauseArgs` were not passed down the equivalency tree - [#2318](https://github.com/fluentassertions/fluentassertions/pull/2318)
 * `BeEquivalentTo` can again compare a non-generic `IDictionary` with a generic one - [#2358](https://github.com/fluentassertions/fluentassertions/pull/23158)
 * Fixed that the `FormattingOptions` were not respected in inner `AssertionScope` - [#2328](https://github.com/fluentassertions/fluentassertions/pull/2328)
-
+* Capitalize `true` and `false` in failure messages - [#2390](https://github.com/fluentassertions/fluentassertions/pull/2390)
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -19,7 +19,8 @@ sidebar:
 * `BeEquivalentTo` can again compare a non-generic `IDictionary` with a generic one - [#2358](https://github.com/fluentassertions/fluentassertions/pull/2358)
 * Fixed that the `FormattingOptions` were not respected in inner `AssertionScope` - [#2329](https://github.com/fluentassertions/fluentassertions/pull/2329)
 * Capitalize `true` and `false` in failure messages and make them formattable to a custom `BooleanFormatter` - [#2390](https://github.com/fluentassertions/fluentassertions/pull/2390), [#2393](https://github.com/fluentassertions/fluentassertions/pull/2393)
-
+* Improved the failure message for `NotBeOfType` when wrapped in an `AssertionScope` and the subject is null  - [#2399](https://github.com/fluentassertions/fluentassertions/pull/2399)
+* Improved the failure message for `BeWritable`/`BeReadable` when wrapped in an `AssertionScope` and the subject is read-only/write-only - [#2399](https://github.com/fluentassertions/fluentassertions/pull/2399)
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,6 +17,8 @@ sidebar:
 * `BeEquivalentTo` will now find and can map subject properties that are implemented through an explicitly-implemented interface - [#2152](https://github.com/fluentassertions/fluentassertions/pull/2152)
 * Fixed that the `because` and `becauseArgs` were not passed down the equivalency tree - [#2318](https://github.com/fluentassertions/fluentassertions/pull/2318)
 * `BeEquivalentTo` can again compare a non-generic `IDictionary` with a generic one - [#2358](https://github.com/fluentassertions/fluentassertions/pull/23158)
+* Fixed that the `FormattingOptions` were not respected in inner `AssertionScope` - [#2328](https://github.com/fluentassertions/fluentassertions/pull/2328)
+
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -24,6 +24,7 @@ sidebar:
 * Improved the failure message for `ThrowExactly[Async]` when wrapped in an `AssertionScope` and no exception is thrown - [#2398](https://github.com/fluentassertions/fluentassertions/pull/2398)
 * Improved the failure message for `[Not]HaveExplicitProperty` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
 * Improved the failure message for `[Not]HaveExplicitMethod` when wrapped in an `AssertionScope` and not implementing the interface - [#2403](https://github.com/fluentassertions/fluentassertions/pull/2403)
+* Changed `BeEquivalentTo` to exclude `private protected` members from the comparison - [#2417](https://github.com/fluentassertions/fluentassertions/pull/2417)
 
 
 ## 6.12.0

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,7 +17,7 @@ sidebar:
 * `BeEquivalentTo` will now find and can map subject properties that are implemented through an explicitly-implemented interface - [#2152](https://github.com/fluentassertions/fluentassertions/pull/2152)
 * Fixed that the `because` and `becauseArgs` were not passed down the equivalency tree - [#2318](https://github.com/fluentassertions/fluentassertions/pull/2318)
 * `BeEquivalentTo` can again compare a non-generic `IDictionary` with a generic one - [#2358](https://github.com/fluentassertions/fluentassertions/pull/2358)
-* Fixed that the `FormattingOptions` were not respected in inner `AssertionScope` - [#2328](https://github.com/fluentassertions/fluentassertions/pull/2328)
+* Fixed that the `FormattingOptions` were not respected in inner `AssertionScope` - [#2329](https://github.com/fluentassertions/fluentassertions/pull/2329)
 * Capitalize `true` and `false` in failure messages and make them formattable to a custom `BooleanFormatter` - [#2390](https://github.com/fluentassertions/fluentassertions/pull/2390), [#2393](https://github.com/fluentassertions/fluentassertions/pull/2393)
 
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,7 +18,8 @@ sidebar:
 * Fixed that the `because` and `becauseArgs` were not passed down the equivalency tree - [#2318](https://github.com/fluentassertions/fluentassertions/pull/2318)
 * `BeEquivalentTo` can again compare a non-generic `IDictionary` with a generic one - [#2358](https://github.com/fluentassertions/fluentassertions/pull/23158)
 * Fixed that the `FormattingOptions` were not respected in inner `AssertionScope` - [#2328](https://github.com/fluentassertions/fluentassertions/pull/2328)
-* Capitalize `true` and `false` in failure messages - [#2390](https://github.com/fluentassertions/fluentassertions/pull/2390)
+* Capitalize `true` and `false` in failure messages and make them formattable to a custom `BooleanFormatter` - [#2390](https://github.com/fluentassertions/fluentassertions/pull/2390), [#2393](https://github.com/fluentassertions/fluentassertions/pull/2393)
+
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -21,6 +21,8 @@ sidebar:
 * Capitalize `true` and `false` in failure messages and make them formattable to a custom `BooleanFormatter` - [#2390](https://github.com/fluentassertions/fluentassertions/pull/2390), [#2393](https://github.com/fluentassertions/fluentassertions/pull/2393)
 * Improved the failure message for `NotBeOfType` when wrapped in an `AssertionScope` and the subject is null  - [#2399](https://github.com/fluentassertions/fluentassertions/pull/2399)
 * Improved the failure message for `BeWritable`/`BeReadable` when wrapped in an `AssertionScope` and the subject is read-only/write-only - [#2399](https://github.com/fluentassertions/fluentassertions/pull/2399)
+* Improved the failure message for `ThrowExactly[Async]` when wrapped in an `AssertionScope` and no exception is thrown - [#2398](https://github.com/fluentassertions/fluentassertions/pull/2398)
+
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,6 +14,7 @@ sidebar:
 ### Fixes
 * Fixed formatting error when checking nullable `DateTimeOffset` with 
 `BeWithin(...).Before(...)` - [#2312](https://github.com/fluentassertions/fluentassertions/pull/2312)
+* `BeEquivalentTo` will now find and can map subject properties that are implemented through an explicitly-implemented interface - [#2152](https://github.com/fluentassertions/fluentassertions/pull/2152)
 
 ## 6.12.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -7,6 +7,12 @@ sidebar:
   nav: "sidebar"
 ---
 
+## 6.12.1
+
+### Improvements
+
+### Fixes
+
 ## 6.12.0
 
 ### What's new

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,6 +10,7 @@ sidebar:
 ## 6.12.1
 
 ### Improvements
+* Improve `BeEmpty()` and `BeNullOrEmpty()` performance for `IEnumerable<T>`, by materializing only the first item - [#2530](https://github.com/fluentassertions/fluentassertions/pull/2530)
 
 ### Fixes
 * Fixed formatting error when checking nullable `DateTimeOffset` with 

--- a/profile.yaml
+++ b/profile.yaml
@@ -1,0 +1,12 @@
+name: "Custom profile"
+
+baseProfile: qodana.starter
+
+groups: # List of configured groups
+  - groupId: InspectionsToExclude
+    groups:
+      - "category:C#/Roslyn Analyzers"
+
+inspections: # Group invocation
+  - group: InspectionsToExclude
+    enabled: false # Disable the InspectionsToExclude group

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -14,6 +14,7 @@ exclude:
   - name: ConvertIfStatementToConditionalTernaryExpression
   - name: InvertIf
   - name: SimilarAnonymousTypeNearby
+  - name: UnusedMember.Local
     paths:
       - Tests
   - name: All

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -3,12 +3,19 @@ version: "1.0"
 linter: jetbrains/qodana-dotnet:latest
 failThreshold: 0
 
+profile:
+  path: profile.yaml
+
 dotnet:
   solution: FluentAssertions.sln
 
 exclude:
   - name: ConvertIfStatementToReturnStatement
   - name: ConvertIfStatementToConditionalTernaryExpression
+  - name: InvertIf
+  - name: SimilarAnonymousTypeNearby
+    paths:
+      - Tests
   - name: All
     paths:
       - Build
@@ -16,4 +23,11 @@ exclude:
       - Tests/AssemblyB
       - Tests/Benchmarks
       - Tests/UWP.Specs
-      
+      - Src/FluentAssertions/Polyfill
+  - name: UnusedMember.Global
+  - name: ArrangeTrailingCommaInMultilineLists
+  - name: ArrangeTrailingCommaInSinglelineLists
+  - name: ConvertToLambdaExpression
+  - name: SwitchExpressionHandlesSomeKnownEnumValuesWithExceptionInDefault
+  - name: UnusedMemberInSuper.Global
+  


### PR DESCRIPTION
Since developing v7 is a larger undertaking than we initially expected, we want to backport _some fixes_ to v6.

This backporting should cover [PRs](https://github.com/fluentassertions/fluentassertions/pulls?q=is%3Apr+is%3Amerged+label%3Abug+-label%3A%22breaking+change%22+merged%3A2023-08-23..2024-08-18+sort%3Acreated-asc+) that were merged since v6.12 and marked as bugs.

🛑 Please do not ask for backporting new features - new features come with new bugs.


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
