### PR TITLE
Properly report the path even if custom mapping is used

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,14 @@ jobs:
         language: [ 'csharp' ]
 
     steps:
+    - name: Setup .NET SDKs
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          8.0.x
+
     - name: Checkout repository
+
       uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.

--- a/FluentAssertions.sln.DotSettings
+++ b/FluentAssertions.sln.DotSettings
@@ -145,6 +145,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	
 	<s:String x:Key="/Default/Environment/Editor/MatchingBraceHighlighting/Style/@EntryValue">OUTLINE</s:String>
+	<s:String x:Key="/Default/Environment/Hierarchy/Build/SolutionBuilderNext/FileVerbosityLevel/@EntryValue">Minimal</s:String>
 	<s:String x:Key="/Default/Environment/Hierarchy/PsiConfigurationSettingsKey/LocationType/@EntryValue">SOLUTION_FOLDER</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002EDaemon_002ESettings_002EMigration_002ESwaWarningsModeSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>

--- a/Src/FluentAssertions/Common/MemberPath.cs
+++ b/Src/FluentAssertions/Common/MemberPath.cs
@@ -20,7 +20,7 @@ internal class MemberPath
     private static readonly MemberPathSegmentEqualityComparer MemberPathSegmentEqualityComparer = new();
 
     public MemberPath(IMember member, string parentPath)
-        : this(member.ReflectedType, member.DeclaringType, parentPath.Combine(member.Name))
+        : this(member.ReflectedType, member.DeclaringType, parentPath.Combine(member.Expectation.Name))
     {
     }
 

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -60,12 +60,6 @@ internal static class StringExtensions
         value.Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal);
 
     /// <summary>
-    /// Replaces all characters that might conflict with formatting placeholders with their escaped counterparts.
-    /// </summary>
-    internal static string UnescapePlaceholders(this string value) =>
-        value.Replace("{{", "{", StringComparison.Ordinal).Replace("}}", "}", StringComparison.Ordinal);
-
-    /// <summary>
     /// Joins a string with one or more other strings using a specified separator.
     /// </summary>
     /// <remarks>
@@ -76,11 +70,6 @@ internal static class StringExtensions
         if (@this.Length == 0)
         {
             return other.Length != 0 ? other : string.Empty;
-        }
-
-        if (other.Length == 0)
-        {
-            return @this;
         }
 
         if (other.StartsWith('['))

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -138,7 +138,7 @@ internal static class TypeExtensions
     {
         return (property.DeclaringType.IsSameOrInherits(otherProperty.DeclaringType) ||
                 otherProperty.DeclaringType.IsSameOrInherits(property.DeclaringType)) &&
-            property.Name == otherProperty.Name;
+            property.Expectation.Name == otherProperty.Expectation.Name;
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/AssertionChainExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionChainExtensions.cs
@@ -10,7 +10,7 @@ internal static class AssertionChainExtensions
     /// </summary>
     public static AssertionChain For(this AssertionChain chain, IEquivalencyValidationContext context)
     {
-        chain.OverrideCallerIdentifier(() => context.CurrentNode.Description);
+        chain.OverrideCallerIdentifier(() => context.CurrentNode.Subject.Description);
 
         return chain
             .WithReportable("configuration", () => context.Options.ToString())

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -74,7 +74,7 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
         bool compareByMembers = expectation is not null && Options.GetEqualityStrategy(expectation.GetType())
             is EqualityStrategy.Members or EqualityStrategy.ForceMembers;
 
-        var reference = new ObjectReference(expectation, CurrentNode.PathAndName, compareByMembers);
+        var reference = new ObjectReference(expectation, CurrentNode.Subject.PathAndName, compareByMembers);
         return CyclicReferenceDetector.IsCyclicReference(reference);
     }
 
@@ -82,6 +82,6 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
 
     public override string ToString()
     {
-        return Invariant($"{{Path=\"{CurrentNode.Description}\"}}");
+        return Invariant($"{{Path=\"{CurrentNode.Subject.PathAndName}\"}}");
     }
 }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -90,7 +90,7 @@ internal class EquivalencyValidator : IValidateChildNodeEquivalency
 
     private void TryToProveNodesAreEquivalent(Comparands comparands, IEquivalencyValidationContext context)
     {
-        using var _ = context.Tracer.WriteBlock(node => node.Description);
+        using var _ = context.Tracer.WriteBlock(node => node.Expectation.Description);
 
         foreach (IEquivalencyStep step in AssertionOptions.EquivalencyPlan)
         {

--- a/Src/FluentAssertions/Equivalency/Execution/ObjectInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/ObjectInfo.cs
@@ -8,7 +8,7 @@ internal class ObjectInfo : IObjectInfo
     {
         Type = currentNode.Type;
         ParentType = currentNode.ParentType;
-        Path = currentNode.PathAndName;
+        Path = currentNode.Expectation.PathAndName;
         CompileTimeType = comparands.CompileTimeType;
         RuntimeType = comparands.RuntimeType;
     }

--- a/Src/FluentAssertions/Equivalency/Field.cs
+++ b/Src/FluentAssertions/Equivalency/Field.cs
@@ -6,7 +6,7 @@ using FluentAssertions.Common;
 namespace FluentAssertions.Equivalency;
 
 /// <summary>
-/// A specialized type of <see cref="INode  "/> that represents a field of an object in a structural equivalency assertion.
+/// A specialized type of <see cref="INode"/> that represents a field of an object in a structural equivalency assertion.
 /// </summary>
 internal class Field : Node, IMember
 {
@@ -14,18 +14,13 @@ internal class Field : Node, IMember
     private bool? isBrowsable;
 
     public Field(FieldInfo fieldInfo, INode parent)
-        : this(fieldInfo.ReflectedType, fieldInfo, parent)
-    {
-    }
-
-    public Field(Type reflectedType, FieldInfo fieldInfo, INode parent)
     {
         this.fieldInfo = fieldInfo;
         DeclaringType = fieldInfo.DeclaringType;
-        ReflectedType = reflectedType;
-        Path = parent.PathAndName;
+        ReflectedType = fieldInfo.ReflectedType;
+        Subject = new Pathway(parent.Subject.PathAndName, fieldInfo.Name,  pathAndName => $"field {parent.GetSubjectId().Combine(pathAndName)}");
+        Expectation = new Pathway(parent.Expectation.PathAndName, fieldInfo.Name, pathAndName => $"field {pathAndName}");
         GetSubjectId = parent.GetSubjectId;
-        Name = fieldInfo.Name;
         Type = fieldInfo.FieldType;
         ParentType = fieldInfo.DeclaringType;
         RootIsCollection = parent.RootIsCollection;
@@ -39,8 +34,6 @@ internal class Field : Node, IMember
     }
 
     public Type DeclaringType { get; set; }
-
-    public override string Description => $"field {GetSubjectId().Combine(PathAndName)}";
 
     public CSharpAccessModifier GetterAccessibility => fieldInfo.GetCSharpAccessModifier();
 

--- a/Src/FluentAssertions/Equivalency/INode.cs
+++ b/Src/FluentAssertions/Equivalency/INode.cs
@@ -1,5 +1,4 @@
 using System;
-using JetBrains.Annotations;
 
 namespace FluentAssertions.Equivalency;
 
@@ -16,14 +15,6 @@ public interface INode
     GetSubjectId GetSubjectId { get; }
 
     /// <summary>
-    /// Gets the name of this node.
-    /// </summary>
-    /// <example>
-    /// "Property2"
-    /// </example>
-    string Name { get; set; }
-
-    /// <summary>
     /// Gets the type of this node, e.g. the type of the field or property, or the type of the collection item.
     /// </summary>
     Type Type { get; }
@@ -34,24 +25,17 @@ public interface INode
     /// <value>
     /// Is <see langword="null"/> for the root object.
     /// </value>
-    [CanBeNull]
     Type ParentType { get; }
 
     /// <summary>
-    /// Gets the path from the root object UNTIL the current node, separated by dots or index/key brackets.
+    /// Gets the path from the root of the subject upto and including the current node.
     /// </summary>
-    /// <example>
-    /// "Parent[0].Property2"
-    /// </example>
-    string Path { get; }
+    Pathway Subject { get; internal set; }
 
     /// <summary>
-    /// Gets the full path from the root object up to and including the name of the node.
+    /// Gets the path from the root of the expectation upto and including the current node.
     /// </summary>
-    /// <example>
-    /// "Parent[0]"
-    /// </example>
-    string PathAndName { get; }
+    Pathway Expectation { get; }
 
     /// <summary>
     /// Gets a zero-based number representing the depth within the object graph
@@ -63,14 +47,6 @@ public interface INode
     int Depth { get; }
 
     /// <summary>
-    /// Gets the path including the description of the subject.
-    /// </summary>
-    /// <example>
-    /// "property subject.Parent[0].Property2"
-    /// </example>
-    string Description { get; }
-
-    /// <summary>
     /// Gets a value indicating whether the current node is the root.
     /// </summary>
     bool IsRoot { get; }
@@ -79,4 +55,14 @@ public interface INode
     /// Gets a value indicating if the root of this graph is a collection.
     /// </summary>
     bool RootIsCollection { get; }
+
+    /// <summary>
+    /// Adjusts the current node to reflect a remapped subject member during a structural equivalency check.
+    /// Ensures that assertion failures report the correct subject member name when the matching process selects
+    /// a different member in the subject compared to the expectation.
+    /// </summary>
+    /// <param name="subjectMember">
+    /// The specific member in the subject that the current node should be remapped to.
+    /// </param>
+    void AdjustForRemappedSubject(IMember subjectMember);
 }

--- a/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
@@ -33,7 +33,7 @@ internal class MappedMemberMatchingRule<TExpectation, TSubject> : IMemberMatchin
     public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyOptions options, AssertionChain assertionChain)
     {
         if (parent.Type.IsSameOrInherits(typeof(TExpectation)) && subject is TSubject &&
-            expectedMember.Name == expectationMemberName)
+            expectedMember.Subject.Name == expectationMemberName)
         {
             var member = MemberFactory.Find(subject, subjectMemberName, parent);
 

--- a/Src/FluentAssertions/Equivalency/Matching/MappedPathMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedPathMatchingRule.cs
@@ -52,7 +52,7 @@ internal class MappedPathMatchingRule : IMemberMatchingRule
             path = path.WithCollectionAsRoot();
         }
 
-        if (path.IsEquivalentTo(expectedMember.PathAndName))
+        if (path.IsEquivalentTo(expectedMember.Expectation.PathAndName))
         {
             var member = MemberFactory.Find(subject, subjectPath.MemberName, parent);
 

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -16,7 +16,7 @@ internal class MustMatchByNameRule : IMemberMatchingRule
         if (options.IncludedProperties != MemberVisibility.None)
         {
             PropertyInfo propertyInfo = subject.GetType().FindProperty(
-                expectedMember.Name,
+                expectedMember.Subject.Name,
                 options.IncludedProperties | MemberVisibility.ExplicitlyImplemented | MemberVisibility.DefaultInterfaceProperties);
 
             subjectMember = propertyInfo is not null && !propertyInfo.IsIndexer() ? new Property(propertyInfo, parent) : null;
@@ -25,7 +25,7 @@ internal class MustMatchByNameRule : IMemberMatchingRule
         if (subjectMember is null && options.IncludedFields != MemberVisibility.None)
         {
             FieldInfo fieldInfo = subject.GetType().FindField(
-                expectedMember.Name,
+                expectedMember.Subject.Name,
                 options.IncludedFields);
 
             subjectMember = fieldInfo is not null ? new Field(fieldInfo, parent) : null;
@@ -34,12 +34,12 @@ internal class MustMatchByNameRule : IMemberMatchingRule
         if (subjectMember is null)
         {
             assertionChain.FailWith(
-                $"Expectation has {expectedMember.Description} that the other object does not have.");
+                $"Expectation has {expectedMember.Expectation} that the other object does not have.");
         }
         else if (options.IgnoreNonBrowsableOnSubject && !subjectMember.IsBrowsable)
         {
             assertionChain.FailWith(
-                $"Expectation has {expectedMember.Description} that is non-browsable in the other object, and non-browsable " +
+                $"Expectation has {expectedMember.Expectation} that is non-browsable in the other object, and non-browsable " +
                 "members on the subject are ignored with the current configuration");
         }
         else

--- a/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
@@ -13,7 +13,7 @@ internal class TryMatchByNameRule : IMemberMatchingRule
     {
         if (options.IncludedProperties != MemberVisibility.None)
         {
-            PropertyInfo property = subject.GetType().FindProperty(expectedMember.Name,
+            PropertyInfo property = subject.GetType().FindProperty(expectedMember.Expectation.Name,
                 options.IncludedProperties | MemberVisibility.ExplicitlyImplemented);
 
             if (property is not null && !property.IsIndexer())
@@ -23,7 +23,7 @@ internal class TryMatchByNameRule : IMemberMatchingRule
         }
 
         FieldInfo field = subject.GetType()
-            .FindField(expectedMember.Name, options.IncludedFields);
+            .FindField(expectedMember.Expectation.Name, options.IncludedFields);
 
         return field is not null ? new Field(field, parent) : null;
     }

--- a/Src/FluentAssertions/Equivalency/Pathway.cs
+++ b/Src/FluentAssertions/Equivalency/Pathway.cs
@@ -1,0 +1,73 @@
+using FluentAssertions.Common;
+
+namespace FluentAssertions.Equivalency;
+
+/// <summary>
+/// Represents the path of a field or property in an object graph.
+/// </summary>
+public record Pathway
+{
+    public delegate string GetDescription(string pathAndName);
+
+    private readonly string path = string.Empty;
+    private string name = string.Empty;
+    private string pathAndName;
+
+    private readonly GetDescription getDescription;
+
+    public Pathway(string path, string name, GetDescription getDescription)
+    {
+        Path = path;
+        Name = name;
+        this.getDescription = getDescription;
+    }
+
+    /// <summary>
+    /// Creates an instance of <see cref="Pathway"/> with the specified parent and name and a factory
+    /// to provide a description for the path and name.
+    /// </summary>
+    public Pathway(Pathway parent, string name, GetDescription getDescription)
+    {
+        Path = parent.PathAndName;
+        Name = name;
+        this.getDescription = getDescription;
+    }
+
+    /// <summary>
+    /// Gets the path of the field or property without the name.
+    /// </summary>
+    public string Path
+    {
+        get => path;
+        private init
+        {
+            path = value;
+            pathAndName = null;
+        }
+    }
+
+    /// <summary>
+    /// Gets the name of the field or property without the path.
+    /// </summary>
+    public string Name
+    {
+        get => name;
+        internal set
+        {
+            name = value;
+            pathAndName = null;
+        }
+    }
+
+    /// <summary>
+    /// Gets the path and name of the field or property separated by dots.
+    /// </summary>
+    public string PathAndName => pathAndName ??= path.Combine(name);
+
+    /// <summary>
+    /// Gets the display representation of this path.
+    /// </summary>
+    public string Description => getDescription(PathAndName);
+
+    public override string ToString() => Description;
+}

--- a/Src/FluentAssertions/Equivalency/Property.cs
+++ b/Src/FluentAssertions/Equivalency/Property.cs
@@ -24,10 +24,10 @@ internal class Property : Node, IMember
         ReflectedType = reflectedType;
         this.propertyInfo = propertyInfo;
         DeclaringType = propertyInfo.DeclaringType;
-        Name = propertyInfo.Name;
+        Subject = new Pathway(parent.Subject.PathAndName, propertyInfo.Name,  pathAndName => $"property {parent.GetSubjectId().Combine(pathAndName)}");
+        Expectation = new Pathway(parent.Expectation.PathAndName, propertyInfo.Name, pathAndName => $"property {pathAndName}");
         Type = propertyInfo.PropertyType;
         ParentType = propertyInfo.DeclaringType;
-        Path = parent.PathAndName;
         GetSubjectId = parent.GetSubjectId;
         RootIsCollection = parent.RootIsCollection;
     }
@@ -40,8 +40,6 @@ internal class Property : Node, IMember
     public Type DeclaringType { get; }
 
     public Type ReflectedType { get; }
-
-    public override string Description => $"property {GetSubjectId().Combine(PathAndName)}";
 
     public CSharpAccessModifier GetterAccessibility => propertyInfo.GetGetMethod(nonPublic: true).GetCSharpAccessModifier();
 

--- a/Src/FluentAssertions/Equivalency/Selection/MemberToMemberInfoAdapter.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/MemberToMemberInfoAdapter.cs
@@ -14,9 +14,9 @@ internal class MemberToMemberInfoAdapter : IMemberInfo
     {
         this.member = member;
         DeclaringType = member.DeclaringType;
-        Name = member.Name;
+        Name = member.Expectation.Name;
         Type = member.Type;
-        Path = member.PathAndName;
+        Path = member.Expectation.PathAndName;
     }
 
     public string Name { get; }

--- a/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
@@ -11,7 +11,7 @@ internal abstract class SelectMemberByPathSelectionRule : IMemberSelectionRule
     public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
         MemberSelectionContext context)
     {
-        var currentPath = RemoveRootIndexQualifier(currentNode.PathAndName);
+        var currentPath = RemoveRootIndexQualifier(currentNode.Expectation.PathAndName);
         var members = selectedMembers.ToList();
         AddOrRemoveMembersFrom(members, currentNode, currentPath, context);
 

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
@@ -72,12 +72,12 @@ public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
 
         assertionChain
                 .ForCondition(subjectIsNull || comparands.Subject.GetType().IsSameOrInherits(typeof(TSubject)))
-                .FailWith("Expected " + context.CurrentNode.Description + " from subject to be a {0}{reason}, but found a {1}.",
+                .FailWith("Expected " + context.CurrentNode.Subject + " from subject to be a {0}{reason}, but found a {1}.",
                     typeof(TSubject), comparands.Subject?.GetType())
                 .Then
                 .ForCondition(expectationIsNull || comparands.Expectation.GetType().IsSameOrInherits(typeof(TSubject)))
                 .FailWith(
-                    "Expected " + context.CurrentNode.Description + " from expectation to be a {0}{reason}, but found a {1}.",
+                    "Expected " + context.CurrentNode.Subject + " from expectation to be a {0}{reason}, but found a {1}.",
                     typeof(TSubject), comparands.Expectation?.GetType());
 
         if (assertionChain.Succeeded)
@@ -88,7 +88,7 @@ public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
             }
 
             // Caller identitification should not get confused about invoking a Should within the assertion action
-            string callerIdentifier = context.CurrentNode.Description;
+            string callerIdentifier = context.CurrentNode.Subject.ToString();
             assertionChain.OverrideCallerIdentifier(() => callerIdentifier);
             assertionChain.ReuseOnce();
 

--- a/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
@@ -37,14 +37,14 @@ public class AutoConversionStep : IEquivalencyStep
         if (TryChangeType(comparands.Subject, expectationType, out object convertedSubject))
         {
             context.Tracer.WriteLine(member =>
-                Invariant($"Converted subject {comparands.Subject} at {member.Description} to {expectationType}"));
+                Invariant($"Converted subject {comparands.Subject} at {member.Subject} to {expectationType}"));
 
             comparands.Subject = convertedSubject;
         }
         else
         {
             context.Tracer.WriteLine(member =>
-                Invariant($"Subject {comparands.Subject} at {member.Description} could not be converted to {expectationType}"));
+                Invariant($"Subject {comparands.Subject} at {member.Subject} could not be converted to {expectationType}"));
         }
 
         return EquivalencyResult.ContinueWithNext;

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
@@ -25,7 +25,7 @@ public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
                 if (context.Options.IsRecursive)
                 {
                     context.Tracer.WriteLine(member =>
-                        Invariant($"Recursing into dictionary item {key} at {member.Description}"));
+                        Invariant($"Recursing into dictionary item {key} at {member.Expectation}"));
 
                     nestedValidator.AssertEquivalencyOf(new Comparands(subject[key], expectation[key], typeof(object)), context.AsDictionaryItem<object, IDictionary>(key));
                 }
@@ -33,7 +33,7 @@ public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
                 {
                     context.Tracer.WriteLine(member =>
                         Invariant(
-                            $"Comparing dictionary item {key} at {member.Description} between subject and expectation"));
+                            $"Comparing dictionary item {key} at {member.Expectation} between subject and expectation"));
 
                     assertionChain.WithCallerPostfix($"[{key.ToFormattedString()}]").ReuseOnce();
                     subject[key].Should().Be(expectation[key], context.Reason.FormattedMessage, context.Reason.Arguments);

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -42,7 +42,7 @@ internal class EnumerableEquivalencyValidator
             if (Recursive)
             {
                 using var _ = context.Tracer.WriteBlock(member =>
-                    Invariant($"Structurally comparing {subject} and expectation {expectation} at {member.Description}"));
+                    Invariant($"Structurally comparing {subject} and expectation {expectation} at {member.Expectation}"));
 
                 AssertElementGraphEquivalency(subject, expectation, context.CurrentNode);
             }
@@ -50,7 +50,7 @@ internal class EnumerableEquivalencyValidator
             {
                 using var _ = context.Tracer.WriteBlock(member =>
                     Invariant(
-                        $"Comparing subject {subject} and expectation {expectation} at {member.Description} using simple value equality"));
+                        $"Comparing subject {subject} and expectation {expectation} at {member.Expectation} using simple value equality"));
 
                 subject.Should().BeEquivalentTo(expectation);
             }
@@ -102,7 +102,7 @@ internal class EnumerableEquivalencyValidator
 
             using var _ = context.Tracer.WriteBlock(member =>
                 Invariant(
-                    $"Strictly comparing expectation {expectation} at {member.Description} to item with index {index} in {subjects}"));
+                    $"Strictly comparing expectation {expectation} at {member.Expectation} to item with index {index} in {subjects}"));
 
             bool succeeded = StrictlyMatchAgainst(subjects, expectation, index);
             if (!succeeded)
@@ -111,7 +111,7 @@ internal class EnumerableEquivalencyValidator
                 if (failedCount >= FailedItemsFastFailThreshold)
                 {
                     context.Tracer.WriteLine(member =>
-                        $"Aborting strict order comparison of collections after {FailedItemsFastFailThreshold} items failed at {member.Description}");
+                        $"Aborting strict order comparison of collections after {FailedItemsFastFailThreshold} items failed at {member.Expectation}");
 
                     break;
                 }
@@ -129,7 +129,7 @@ internal class EnumerableEquivalencyValidator
 
             using var _ = context.Tracer.WriteBlock(member =>
                 Invariant(
-                    $"Finding the best match of {expectation} within all items in {subjects} at {member.Description}[{index}]"));
+                    $"Finding the best match of {expectation} within all items in {subjects} at {member.Expectation}[{index}]"));
 
             bool succeeded = LooselyMatchAgainst(subjects, expectation, index);
 
@@ -140,7 +140,7 @@ internal class EnumerableEquivalencyValidator
                 if (failedCount >= FailedItemsFastFailThreshold)
                 {
                     context.Tracer.WriteLine(member =>
-                        $"Fail failing loose order comparison of collection after {FailedItemsFastFailThreshold} items failed at {member.Description}");
+                        $"Fail failing loose order comparison of collection after {FailedItemsFastFailThreshold} items failed at {member.Expectation}");
 
                     break;
                 }
@@ -156,7 +156,7 @@ internal class EnumerableEquivalencyValidator
         int index = 0;
 
         GetTraceMessage getMessage = member =>
-            $"Comparing subject at {member.Description}[{index}] with the expectation at {member.Description}[{expectationIndex}]";
+            $"Comparing subject at {member.Subject}[{index}] with the expectation at {member.Expectation}[{expectationIndex}]";
 
         int indexToBeRemoved = -1;
 

--- a/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -79,7 +79,7 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         if (onlyOneNull)
         {
             assertionChain.FailWith(
-                $"Expected {currentNode.Description} to be {{0}}{{reason}}, but found {{1}}.", expected, subject);
+                $"Expected {currentNode.Subject.Description} to be {{0}}{{reason}}, but found {{1}}.", expected, subject);
 
             return false;
         }

--- a/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
@@ -60,7 +60,6 @@ public class StructuralEqualityEquivalencyStep : IEquivalencyStep
         var assertionChain = AssertionChain.GetOrCreate().For(context);
 
         IMember matchingMember = FindMatchFor(selectedMember, context.CurrentNode, comparands.Subject, options, assertionChain);
-
         if (matchingMember is not null)
         {
             var nestedComparands = new Comparands
@@ -70,12 +69,9 @@ public class StructuralEqualityEquivalencyStep : IEquivalencyStep
                 CompileTimeType = selectedMember.Type
             };
 
-            if (selectedMember.Name != matchingMember.Name)
-            {
-                // In case the matching process selected a different member on the subject,
-                // adjust the current member so that assertion failures report the proper name.
-                selectedMember.Name = matchingMember.Name;
-            }
+            // In case the matching process selected a different member on the subject,
+            // adjust the current member so that assertion failures report the proper name.
+            selectedMember.AdjustForRemappedSubject(matchingMember);
 
             parent.AssertEquivalencyOf(nestedComparands, context.AsNestedMember(selectedMember));
         }

--- a/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
@@ -24,7 +24,7 @@ public class ValueTypeEquivalencyStep : IEquivalencyStep
                     ? $"{expectationType} overrides Equals"
                     : "we are forced to use Equals";
 
-                return $"Treating {member.Description} as a value type because {strategyName}.";
+                return $"Treating {member.Expectation.Description} as a value type because {strategyName}.";
             });
 
             AssertionChain.GetOrCreate()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -792,15 +792,14 @@ namespace FluentAssertions.Equivalency
     public interface INode
     {
         int Depth { get; }
-        string Description { get; }
+        FluentAssertions.Equivalency.Pathway Expectation { get; }
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
-        string Name { get; set; }
         System.Type ParentType { get; }
-        string Path { get; }
-        string PathAndName { get; }
         bool RootIsCollection { get; }
+        FluentAssertions.Equivalency.Pathway Subject { get; }
         System.Type Type { get; }
+        void AdjustForRemappedSubject(FluentAssertions.Equivalency.IMember subjectMember);
     }
     public interface IObjectInfo
     {
@@ -857,6 +856,17 @@ namespace FluentAssertions.Equivalency
         public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
         public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
         public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IObjectInfo objectInfo) { }
+    }
+    public class Pathway : System.IEquatable<FluentAssertions.Equivalency.Pathway>
+    {
+        public Pathway(FluentAssertions.Equivalency.Pathway parent, string name, FluentAssertions.Equivalency.Pathway.GetDescription getDescription) { }
+        public Pathway(string path, string name, FluentAssertions.Equivalency.Pathway.GetDescription getDescription) { }
+        public string Description { get; }
+        public string Name { get; }
+        public string Path { get; }
+        public string PathAndName { get; }
+        public override string ToString() { }
+        public delegate string GetDescription(string pathAndName);
     }
     public abstract class SelfReferenceEquivalencyOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyOptions
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyOptions<TSelf>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -805,15 +805,14 @@ namespace FluentAssertions.Equivalency
     public interface INode
     {
         int Depth { get; }
-        string Description { get; }
+        FluentAssertions.Equivalency.Pathway Expectation { get; }
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
-        string Name { get; set; }
         System.Type ParentType { get; }
-        string Path { get; }
-        string PathAndName { get; }
         bool RootIsCollection { get; }
+        FluentAssertions.Equivalency.Pathway Subject { get; }
         System.Type Type { get; }
+        void AdjustForRemappedSubject(FluentAssertions.Equivalency.IMember subjectMember);
     }
     public interface IObjectInfo
     {
@@ -870,6 +869,17 @@ namespace FluentAssertions.Equivalency
         public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
         public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
         public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IObjectInfo objectInfo) { }
+    }
+    public class Pathway : System.IEquatable<FluentAssertions.Equivalency.Pathway>
+    {
+        public Pathway(FluentAssertions.Equivalency.Pathway parent, string name, FluentAssertions.Equivalency.Pathway.GetDescription getDescription) { }
+        public Pathway(string path, string name, FluentAssertions.Equivalency.Pathway.GetDescription getDescription) { }
+        public string Description { get; }
+        public string Name { get; }
+        public string Path { get; }
+        public string PathAndName { get; }
+        public override string ToString() { }
+        public delegate string GetDescription(string pathAndName);
     }
     public abstract class SelfReferenceEquivalencyOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyOptions
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyOptions<TSelf>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -784,15 +784,14 @@ namespace FluentAssertions.Equivalency
     public interface INode
     {
         int Depth { get; }
-        string Description { get; }
+        FluentAssertions.Equivalency.Pathway Expectation { get; }
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
-        string Name { get; set; }
         System.Type ParentType { get; }
-        string Path { get; }
-        string PathAndName { get; }
         bool RootIsCollection { get; }
+        FluentAssertions.Equivalency.Pathway Subject { get; }
         System.Type Type { get; }
+        void AdjustForRemappedSubject(FluentAssertions.Equivalency.IMember subjectMember);
     }
     public interface IObjectInfo
     {
@@ -849,6 +848,17 @@ namespace FluentAssertions.Equivalency
         public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
         public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
         public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IObjectInfo objectInfo) { }
+    }
+    public class Pathway : System.IEquatable<FluentAssertions.Equivalency.Pathway>
+    {
+        public Pathway(FluentAssertions.Equivalency.Pathway parent, string name, FluentAssertions.Equivalency.Pathway.GetDescription getDescription) { }
+        public Pathway(string path, string name, FluentAssertions.Equivalency.Pathway.GetDescription getDescription) { }
+        public string Description { get; }
+        public string Name { get; }
+        public string Path { get; }
+        public string PathAndName { get; }
+        public override string ToString() { }
+        public delegate string GetDescription(string pathAndName);
     }
     public abstract class SelfReferenceEquivalencyOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyOptions
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyOptions<TSelf>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -792,15 +792,14 @@ namespace FluentAssertions.Equivalency
     public interface INode
     {
         int Depth { get; }
-        string Description { get; }
+        FluentAssertions.Equivalency.Pathway Expectation { get; }
         FluentAssertions.Equivalency.GetSubjectId GetSubjectId { get; }
         bool IsRoot { get; }
-        string Name { get; set; }
         System.Type ParentType { get; }
-        string Path { get; }
-        string PathAndName { get; }
         bool RootIsCollection { get; }
+        FluentAssertions.Equivalency.Pathway Subject { get; }
         System.Type Type { get; }
+        void AdjustForRemappedSubject(FluentAssertions.Equivalency.IMember subjectMember);
     }
     public interface IObjectInfo
     {
@@ -857,6 +856,17 @@ namespace FluentAssertions.Equivalency
         public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
         public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
         public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IObjectInfo objectInfo) { }
+    }
+    public class Pathway : System.IEquatable<FluentAssertions.Equivalency.Pathway>
+    {
+        public Pathway(FluentAssertions.Equivalency.Pathway parent, string name, FluentAssertions.Equivalency.Pathway.GetDescription getDescription) { }
+        public Pathway(string path, string name, FluentAssertions.Equivalency.Pathway.GetDescription getDescription) { }
+        public string Description { get; }
+        public string Name { get; }
+        public string Path { get; }
+        public string PathAndName { get; }
+        public override string ToString() { }
+        public delegate string GetDescription(string pathAndName);
     }
     public abstract class SelfReferenceEquivalencyOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyOptions
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyOptions<TSelf>

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -580,7 +580,7 @@ public class BasicSpecs
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Expectation has field onlyAProperty.Value that the other object does not have.*");
+            .WithMessage("Expectation has field Value that the other object does not have.*");
     }
 
     [Fact]
@@ -595,7 +595,7 @@ public class BasicSpecs
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Expectation has property onlyAField.Value that the other object does not have*");
+            .WithMessage("Expectation has property Value that the other object does not have*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
@@ -76,7 +76,7 @@ public class ExtensibilitySpecs
         public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
             MemberSelectionContext context)
         {
-            return selectedMembers.Where(pi => !pi.Name.EndsWith("Id", StringComparison.Ordinal)).ToArray();
+            return selectedMembers.Where(pi => !pi.Subject.Name.EndsWith("Id", StringComparison.Ordinal)).ToArray();
         }
 
         bool IMemberSelectionRule.IncludesMembers
@@ -145,7 +145,7 @@ public class ExtensibilitySpecs
         public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyOptions options,
             AssertionChain assertionChain)
         {
-            string name = expectedMember.Name;
+            string name = expectedMember.Subject.Name;
 
             if (name.EndsWith("Id", StringComparison.Ordinal))
             {

--- a/Tests/FluentAssertions.Equivalency.Specs/MemberLessObjectsSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/MemberLessObjectsSpecs.cs
@@ -139,7 +139,7 @@ public class MemberLessObjectsSpecs
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Expectation has property subject.Age that the other object does not have*");
+            .WithMessage("Expectation has property Age that the other object does not have*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
 
@@ -87,7 +88,8 @@ public class MemberMatchingSpecs
     public void Nested_explicitly_implemented_properties_can_be_mapped_using_a_nested_type_and_property_names()
     {
         // Arrange
-        var subject = new ParentOfSubjectWithExplicitlyImplementedProperty([new SubjectWithExplicitImplementedProperty()]);
+        var subject =
+            new ParentOfSubjectWithExplicitlyImplementedProperty(new[] { new SubjectWithExplicitImplementedProperty() });
 
         ((IProperty)subject.Children[0]).Property = "Hello";
 
@@ -537,10 +539,166 @@ public class MemberMatchingSpecs
             c.WithMapping<EntityDto>(s => s.EntityId, d => d.Id));
     }
 
+    [Fact]
+    public void Can_explicitly_include_a_property_on_a_mapped_type()
+    {
+        // Arrange
+        var expectation = new CustomerWithPropertiesDto
+        {
+            AddressInformation = new CustomerWithPropertiesDto.ResidenceDto
+            {
+                Address = "123 Main St",
+                IsValidated = true,
+            },
+        };
+
+        var subject = new CustomerWithProperty
+        {
+            Address = new CustomerWithProperty.Residence
+            {
+                Address = "123 Main St",
+            },
+        };
+
+        // Act / Assert
+        subject.Should().BeEquivalentTo(expectation, o => o
+            .Including(r => r.AddressInformation.Address)
+            .WithMapping<CustomerWithPropertiesDto, CustomerWithProperty>(s => s.AddressInformation, d => d.Address));
+    }
+
+    [Fact]
+    public void Can_exclude_a_property_on_a_mapped_type()
+    {
+        // Arrange
+        var expectation = new CustomerWithPropertiesDto
+        {
+            AddressInformation = new CustomerWithPropertiesDto.ResidenceDto
+            {
+                Address = "123 Main St",
+                IsValidated = true,
+            },
+        };
+
+        var subject = new CustomerWithProperty
+        {
+            Address = new CustomerWithProperty.Residence
+            {
+                Address = "123 Main St",
+            },
+        };
+
+        // Act / Assert
+        subject.Should().BeEquivalentTo(expectation, o => o
+            .Excluding(r => r.AddressInformation.IsValidated)
+            .WithMapping<CustomerWithPropertiesDto, CustomerWithProperty>(s => s.AddressInformation, d => d.Address));
+    }
+
+    [Fact]
+    public void Can_explicitly_include_a_field_on_a_mapped_type()
+    {
+        // Arrange
+        var expectation = new CustomerWithFieldDto
+        {
+            AddressInformation = new CustomerWithFieldDto.ResidenceDto
+            {
+                Address = "123 Main St",
+                IsValidated = true,
+            },
+        };
+
+        var subject = new CustomerWithField
+        {
+            Address = new CustomerWithField.Residence
+            {
+                Address = "123 Main St",
+            },
+        };
+
+        // Act / Assert
+        subject.Should().BeEquivalentTo(expectation, o => o
+            .Including(r => r.AddressInformation.Address)
+            .WithMapping<CustomerWithFieldDto, CustomerWithField>(s => s.AddressInformation, d => d.Address));
+    }
+
+    [Fact]
+    public void Can_exclude_a_field_on_a_mapped_type()
+    {
+        // Arrange
+        var expectation = new CustomerWithFieldDto
+        {
+            AddressInformation = new CustomerWithFieldDto.ResidenceDto
+            {
+                Address = "123 Main St",
+                IsValidated = true,
+            },
+        };
+
+        var subject = new CustomerWithField
+        {
+            Address = new CustomerWithField.Residence
+            {
+                Address = "123 Main St",
+            },
+        };
+
+        // Act / Assert
+        subject.Should().BeEquivalentTo(expectation, o => o
+            .Excluding(r => r.AddressInformation.IsValidated)
+            .WithMapping<CustomerWithFieldDto, CustomerWithField>(s => s.AddressInformation, d => d.Address));
+    }
+
+    private class CustomerWithProperty
+    {
+        public Residence Address { get; set; }
+
+        public class Residence
+        {
+            [UsedImplicitly]
+            public string Address { get; set; }
+        }
+    }
+
+    private class CustomerWithPropertiesDto
+    {
+        public ResidenceDto AddressInformation { get; set; }
+
+        public class ResidenceDto
+        {
+            public string Address { get; set; }
+
+            public bool IsValidated { get; set; }
+        }
+    }
+
+    private class CustomerWithField
+    {
+        public Residence Address;
+
+        public class Residence
+        {
+            [UsedImplicitly]
+            public string Address;
+        }
+    }
+
+    private class CustomerWithFieldDto
+    {
+        public ResidenceDto AddressInformation;
+
+        public class ResidenceDto
+        {
+            public string Address;
+
+            [UsedImplicitly]
+            public bool IsValidated;
+        }
+    }
+
     private class Entity
     {
         public int EntityId { get; init; }
 
+        [UsedImplicitly]
         public string Name { get; init; }
     }
 
@@ -548,6 +706,7 @@ public class MemberMatchingSpecs
     {
         public int Id { get; init; }
 
+        [UsedImplicitly]
         public string Name { get; init; }
     }
 

--- a/Tests/FluentAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
@@ -229,7 +229,7 @@ public class NestedPropertiesSpecs
         // Assert
         act
             .Should().Throw<XunitException>()
-            .WithMessage("Expectation has property subject.Level.OtherProperty that the other object does not have*");
+            .WithMessage("Expectation has property Level.OtherProperty that the other object does not have*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Basic.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Basic.cs
@@ -31,7 +31,7 @@ public partial class SelectionRulesSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expectation*subject.name**other*not have*");
+                "Expectation*name**other*not have*");
         }
 
         [Fact]
@@ -53,7 +53,7 @@ public partial class SelectionRulesSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expectation*subject.name**other*not have*");
+                "Expectation*name**other*not have*");
         }
 
         private class ClassWithFieldInLowerCase
@@ -120,7 +120,7 @@ public partial class SelectionRulesSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expectation has property subject.City that the other object does not have*");
+                "Expectation has property City that the other object does not have*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Browsability.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Browsability.cs
@@ -248,7 +248,7 @@ public partial class SelectionRulesSpecs
 
             // Assert
             action.Should().Throw<XunitException>().WithMessage(
-                "Expectation has * subject.*ThatMightBeNonBrowsable that is non-browsable in the other object, and non-browsable " +
+                "Expectation has*ThatMightBeNonBrowsable that is non-browsable in the other object, and non-browsable " +
                 "members on the subject are ignored with the current configuration*");
         }
 

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FluentAssertions.Equivalency.Matching;
 using FluentAssertions.Equivalency.Ordering;
 using FluentAssertions.Equivalency.Selection;

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentificationSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentificationSpecs.cs
@@ -567,7 +567,7 @@ namespace FluentAssertions.Specs.Execution
             var node = Node.From<Foo>(GetSubjectId);
 
             // Assert
-            node.Description.Should().StartWith("node.Description");
+            node.Subject.Description.Should().StartWith("node.Subject.Description");
         }
 
         [CustomAssertion]

--- a/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
@@ -236,7 +236,7 @@ public class ComparableSpecs
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expectation has property subject.SomeOtherProperty*that the other object does not have*");
+                    "Expectation has property SomeOtherProperty*that the other object does not have*");
         }
     }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -65,6 +65,7 @@ sidebar:
 * Fixed `ThrowWithinAsync` not respecting `OperationCanceledException` - [#2614](https://github.com/fluentassertions/fluentassertions/pull/2614)
 * Fixed using `BeEquivalentTo` with an `IEqualityComparer` targeting nullable types - [#2648](https://github.com/fluentassertions/fluentassertions/pull/2648)
 * Fixed `RaisePropertyChangeFor` to return a filtered list of events - [#2677](https://github.com/fluentassertions/fluentassertions/pull/2677)
+* Including or excluding members did not work when `WithMapping` was used in `BeEquivalentTo` - [#2860](https://github.com/fluentassertions/fluentassertions/pull/2860) 
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION

This pull request includes several important changes to improve the consistency and accuracy of member path handling in the `FluentAssertions` library. The changes focus on replacing the use of `Name` and `PathAndName` with `Subject` and `Expectation` properties in various classes and methods.

### Member Path Handling Improvements:

* [`Src/FluentAssertions/Common/MemberPath.cs`](diffhunk://#diff-577dd9dac264ec2984041459dcf9793a3c07c98a3bf790a200241b5d2d3cc4fbL23-R23): Changed the constructor to use `member.Expectation.Name` instead of `member.Name`.
* [`Src/FluentAssertions/Common/TypeExtensions.cs`](diffhunk://#diff-4cd9833333753360b720fc8774b3a69379049ef8480483a504183c4c8a3a53e4L141-R141): Updated the `IsEquivalentTo` method to compare `property.Expectation.Name` with `otherProperty.Expectation.Name` instead of `property.Name`.

### Consistency in Node Handling:

* [`Src/FluentAssertions/Equivalency/Node.cs`](diffhunk://#diff-e9afe45a1e0f0a238d703b116e1a2f01f6f1c07b21247a16ce4ddda9b29d2ccfL15-R16): Replaced `Path` and `PathAndName` with `Subject` and `Expectation` properties. Added the `AdjustForRemappedSubject` method to handle remapped subject members during structural equivalency checks. [[1]](diffhunk://#diff-e9afe45a1e0f0a238d703b116e1a2f01f6f1c07b21247a16ce4ddda9b29d2ccfL15-R16) [[2]](diffhunk://#diff-e9afe45a1e0f0a238d703b116e1a2f01f6f1c07b21247a16ce4ddda9b29d2ccfL30-R71) [[3]](diffhunk://#diff-e9afe45a1e0f0a238d703b116e1a2f01f6f1c07b21247a16ce4ddda9b29d2ccfL87-R85) [[4]](diffhunk://#diff-e9afe45a1e0f0a238d703b116e1a2f01f6f1c07b21247a16ce4ddda9b29d2ccfR94-R116)
* [`Src/FluentAssertions/Equivalency/INode.cs`](diffhunk://#diff-9bf751f9b4e02187e7db5c7af36c42589a51293acc43a21dc6b4ad8b3d3f9fc5L18-L25): Removed `Name`, `Path`, `PathAndName`, and `Description` properties. Added `Subject` and `Expectation` properties. [[1]](diffhunk://#diff-9bf751f9b4e02187e7db5c7af36c42589a51293acc43a21dc6b4ad8b3d3f9fc5L18-L25) [[2]](diffhunk://#diff-9bf751f9b4e02187e7db5c7af36c42589a51293acc43a21dc6b4ad8b3d3f9fc5L37-R38) [[3]](diffhunk://#diff-9bf751f9b4e02187e7db5c7af36c42589a51293acc43a21dc6b4ad8b3d3f9fc5L65-L72) [[4]](diffhunk://#diff-9bf751f9b4e02187e7db5c7af36c42589a51293acc43a21dc6b4ad8b3d3f9fc5R58-R67)

### Adjustments in Equivalency Validation:

* [`Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs`](diffhunk://#diff-fee28d60cb5893e8661b289db68d9852d76d99cf27d70f60f326124c8d36fcdcL77-R85): Updated `IsCyclicReference` and `ToString` methods to use `CurrentNode.Subject.PathAndName` instead of `CurrentNode.PathAndName`.
* [`Src/FluentAssertions/Equivalency/AssertionChainExtensions.cs`](diffhunk://#diff-f6d0e1e366b7e364c16e79c1f7152e2fbf920d12cd205ad071f7ff4673beb357L13-R13): Modified the `For` method to use `context.CurrentNode.Subject.Description` instead of `context.CurrentNode.Description`.

### Updates in Matching Rules:

* [`Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs`](diffhunk://#diff-90a916bfec24a37c63a96b92a896f8b3287ae1e05ac11a447bbdf29e79493cf2L36-R36): Changed the `Match` method to compare `expectedMember.Subject.Name` with `expectationMemberName` instead of `expectedMember.Name`.
* [`Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs`](diffhunk://#diff-f495469cc21ec31890dcd0c94b00050d5b6053817efcdbcc4a1c97222bcb9af5L19-R19): Updated the `Match` method to use `expectedMember.Subject.Name` instead of `expectedMember.Name`. [[1]](diffhunk://#diff-f495469cc21ec31890dcd0c94b00050d5b6053817efcdbcc4a1c97222bcb9af5L19-R19) [[2]](diffhunk://#diff-f495469cc21ec31890dcd0c94b00050d5b6053817efcdbcc4a1c97222bcb9af5L28-R28) [[3]](diffhunk://#diff-f495469cc21ec31890dcd0c94b00050d5b6053817efcdbcc4a1c97222bcb9af5L37-R42)

These changes collectively enhance the handling of member paths and improve the overall consistency and accuracy of the `FluentAssertions` library.

Closes #2812

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
