### PR TITLE
Update to NUKE 9

### DIFF
--- a/Build/CustomNpmTasks.cs
+++ b/Build/CustomNpmTasks.cs
@@ -6,7 +6,6 @@ using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
-using NukeDictionaryExtensions = Nuke.Common.Utilities.Collections.DictionaryExtensions;
 using static Serilog.Log;
 
 public static class CustomNpmTasks
@@ -167,9 +166,9 @@ public static class CustomNpmTasks
 
     static void SetEnvVars()
     {
-        NpmEnvironmentVariables = NukeDictionaryExtensions.AsReadOnly(EnvironmentInfo.Variables
+        NpmEnvironmentVariables = EnvironmentInfo.Variables
             .ToDictionary(x => x.Key, x => x.Value)
-            .SetKeyValue("path", WorkingDirectory));
+            .SetKeyValue("path", WorkingDirectory).AsReadOnly();
     }
 
     public static void NpmInstall(bool silent = false, string workingDirectory = null)

--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -18,7 +18,7 @@
     <DefineConstants>OS_MAC</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageDownload Include="GitVersion.Tool" Version="[6.0.2]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[6.0.5]" />
     <PackageDownload Include="ReportGenerator" Version="[5.2.0]" />
     <PackageDownload Include="xunit.runner.console" Version="[2.9.2]" />
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />

--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -6,7 +6,7 @@
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..\</NukeRootDirectory>
     <NukeScriptDirectory>..\</NukeScriptDirectory>
-    <NukeVersion>8.1.4</NukeVersion>
+    <NukeVersion>9.0.1</NukeVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <DefineConstants>OS_WINDOWS</DefineConstants>


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
In https://github.com/fluentassertions/fluentassertions/pull/2837 I actually misunderstood that NUKE 9 runs fine on .NET8 and it is just .NET9 ready.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
