### PR TITLE
Fix a crash when using `WithStrictOrderingFor(x => x)` with `BeEquivalentTo`

### DIFF
--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -143,8 +143,10 @@ internal static class ExpressionExtensions
     /// </example>
     /// <exception cref="ArgumentNullException"><paramref name="expression"/> is <see langword="null"/>.</exception>
     public static MemberPath GetMemberPath<TDeclaringType, TPropertyType>(
-        this Expression<Func<TDeclaringType, TPropertyType>> expression) =>
-        expression.GetMemberPaths().First();
+        this Expression<Func<TDeclaringType, TPropertyType>> expression)
+    {
+        return expression.GetMemberPaths().FirstOrDefault() ?? new MemberPath("");
+    }
 
     /// <summary>
     /// Validates that the expression can be used to construct a <see cref="MemberPath"/>.

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -1603,6 +1603,20 @@ public class CollectionSpecs
     }
 
     [Fact]
+    public void Can_request_strict_ordering_using_an_expression_that_points_to_the_collection_items()
+    {
+        // Arrange
+        var subject = new List<string> { "first", "second" };
+
+        var expectation = new List<string> { "second", "first" };
+
+        var act = () => subject.Should().BeEquivalentTo(expectation,
+            options => options.WithStrictOrderingFor(v => v));
+
+        act.Should().Throw<XunitException>().WithMessage("Expected*second*but*first*");
+    }
+
+    [Fact]
     public void
         When_asserting_equivalence_of_collections_and_configured_to_use_runtime_properties_it_should_respect_the_runtime_type()
     {
@@ -2559,7 +2573,10 @@ public class CollectionSpecs
         // Arrange
         Customer[] subject =
         [
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new()
+                { Name = "John", Age = 27, Id = 1 },
+            new()
+                { Name = "Jane", Age = 24, Id = 2 }
         ];
 
         var expectation = new Collection<Customer>
@@ -2583,7 +2600,10 @@ public class CollectionSpecs
         // Arrange
         Customer[] subject =
         [
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new()
+                { Name = "John", Age = 27, Id = 1 },
+            new()
+                { Name = "Jane", Age = 24, Id = 2 }
         ];
 
         var expectation = new Collection<Customer>
@@ -2612,7 +2632,10 @@ public class CollectionSpecs
         // Arrange
         Customer[] subject =
         [
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new()
+                { Name = "John", Age = 27, Id = 1 },
+            new()
+                { Name = "Jane", Age = 24, Id = 2 }
         ];
 
         var expectation = new Collection<Customer>
@@ -2635,7 +2658,10 @@ public class CollectionSpecs
         // Arrange
         Customer[] subject =
         [
-            new Customer { Name = "John", Age = 27, Id = 1 }, new Customer { Name = "Jane", Age = 24, Id = 2 }
+            new()
+                { Name = "John", Age = 27, Id = 1 },
+            new()
+                { Name = "Jane", Age = 24, Id = 2 }
         ];
 
         var expectation = new Collection<Customer>

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -46,6 +46,7 @@ sidebar:
 * Fixed incorrect treatment of "\\r\\n" as new line - [#2569](https://github.com/fluentassertions/fluentassertions/pull/2569)
 * Fixed `RaisePropertyChangeFor` to return a filtered list of events - [#2677](https://github.com/fluentassertions/fluentassertions/pull/2677)
 * Including or excluding members did not work when `WithMapping` was used in `BeEquivalentTo` - [#2860](https://github.com/fluentassertions/fluentassertions/pull/2860)
+* Fix a crash when using `WithStrictOrderingFor(x => x)` with `BeEquivalentTo` - [#](https://github.com/fluentassertions/fluentassertions/pull/x)
 
 ### Breaking Changes (for users)
 * Moved support for `DataSet`, `DataTable`, `DataRow` and `DataColumn` into a new package `FluentAssertions.DataSet` - [#2267](https://github.com/fluentassertions/fluentassertions/pull/2267)


### PR DESCRIPTION
Fixes #2927