### PR TITLE
GlobalEquivalencyOptions.CloneDefaults needs to be public

### DIFF
--- a/Src/FluentAssertions/Configuration/GlobalEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Configuration/GlobalEquivalencyOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
+using JetBrains.Annotations;
 
 namespace FluentAssertions.Configuration;
 
@@ -39,7 +40,11 @@ public class GlobalEquivalencyOptions
     /// <summary>
     /// Creates a clone of the default options and allows the caller to modify them.
     /// </summary>
-    internal EquivalencyOptions<T> CloneDefaults<T>()
+    /// <remarks>
+    /// Can be used by external packages like FluentAssertions.DataSets to create a copy of the default equivalency options.
+    /// </remarks>
+    [PublicAPI]
+    public EquivalencyOptions<T> CloneDefaults<T>()
     {
         return new EquivalencyOptions<T>(defaults);
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -602,6 +602,7 @@ namespace FluentAssertions.Configuration
     {
         public GlobalEquivalencyOptions() { }
         public FluentAssertions.Equivalency.EquivalencyPlan Plan { get; }
+        public FluentAssertions.Equivalency.EquivalencyOptions<T> CloneDefaults<T>() { }
         public void Modify(System.Func<FluentAssertions.Equivalency.EquivalencyOptions, FluentAssertions.Equivalency.EquivalencyOptions> configureOptions) { }
     }
     public class GlobalFormattingOptions : FluentAssertions.Formatting.FormattingOptions

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -615,6 +615,7 @@ namespace FluentAssertions.Configuration
     {
         public GlobalEquivalencyOptions() { }
         public FluentAssertions.Equivalency.EquivalencyPlan Plan { get; }
+        public FluentAssertions.Equivalency.EquivalencyOptions<T> CloneDefaults<T>() { }
         public void Modify(System.Func<FluentAssertions.Equivalency.EquivalencyOptions, FluentAssertions.Equivalency.EquivalencyOptions> configureOptions) { }
     }
     public class GlobalFormattingOptions : FluentAssertions.Formatting.FormattingOptions

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -594,6 +594,7 @@ namespace FluentAssertions.Configuration
     {
         public GlobalEquivalencyOptions() { }
         public FluentAssertions.Equivalency.EquivalencyPlan Plan { get; }
+        public FluentAssertions.Equivalency.EquivalencyOptions<T> CloneDefaults<T>() { }
         public void Modify(System.Func<FluentAssertions.Equivalency.EquivalencyOptions, FluentAssertions.Equivalency.EquivalencyOptions> configureOptions) { }
     }
     public class GlobalFormattingOptions : FluentAssertions.Formatting.FormattingOptions

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -602,6 +602,7 @@ namespace FluentAssertions.Configuration
     {
         public GlobalEquivalencyOptions() { }
         public FluentAssertions.Equivalency.EquivalencyPlan Plan { get; }
+        public FluentAssertions.Equivalency.EquivalencyOptions<T> CloneDefaults<T>() { }
         public void Modify(System.Func<FluentAssertions.Equivalency.EquivalencyOptions, FluentAssertions.Equivalency.EquivalencyOptions> configureOptions) { }
     }
     public class GlobalFormattingOptions : FluentAssertions.Formatting.FormattingOptions


### PR DESCRIPTION
This is needed by packages like [FluentAssertions.DataSets](https://github.com/fluentassertions/fluentassertions.datasets) to be able to hook into the equivalency engine.


* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
