### PR TITLE
Fixed typo in introduction page

### DIFF
--- a/docs/_pages/introduction.md
+++ b/docs/_pages/introduction.md
@@ -170,7 +170,7 @@ The above will batch the two failures, and throw an exception at the point of di
 E.g. Exception thrown at point of dispose contains:
 
 ```text
-Expected value to be 100, but found 95 (difference of -5).
+Expected value to be 10, but found 5 (difference of -5).
 Expected string to be "Expected" with a length of 8, but "Actual" has a length of 6, differs near "Act" (index 0).
 ```
 
@@ -255,7 +255,7 @@ using (var innerScope = new AssertionScope())
 
 Version 7 will remain fully open-source indefinitely and receive bugfixes and other important corrections.
 
-Versions 8 and beyond are/will be free for open-source projects and non-commercial use, but commercial use requires a [paid license](https://xceed.com/products/unit-testing/fluent-assertions/). Check out the [license page](LICENSE) for more information. 
+Versions 8 and beyond are/will be free for open-source projects and non-commercial use, but commercial use requires a [paid license](https://xceed.com/products/unit-testing/fluent-assertions/). Check out the [license page](LICENSE) for more information.
 
 Since Fluent Assertions 8 doesn't need any license key, there's a soft warning that is displayed for every test run. This is to remind consumers that you need a paid license for commercial use. To suppress this warning, there's a static property called `License.Accepted` that can be set to `true`. You can add the following code to your test project to automatically toggle this flag.
 


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->

This fixes an error in the [introduction page](https://fluentassertions.com/introduction#assertion-scopes). Presently it shows the assertion 

```C#
    5.Should().Be(10);
```

and says the output would be 

```
Expected value to be 100, but found 95 (difference of -5).
```

The correct output would be 

```
Expected value to be 10, but found 5 (difference of -5).
```

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
