### PR TITLE
Improves the subject identification for chained assertions and those that use Which

### DIFF
--- a/Src/FluentAssertions/AndWhichConstraint.cs
+++ b/Src/FluentAssertions/AndWhichConstraint.cs
@@ -47,10 +47,27 @@ public class AndWhichConstraint<TParent, TSubject> : AndConstraint<TParent>
     /// <remarks>
     /// If <paramref name="subjects"/> contains more than one object, a clear exception is thrown.
     /// </remarks>
+    // REFACTOR: In a next major version, we need to remove this overload and make the AssertionChain required
     public AndWhichConstraint(TParent parent, IEnumerable<TSubject> subjects)
         : base(parent)
     {
         getSubject = new Lazy<TSubject>(() => Single(subjects));
+    }
+
+    /// <summary>
+    /// Creates an object that allows continuing an assertion executed through <paramref name="parent"/> and
+    /// which resulted in a potential collection of objects through <paramref name="subjects"/> on an
+    /// existing <paramref name="assertionChain"/>.
+    /// </summary>
+    /// <remarks>
+    /// If <paramref name="subjects"/> contains more than one object, a clear exception is thrown.
+    /// </remarks>
+    public AndWhichConstraint(TParent parent, IEnumerable<TSubject> subjects, AssertionChain assertionChain)
+        : base(parent)
+    {
+        getSubject = new Lazy<TSubject>(() => Single(subjects));
+
+        this.assertionChain = assertionChain;
     }
 
     /// <summary>
@@ -107,6 +124,12 @@ public class AndWhichConstraint<TParent, TSubject> : AndConstraint<TParent>
             if (pathPostfix is not null and not "")
             {
                 assertionChain.WithCallerPostfix(pathPostfix).ReuseOnce();
+            }
+            else
+            {
+                // Make sure the caller identification restarts with the code following the Which property.
+                assertionChain?.AdvanceToNextIdentifier();
+                assertionChain?.ReuseOnce();
             }
 
             return getSubject.Value;

--- a/Src/FluentAssertions/CallerIdentification/ParsingState.cs
+++ b/Src/FluentAssertions/CallerIdentification/ParsingState.cs
@@ -2,7 +2,24 @@
 
 internal enum ParsingState
 {
+    /// <summary>
+    /// Is returned by a parser when the next one can take a look at the current symbol
+    /// </summary>
     InProgress,
+
+    /// <summary>
+    /// Is returned by a parser when it decides a symbol has been processed enough and no
+    /// other parsers need to look at the current symbol anymore.
+    /// </summary>
     GoToNextSymbol,
-    Done
+
+    /// <summary>
+    /// Is returned by a parser if it has found a candidate identifier.
+    /// </summary>
+    CandidateFound,
+
+    /// <summary>
+    /// Is returned by a parser to indicate that the parsing has been fully completed.
+    /// </summary>
+    Completed
 }

--- a/Src/FluentAssertions/CallerIdentification/SemicolonParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/SemicolonParsingStrategy.cs
@@ -9,7 +9,7 @@ internal class SemicolonParsingStrategy : IParsingStrategy
         if (symbol is ';')
         {
             statement.Clear();
-            return ParsingState.Done;
+            return ParsingState.Completed;
         }
 
         return ParsingState.InProgress;

--- a/Src/FluentAssertions/CallerIdentification/WhichParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/WhichParsingStrategy.cs
@@ -1,0 +1,54 @@
+using System.Text;
+
+namespace FluentAssertions.CallerIdentification;
+
+/// <summary>
+/// Tries to find the <c>.Which.</c> construct and assumes everything preceding it has become irrelevant
+/// for the chained assertion.
+/// </summary>
+internal class WhichParsingStrategy : IParsingStrategy
+{
+    private const string ExpectedPhrase = ".Which.";
+
+    public ParsingState Parse(char symbol, StringBuilder statement)
+    {
+        if (IsLongEnough(statement) && EndsWithExpectedPhrase(statement))
+        {
+            // Remove everything we collected up to know and assume everything following the
+            // .Which. property is a new assertion
+            statement.Clear();
+        }
+
+        return ParsingState.InProgress;
+    }
+
+    private static bool IsLongEnough(StringBuilder statement) => statement.Length >= ExpectedPhrase.Length;
+
+    private static bool EndsWithExpectedPhrase(StringBuilder statement)
+    {
+        // Start from the index of the last character
+        var rightIndexInStatement = statement.Length - 1;
+
+        var rightIndexInExpectedPhrase = ExpectedPhrase.Length - 1;
+
+        // Do a reverse comparison to see if the statement ends with ".Which."
+        for (var i = 0; i < ExpectedPhrase.Length; i++)
+        {
+            if (statement[rightIndexInStatement - i] != ExpectedPhrase[rightIndexInExpectedPhrase - i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public bool IsWaitingForContextEnd()
+    {
+        return false;
+    }
+
+    public void NotifyEndOfLineReached()
+    {
+    }
+}

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -725,7 +725,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             matches = collection.Where(item => EqualityComparer<T>.Default.Equals(item, expected));
         }
 
-        return new AndWhichConstraint<TAssertions, T>((TAssertions)this, matches);
+        return new AndWhichConstraint<TAssertions, T>((TAssertions)this, matches, assertionChain);
     }
 
     /// <summary>
@@ -775,9 +775,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             matches = Subject.Where(func);
         }
 
-        assertionChain.WithCallerPostfix($"[{firstMatchingIndex}]").ReuseOnce();
-
-        return new AndWhichConstraint<TAssertions, T>((TAssertions)this, matches);
+        return new AndWhichConstraint<TAssertions, T>((TAssertions)this, matches, assertionChain, $"[{firstMatchingIndex}]");
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -60,24 +60,25 @@ internal static class StringExtensions
         value.Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal);
 
     /// <summary>
-    /// Joins a string with one or more other strings using a specified separator.
+    /// Joins a string with another string using the specified separator.
     /// </summary>
     /// <remarks>
-    /// Any string that is empty (including the original string) is ignored.
+    /// Any string that is empty or null (including the original string) is ignored. Also, if the second
+    /// string starts with an index operator, the separator is omitted.
     /// </remarks>
     public static string Combine(this string @this, string other, string separator = ".")
     {
-        if (@this.Length == 0)
+        if (@this.IsNullOrEmpty())
         {
-            return other.Length != 0 ? other : string.Empty;
+            return !other.IsNullOrEmpty() ? other : string.Empty;
         }
 
-        if (other.StartsWith('['))
+        if (other is null || other.StartsWith('['))
         {
             separator = string.Empty;
         }
 
-        return @this + separator + other;
+        return @this + separator + (other ?? "");
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Execution/SubjectIdentificationBuilder.cs
+++ b/Src/FluentAssertions/Execution/SubjectIdentificationBuilder.cs
@@ -1,0 +1,102 @@
+using System;
+using FluentAssertions.Common;
+
+namespace FluentAssertions.Execution;
+
+/// <summary>
+/// Responsible for constructing the code phrase that identifies the subject-under-test and which is used
+/// in assertion failures managed by a single <see cref="AssertionChain"/>.
+/// </summary>
+/// <remarks>
+/// Takes into account the caller identifiers extracted from the invoking code, any scopes created through
+/// (nested) instances of <see cref="AssertionScope"/> and modifications made by the
+/// <see cref="AndWhichConstraint{TParent,TSubject}"/>.
+/// </remarks>
+internal class SubjectIdentificationBuilder
+{
+    private readonly Func<string> getScopeName;
+    private readonly Lazy<string[]> identifiersExtractedFromTheCode;
+    private int identifierIndex;
+    private Func<string> getSubject;
+
+    public SubjectIdentificationBuilder(Func<string[]> getCallerIdentifiers, Func<string> getScopeName)
+    {
+        this.getScopeName = getScopeName;
+
+        identifiersExtractedFromTheCode = new(() => getCallerIdentifiers());
+
+        getSubject = () => GetIdentifier(0);
+    }
+
+    /// <summary>
+    /// Tells the builder to assume the assertion has moved to the next identifier in a chained assertion.
+    /// </summary>
+    public void AdvanceToNextSubject()
+    {
+        identifierIndex++;
+        var localIndex = identifierIndex;
+
+        getSubject = () => GetIdentifier(localIndex);
+    }
+
+    /// <summary>
+    /// Indicates whether the subject identifier has been overridden with a custom value during the assertion process.
+    /// </summary>
+    /// <remarks>
+    /// When <see cref="OverrideSubjectIdentifier"/> or <see cref="UsePostfix(string)"/> is called,
+    /// this property is set to true, signaling that a manually defined identifier is now used instead of
+    /// automatically constructed identifiers.
+    /// </remarks>
+    public bool HasOverriddenIdentifier { get; private set; }
+
+    /// <summary>
+    /// Completely overrides the construction process with the specified lazy-evaluated identifier.
+    /// </summary>
+    public void OverrideSubjectIdentifier(Func<string> getSubject)
+    {
+        HasOverriddenIdentifier = true;
+        this.getSubject = getSubject;
+    }
+
+    /// <summary>
+    /// Appends the given postfix to the current subject and combines that with next subject.
+    /// </summary>
+    /// <remarks>
+    /// If the postfix is <c>[0]</c>, the current identifier is <c>collection</c>, and the next one
+    /// is <c>Parameters</c>, this method will assume the subject is <c>collection[0].Parameters</c>.
+    /// </remarks>
+    public void UsePostfix(string postfix)
+    {
+        var localIndex = identifierIndex;
+        getSubject = () => (GetIdentifier(localIndex) + postfix).Combine(GetIdentifier(localIndex + 1));
+
+        HasOverriddenIdentifier = true;
+    }
+
+    /// <summary>
+    /// Returns the constructed subject identifier.
+    /// </summary>
+    public string Build()
+    {
+        var scopeName = getScopeName();
+        var callerIdentifier = getSubject();
+
+        if (scopeName is null)
+        {
+            return callerIdentifier;
+        }
+        else if (callerIdentifier is null)
+        {
+            return scopeName;
+        }
+        else
+        {
+            return $"{scopeName}/{callerIdentifier}";
+        }
+    }
+
+    private string GetIdentifier(int index)
+    {
+        return identifiersExtractedFromTheCode.Value.Length > index ? identifiersExtractedFromTheCode.Value[index] : null;
+    }
+}

--- a/Src/FluentAssertions/Types/MemberInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MemberInfoAssertions.cs
@@ -104,7 +104,7 @@ public abstract class MemberInfoAssertions<TSubject, TAssertions> : ReferenceTyp
                     ", but that attribute was not found.");
         }
 
-        return new AndWhichConstraint<MemberInfoAssertions<TSubject, TAssertions>, TAttribute>(this, attributes);
+        return new AndWhichConstraint<MemberInfoAssertions<TSubject, TAssertions>, TAttribute>(this, attributes, assertionChain);
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -251,7 +251,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
             .FailWith("Expected type {0} to be decorated with {1}{reason}, but the attribute was not found.",
                 Subject, typeof(TAttribute));
 
-        return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes);
+        return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes, assertionChain);
     }
 
     /// <summary>
@@ -287,7 +287,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                 "Expected type {0} to be decorated with {1} that matches {2}{reason}, but no matching attribute was found.",
                 Subject, typeof(TAttribute), isMatchingAttributePredicate);
 
-        return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes);
+        return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes, assertionChain);
     }
 
     /// <summary>
@@ -312,7 +312,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
             .FailWith("Expected type {0} to be decorated with or inherit {1}{reason}, but the attribute was not found.",
                 Subject, typeof(TAttribute));
 
-        return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes);
+        return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes, assertionChain);
     }
 
     /// <summary>
@@ -348,7 +348,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                 "Expected type {0} to be decorated with or inherit {1} that matches {2}{reason}" +
                 ", but no matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate);
 
-        return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes);
+        return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes, assertionChain);
     }
 
     /// <summary>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -19,6 +19,7 @@ namespace FluentAssertions
     {
         public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects) { }
         public AndWhichConstraint(TParent parent, TSubject subject) { }
+        public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects, FluentAssertions.Execution.AssertionChain assertionChain) { }
         public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects, FluentAssertions.Execution.AssertionChain assertionChain, string pathPostfix) { }
         public AndWhichConstraint(TParent parent, TSubject subject, FluentAssertions.Execution.AssertionChain assertionChain, string pathPostfix = "") { }
         public TSubject Subject { get; }
@@ -191,6 +192,7 @@ namespace FluentAssertions
     public static class CallerIdentifier
     {
         public static System.Action<string> Logger { get; set; }
+        public static string[] DetermineCallerIdentities() { }
         public static string DetermineCallerIdentity() { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method)]

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -19,6 +19,7 @@ namespace FluentAssertions
     {
         public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects) { }
         public AndWhichConstraint(TParent parent, TSubject subject) { }
+        public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects, FluentAssertions.Execution.AssertionChain assertionChain) { }
         public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects, FluentAssertions.Execution.AssertionChain assertionChain, string pathPostfix) { }
         public AndWhichConstraint(TParent parent, TSubject subject, FluentAssertions.Execution.AssertionChain assertionChain, string pathPostfix = "") { }
         public TSubject Subject { get; }
@@ -204,6 +205,7 @@ namespace FluentAssertions
     public static class CallerIdentifier
     {
         public static System.Action<string> Logger { get; set; }
+        public static string[] DetermineCallerIdentities() { }
         public static string DetermineCallerIdentity() { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method)]

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -19,6 +19,7 @@ namespace FluentAssertions
     {
         public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects) { }
         public AndWhichConstraint(TParent parent, TSubject subject) { }
+        public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects, FluentAssertions.Execution.AssertionChain assertionChain) { }
         public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects, FluentAssertions.Execution.AssertionChain assertionChain, string pathPostfix) { }
         public AndWhichConstraint(TParent parent, TSubject subject, FluentAssertions.Execution.AssertionChain assertionChain, string pathPostfix = "") { }
         public TSubject Subject { get; }
@@ -189,6 +190,7 @@ namespace FluentAssertions
     public static class CallerIdentifier
     {
         public static System.Action<string> Logger { get; set; }
+        public static string[] DetermineCallerIdentities() { }
         public static string DetermineCallerIdentity() { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method)]

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -19,6 +19,7 @@ namespace FluentAssertions
     {
         public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects) { }
         public AndWhichConstraint(TParent parent, TSubject subject) { }
+        public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects, FluentAssertions.Execution.AssertionChain assertionChain) { }
         public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects, FluentAssertions.Execution.AssertionChain assertionChain, string pathPostfix) { }
         public AndWhichConstraint(TParent parent, TSubject subject, FluentAssertions.Execution.AssertionChain assertionChain, string pathPostfix = "") { }
         public TSubject Subject { get; }
@@ -191,6 +192,7 @@ namespace FluentAssertions
     public static class CallerIdentifier
     {
         public static System.Action<string> Logger { get; set; }
+        public static string[] DetermineCallerIdentities() { }
         public static string DetermineCallerIdentity() { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method)]

--- a/Tests/FluentAssertions.Specs/AndWhichConstraintSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AndWhichConstraintSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions.Collections;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -11,7 +12,7 @@ public class AndWhichConstraintSpecs
     public void When_many_objects_are_provided_accessing_which_should_throw_a_descriptive_exception()
     {
         // Arrange
-        var continuation = new AndWhichConstraint<StringCollectionAssertions, string>(null, ["hello", "world"]);
+        var continuation = new AndWhichConstraint<StringCollectionAssertions, string>(null, ["hello", "world"], AssertionChain.GetOrCreate());
 
         // Act
         Action act = () => _ = continuation.Which;

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
@@ -224,20 +224,6 @@ public class MethodInfoAssertionSpecs
         }
 
         [Fact]
-        public void When_a_method_is_decorated_with_an_attribute_it_should_allow_chaining_assertions_on_it()
-        {
-            // Arrange
-            MethodInfo methodInfo =
-                typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
-
-            // Act
-            Action act = () => methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>().Which.Filter.Should().BeFalse();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
         public void When_asserting_a_method_is_decorated_with_an_attribute_but_it_is_not_it_throws_with_a_useful_message()
         {
             // Arrange

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -9,6 +9,9 @@ sidebar:
 
 ## 8.1.0
 
+### Improvements
+* Improved subject identification when chaining multiple assertions using `Which` - [#3000](https://github.com/fluentassertions/fluentassertions/pull/3000)
+* All `Should()` methods on reference types are now annotated with the `[NotNull]` attribute for a better Fluent Assertions experience when nullable reference types are enabled - [#2987](https://github.com/fluentassertions/fluentassertions/pull/2987)
 * Provide a toggle to suppress the soft warning that commercial use requires a paid license - [#2984](https://github.com/fluentassertions/fluentassertions/pull/2984)
 
 ## 8.0.0


### PR DESCRIPTION
Given the following chained assertion

```csharp
collection.Should().ContainSingle().Which.Parameters.Should().ContainSingle().Which.Should().Be(3)
```

If the second `ContainSingle`, fails, this PR ensures that the subject is displayed as 

`collection[0].Parameters[0]`. 

This required several changes to make this possible:
* Establishes the term "subject identification" instead of "caller identifier"
* The existing `CallerIdentifier` has received a new method `DetermineCallerIdentities` that extracts all subjects from a chained assertion like the one above. 
* The `AssertionChain` delegates tracking which subject to use for its failures using a new `SubjectIdentificationBuilder` class. This one also takes into account any ambient `AssertionScope`s and modifications that `Which` does to the subject/
* The names `CallerIdentifier` and `CallerStatementBuilder` are really not correct, but I've decided to keep that out of this PR.

Fixes #2747 

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
