### PR TITLE
Ignore updates to System.Collections.Immutable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,7 @@ updates:
       time: "16:00"
       timezone: "Europe/Copenhagen"
     ignore:
+      - dependency-name: "System.Collections.Immutable"
       - dependency-name: "System.Configuration.ConfigurationManager"
       - dependency-name: "System.Threading.Tasks.Extensions"
     groups:


### PR DESCRIPTION
Follow up to #2890 as dependabot chose to ignore the explicit version range `[1.5.0]` in 
https://github.com/fluentassertions/fluentassertions/blob/de6adcf532651ab29b88aa3fafa33056518d98e7/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj#L20


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
