### PR TITLE
Backport bump of `System.Configuration.ConfigurationManager` and `System.Threading.Tasks.Extensions`

### DIFF
--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -72,7 +72,7 @@
         <Compile Remove="SystemExtensions.cs" />
       </ItemGroup>
       <ItemGroup>
-        <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+        <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
       </ItemGroup>
     </When>
     <When Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -72,7 +72,7 @@
         <Compile Remove="SystemExtensions.cs" />
       </ItemGroup>
       <ItemGroup>
-        <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
+        <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
       </ItemGroup>
     </When>
     <When Condition="'$(TargetFramework)' == 'netstandard2.1'">
@@ -90,7 +90,7 @@
         <Compile Remove="EventRaisingExtensions.cs" />
       </ItemGroup>
       <ItemGroup>
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
       </ItemGroup>
     </When>
     <When Condition="'$(TargetFramework)' == 'net47'">
@@ -98,7 +98,7 @@
         <Compile Remove="Common/NullConfigurationStore.cs" />
       </ItemGroup>
       <ItemGroup>
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
         <TfmSpecificFrameworkAssemblyReferences Include="System.Net.Http">
           <TargetFramework>$(TargetFramework)</TargetFramework>
         </TfmSpecificFrameworkAssemblyReferences>

--- a/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
+++ b/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
@@ -18,4 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
 </Project>

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,7 @@ sidebar:
 
 * Dropped direct support for .NET Core 2.x and .NET Core 3.x - [#2302](https://github.com/fluentassertions/fluentassertions/pull/2302)
 * Dropped support for `NSpec3` test framework - [#2356](https://github.com/fluentassertions/fluentassertions/pull/2356)
+* Raised dependencies on `System.Configuration.ConfigurationManager` to 6.0.0 and `System.Threading.Tasks.Extensions` to 4.5.4 - [#2673](https://github.com/fluentassertions/fluentassertions/pull/2673) and [#2855](https://github.com/fluentassertions/fluentassertions/pull/2855)
 
 ### Fixes
 


### PR DESCRIPTION
Backport of #2673 and #2855 to v7.
See those two PRs for detailed analyses.

CC: @ViktorHofer @AArnott @jacekmlynek
Since you've previously been involved in package vs framework references.

Additional details:

In https://github.com/fluentassertions/fluentassertions/pull/2122#issuecomment-1419701160 I experimented with referencing 6.9.0 and 6.10.0 as nuget packages from a net47 project and then comparing detailed MSBuild logs.
It showed how 6.10.0 no longer had conflicts between package and framework assemblies.
 
Doing that same comparison between `main` and this PR, the MSBuild log is now down from 90 to 0 occurrences of
```
Encountered conflict between 'Reference:'System.Foo' and 'Platform:System.Foo'
````
and now skips the running the build task `AddFacadesToReferences`

Comparing the `bin/` folder of a net47 project that references Fluent Assertions via a nuget packages.
main:
![image](https://github.com/user-attachments/assets/6c6c69f2-d281-42e3-9e41-5ab39d35f452)
![image](https://github.com/user-attachments/assets/92852cdf-3a18-460d-8031-22d59cf03552)

PR:
![image](https://github.com/user-attachments/assets/7e657448-754b-47a9-9727-9fdb86621633)

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
