### PR TITLE
Rollback Qodana version to solve a conflict with PolySharp

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2024.3
+        uses: JetBrains/qodana-action@v2024.2
         with:
           upload-result: ${{ github.ref_name == 'main' || github.ref_name == 'develop' }}
           args: --baseline,qodana.sarif.json,--ide,QDNET


### PR DESCRIPTION
The new version is having a conflict with PolySharp 1.15, so we need to rollback.

See also https://github.com/fluentassertions/fluentassertions/pull/2884