### PR TITLE
Avoid `InvalidOperationException` for `HaveElementWithValue`

### DIFF
--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -531,8 +531,8 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
                     .ForCondition(Subject is not null)
                     .FailWith("but the element itself is <null>.")
                     .Then
-                    .ForCondition(Subject!.Root!.Elements(unexpectedElement)
-                        .FirstOrDefault(e => e.Value == unexpectedValue) is null)
+                    .ForCondition(!Subject!.Root!.Elements(unexpectedElement)
+                        .Any(e => e.Value == unexpectedValue))
                     .FailWith("but the element {0} does have this value.", unexpectedElement));
 
         return new AndConstraint<XDocumentAssertions>(this);

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -472,7 +472,7 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
                     .ForCondition(collection => collection.Any(e => e.Value == expectedValue))
                     .FailWith("but the element {0} does not have such a value.", expectedElement));
 
-        return new AndWhichConstraint<XDocumentAssertions, XElement>(this, xElements.First());
+        return new AndWhichConstraint<XDocumentAssertions, XElement>(this, xElements.FirstOrDefault());
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -750,8 +750,8 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
                     .BecauseOf(because, becauseArgs)
                     .FailWith("but the element itself is <null>.")
                     .Then
-                    .ForCondition(Subject!.Elements(unexpectedElement)
-                        .FirstOrDefault(e => e.Value == unexpectedValue) is null)
+                    .ForCondition(!Subject!.Elements(unexpectedElement)
+                        .Any(e => e.Value == unexpectedValue))
                     .FailWith("but the element {0} does have this value.", unexpectedElement));
 
         return new AndConstraint<XElementAssertions>(this);

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -690,7 +690,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
                     .ForCondition(elements => elements.Any(e => e.Value == expectedValue))
                     .FailWith("but the element {0} does not have such a value.", expectedElement));
 
-        return new AndWhichConstraint<XElementAssertions, XElement>(this, xElements.First());
+        return new AndWhichConstraint<XElementAssertions, XElement>(this, xElements.FirstOrDefault());
     }
 
     /// <summary>

--- a/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -1457,7 +1457,11 @@ public class XDocumentAssertionSpecs
                 """);
 
             // Act
-            Action act = () => document.Should().HaveElementWithValue(XNamespace.None + "grandchild", "f");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                document.Should().HaveElementWithValue(XNamespace.None + "grandchild", "f");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*grandchild*f*element*isn't found*");

--- a/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -2081,7 +2081,11 @@ public class XElementAssertionSpecs
                 """);
 
             // Act
-            Action act = () => element.Should().HaveElementWithValue(XNamespace.None + "c", "f");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                element.Should().HaveElementWithValue(XNamespace.None + "c", "f");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*c*f*element*isn't found*");


### PR DESCRIPTION
Inspired by #2932 I had a look at other places where we use `First()`

Follow-up to #2690


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
