### PR TITLE
The expectation node identified as a cyclic reference is still compared to the subject node using simple equality.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -35,7 +35,11 @@ public class EquivalencyValidator : IEquivalencyValidator
         {
             TrackWhatIsNeededToProvideContextToFailures(scope, comparands, context.CurrentNode);
 
-            if (!context.IsCyclicReference(comparands.Expectation))
+            if (context.IsCyclicReference(comparands.Expectation))
+            {
+                AssertComparandsPointToActualObjects(comparands);
+            }
+            else
             {
                 TryToProveNodesAreEquivalent(comparands, context);
             }
@@ -60,6 +64,19 @@ public class EquivalencyValidator : IEquivalencyValidator
         scope.Context = new Lazy<string>(() => currentNode.Description);
 
         scope.TrackComparands(comparands.Subject, comparands.Expectation);
+    }
+
+    private static void AssertComparandsPointToActualObjects(Comparands comparands)
+    {
+        if (ReferenceEquals(comparands.Subject, comparands.Expectation))
+        {
+            return;
+        }
+
+        if (comparands.Subject is null)
+        {
+            comparands.Subject.Should().BeSameAs(comparands.Expectation);
+        }
     }
 
     private void TryToProveNodesAreEquivalent(Comparands comparands, IEquivalencyValidationContext context)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -7,6 +7,12 @@ sidebar:
   nav: "sidebar"
 ---
 
+## 6.12.3
+
+### Fixes
+
+* The expectation node identified as a cyclic reference is still compared to the subject node using simple equality - [2819](https://github.com/fluentassertions/fluentassertions/pull/2819)
+
 ## 6.12.2
 
 ### Fixes


### PR DESCRIPTION
When the equivalency validation engine detects a cyclic reference, it excludes the node from further comparisons. But if the expectation is non-null and the subject is null (or vice versa), it should still trigger an assertion failure.

Fixes #2787 

