### PR TITLE
Fix a formatting exception when {} is used as a dictionary key.

### DIFF
--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -34,13 +34,13 @@ internal class MustMatchByNameRule : IMemberMatchingRule
         if (subjectMember is null)
         {
             assertionChain.FailWith(
-                $"Expectation has {expectedMember.Expectation} that the other object does not have.");
+                "Expectation has {0} that the other object does not have.", expectedMember.Expectation.AsNonFormattable());
         }
         else if (options.IgnoreNonBrowsableOnSubject && !subjectMember.IsBrowsable)
         {
             assertionChain.FailWith(
-                $"Expectation has {expectedMember.Expectation} that is non-browsable in the other object, and non-browsable " +
-                "members on the subject are ignored with the current configuration");
+                "Expectation has {0} that is non-browsable in the other object, and non-browsable " +
+                "members on the subject are ignored with the current configuration", expectedMember.Expectation.AsNonFormattable());
         }
         else
         {

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
@@ -72,12 +72,14 @@ public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
 
         assertionChain
                 .ForCondition(subjectIsNull || comparands.Subject.GetType().IsSameOrInherits(typeof(TSubject)))
-                .FailWith("Expected " + context.CurrentNode.Subject + " from subject to be a {0}{reason}, but found a {1}.",
+                .FailWith("Expected {0} from subject to be a {1}{reason}, but found a {2}.",
+                    context.CurrentNode.Subject.AsNonFormattable(),
                     typeof(TSubject), comparands.Subject?.GetType())
                 .Then
                 .ForCondition(expectationIsNull || comparands.Expectation.GetType().IsSameOrInherits(typeof(TSubject)))
                 .FailWith(
-                    "Expected " + context.CurrentNode.Subject + " from expectation to be a {0}{reason}, but found a {1}.",
+                    "Expected {0} from expectation to be a {1}{reason}, but found a {2}.",
+                    context.CurrentNode.Subject.AsNonFormattable(),
                     typeof(TSubject), comparands.Expectation?.GetType());
 
         if (assertionChain.Succeeded)

--- a/Src/FluentAssertions/Equivalency/Steps/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumEqualityStep.cs
@@ -29,7 +29,8 @@ public class EnumEqualityStep : IEquivalencyStep
                 string expectationName = GetDisplayNameForEnumComparison(comparands.Expectation, expectationsUnderlyingValue);
 
                 return new FailReason(
-                    $"Expected {{context:enum}} to be equivalent to {expectationName}{{reason}}, but found {{0}}.",
+                    "Expected {context:enum} to be equivalent to {0}{reason}, but found {1}.",
+                    expectationName.AsNonFormattable(),
                     comparands.Subject);
             });
 
@@ -67,7 +68,8 @@ public class EnumEqualityStep : IEquivalencyStep
                 string expectationName = GetDisplayNameForEnumComparison(comparands.Expectation, expectationsUnderlyingValue);
 
                 return new FailReason(
-                    $"Expected {{context:enum}} to equal {expectationName} by value{{reason}}, but found {subjectsName}.");
+                    "Expected {context:enum} to equal {0} by value{reason}, but found {1}.",
+                    expectationName.AsNonFormattable(), subjectsName.AsNonFormattable());
             });
     }
 
@@ -88,7 +90,8 @@ public class EnumEqualityStep : IEquivalencyStep
                 string expectationName = GetDisplayNameForEnumComparison(comparands.Expectation, expectationsUnderlyingValue);
 
                 return new FailReason(
-                    $"Expected {{context:enum}} to equal {expectationName} by name{{reason}}, but found {subjectsName}.");
+                    "Expected {context:enum} to equal {0} by name{reason}, but found {1}.",
+                    expectationName.AsNonFormattable(), subjectsName.AsNonFormattable());
             });
     }
 
@@ -102,7 +105,7 @@ public class EnumEqualityStep : IEquivalencyStep
         string typePart = o.GetType().Name;
         string namePart = o.ToString().Replace(", ", "|", StringComparison.Ordinal);
         string valuePart = v.Value.ToString(CultureInfo.InvariantCulture);
-        return $"{typePart}.{namePart} {{{{value: {valuePart}}}}}";
+        return $"{typePart}.{namePart} {{value: {valuePart}}}";
     }
 
     private static decimal? ExtractDecimal(object o)

--- a/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -79,7 +79,7 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         if (onlyOneNull)
         {
             assertionChain.FailWith(
-                $"Expected {currentNode.Subject.Description} to be {{0}}{{reason}}, but found {{1}}.", expected, subject);
+                "Expected {0} to be {1}{reason}, but found {2}.", currentNode.Subject.Description.AsNonFormattable(), expected, subject);
 
             return false;
         }
@@ -95,7 +95,7 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         }
 
         assertionChain.FailWith(
-            $"Expected {currentNode} to be {{0}}, but found {{1}}.",
+            "Expected {0} to be {1}, but found {2}.", currentNode.AsNonFormattable(),
             comparands.RuntimeType, comparands.Subject.GetType());
 
         return assertionChain.Succeeded;

--- a/Src/FluentAssertions/Execution/StringExtensions.cs
+++ b/Src/FluentAssertions/Execution/StringExtensions.cs
@@ -1,0 +1,24 @@
+namespace FluentAssertions.Execution;
+
+internal static class StringExtensions
+{
+    /// <summary>
+    /// Can be used
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static WithoutFormattingWrapper AsNonFormattable(this string value)
+    {
+        return new WithoutFormattingWrapper(value);
+    }
+
+    /// <summary>
+    /// Can be used
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static WithoutFormattingWrapper AsNonFormattable(this object value)
+    {
+        return new WithoutFormattingWrapper(value?.ToString());
+    }
+}

--- a/Src/FluentAssertions/Execution/WithoutFormattingWrapper.cs
+++ b/Src/FluentAssertions/Execution/WithoutFormattingWrapper.cs
@@ -1,0 +1,11 @@
+using FluentAssertions.Formatting;
+
+namespace FluentAssertions.Execution;
+
+/// <summary>
+/// Wrapper to tell the <see cref="Formatter"/> not to apply any value formatters on this string.
+/// </summary>
+internal class WithoutFormattingWrapper(string value)
+{
+    public override string ToString() => value;
+}

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -19,6 +19,7 @@ public static class Formatter
 
     private static readonly List<IValueFormatter> DefaultFormatters =
     [
+        new PassthroughValueFormatter(),
         new XmlReaderValueFormatter(),
         new XmlNodeFormatter(),
         new AttributeBasedFormatter(),

--- a/Src/FluentAssertions/Formatting/PassthroughValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PassthroughValueFormatter.cs
@@ -1,0 +1,17 @@
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Formatting;
+
+/// <summary>
+/// Ensures that any value wrapped in a <see cref="WithoutFormattingWrapper"/>
+/// is passed through as-is.
+/// </summary>
+internal class PassthroughValueFormatter : IValueFormatter
+{
+    public bool CanHandle(object value) => value is WithoutFormattingWrapper;
+
+    public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
+    {
+        formattedGraph.AddFragment(((WithoutFormattingWrapper)value).ToString());
+    }
+}

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -287,10 +287,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
 
         foreach (string failure in results.GetTheFailuresForTheSetWithTheFewestFailures())
         {
-            string replacedCurlyBraces =
-                failure.EscapePlaceholders();
-
-            assertionChain.FailWith(replacedCurlyBraces);
+            assertionChain.FailWith("{0}", failure.AsNonFormattable());
         }
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -7,6 +7,12 @@ sidebar:
   nav: "sidebar"
 ---
 
+## 8.1.1
+
+## Fixes
+
+* Fix a formatting exception when {} is used as a dictionary key - [#3008](https://github.com/fluentassertions/fluentassertions/pull/3008)
+
 ## 8.1.0
 
 ### Improvements


### PR DESCRIPTION
Especially in `BeEquivalentTo` calls we often pass the path from the root of the graph to the position in the graph that is being compared as a string into the `FailWith` calls. Since it's (apparently) possible that dictionary keys contain `{` and/or `}`, this caused a crash in the `MessageBuilder` while building the final failure message. We couldn't use normal `string.Format` placeholders like `{0}`, `{1}` and such because that caused the `Formatter` class to enclose strings with quotes. We solved that by introducing a special internal extension method `AsNonFormattable` that wraps the object to be formatted in such a way that the `Formatter` will not try to apply any formatting. 

This solves #2704


