### PR TITLE
The CodeQL build needed the .NET 8.0 SDK

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,12 @@ jobs:
         language: [ 'csharp' ]
 
     steps:
+    - name: Setup .NET SDKs
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          8.0.x
+
     - name: Checkout repository
       uses: actions/checkout@v4
 


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow configuration for CodeQL analysis. The most important change is the addition of a step to set up the .NET SDKs.

Workflow configuration update:

* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27R27-R32): Added a step to set up .NET SDKs using `actions/setup-dotnet@v4` with version `8.0.x`.



