### PR TITLE
Upgrade MSTest for UWP.Specs

### DIFF
--- a/Tests/UWP.Specs/App.xaml.cs
+++ b/Tests/UWP.Specs/App.xaml.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using Microsoft.VisualStudio.TestPlatform.TestExecutor;
+﻿using Microsoft.VisualStudio.TestPlatform.TestExecutor;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Navigation;
 
 namespace UWP.Specs;
 
@@ -18,18 +15,8 @@ internal sealed partial class App : Application
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
-        if (Window.Current.Content is not Frame rootFrame)
-        {
-            rootFrame = new Frame();
-            rootFrame.NavigationFailed += OnNavigationFailed;
-            Window.Current.Content = rootFrame;
-        }
-
         UnitTestClient.Run(args.Arguments);
     }
-
-    private void OnNavigationFailed(object sender, NavigationFailedEventArgs e) =>
-        throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
 
     private void OnSuspending(object sender, SuspendingEventArgs e) =>
         e.SuspendingOperation.GetDeferral().Complete();

--- a/Tests/UWP.Specs/Directory.Build.props
+++ b/Tests/UWP.Specs/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <LangVersion>12.0</LangVersion>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/Tests/UWP.Specs/Package.appxmanifest
+++ b/Tests/UWP.Specs/Package.appxmanifest
@@ -10,7 +10,7 @@
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
   </Dependencies>
   <Resources>
-    <Resource Language="x-generate" />
+    <Resource Language="EN-US" />
   </Resources>
   <Applications>
     <Application Id="vstest.executionengine.universal.App" Executable="$targetnametoken$.exe" EntryPoint="UWP.Specs.App">

--- a/Tests/UWP.Specs/UWP.Specs.csproj
+++ b/Tests/UWP.Specs/UWP.Specs.csproj
@@ -20,6 +20,8 @@
     <NoWarn>$(NoWarn);2008</NoWarn>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
     <IsTestProject>true</IsTestProject>
+    <!-- EnableMSTestV2CopyResources is disabled due to https://github.com/microsoft/testfx/issues/4371 -->
+    <EnableMSTestV2CopyResources>false</EnableMSTestV2CopyResources>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -87,10 +89,10 @@
       <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.3.1</Version>
+      <Version>3.6.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.3.1</Version>
+      <Version>3.6.4</Version>
     </PackageReference>
     <PackageReference Include="System.Xml.XPath.XmlDocument">
       <Version>4.3.0</Version>


### PR DESCRIPTION
Got UWP.Specs to build at all and `Determining_caller_identity_should_not_throw_for_native_programs` to run using MSTest 3.6.4


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
