### PR TITLE
Introducing Fluent Assertions Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/fluentassertions/fluentassertions)](https://github.com/fluentassertions/fluentassertions/graphs/commit-activity)
 [![open issues](https://img.shields.io/github/issues/fluentassertions/fluentassertions)](https://github.com/fluentassertions/fluentassertions/issues)
 ![](https://img.shields.io/badge/release%20strategy-githubflow-orange.svg)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Fluent%20Assertions%20Guru-006BFF)](https://gurubase.io/g/fluent-assertions)
 
 A very extensive set of extension methods that allow you to more naturally specify the expected outcome of a TDD or BDD-style unit tests. Works with .NET Standard 2.0 and higher, .NET Framework 4.7 and higher and .NET 6 and higher.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Fluent Assertions Guru](https://gurubase.io/g/fluent-assertions) to Gurubase. Fluent Assertions Guru uses the data from this repo and data from the [docs](https://www.fluentassertions.com) to answer questions by leveraging the LLM.

In this PR, I showcased the "Fluent Assertions Guru", which highlights that Fluent Assertions now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Fluent Assertions Guru in Gurubase, just let me know that's totally fine.
