### PR TITLE
Fixed a regression in which CompleteWithinAsync treated a canceled task as an exception

### DIFF
--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -51,7 +51,7 @@ public class GenericAsyncFunctionAssertions<TResult>
 
             if (success)
             {
-                bool completesWithinTimeout = await CompletesWithinTimeoutAsync(task, remainingTime);
+                bool completesWithinTimeout = await CompletesWithinTimeoutAsync(task, remainingTime, _ => Task.CompletedTask);
 
                 success = Execute.Assertion
                     .ForCondition(completesWithinTimeout)

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -104,6 +104,46 @@ public static class TaskAssertionSpecs
             // Assert
             await action.Should().ThrowAsync<XunitException>();
         }
+
+        [Fact]
+        public async Task Canceled_tasks_are_also_completed()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
+
+            // Act
+            Func<Task> action = () => taskFactory
+                .Awaiting(t => (Task)t.Task)
+                .Should(timer)
+                .CompleteWithinAsync(100.Milliseconds());
+
+            taskFactory.SetCanceled();
+            timer.Complete();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Excepted_tasks_unexpectedly_completed()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
+
+            // Act
+            Func<Task> action = () => taskFactory
+                .Awaiting(t => (Task)t.Task)
+                .Should(timer)
+                .CompleteWithinAsync(100.Milliseconds());
+
+            taskFactory.SetException(new OperationCanceledException());
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<OperationCanceledException>();
+        }
     }
 
     public class NotCompleteWithinAsync
@@ -184,6 +224,44 @@ public static class TaskAssertionSpecs
 
             // Assert
             await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Canceled_tasks_are_also_completed()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
+
+            // Act
+            Func<Task> action = () => taskFactory
+                .Awaiting(t => (Task)t.Task).Should(timer)
+                .NotCompleteWithinAsync(100.Milliseconds());
+
+            taskFactory.SetCanceled();
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>();
+        }
+
+        [Fact]
+        public async Task Excepted_tasks_unexpectedly_completed()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
+
+            // Act
+            Func<Task> action = () => taskFactory
+                .Awaiting(t => (Task)t.Task).Should(timer)
+                .NotCompleteWithinAsync(100.Milliseconds());
+
+            taskFactory.SetException(new OperationCanceledException());
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<OperationCanceledException>();
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
@@ -74,6 +74,38 @@ public class TaskCompletionSourceAssertionSpecs
         }
 
         [Fact]
+        public async Task When_it_is_canceled_before_completion_and_it_is_not_expected_it_should_fail()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds());
+            subject.SetCanceled();
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>();
+        }
+
+        [Fact]
+        public async Task When_it_throws_before_completion_and_it_is_not_expected_it_should_fail()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds());
+            subject.SetException(new OperationCanceledException());
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>();
+        }
+
+        [Fact]
         public async Task When_it_did_not_complete_in_time_and_it_is_not_expected_it_should_succeed()
         {
             // Arrange
@@ -115,6 +147,38 @@ public class TaskCompletionSourceAssertionSpecs
             await action.Should().ThrowAsync<NotSupportedException>()
                 .WithMessage("Equals is not part of Fluent Assertions. Did you mean CompleteWithinAsync() instead?");
         }
+
+        [Fact]
+        public async Task Canceled_tasks_are_also_completed()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds());
+            subject.SetCanceled();
+            timer.Complete();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Excepted_tasks_unexpectedly_completed()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds());
+            subject.SetException(new OperationCanceledException());
+            timer.Complete();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
     }
 #endif
 
@@ -134,6 +198,38 @@ public class TaskCompletionSourceAssertionSpecs
 
             // Assert
             await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Canceled_tasks_do_not_return_default_value()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource<bool>();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds()).WithResult(false);
+            subject.SetCanceled();
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<OperationCanceledException>();
+        }
+
+        [Fact]
+        public async Task Exception_throwing_tasks_do_not_cause_a_default_value_to_be_returned()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource<bool>();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds()).WithResult(false);
+            subject.SetException(new OperationCanceledException());
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<OperationCanceledException>();
         }
 
         [Fact]
@@ -249,6 +345,38 @@ public class TaskCompletionSourceAssertionSpecs
             // Assert
             await action.Should().ThrowAsync<XunitException>()
                 .WithMessage("Did not expect*to complete within*because test testArg*");
+        }
+
+        [Fact]
+        public async Task Canceled_tasks_are_also_completed()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource<bool>();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds());
+            subject.SetCanceled();
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>();
+        }
+
+        [Fact]
+        public async Task Excepted_tasks_unexpectedly_completed()
+        {
+            // Arrange
+            var subject = new TaskCompletionSource<bool>();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds());
+            subject.SetException(new OperationCanceledException());
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>();
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -215,6 +215,48 @@ public static class TaskOfTAssertionSpecs
             // Assert
             await action.Should().ThrowAsync<XunitException>();
         }
+
+        [Fact]
+        public async Task Canceled_tasks_do_not_cause_a_default_value_to_be_returned()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<int>();
+
+            // Act
+            Func<Task> action = () => taskFactory
+                .Awaiting(t => t.Task)
+                .Should(timer)
+                .CompleteWithinAsync(100.Milliseconds())
+                .WithResult(0);
+
+            taskFactory.SetCanceled();
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<OperationCanceledException>();
+        }
+
+        [Fact]
+        public async Task Exception_throwing_tasks_do_not_cause_a_default_value_to_be_returned()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<int>();
+
+            // Act
+            Func<Task> action = () => taskFactory
+                .Awaiting(t => t.Task)
+                .Should(timer)
+                .CompleteWithinAsync(100.Milliseconds())
+                .WithResult(0);
+
+            taskFactory.SetException(new OperationCanceledException());
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<OperationCanceledException>();
+        }
     }
 
     public class NotThrowAsync

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -9,6 +9,10 @@ sidebar:
 
 ## 7.2.0
 
+### Fixes
+
+* Fixed a regression in which `CompleteWithinAsync` treated a canceled task as an exception - [#2853](https://github.com/fluentassertions/fluentassertions/pull/2853)
+
 ### Improvements
 * Improve failure message for string assertions when checking for equality - [#2307](https://github.com/fluentassertions/fluentassertions/pull/2307)
 * All `Should()` methods on reference types are now annotated with the `[NotNull]` attribute for a better Fluent Assertions experience when nullable reference types are enabled - [#2987](https://github.com/fluentassertions/fluentassertions/pull/2987)


### PR DESCRIPTION
Closes #2833 


## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
