### PR TITLE
Jn/regex fixups

### DIFF
--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -120,7 +120,7 @@ internal static class StringExtensions
 
     public static string RemoveTrailingWhitespaceFromLines(this string input)
     {
-        // This regex matches whitespace characters (\s) that are followed by a line ending (\r?\n)
+        // This regex matches space (' ') and tab ('\t') characters followed by a line ending ('\r\n' or '\n')
         return Regex.Replace(input, @"[ \t]+(?=\r?\n)", string.Empty);
     }
 

--- a/Src/FluentAssertions/Execution/FailureMessageFormatter.cs
+++ b/Src/FluentAssertions/Execution/FailureMessageFormatter.cs
@@ -94,7 +94,7 @@ internal class FailureMessageFormatter(FormattingOptions formattingOptions)
 
     private static string SubstituteIdentifier(string message, string identifier, string fallbackIdentifier)
     {
-        const string pattern = @"(?:\s|^)\{context(?:\:(?<default>[a-z|A-Z|\s]+))?\}";
+        const string pattern = @"(?:\s|^)\{context(?:\:(?<default>[a-zA-Z\s]+))?\}";
 
         message = Regex.Replace(message, pattern, match =>
         {
@@ -125,7 +125,7 @@ internal class FailureMessageFormatter(FormattingOptions formattingOptions)
 
     private static string SubstituteContextualTags(string message, ContextDataDictionary contextData)
     {
-        const string pattern = @"(?<!\{)\{(?<key>[a-z|A-Z]+)(?:\:(?<default>[a-z|A-Z|\s]+))?\}(?!\})";
+        const string pattern = @"(?<!\{)\{(?<key>[a-zA-Z]+)(?:\:(?<default>[a-zA-Z\s]+))?\}(?!\})";
 
         return Regex.Replace(message, pattern, match =>
         {


### PR DESCRIPTION
1) Adjust incorrect explaining comment about regex.

2) Remove `|` from regex character classes

`|` means the literal `|` and not alternation, i.e. `[a|b]` means "`a`, `|` or `b`".
On the other hand in groups `(a|b)` means "either `a` or `b`"


## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
