### PR TITLE
Prevent NullReferenceException when tracing.

### DIFF
--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using FluentAssertions.Equivalency.Tracing;
 using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
@@ -284,6 +285,23 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected strings to contain (x == \"xxx\") because we're checking how it reacts to a null subject, but found <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_collection_is_equivalent_expected_trace_to_be_written()
+        {
+            // Arrange
+            var traceWriter = new StringBuilderTraceWriter();
+
+            // Act
+            new[] { "a string" }.Should().BeEquivalentTo(["a string"], opts => opts.WithTracing(traceWriter));
+
+            // Assert
+            string trace = traceWriter.ToString();
+            trace.Should()
+                .Contain("Comparing subject at [0] with the expectation at [0]")
+                .And.Contain("Equivalency was proven by ReferenceEqualityEquivalencyStep")
+                .And.Contain("It's a match");
         }
     }
 


### PR DESCRIPTION
I'm raising this to initially demonstrate the issue #3031 with a test. This may end up fixing #3031.


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
