### PR TITLE
Backport TUnit to v7

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -34,9 +34,11 @@
         "Restore",
         "SpellCheck",
         "TestFrameworks",
+        "TestingPlatformFrameworks",
         "UnitTests",
         "UnitTestsNetCore",
-        "UnitTestsNetFramework"
+        "UnitTestsNetFramework",
+        "VSTestFrameworks"
       ]
     },
     "Verbosity": {

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -261,7 +261,7 @@ class Build : NukeBuild
             Information($"Code coverage report: \x1b]8;;file://{link.Replace('\\', '/')}\x1b\\{link}\x1b]8;;\x1b\\");
         });
 
-    Target TestFrameworks => _ => _
+    Target VSTestFrameworks => _ => _
         .DependsOn(Compile)
         .OnlyWhenDynamic(() => RunAllTargets || HasSourceChanges)
         .Executes(() =>
@@ -301,6 +301,46 @@ class Build : NukeBuild
 
             ReportTestOutcome(projects.Select(p => $"*{p.Name}*.trx").ToArray());
         });
+
+    Target TestingPlatformFrameworks => _ => _
+        .DependsOn(Compile)
+        .OnlyWhenDynamic(() => RunAllTargets || HasSourceChanges)
+        .Executes(() =>
+        {
+            Project[] projects =
+            [
+                Solution.TestFrameworks.TUnit_Specs
+            ];
+
+            var testCombinations =
+                from project in projects
+                let frameworks = project.GetTargetFrameworks()
+                from framework in frameworks
+                select new { project, framework };
+
+            DotNetTest(s => s
+                .SetConfiguration(Configuration.Debug)
+                .SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+                .EnableNoBuild()
+                .CombineWith(
+                    testCombinations,
+                    (settings, v) => settings
+                        .SetProjectFile(v.project)
+                        .SetFramework(v.framework)
+                        .SetProcessAdditionalArguments(
+                            "--",
+                            "--coverage",
+                            "--report-trx",
+                            $"--report-trx-filename {v.project.Name}_{v.framework}.trx",
+                            $"--results-directory {TestResultsDirectory}"
+                        )
+                )
+            );
+        });
+
+    Target TestFrameworks => _ => _
+        .DependsOn(VSTestFrameworks)
+        .DependsOn(TestingPlatformFrameworks);
 
     Target Pack => _ => _
         .DependsOn(ApiChecks)

--- a/FluentAssertions.sln
+++ b/FluentAssertions.sln
@@ -55,6 +55,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XUnit3.Specs", "Tests\TestF
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XUnit3Core.Specs", "Tests\TestFrameworks\XUnit3Core.Specs\XUnit3Core.Specs.csproj", "{FCD60E63-F1DC-4DF0-AB75-69CCB6931FF7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TUnit.Specs", "Tests\TestFrameworks\TUnit.Specs\TUnit.Specs.csproj", "{61DC52C4-C0EF-4059-B634-A8FC6826EFA1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		CI|Any CPU = CI|Any CPU
@@ -157,6 +159,12 @@ Global
 		{FCD60E63-F1DC-4DF0-AB75-69CCB6931FF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FCD60E63-F1DC-4DF0-AB75-69CCB6931FF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FCD60E63-F1DC-4DF0-AB75-69CCB6931FF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{61DC52C4-C0EF-4059-B634-A8FC6826EFA1}.CI|Any CPU.ActiveCfg = Debug|Any CPU
+		{61DC52C4-C0EF-4059-B634-A8FC6826EFA1}.CI|Any CPU.Build.0 = Debug|Any CPU
+		{61DC52C4-C0EF-4059-B634-A8FC6826EFA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61DC52C4-C0EF-4059-B634-A8FC6826EFA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61DC52C4-C0EF-4059-B634-A8FC6826EFA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61DC52C4-C0EF-4059-B634-A8FC6826EFA1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -178,6 +186,7 @@ Global
 		{0A69DC62-CA14-44E5-BAF9-2EB2E2E2CADF} = {963262D0-9FD5-4741-8C0E-E2F34F110EF3}
 		{60335A74-208E-4B33-BA4F-70A36541705E} = {4D8FA213-8724-4C43-B68A-F018148D238C}
 		{FCD60E63-F1DC-4DF0-AB75-69CCB6931FF7} = {4D8FA213-8724-4C43-B68A-F018148D238C}
+		{61DC52C4-C0EF-4059-B634-A8FC6826EFA1} = {4D8FA213-8724-4C43-B68A-F018148D238C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {75DDA3D8-9D6F-4865-93F4-DDE11DEE8290}

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -48,6 +48,10 @@ internal abstract class LateBoundTestFramework : ITestFramework
             {
                 return null;
             }
+            catch (FileLoadException)
+            {
+                return null;
+            }
         }
 
         return assembly;

--- a/Src/FluentAssertions/Execution/TUnitFramework.cs
+++ b/Src/FluentAssertions/Execution/TUnitFramework.cs
@@ -1,0 +1,8 @@
+﻿namespace FluentAssertions.Execution;
+
+internal class TUnitFramework() : LateBoundTestFramework(loadAssembly: true)
+{
+    protected override string ExceptionFullName => "TUnit.Assertions.Exceptions.AssertionException";
+
+    protected internal override string AssemblyName => "TUnit.Assertions";
+}

--- a/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
+++ b/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
@@ -20,6 +20,7 @@ internal class TestFrameworkProvider
         ["mstestv2"] = new MSTestFrameworkV2(),
 
         // Keep XUnitTestFramework last as they use a try/catch approach
+        ["tunit"] = new TUnitFramework(),
         ["xunit2"] = new XUnitTestFramework("xunit.assert"),
         ["xunit3"] = new XUnitTestFramework("xunit.v3.assert"),
     };

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -19,14 +19,14 @@
     <PackageDescription>
       A very extensive set of extension methods that allow you to more naturally specify the expected outcome of a TDD or
       BDD-style unit tests. Targets .NET Framework 4.7, .NET 6, as well as .NET Standard 2.0 and 2.1.
-      Supports the unit test frameworks MSTest2, NUnit3, XUnit2, XUnit3 and MSpec.
+      Supports the unit test frameworks MSTest2, NUnit3, XUnit2, XUnit3, MSpec and TUnit.
 
       Supported by InfoSupport B.V.
     </PackageDescription>
     <PackageProjectUrl>https://www.fluentassertions.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/fluentassertions/fluentassertions</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>MSTest2;xUnit;NUnit;MSpec;TDD;BDD;Fluent;netstandard;uwp</PackageTags>
+    <PackageTags>MSTest2;xUnit;NUnit;MSpec;TUnit;TDD;BDD;Fluent;netstandard;uwp</PackageTags>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>FluentAssertions.png</PackageIcon>
     <PackageReleaseNotes>See https://fluentassertions.com/releases/</PackageReleaseNotes>

--- a/Tests/TestFrameworks/TUnit.Specs/FrameworkSpecs.cs
+++ b/Tests/TestFrameworks/TUnit.Specs/FrameworkSpecs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using FluentAssertions;
+
+namespace TUnit.Specs;
+
+public class FrameworkSpecs
+{
+    [Test]
+    public void When_tunit_is_used_it_should_throw_tunit_exceptions_for_assertion_failures()
+    {
+        // Act
+        Action act = () => 0.Should().Be(1);
+
+        // Assert
+        Exception exception = act.Should().Throw<Exception>().Which;
+
+        // Don't reference the exception type explicitly like this: act.Should().Throw<AssertionException>()
+        // It could cause this specs project to load the assembly containing the exception (this actually happens for xUnit)
+        exception.GetType().FullName.Should().Be("TUnit.Assertions.Exceptions.AssertionException");
+    }
+}

--- a/Tests/TestFrameworks/TUnit.Specs/TUnit.Specs.csproj
+++ b/Tests/TestFrameworks/TUnit.Specs/TUnit.Specs.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>TUnit.Specs</RootNamespace>
+    <AssemblyName>TUnit.Specs</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="TUnit" Version="0.6.33" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.5.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.13.1" />
+  </ItemGroup>
+
+</Project>

--- a/docs/_pages/about.md
+++ b/docs/_pages/about.md
@@ -54,6 +54,7 @@ Fluent Assertions supports the following unit test frameworks:
 * [NUnit](http://www.nunit.org/)
 * [XUnit2](https://github.com/xunit/xunit/releases)
 * [MSpec](https://github.com/machine/machine.specifications)
+* [TUnit](https://github.com/thomhurst/TUnit)
 
 ## Coding by Example
 

--- a/docs/_pages/introduction.md
+++ b/docs/_pages/introduction.md
@@ -72,7 +72,7 @@ If, for some unknown reason, Fluent Assertions fails to find the assembly, and y
 ```xml
 <configuration>
   <appSettings>
-    <!-- Supported values: nunit, xunit2, xunit3, mstestv2 and mspec -->
+    <!-- Supported values: nunit, xunit2, xunit3, mstestv2, mspec and tunit -->
     <add key="FluentAssertions.TestFramework" value="nunit"/>
   </appSettings>
 </configuration>

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### Improvements
 
 * Added compatibility with xUnit.net v3 - [#2970](https://github.com/fluentassertions/fluentassertions/issues/2970)
+* Added support for throwing TUnit exceptions when using TUnit as your testing framework - [#2971](https://github.com/fluentassertions/fluentassertions/pull/2971)
 
 ## 7.0.0
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,7 +54,7 @@ feature_row2:
     image_path: /assets/images/checklist.svg
     excerpt: '
 Targets .NET 4.7, .NET 6, .NET Standard 2.0 and 2.1.
-Supports MSTest2, XUnit2, XUnit3, NUnit3 and MSpec.
+Supports MSTest2, XUnit2, XUnit3, NUnit3, MSpec and TUnit.
 '
   - title: "Great Support"
     image_path: /assets/images/customer-service.svg


### PR DESCRIPTION
Backported [the work](https://github.com/fluentassertions/fluentassertions/pull/2758) of @thomhurst to add support for [TUnit](https://github.com/thomhurst/TUnit) to v7 of Fluent Assertions. 

#2935 

Needs to be merged after #2970 is merged. 