### PR TITLE
Renamed ExcludingNestedObjects to WithoutRecursing to better describe its purpose

### DIFF
--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -413,7 +413,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     /// properties of any nested objects and objects in collections.
     /// </summary>
     /// <remarks>
-    /// This is the default behavior. You can override this using <see cref="ExcludingNestedObjects"/>.
+    /// This is the default behavior. You can override this using <see cref="WithoutRecursing"/>.
     /// </remarks>
     public TSelf IncludingNestedObjects()
     {
@@ -422,13 +422,13 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     }
 
     /// <summary>
-    /// Stops the structural equality check from recursively comparing the members any nested objects.
+    /// Stops the structural equality check from recursively comparing the members of any nested objects.
     /// </summary>
     /// <remarks>
     /// If a property or field points to a complex type or collection, a simple <see cref="object.Equals(object)"/> call will
-    /// be done instead of recursively looking at the properties or fields of the nested object.
+    /// be done instead of recursively looking at the members of the nested object.
     /// </remarks>
-    public TSelf ExcludingNestedObjects()
+    public TSelf WithoutRecursing()
     {
         isRecursive = false;
         return (TSelf)this;

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -886,7 +886,6 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
-        public TSelf ExcludingNestedObjects() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCase() { }
@@ -923,6 +922,7 @@ namespace FluentAssertions.Equivalency
         public TSelf WithTracing(FluentAssertions.Equivalency.Tracing.ITraceWriter writer = null) { }
         public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
         public TSelf WithoutMatchingRules() { }
+        public TSelf WithoutRecursing() { }
         public TSelf WithoutSelectionRules() { }
         public TSelf WithoutStrictOrdering() { }
         public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -899,7 +899,6 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
-        public TSelf ExcludingNestedObjects() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCase() { }
@@ -936,6 +935,7 @@ namespace FluentAssertions.Equivalency
         public TSelf WithTracing(FluentAssertions.Equivalency.Tracing.ITraceWriter writer = null) { }
         public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
         public TSelf WithoutMatchingRules() { }
+        public TSelf WithoutRecursing() { }
         public TSelf WithoutSelectionRules() { }
         public TSelf WithoutStrictOrdering() { }
         public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -878,7 +878,6 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
-        public TSelf ExcludingNestedObjects() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCase() { }
@@ -915,6 +914,7 @@ namespace FluentAssertions.Equivalency
         public TSelf WithTracing(FluentAssertions.Equivalency.Tracing.ITraceWriter writer = null) { }
         public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
         public TSelf WithoutMatchingRules() { }
+        public TSelf WithoutRecursing() { }
         public TSelf WithoutSelectionRules() { }
         public TSelf WithoutStrictOrdering() { }
         public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -886,7 +886,6 @@ namespace FluentAssertions.Equivalency
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }
-        public TSelf ExcludingNestedObjects() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCase() { }
@@ -923,6 +922,7 @@ namespace FluentAssertions.Equivalency
         public TSelf WithTracing(FluentAssertions.Equivalency.Tracing.ITraceWriter writer = null) { }
         public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
         public TSelf WithoutMatchingRules() { }
+        public TSelf WithoutRecursing() { }
         public TSelf WithoutSelectionRules() { }
         public TSelf WithoutStrictOrdering() { }
         public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -1709,7 +1709,7 @@ public class CollectionSpecs
         IList<MyObject> expectationList = new List<MyObject> { expectation };
 
         // Act
-        Action act = () => actualList.Should().BeEquivalentTo(expectationList, opt => opt.ExcludingNestedObjects());
+        Action act = () => actualList.Should().BeEquivalentTo(expectationList, opt => opt.WithoutRecursing());
 
         // Assert
         act.Should().NotThrow();

--- a/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
@@ -587,7 +587,7 @@ public class DictionarySpecs
         };
 
         // Act
-        Action act = () => subject.Should().BeEquivalentTo(expected, options => options.ExcludingNestedObjects());
+        Action act = () => subject.Should().BeEquivalentTo(expected, options => options.WithoutRecursing());
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage("Expected subject[\"Key2\"] to be \"Value2\", but found <null>*");
@@ -1262,7 +1262,7 @@ public class DictionarySpecs
             ["CustomerId"] = 33
         };
 
-        subject.Should().BeEquivalentTo(expected, opt => opt.ExcludingNestedObjects());
+        subject.Should().BeEquivalentTo(expected, opt => opt.WithoutRecursing());
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
@@ -71,7 +71,7 @@ public class NestedPropertiesSpecs
 
         // Act
         Action act = () => subject.Should().BeEquivalentTo(expected,
-            options => options.ExcludingNestedObjects());
+            options => options.WithoutRecursing());
 
         // Assert
         act.Should().NotThrow();
@@ -84,7 +84,7 @@ public class NestedPropertiesSpecs
         var item = new Item { Child = new Item() };
 
         // Act
-        Action act = () => item.Should().BeEquivalentTo(new Item(), options => options.ExcludingNestedObjects());
+        Action act = () => item.Should().BeEquivalentTo(new Item(), options => options.WithoutRecursing());
 
         // Assert
         act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Including.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Including.cs
@@ -346,7 +346,7 @@ public partial class SelectionRulesSpecs
 
             // Act
             Action act = () => subject.Should().BeEquivalentTo(expected,
-                options => options.ExcludingNestedObjects().IncludingNestedObjects());
+                options => options.WithoutRecursing().IncludingNestedObjects());
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*Level.Level.Text*Level2*Mismatch*");

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -30,7 +30,7 @@ public partial class SelectionRulesSpecs
                 .Excluding(r => r.Level)
                 .ExcludingFields()
                 .ExcludingMissingMembers()
-                .ExcludingNestedObjects()
+                .WithoutRecursing()
                 .ExcludingNonBrowsableMembers()
                 .ExcludingProperties()
                 .IgnoringCyclicReferences()

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -97,6 +97,7 @@ sidebar:
 * The semantics of `BeLowerCased`/`BeUpperCased` have been changed to align with the behavior of `ToLower`/`ToUpper` - [#2660](https://github.com/fluentassertions/fluentassertions/pull/2660)
 * Renamed `HaveAttribute` to `HaveAttributeWithValue` on `XElement` - [#2690](https://github.com/fluentassertions/fluentassertions/pull/2690)
 * Renamed `RespectingRuntimeTypes` to `PreferringRuntimeMemberTypes` and `RespectingDeclaredTypes` to `PreferringDeclaredMemberTypes` - [#2866](https://github.com/fluentassertions/fluentassertions/pull/2866)
+* Renamed `ExcludingNestedObjects` to `WithoutRecursing` to better describe its purpose - [#2876](https://github.com/fluentassertions/fluentassertions/pull/2876)
 
 ### Breaking Changes (for extensions)
 * Add `ForConstraint` to `IAssertionsScope` to support chaining `.ForConstraint()` after `.Then` - [#2324](https://github.com/fluentassertions/fluentassertions/pull/2324)


### PR DESCRIPTION
This pull request primarily focuses on renaming the `ExcludingNestedObjects` method to `WithoutRecursing` across various files to improve clarity and better describe its purpose. Additionally, it updates related documentation and test cases to reflect this change.

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
