### PR TITLE
Increase code coverage

### DIFF
--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -20,7 +20,7 @@ internal static class ExpressionExtensions
 
         if (memberInfo is not PropertyInfo propertyInfo)
         {
-            throw new ArgumentException("Cannot use <" + expression.Body + "> when a property expression is expected.",
+            throw new ArgumentException($"Cannot use <{expression.Body}> when a property expression is expected.",
                 nameof(expression));
         }
 
@@ -77,7 +77,7 @@ internal static class ExpressionExtensions
                     var indexExpression = (ConstantExpression)binaryExpression.Right;
                     node = binaryExpression.Left;
 
-                    segments.Add("[" + indexExpression.Value + "]");
+                    segments.Add($"[{indexExpression.Value}]");
                     break;
 
                 case ExpressionType.Parameter:
@@ -93,7 +93,7 @@ internal static class ExpressionExtensions
                     }
 
                     node = methodCallExpression.Object;
-                    segments.Add("[" + argumentExpression.Value + "]");
+                    segments.Add($"[{argumentExpression.Value}]");
                     break;
 
                 default:

--- a/Src/FluentAssertions/Execution/AssertionFailedException.cs
+++ b/Src/FluentAssertions/Execution/AssertionFailedException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 
 namespace FluentAssertions.Execution;
@@ -16,6 +17,7 @@ public class AssertionFailedException : Exception
     {
     }
 
+    [ExcludeFromCodeCoverage]
     protected AssertionFailedException(SerializationInfo info, StreamingContext context)
         : base(info, context)
     {

--- a/Src/FluentAssertions/Execution/AssertionFailedException.cs
+++ b/Src/FluentAssertions/Execution/AssertionFailedException.cs
@@ -5,6 +5,7 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Represents the default exception in case no test framework is configured.
 /// </summary>
+/// <param name="message">The <em>mandatory</em> exception message</param>
 #pragma warning disable CA1032, RCS1194 // AssertionFailedException should never be constructed with an empty message
 public class AssertionFailedException(string message) : Exception(message)
 #pragma warning restore CA1032, RCS1194

--- a/Src/FluentAssertions/Execution/AssertionFailedException.cs
+++ b/Src/FluentAssertions/Execution/AssertionFailedException.cs
@@ -1,25 +1,12 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.Serialization;
 
 namespace FluentAssertions.Execution;
 
 /// <summary>
 /// Represents the default exception in case no test framework is configured.
 /// </summary>
-[Serializable]
 #pragma warning disable CA1032, RCS1194 // AssertionFailedException should never be constructed with an empty message
-public class AssertionFailedException : Exception
+public class AssertionFailedException(string message) : Exception(message)
 #pragma warning restore CA1032, RCS1194
 {
-    public AssertionFailedException(string message)
-        : base(message)
-    {
-    }
-
-    [ExcludeFromCodeCoverage]
-    protected AssertionFailedException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
 }

--- a/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Execution;
 
+[ExcludeFromCodeCoverage]
 internal class DefaultAssertionStrategy : IAssertionStrategy
 {
     /// <summary>

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -14,6 +14,7 @@ namespace FluentAssertions.Formatting;
 public static class Formatter
 {
     #region Private Definitions
+
     private static readonly List<IValueFormatter> CustomFormatters = [];
 
     private static readonly List<IValueFormatter> DefaultFormatters =

--- a/Src/FluentAssertions/Formatting/MaxLinesExceededException.cs
+++ b/Src/FluentAssertions/Formatting/MaxLinesExceededException.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace FluentAssertions.Formatting;
 
+[ExcludeFromCodeCoverage]
 public class MaxLinesExceededException : Exception
 {
     public MaxLinesExceededException(string message, Exception innerException)

--- a/Src/FluentAssertions/Formatting/MaxLinesExceededException.cs
+++ b/Src/FluentAssertions/Formatting/MaxLinesExceededException.cs
@@ -1,22 +1,7 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace FluentAssertions.Formatting;
 
-[ExcludeFromCodeCoverage]
-public class MaxLinesExceededException : Exception
-{
-    public MaxLinesExceededException(string message, Exception innerException)
-        : base(message, innerException)
-    {
-    }
-
-    public MaxLinesExceededException(string message)
-        : base(message)
-    {
-    }
-
-    public MaxLinesExceededException()
-    {
-    }
-}
+#pragma warning disable RCS1194, CA1032 // Add constructors
+public class MaxLinesExceededException : Exception;
+#pragma warning restore CA1032, RCS1194

--- a/Src/FluentAssertions/Primitives/StringContainsStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringContainsStrategy.cs
@@ -15,7 +15,7 @@ internal class StringContainsStrategy : IStringComparisonStrategy
         this.occurrenceConstraint = occurrenceConstraint;
     }
 
-    public string ExpectationDescription => "Expected {context:string} to contain the equivalent of ";
+    public string ExpectationDescription => "Expected {context:string} {0} to contain the equivalent of ";
 
     public void ValidateAgainstMismatch(AssertionChain assertionChain, string subject, string expected)
     {
@@ -24,7 +24,7 @@ internal class StringContainsStrategy : IStringComparisonStrategy
         assertionChain
             .ForConstraint(occurrenceConstraint, actual)
             .FailWith(
-                $"Expected {{context:string}} {{0}} to contain the equivalent of {{1}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
+                $"{ExpectationDescription}{{1}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
                 subject, expected);
     }
 }

--- a/Src/FluentAssertions/Primitives/StringEndStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEndStrategy.cs
@@ -15,13 +15,13 @@ internal class StringEndStrategy : IStringComparisonStrategy
         this.predicateDescription = predicateDescription;
     }
 
-    public string ExpectationDescription => "Expected {context:string} to " + predicateDescription + " ";
+    public string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} ";
 
     public void ValidateAgainstMismatch(AssertionChain assertionChain, string subject, string expected)
     {
         assertionChain
             .ForCondition(subject!.Length >= expected.Length)
-            .FailWith(ExpectationDescription + "{0}{reason}, but {1} is too short.", expected, subject);
+            .FailWith($"{ExpectationDescription}{{0}}{{reason}}, but {{1}} is too short.", expected, subject);
 
         if (!assertionChain.Succeeded)
         {
@@ -36,8 +36,7 @@ internal class StringEndStrategy : IStringComparisonStrategy
         }
 
         assertionChain.FailWith(
-            ExpectationDescription + "{0}{reason}, but {1} differs near " + subject.IndexedSegmentAt(indexOfMismatch) +
-            ".",
+            $"{ExpectationDescription}{{0}}{{reason}}, but {{1}} differs near {subject.IndexedSegmentAt(indexOfMismatch)}.",
             expected, subject);
     }
 }

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -44,9 +44,7 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
             }
 
             assertionChain.FailWith(
-                ExpectationDescription + "the same string{reason}, but they differ " + locationDescription + ":" +
-                Environment.NewLine
-                + GetMismatchSegmentForLongStrings(subject, expected, indexOfMismatch) + ".");
+                $"{ExpectationDescription}the same string{{reason}}, but they differ {locationDescription}:{Environment.NewLine}{GetMismatchSegmentForLongStrings(subject, expected, indexOfMismatch)}.");
         }
         else if (ValidateAgainstLengthDifferences(assertionChain, subject, expected))
         {
@@ -55,23 +53,23 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
             if (indexOfMismatch != -1)
             {
                 assertionChain.FailWith(
-                    ExpectationDescription + "{0}{reason}, but {1} differs near " + subject.IndexedSegmentAt(indexOfMismatch) +
+                    $"{ExpectationDescription}{{0}}{{reason}}, but {{1}} differs near " + subject.IndexedSegmentAt(indexOfMismatch) +
                     ".",
                     expected, subject);
             }
         }
     }
 
-    public string ExpectationDescription => "Expected {context:string} to " + predicateDescription + " ";
+    public string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} ";
 
     private void ValidateAgainstSuperfluousWhitespace(AssertionChain assertion, string subject, string expected)
     {
         assertion
             .ForCondition(!(expected.Length > subject.Length && comparer.Equals(expected.TrimEnd(), subject)))
-            .FailWith(ExpectationDescription + "{0}{reason}, but it misses some extra whitespace at the end.", expected)
+            .FailWith($"{ExpectationDescription}{{0}}{{reason}}, but it misses some extra whitespace at the end.", expected)
             .Then
             .ForCondition(!(subject.Length > expected.Length && comparer.Equals(subject.TrimEnd(), expected)))
-            .FailWith(ExpectationDescription + "{0}{reason}, but it has unexpected whitespace at the end.", expected);
+            .FailWith($"{ExpectationDescription}{{0}}{{reason}}, but it has unexpected whitespace at the end.", expected);
     }
 
     private bool ValidateAgainstLengthDifferences(AssertionChain assertion, string subject, string expected)
@@ -82,8 +80,7 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
             {
                 string mismatchSegment = GetMismatchSegmentForStringsOfDifferentLengths(subject, expected);
 
-                string message = ExpectationDescription +
-                    "{0} with a length of {1}{reason}, but {2} has a length of {3}, differs near " + mismatchSegment + ".";
+                string message = $"{ExpectationDescription}{{0}} with a length of {{1}}{{reason}}, but {{2}} has a length of {{3}}, differs near " + mismatchSegment + ".";
 
                 return new FailReason(message, expected, expected.Length, subject, subject.Length);
             });

--- a/Src/FluentAssertions/Primitives/StringStartStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringStartStrategy.cs
@@ -15,13 +15,13 @@ internal class StringStartStrategy : IStringComparisonStrategy
         this.predicateDescription = predicateDescription;
     }
 
-    public string ExpectationDescription => "Expected {context:string} to " + predicateDescription + " ";
+    public string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} ";
 
     public void ValidateAgainstMismatch(AssertionChain assertionChain, string subject, string expected)
     {
         assertionChain
             .ForCondition(subject.Length >= expected.Length)
-            .FailWith(ExpectationDescription + "{0}{reason}, but {1} is too short.", expected, subject);
+            .FailWith($"{ExpectationDescription}{{0}}{{reason}}, but {{1}} is too short.", expected, subject);
 
         if (!assertionChain.Succeeded)
         {
@@ -36,8 +36,7 @@ internal class StringStartStrategy : IStringComparisonStrategy
         }
 
         assertionChain.FailWith(
-            ExpectationDescription + "{0}{reason}, but {1} differs near " + subject.IndexedSegmentAt(indexOfMismatch) +
-            ".",
+            $"{ExpectationDescription}{{0}}{{reason}}, but {{1}} differs near {subject.IndexedSegmentAt(indexOfMismatch)}.",
             expected, subject);
     }
 }

--- a/Src/FluentAssertions/Primitives/StringValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringValidator.cs
@@ -42,7 +42,7 @@ internal class StringValidator
             return true;
         }
 
-        assertionChain.FailWith(comparisonStrategy.ExpectationDescription + "{0}{reason}, but found {1}.", expected, subject);
+        assertionChain.FailWith($"{comparisonStrategy.ExpectationDescription}{{0}}{{reason}}, but found {{1}}.", expected, subject);
         return false;
     }
 }

--- a/Src/FluentAssertions/Primitives/StringValidatorSupportingNull.cs
+++ b/Src/FluentAssertions/Primitives/StringValidatorSupportingNull.cs
@@ -18,11 +18,6 @@ internal class StringValidatorSupportingNull
 
     public void Validate(string subject, string expected)
     {
-        if (expected is null && subject is null)
-        {
-            return;
-        }
-
         if (expected?.IsLongOrMultiline() == true ||
             subject?.IsLongOrMultiline() == true)
         {

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingStrategy.cs
@@ -19,11 +19,11 @@ internal class StringWildcardMatchingStrategy : IStringComparisonStrategy
 
         if (Negate)
         {
-            assertionChain.FailWith(ExpectationDescription + "but {1} matches.", expected, subject);
+            assertionChain.FailWith($"{ExpectationDescription}but {{1}} matches.", expected, subject);
         }
         else
         {
-            assertionChain.FailWith(ExpectationDescription + "but {1} does not.", expected, subject);
+            assertionChain.FailWith($"{ExpectationDescription}but {{1}} does not.", expected, subject);
         }
     }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1137,12 +1137,9 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionChain WithReportable(string name, System.Func<string> content) { }
         public static FluentAssertions.Execution.AssertionChain GetOrCreate() { }
     }
-    [System.Serializable]
     public class AssertionFailedException : System.Exception
     {
         public AssertionFailedException(string message) { }
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class AssertionScope : System.IDisposable
     {
@@ -1419,12 +1416,9 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class MaxLinesExceededException : System.Exception
     {
         public MaxLinesExceededException() { }
-        public MaxLinesExceededException(string message) { }
-        public MaxLinesExceededException(string message, System.Exception innerException) { }
     }
     public class MethodInfoFormatter : FluentAssertions.Formatting.IValueFormatter
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1141,6 +1141,7 @@ namespace FluentAssertions.Execution
     public class AssertionFailedException : System.Exception
     {
         public AssertionFailedException(string message) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class AssertionScope : System.IDisposable
@@ -1418,6 +1419,7 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class MaxLinesExceededException : System.Exception
     {
         public MaxLinesExceededException() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1154,6 +1154,7 @@ namespace FluentAssertions.Execution
     public class AssertionFailedException : System.Exception
     {
         public AssertionFailedException(string message) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class AssertionScope : System.IDisposable
@@ -1437,6 +1438,7 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class MaxLinesExceededException : System.Exception
     {
         public MaxLinesExceededException() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1150,12 +1150,9 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionChain WithReportable(string name, System.Func<string> content) { }
         public static FluentAssertions.Execution.AssertionChain GetOrCreate() { }
     }
-    [System.Serializable]
     public class AssertionFailedException : System.Exception
     {
         public AssertionFailedException(string message) { }
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class AssertionScope : System.IDisposable
     {
@@ -1438,12 +1435,9 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class MaxLinesExceededException : System.Exception
     {
         public MaxLinesExceededException() { }
-        public MaxLinesExceededException(string message) { }
-        public MaxLinesExceededException(string message, System.Exception innerException) { }
     }
     public class MethodInfoFormatter : FluentAssertions.Formatting.IValueFormatter
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1081,12 +1081,9 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionChain WithReportable(string name, System.Func<string> content) { }
         public static FluentAssertions.Execution.AssertionChain GetOrCreate() { }
     }
-    [System.Serializable]
     public class AssertionFailedException : System.Exception
     {
         public AssertionFailedException(string message) { }
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class AssertionScope : System.IDisposable
     {
@@ -1363,12 +1360,9 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class MaxLinesExceededException : System.Exception
     {
         public MaxLinesExceededException() { }
-        public MaxLinesExceededException(string message) { }
-        public MaxLinesExceededException(string message, System.Exception innerException) { }
     }
     public class MethodInfoFormatter : FluentAssertions.Formatting.IValueFormatter
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1085,6 +1085,7 @@ namespace FluentAssertions.Execution
     public class AssertionFailedException : System.Exception
     {
         public AssertionFailedException(string message) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class AssertionScope : System.IDisposable
@@ -1362,6 +1363,7 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class MaxLinesExceededException : System.Exception
     {
         public MaxLinesExceededException() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1137,12 +1137,9 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionChain WithReportable(string name, System.Func<string> content) { }
         public static FluentAssertions.Execution.AssertionChain GetOrCreate() { }
     }
-    [System.Serializable]
     public class AssertionFailedException : System.Exception
     {
         public AssertionFailedException(string message) { }
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class AssertionScope : System.IDisposable
     {
@@ -1419,12 +1416,9 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class MaxLinesExceededException : System.Exception
     {
         public MaxLinesExceededException() { }
-        public MaxLinesExceededException(string message) { }
-        public MaxLinesExceededException(string message, System.Exception innerException) { }
     }
     public class MethodInfoFormatter : FluentAssertions.Formatting.IValueFormatter
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1141,6 +1141,7 @@ namespace FluentAssertions.Execution
     public class AssertionFailedException : System.Exception
     {
         public AssertionFailedException(string message) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class AssertionScope : System.IDisposable
@@ -1418,6 +1419,7 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class MaxLinesExceededException : System.Exception
     {
         public MaxLinesExceededException() { }

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Excluding.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Excluding.cs
@@ -666,5 +666,26 @@ public partial class SelectionRulesSpecs
                 .Excluding(o => o.VirtualProperty)
                 .Excluding(o => o.DerivedProperty2));
         }
+
+        [Fact]
+        public void Abstract_properties_cannot_be_excluded()
+        {
+            var obj1 = new Derived
+            {
+                DerivedProperty1 = "Something",
+                DerivedProperty2 = "A"
+            };
+
+            var obj2 = new Derived
+            {
+                DerivedProperty1 = "Something",
+                DerivedProperty2 = "B"
+            };
+
+            Action act = () => obj1.Should().BeEquivalentTo(obj2, opt => opt
+                .Excluding(o => o.AbstractProperty + "B"));
+
+            act.Should().Throw<ArgumentException>().WithMessage("*(o.AbstractProperty + \"B\")*cannot be used to select a member*");
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.EndWith.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.EndWith.cs
@@ -84,6 +84,21 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
+        public void Correctly_stop_further_execution_when_inside_assertion_scope()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                "ABC".Should().EndWith("00ABC").And.EndWith("CBA00");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*\"00ABC\"*");
+        }
+
+        [Fact]
         public void When_string_ending_is_compared_and_actual_value_is_null_then_it_should_throw()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.StartWith.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.StartWith.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -87,6 +88,22 @@ public partial class StringAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected string to start with \"ABCDEF\", but \"ABC\" is too short.");
+        }
+
+        [Fact]
+        [SuppressMessage("ReSharper", "StringLiteralTypo")]
+        public void Correctly_stop_further_execution_when_inside_assertion_scope()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                "ABC".Should().StartWith("ABCDEF").And.StartWith("FEDCBA");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*\"ABCDEF\"*");
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
#### First commit:
This applies to places where removal is not an option. E.g. custom `Exceptions`.

Thus: exclude from coverage report

#### Second commit
Using interpolation instead of concatenation should also increase CC


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
