### PR TITLE
Fix a formatting exception when {} is used as a dictionary key.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ _TeamCity*
 
 # NCrunch
 .*crunch*.local.xml
-_NCrunch_FluentAssertions/*
+.NCrunch_*/*
 
 # Installshield output folder
 [Ee]xpress/

--- a/Build/_build.v3.ncrunchproject
+++ b/Build/_build.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/FluentAssertions.v3.ncrunchsolution
+++ b/FluentAssertions.v3.ncrunchsolution
@@ -1,0 +1,8 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <EnableRDI>False</EnableRDI>
+    <RdiConfigured>True</RdiConfigured>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -65,12 +65,6 @@ internal static class StringExtensions
         value.Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal);
 
     /// <summary>
-    /// Replaces all characters that might conflict with formatting placeholders with their escaped counterparts.
-    /// </summary>
-    internal static string UnescapePlaceholders(this string value) =>
-        value.Replace("{{", "{", StringComparison.Ordinal).Replace("}}", "}", StringComparison.Ordinal);
-
-    /// <summary>
     /// Joins a string with one or more other strings using a specified separator.
     /// </summary>
     /// <remarks>

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -34,13 +34,13 @@ internal class MustMatchByNameRule : IMemberMatchingRule
         if (subjectMember is null)
         {
             Execute.Assertion.FailWith(
-                $"Expectation has {expectedMember.Description} that the other object does not have.");
+                "Expectation has {0} that the other object does not have.", expectedMember.Description.AsNonFormatable());
         }
         else if (options.IgnoreNonBrowsableOnSubject && !subjectMember.IsBrowsable)
         {
             Execute.Assertion.FailWith(
-                $"Expectation has {expectedMember.Description} that is non-browsable in the other object, and non-browsable " +
-                "members on the subject are ignored with the current configuration");
+                "Expectation has {0} that is non-browsable in the other object, and non-browsable " +
+                "members on the subject are ignored with the current configuration", expectedMember.Description.AsNonFormatable());
         }
         else
         {

--- a/Src/FluentAssertions/Equivalency/Steps/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumEqualityStep.cs
@@ -100,7 +100,7 @@ public class EnumEqualityStep : IEquivalencyStep
         string typePart = o.GetType().Name;
         string namePart = o.ToString().Replace(", ", "|", StringComparison.Ordinal);
         string valuePart = v.Value.ToString(CultureInfo.InvariantCulture);
-        return $"{typePart}.{namePart} {{{{value: {valuePart}}}}}";
+        return $"{typePart}.{namePart} {{value: {valuePart}}}";
     }
 
     private static decimal? ExtractDecimal(object o)

--- a/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -1,4 +1,5 @@
 using System;
+using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
@@ -44,7 +45,8 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         if (onlyOneNull)
         {
             AssertionScope.Current.FailWith(
-                $"Expected {currentNode.Description} to be {{0}}{{reason}}, but found {{1}}.", expected, subject);
+                "Expected {0} to be {1}{reason}, but found {2}.",
+                currentNode.Description.AsNonFormatable(), expected, subject);
 
             return false;
         }
@@ -61,7 +63,7 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
 
         return
             AssertionScope.Current
-                .FailWith($"Expected {currentNode} to be {{0}}, but found {{1}}.",
+                .FailWith("Expected {0} to be {1}, but found {2}.", currentNode.ToString().AsNonFormatable(),
                     comparands.RuntimeType, comparands.Subject.GetType());
     }
 }

--- a/Src/FluentAssertions/Execution/StringExtensions.cs
+++ b/Src/FluentAssertions/Execution/StringExtensions.cs
@@ -1,0 +1,14 @@
+namespace FluentAssertions.Execution;
+
+internal static class StringExtensions
+{
+    /// <summary>
+    /// Can be used
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static WithoutFormattingWrapper AsNonFormatable(this string value)
+    {
+        return new WithoutFormattingWrapper(value);
+    }
+}

--- a/Src/FluentAssertions/Execution/WithoutFormattingWrapper.cs
+++ b/Src/FluentAssertions/Execution/WithoutFormattingWrapper.cs
@@ -1,0 +1,11 @@
+using FluentAssertions.Formatting;
+
+namespace FluentAssertions.Execution;
+
+/// <summary>
+/// Wrapper to tell the <see cref="Formatter"/> not to apply any value formatters on this string.
+/// </summary>
+internal class WithoutFormattingWrapper(string value)
+{
+    public override string ToString() => value;
+}

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -20,6 +20,7 @@ public static class Formatter
 
     private static readonly List<IValueFormatter> DefaultFormatters = new()
     {
+        new PassthroughValueFormatter(),
         new XmlReaderValueFormatter(),
         new XmlNodeFormatter(),
         new AttributeBasedFormatter(),

--- a/Src/FluentAssertions/Formatting/PassthroughValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PassthroughValueFormatter.cs
@@ -1,0 +1,17 @@
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Formatting;
+
+/// <summary>
+/// Ensures that any value wrapped in a <see cref="WithoutFormattingWrapper"/>
+/// is passed through as-is.
+/// </summary>
+internal class PassthroughValueFormatter : IValueFormatter
+{
+    public bool CanHandle(object value) => value is WithoutFormattingWrapper;
+
+    public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
+    {
+        formattedGraph.AddFragment(((WithoutFormattingWrapper)value).ToString());
+    }
+}

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -286,10 +286,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
 
             foreach (string failure in results.SelectClosestMatchFor())
             {
-                string replacedCurlyBraces =
-                    failure.EscapePlaceholders();
-
-                AssertionScope.Current.FailWith(replacedCurlyBraces);
+                AssertionScope.Current.FailWith(failure);
             }
         }
     }

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScope.MessageFormatingSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScope.MessageFormatingSpecs.cs
@@ -200,7 +200,7 @@ public partial class AssertionScopeSpecs
         // Arrange
         var scope = new AssertionScope("context");
 
-        AssertionScope.Current.FailWith("{{empty}}");
+        AssertionScope.Current.FailWith("{empty}");
 
         // Act
         Action act = scope.Dispose;
@@ -510,5 +510,53 @@ public partial class AssertionScopeSpecs
         // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("Expected because reasons");
+    }
+
+    [Fact]
+    public void Can_handle_braces_in_dictionary_keys()
+    {
+        // Arrange
+        var subject = new Dictionary<string, string> { ["{}"] = "" };
+        var expectation = new Dictionary<string, string> { ["{}"] = null };
+
+        // Act
+        var act = () => expectation.Should().BeEquivalentTo(subject);
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected expectation[{}] to be \"\", but found <null>.*");
+    }
+
+    [Theory]
+    [InlineData("{0}{0}", "\"foo\"\"foo\"")]
+    [InlineData("{{0}}{0}", "{0}\"foo\"")]
+    [InlineData("{0}{{0}}", "\"foo\"{0}")]
+    [InlineData("{{{0}}}{0}", "{\"foo\"}\"foo\"")]
+    [InlineData("{0}{{{0}}}", "\"foo\"{\"foo\"}")]
+    public void Can_handle_escaped_braces(string format, string expected)
+    {
+        Execute.Assertion
+            .Invoking(e => e.FailWith(format, "foo"))
+            .Should().Throw<XunitException>().WithMessage(expected);
+    }
+
+    [Theory]
+    [InlineData("{")]
+    [InlineData("}")]
+    [InlineData("{}")]
+    [InlineData("{0}")]
+    [InlineData("{{0}}")]
+    public void Can_handle_more_braces_in_dictionary_keys(string key)
+    {
+        // Arrange
+        var subject = new Dictionary<string, string> { [key] = "" };
+        var expectation = new Dictionary<string, string> { [key] = null };
+
+        // Act
+        var act = () => expectation.Should().BeEquivalentTo(subject);
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage($"Expected expectation[{key}] to be \"\", but found <null>.*");
     }
 }

--- a/Tests/TestFrameworks/XUnit3Core.Specs/XUnit3Core.Specs.net472.v3.ncrunchproject
+++ b/Tests/TestFrameworks/XUnit3Core.Specs/XUnit3Core.Specs.net472.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/Tests/UWP.Specs/UWP.Specs.v3.ncrunchproject
+++ b/Tests/UWP.Specs/UWP.Specs.v3.ncrunchproject
@@ -1,0 +1,7 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoredTests>
+      <AllTestsSelector />
+    </IgnoredTests>
+  </Settings>
+</ProjectConfiguration>

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### Fixes
 
 * Fixed a regression in which `CompleteWithinAsync` treated a canceled task as an exception - [#2853](https://github.com/fluentassertions/fluentassertions/pull/2853)
+* Fix a formatting exception when {} is used as a dictionary key - [#3008](https://github.com/fluentassertions/fluentassertions/pull/3008)
 
 ### Improvements
 * Improve failure message for string assertions when checking for equality - [#2307](https://github.com/fluentassertions/fluentassertions/pull/2307)


### PR DESCRIPTION
This pull request includes several changes to improve the handling of placeholders and formatting in various parts of the codebase, making a lot of calls to `EscapePlaceholders` unnecessary. With this, strings like `{}` in dictionary keys will no longer cause crashes.

Resolves #2704