### PR TITLE
Provide a toggle to suppress the soft warning about commercial use

### DIFF
--- a/Src/FluentAssertions/AssertionEngine.cs
+++ b/Src/FluentAssertions/AssertionEngine.cs
@@ -78,26 +78,29 @@ public static class AssertionEngine
         {
             if (!isInitialized)
             {
-                const string softWarning =
-                    """
-                         Warning:
-                         The component "Fluent Assertions" is governed by the rules defined in the Xceed License Agreement and
-                         the Xceed Fluent Assertions Community License. You may use Fluent Assertions free of charge for
-                         non-commercial use only. An active subscription is required to use Fluent Assertions for commercial use.
-
-                         Please contact Xceed Sales mailto:sales@xceed.com to acquire a subscription at a very low cost.
-
-                         A paid commercial license supports the development and continued increasing support of
-                         Fluent Assertions users under both commercial and community licenses. Help us
-                         keep Fluent Assertions at the forefront of unit testing.
-
-                         For more information, visit https://xceed.com/products/unit-testing/fluent-assertions/
-                    """;
-
-                Console.WriteLine(softWarning);
-                Trace.WriteLine(softWarning);
-
                 ExecuteCustomInitializers();
+
+                if (!License.Accepted)
+                {
+                    const string softWarning =
+                        """
+                             Warning:
+                             The component "Fluent Assertions" is governed by the rules defined in the Xceed License Agreement and
+                             the Xceed Fluent Assertions Community License. You may use Fluent Assertions free of charge for
+                             non-commercial use only. An active subscription is required to use Fluent Assertions for commercial use.
+
+                             Please contact Xceed Sales mailto:sales@xceed.com to acquire a subscription at a very low cost.
+
+                             A paid commercial license supports the development and continued increasing support of
+                             Fluent Assertions users under both commercial and community licenses. Help us
+                             keep Fluent Assertions at the forefront of unit testing.
+
+                             For more information, visit https://xceed.com/products/unit-testing/fluent-assertions/
+                        """;
+
+                    Console.WriteLine(softWarning);
+                    Trace.WriteLine(softWarning);
+                }
 
                 isInitialized = true;
             }

--- a/Src/FluentAssertions/License.cs
+++ b/Src/FluentAssertions/License.cs
@@ -1,0 +1,12 @@
+namespace FluentAssertions;
+
+/// <summary>
+/// Provides access to the licensing state of Fluent Assertions
+/// </summary>
+public static class License
+{
+    /// <summary>
+    /// Can be used to accept the license and suppress the soft warning about the license requirements for commercial use
+    /// </summary>
+    public static bool Accepted { get; set; }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -259,6 +259,10 @@ namespace FluentAssertions
         public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
         public static FluentAssertions.OccurrenceConstraint Twice() { }
     }
+    public static class License
+    {
+        public static bool Accepted { get; set; }
+    }
     public static class MoreThan
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -272,6 +272,10 @@ namespace FluentAssertions
         public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
         public static FluentAssertions.OccurrenceConstraint Twice() { }
     }
+    public static class License
+    {
+        public static bool Accepted { get; set; }
+    }
     public static class MoreThan
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -251,6 +251,10 @@ namespace FluentAssertions
         public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
         public static FluentAssertions.OccurrenceConstraint Twice() { }
     }
+    public static class License
+    {
+        public static bool Accepted { get; set; }
+    }
     public static class MoreThan
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -259,6 +259,10 @@ namespace FluentAssertions
         public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
         public static FluentAssertions.OccurrenceConstraint Twice() { }
     }
+    public static class License
+    {
+        public static bool Accepted { get; set; }
+    }
     public static class MoreThan
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }

--- a/Tests/FluentAssertions.Specs/AssemblyInitializer.cs
+++ b/Tests/FluentAssertions.Specs/AssemblyInitializer.cs
@@ -1,0 +1,16 @@
+using FluentAssertions.Specs;
+
+[assembly: FluentAssertions.Extensibility.AssertionEngineInitializer(
+    typeof(AssemblyInitializer),
+    nameof(AssemblyInitializer.AcknowledgeSoftWarning))]
+
+namespace FluentAssertions.Specs;
+
+public static class AssemblyInitializer
+{
+    public static void AcknowledgeSoftWarning()
+    {
+        // Suppress the soft warning about the license requirements for commercial use
+        License.Accepted = true;
+    }
+}

--- a/docs/_pages/introduction.md
+++ b/docs/_pages/introduction.md
@@ -250,3 +250,25 @@ using (var innerScope = new AssertionScope())
 
 // outerScope still contains outerFormatter
 ```
+
+## Licensing
+
+Version 7 will remain fully open-source indefinitely and receive bugfixes and other important corrections.
+
+Versions 8 and beyond are/will be free for open-source projects and non-commercial use, but commercial use requires a [paid license](https://xceed.com/products/unit-testing/fluent-assertions/). Check out the [license page](LICENSE.md) for more information. 
+
+Since Fluent Assertions 8 doesn't need any license key, there's a soft warning that is displayed for every test run. This is to remind consumers that you need a paid license for commercial use. To suppress this warning, there's a static property called `License.Accepted` that can be set to `true`. You can add the following code to your test project to automatically toggle this flag.
+
+```csharp
+[assembly: FluentAssertions.Extensibility.AssertionEngineInitializer(
+    typeof(AssertionEngineInitializer),
+    nameof(AssertionEngineInitializer.AcknowledgeSoftWarning))]
+
+public static class AssertionEngineInitializer
+{
+    public static void AcknowledgeSoftWarning()
+    {
+        License.Accepted = true;
+    }
+}
+```

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -7,6 +7,10 @@ sidebar:
   nav: "sidebar"
 ---
 
+## 8.1.0
+
+* Provide a toggle to suppress the soft warning that commercial use requires a paid license - [#2984](https://github.com/fluentassertions/fluentassertions/pull/2984)
+
 ## 8.0.0
 
 ### License Change


### PR DESCRIPTION
Resolves #2963 by providing a toggle to suppress the license warning that happens during each test run.