### PR TITLE
You can exclude explicitly implemented properties from BeEquivalentTo

### DIFF
--- a/Src/FluentAssertions/Equivalency/Selection/AllPropertiesSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/AllPropertiesSelectionRule.cs
@@ -14,8 +14,7 @@ internal class AllPropertiesSelectionRule : IMemberSelectionRule
     public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
         MemberSelectionContext context)
     {
-        MemberVisibility visibility = context.IncludedProperties | MemberVisibility.ExplicitlyImplemented |
-            MemberVisibility.DefaultInterfaceProperties;
+        MemberVisibility visibility = context.IncludedProperties;
 
         IEnumerable<IMember> selectedProperties = context.Type
             .GetProperties(visibility.ToMemberKind())

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -273,7 +273,8 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     /// </remarks>
     public TSelf IncludingProperties()
     {
-        includedProperties = MemberVisibility.Public;
+        includedProperties = MemberVisibility.Public | MemberVisibility.ExplicitlyImplemented |
+            MemberVisibility.DefaultInterfaceProperties;
         return (TSelf)this;
     }
 
@@ -282,7 +283,8 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     /// </summary>
     public TSelf IncludingInternalProperties()
     {
-        includedProperties = MemberVisibility.Public | MemberVisibility.Internal;
+        includedProperties = MemberVisibility.Public | MemberVisibility.Internal | MemberVisibility.ExplicitlyImplemented |
+            MemberVisibility.DefaultInterfaceProperties;
         return (TSelf)this;
     }
 
@@ -295,6 +297,15 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     public TSelf ExcludingProperties()
     {
         includedProperties = MemberVisibility.None;
+        return (TSelf)this;
+    }
+
+    /// <summary>
+    /// Excludes properties that are explicitly implemented from the equivalency comparison.
+    /// </summary>
+    public TSelf ExcludingExplicitlyImplementedProperties()
+    {
+        includedProperties &= ~MemberVisibility.ExplicitlyImplemented;
         return (TSelf)this;
     }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -889,6 +889,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -902,6 +902,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -881,6 +881,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -889,6 +889,7 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNestedObjects() { }

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Interfaces.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Interfaces.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
 
@@ -291,6 +292,28 @@ public partial class SelectionRulesSpecs
             person.Should().BeEquivalentTo(new { Name = "Bob" });
         }
 
+        [Fact]
+        public void Can_exclude_explicitly_implemented_properties()
+        {
+            // Arrange
+            var subject = new Person
+            {
+                NormalProperty = "Normal",
+            };
+
+            ((IPerson)subject).Name = "Bob";
+
+            var expectation = new Person
+            {
+                NormalProperty = "Normal",
+            };
+
+            ((IPerson)expectation).Name = "Jim";
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, options => options.ExcludingExplicitlyImplementedProperties());
+        }
+
         private interface IPerson
         {
             string Name { get; set; }
@@ -298,6 +321,9 @@ public partial class SelectionRulesSpecs
 
         private class Person : IPerson
         {
+            [UsedImplicitly]
+            public string NormalProperty { get; set; }
+
             string IPerson.Name { get; set; }
         }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -7,7 +7,7 @@ sidebar:
   nav: "sidebar"
 ---
 
-## 7.0 Alpha X
+## 8.0 Alpha X
 
 ### What's new
 
@@ -41,6 +41,7 @@ sidebar:
 * All assertions that support chaining using the `.Which` construct will now amend the caller identifier - [2539](https://github.com/fluentassertions/pull/2539)
 * Introduced a `MethodInfoFormatter` and improved the `PropertyInfoFormatter` - [2539](https://github.com/fluentassertions/pull/2539)
 * `Excluding()` / `For().Exclude()` and `Including()` on `BeEquivalentTo()` now also accepts an anonymous object to include/exclude multiple members at once - [#2488](https://github.com/fluentassertions/fluentassertions/pull/2488)
+* You can exclude explicitly implemented properties from `BeEquivalentTo` via `ExcludingExplicitlyImplementedProperties` - [9999](https://github.com/fluentassertions/pull/9999)
 
 ### Fixes
 * Fixed formatting error when checking nullable `DateTimeOffset` with


### PR DESCRIPTION
You can exclude explicitly implemented properties from `BeEquivalentTo` via `ExcludingExplicitlyImplementedProperties` 

Closes #2811

* [X] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [X] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [X] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [X] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [X] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [X] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [X] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
