### PR TITLE
Renamed CallerStatementBuilder to StatementParser

### DIFF
--- a/Src/FluentAssertions/CallerIdentification/StatementParser.cs
+++ b/Src/FluentAssertions/CallerIdentification/StatementParser.cs
@@ -4,15 +4,14 @@ using System.Text;
 
 namespace FluentAssertions.CallerIdentification;
 
-// REFACTOR: This is not a builder, but a parser, so rename it accordingly.
-internal class CallerStatementBuilder
+internal class StatementParser
 {
     private readonly StringBuilder statement;
     private readonly List<IParsingStrategy> parsingStrategies;
     private readonly List<string> candidates = new();
     private ParsingState state = ParsingState.InProgress;
 
-    internal CallerStatementBuilder()
+    internal StatementParser()
     {
         statement = new StringBuilder();
 

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -246,7 +246,7 @@ public static class CallerIdentifier
             line = line.Substring(Math.Min(column - 1, line.Length - 1));
         }
 
-        var parser = new CallerStatementBuilder();
+        var parser = new StatementParser();
 
         do
         {


### PR DESCRIPTION
This pull request includes a renaming and refactoring of a class in the `Src/FluentAssertions/CallerIdentification` directory to better reflect its functionality. The most important changes include renaming `CallerStatementBuilder` to `StatementParser` and updating the corresponding references.

