### PR TITLE
Fixed referenced version in migration guide V8

### DIFF
--- a/docs/_pages/upgradingtov8.md
+++ b/docs/_pages/upgradingtov8.md
@@ -82,7 +82,7 @@ Execute.Assertion
 
 When using an `using new AssertionScope()` construct to wrap multiple assertions, all assertions executed within that scope will reuse the same instance of `AssertionScope` (which is what `Execute.Assertion` returned). The problem was that you had to explicitly call `ClearExpectation` to prevent the failure message passed to `WithExpectation` to leak into the next assertion within that scope. People often forgot that.
 
-We solved this in v7, by making `WithExpectation` use a nested construct. This is what it now looks like:
+We solved this in v8, by making `WithExpectation` use a nested construct. This is what it now looks like:
 
 ```csharp
 assertionChain
@@ -115,15 +115,15 @@ var element = XElement.Parse(
 element.Should().HaveElement("child", AtLeast.Twice()).Which.Should().HaveCount(1);
 ```
 
-Prior to version 7, if the `HaveElement` assertion succeeded, but the `NotBeNull` failed, you would get the following exception:
+Prior to version 8, if the `HaveElement` assertion succeeded, but the `NotBeNull` failed, you would get the following exception:
 
     Expected element to contain 1 item(s), but found 3: {<child />, <child />, <child />}.
 
-Now, in v7, it'll will return the following:
+Now, in v8, it'll will return the following:
 
     Expected element/child to contain 1 item(s), but found 3: {<child />, <child />, <child />}.
 
-This is possible because `HaveElement` will pass the `AssertionChain` through `ReuseOnce` to the succeeding `HaveCount()` _and_ amend the automatically detected caller identifier `element` (the part on which the first `Should` is invoked) with `"/child"` using `WithCallerPostfix`. Since this is a common thing in v7, the `AndWhichConstraint` has a constructor that does most of that automatically.
+This is possible because `HaveElement` will pass the `AssertionChain` through `ReuseOnce` to the succeeding `HaveCount()` _and_ amend the automatically detected caller identifier `element` (the part on which the first `Should` is invoked) with `"/child"` using `WithCallerPostfix`. Since this is a common thing in v8, the `AndWhichConstraint` has a constructor that does most of that automatically.
 
 This is what `HaveElement` looks like (with some details left out):
 


### PR DESCRIPTION
I started testing V8 RC2 with my major projects. I tried to follow the migration guide and found some issues.
Some minor are already included in this PR. I'll start a separate discussion on some unclear issues. For now this PR is DRAFT.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
