### PR TITLE
Make sure developers don't accidentally update to v8 without understanding the new license

### DIFF
--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -29,6 +29,7 @@ Check out the [license page](LICENSE) for more information.
     <RepositoryType>git</RepositoryType>
     <PackageTags>MSTest2;xUnit;NUnit;MSpec;TUnit;TDD;BDD;Fluent;netstandard;uwp</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIcon>FluentAssertions.png</PackageIcon>
     <PackageReleaseNotes>See https://fluentassertions.com/releases/</PackageReleaseNotes>
     <Copyright>Copyright 2024-$([System.DateTime]::Now.ToString(yyyy)) Xceed Software Inc., all rights reserved</Copyright>


### PR DESCRIPTION
Added the `PackageRequireLicenseAcceptance` to the package to request people to accept the license so they don't accidentally update to v8 without making sure they comply to the new license. 

**Note** Only works on Visual Studio. Rider doesn't support this. 
