### PR TITLE
Update to `GitVersion` 6.0.2 and fix PR version generation

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -117,8 +117,8 @@ class Build : NukeBuild
         .Executes(() =>
         {
             ReportSummary(s => s
-                .WhenNotNull(GitVersion, (v, o) => v
-                    .AddPair("Version", o.SemVer)));
+                .WhenNotNull(GitVersion, (summary, gitVersion) => summary
+                    .AddPair("Version", gitVersion.SemVer)));
 
             DotNetBuild(s => s
                 .SetProjectFile(Solution)

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -113,12 +113,13 @@ class Build : NukeBuild
 
     Target Compile => _ => _
         .DependsOn(Restore)
+        .DependsOn(CalculateNugetVersion)
         .OnlyWhenDynamic(() => RunAllTargets || HasSourceChanges)
         .Executes(() =>
         {
             ReportSummary(s => s
-                .WhenNotNull(GitVersion, (summary, gitVersion) => summary
-                    .AddPair("Version", gitVersion.SemVer)));
+                .WhenNotNull(SemVer, (summary, semVer) => summary
+                    .AddPair("Version", semVer)));
 
             DotNetBuild(s => s
                 .SetProjectFile(Solution)
@@ -128,6 +129,7 @@ class Build : NukeBuild
                 )
                 .EnableNoLogo()
                 .EnableNoRestore()
+                .SetVersion(SemVer)
                 .SetAssemblyVersion(GitVersion.AssemblySemVer)
                 .SetFileVersion(GitVersion.AssemblySemFileVer)
                 .SetInformationalVersion(GitVersion.InformationalVersion));
@@ -305,7 +307,6 @@ class Build : NukeBuild
         .DependsOn(TestFrameworks)
         .DependsOn(UnitTests)
         .DependsOn(CodeCoverage)
-        .DependsOn(CalculateNugetVersion)
         .OnlyWhenDynamic(() => RunAllTargets || HasSourceChanges)
         .Executes(() =>
         {

--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -17,7 +17,7 @@
     <DefineConstants>OS_MAC</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageDownload Include="GitVersion.Tool" Version="[5.10.0]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[6.0.2]" />
     <PackageDownload Include="ReportGenerator" Version="[5.2.0]" />
     <PackageDownload Include="xunit.runner.console" Version="[2.9.0]" />
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,13 +1,20 @@
-next-version: 7.0
+next-version: 7.0.0
+workflow: GitHubFlow/v1
 branches:
+  develop:
+    regex: ^dev(elop)?(ment)?$
+    label: alpha
+    increment: Minor
   release:
     regex: releases?[/-]
-    tag: rc
+    label: rc
+    increment: Patch
   pull-request:
-    mode: ContinuousDeployment
+    mode: ContinuousDelivery
     regex: ((pull|pull\-requests|pr)[/-]|[/-](merge))
-    tag: pr
-    tag-number-pattern: '[/-]?(?<number>\d+)'
-    prevent-increment-of-merged-branch-version: false
+    label: pr
+    label-number-pattern: '[/-]?(?<number>\d+)'
+    prevent-increment:
+      of-merged-branch: false
 ignore:
   sha: []


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
~**Note**: This issue is possibly related to NUKE, because the `GitVersion` class have some fields which the actual response of `dotnet gitversion` doesn't have (because of breaking changes), so this should also be fixed in NUKE itself.~

~But until then, we do this generation manually...~

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
