### PR TITLE
Handle missing caller identifier

### DIFF
--- a/Src/FluentAssertions/Execution/SubjectIdentificationBuilder.cs
+++ b/Src/FluentAssertions/Execution/SubjectIdentificationBuilder.cs
@@ -83,7 +83,7 @@ internal class SubjectIdentificationBuilder
 
         if (scopeName is null)
         {
-            return callerIdentifier;
+            return callerIdentifier ?? "";
         }
         else if (callerIdentifier is null)
         {

--- a/Tests/FluentAssertions.Specs/Execution/AssertionChainSpecs.Chaining.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionChainSpecs.Chaining.cs
@@ -578,6 +578,20 @@ public partial class AssertionChainSpecs
             Assert.Contains("First \"assertion\"", failures);
         }
 
+        [Fact]
+        public void Returns_an_empty_identification_when_neither_scope_name_nor_caller_identifier_are_available()
+        {
+            // Arrange
+            var assertionChain = AssertionChain.GetOrCreate();
+            assertionChain.OverrideCallerIdentifier(() => null);
+
+            // Act
+            string identification = assertionChain.CallerIdentifier;
+
+            // Assert
+            identification.Should().BeEmpty();
+        }
+
         // [Fact]
         // public void Get_info_about_line_breaks_from_parent_scope_after_continuing_chained_assertion()
         // {

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -7,6 +7,12 @@ sidebar:
   nav: "sidebar"
 ---
 
+## 8.1.2
+
+## Fixes
+
+* Fixed a regression from 8.1.0 where a `NullReferenceException` was thrown during subject identification - [#3036](https://github.com/fluentassertions/fluentassertions/pull/3036
+
 ## 8.1.1
 
 ## Fixes


### PR DESCRIPTION
Fixes #3031
Regression from #3000 where previously `getCallerIdentifier() + callerPostfix` would return an empty string.
See https://github.com/fluentassertions/fluentassertions/pull/3000/files#diff-f1890f45abb0a4df9c59f857aff667980d90f2c1ece7ea0f12e5dd85590ae8ccL105

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
