### PR TITLE
list more items in .BeEmpty()

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -296,9 +296,19 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
                 .FailWith("but found <null>.")
                 .Then
                 .ForCondition(!hasFirstItem.Value)
-                .FailWith("but found at least one item {0}.", () => new[] { enumerator.Current }));
+                .FailWith("but found {0}.", () => EnumerateWithSavedFirstItem(enumerator.Current, enumerator)));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    private static IEnumerable<T> EnumerateWithSavedFirstItem(T firstItem, IEnumerator<T> remaining)
+    {
+        yield return firstItem;
+
+        while (remaining.MoveNext())
+        {
+            yield return remaining.Current;
+        }
     }
 
     /// <summary>

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
@@ -35,7 +36,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty because that's what we expect, but found at least one item*1*");
+                .WithMessage("*to be empty because that's what we expect, but found {1, 2, 3}.");
         }
 
         [Fact]
@@ -130,8 +131,22 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty, but found at least one item {1}.");
+                .WithMessage("*to be empty, but found {1, 2, 3}.");
             collection.GetEnumeratorCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void When_asserting_large_collection_is_empty_it_respects_limit_from_enumerable_formatter()
+        {
+            // Arrange
+            var collection = Enumerable.Range(0, 40);
+
+            // Act
+            Action act = () => collection.Should().BeEmpty();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*to be empty, but found {0, 1,*31, …more…}.");
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->

resolves https://github.com/fluentassertions/fluentassertions/issues/2782

todo:
- [ ] make the same change to BeNullOrEmpty
- [ ] change remaining specs that need updating

I'm not sure why `hasFirstItem.Value` doesn't throw if the subject/enumerator is null, but the test for that case seems to be passing :/

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
