### PR TITLE
Improve rendering of exception messages when using WithMessage 

### DIFF
--- a/Src/FluentAssertions/Formatting/Line.cs
+++ b/Src/FluentAssertions/Formatting/Line.cs
@@ -107,5 +107,9 @@ internal class Line
         return state.Truncate(characterIndex, indentation, whitespaceOffset);
     }
 
-    public override string ToString() => state.Render().TrimEnd();
+    public override string ToString()
+    {
+        // Only trim spaces, but keep line breaks.
+        return state.Render().TrimEnd(' ');
+    }
 }

--- a/Src/FluentAssertions/Primitives/IStringComparisonStrategy.cs
+++ b/Src/FluentAssertions/Primitives/IStringComparisonStrategy.cs
@@ -8,12 +8,12 @@ namespace FluentAssertions.Primitives;
 internal interface IStringComparisonStrategy
 {
     /// <summary>
-    /// The prefix for the message when the assertion fails.
+    /// Asserts that neither the <paramref name="subject"/> nor the <paramref name="expected"/> strings are null.
     /// </summary>
-    string ExpectationDescription { get; }
+    void AssertNeitherIsNull(AssertionChain assertionChain, string subject, string expected);
 
     /// <summary>
     /// Asserts that the <paramref name="subject"/> matches the <paramref name="expected"/> value.
     /// </summary>
-    void ValidateAgainstMismatch(AssertionChain assertionChain, string subject, string expected);
+    void AssertForEquality(AssertionChain assertionChain, string subject, string expected);
 }

--- a/Src/FluentAssertions/Primitives/StringContainsStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringContainsStrategy.cs
@@ -15,16 +15,22 @@ internal class StringContainsStrategy : IStringComparisonStrategy
         this.occurrenceConstraint = occurrenceConstraint;
     }
 
-    public string ExpectationDescription => "Expected {context:string} {0} to contain the equivalent of ";
-
-    public void ValidateAgainstMismatch(AssertionChain assertionChain, string subject, string expected)
+    public void AssertForEquality(AssertionChain assertionChain, string subject, string expected)
     {
         int actual = subject.CountSubstring(expected, comparer);
 
         assertionChain
             .ForConstraint(occurrenceConstraint, actual)
             .FailWith(
-                $"{ExpectationDescription}{{1}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
+                $"Expected {{context:string}} {{0}} to contain the equivalent of {{1}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
                 subject, expected);
+    }
+
+    public void AssertNeitherIsNull(AssertionChain assertionChain, string subject, string expected)
+    {
+        if (subject is null || expected is null)
+        {
+            assertionChain.FailWith("Expected {context:string} to contain the equivalent of {0}{reason}, but found {1}", subject, expected);
+        }
     }
 }

--- a/Src/FluentAssertions/Primitives/StringEndStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEndStrategy.cs
@@ -15,13 +15,11 @@ internal class StringEndStrategy : IStringComparisonStrategy
         this.predicateDescription = predicateDescription;
     }
 
-    public string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} ";
-
-    public void ValidateAgainstMismatch(AssertionChain assertionChain, string subject, string expected)
+    public void AssertForEquality(AssertionChain assertionChain, string subject, string expected)
     {
         assertionChain
             .ForCondition(subject!.Length >= expected.Length)
-            .FailWith($"{ExpectationDescription}{{0}}{{reason}}, but {{1}} is too short.", expected, subject);
+            .FailWith($"{ExpectationDescription}, but {{1}} is too short.", expected, subject);
 
         if (!assertionChain.Succeeded)
         {
@@ -36,7 +34,18 @@ internal class StringEndStrategy : IStringComparisonStrategy
         }
 
         assertionChain.FailWith(
-            $"{ExpectationDescription}{{0}}{{reason}}, but {{1}} differs near {subject.IndexedSegmentAt(indexOfMismatch)}.",
+            $"{ExpectationDescription}, but {{1}} differs near {subject.IndexedSegmentAt(indexOfMismatch)}.",
             expected, subject);
     }
+
+    /// <inheritdoc />
+    public void AssertNeitherIsNull(AssertionChain assertionChain, string subject, string expected)
+    {
+        if (subject is null || expected is null)
+        {
+            assertionChain.FailWith($"{ExpectationDescription}, but found {{1}}.", expected, subject);
+        }
+    }
+
+    private string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} {{0}}{{reason}}";
 }

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -18,7 +18,7 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
         this.predicateDescription = predicateDescription;
     }
 
-    public void ValidateAgainstMismatch(AssertionChain assertionChain, string subject, string expected)
+    public void AssertForEquality(AssertionChain assertionChain, string subject, string expected)
     {
         ValidateAgainstSuperfluousWhitespace(assertionChain, subject, expected);
 
@@ -60,7 +60,15 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
         }
     }
 
-    public string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} ";
+    public void AssertNeitherIsNull(AssertionChain assertionChain, string subject, string expected)
+    {
+        if (subject is null || expected is null)
+        {
+            assertionChain.FailWith($"{ExpectationDescription}{{0}}{{reason}}, but found {{1}}.", expected, subject);
+        }
+    }
+
+    private string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} ";
 
     private void ValidateAgainstSuperfluousWhitespace(AssertionChain assertion, string subject, string expected)
     {

--- a/Src/FluentAssertions/Primitives/StringStartStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringStartStrategy.cs
@@ -15,9 +15,7 @@ internal class StringStartStrategy : IStringComparisonStrategy
         this.predicateDescription = predicateDescription;
     }
 
-    public string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} ";
-
-    public void ValidateAgainstMismatch(AssertionChain assertionChain, string subject, string expected)
+    public void AssertForEquality(AssertionChain assertionChain, string subject, string expected)
     {
         assertionChain
             .ForCondition(subject.Length >= expected.Length)
@@ -39,4 +37,15 @@ internal class StringStartStrategy : IStringComparisonStrategy
             $"{ExpectationDescription}{{0}}{{reason}}, but {{1}} differs near {subject.IndexedSegmentAt(indexOfMismatch)}.",
             expected, subject);
     }
+
+    /// <inheritdoc />
+    public void AssertNeitherIsNull(AssertionChain assertionChain, string subject, string expected)
+    {
+        if (subject is null || expected is null)
+        {
+            assertionChain.FailWith($"{ExpectationDescription}{{0}}{{reason}}, but found {{1}}.", expected, subject);
+        }
+    }
+
+    private string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} ";
 }

--- a/Src/FluentAssertions/Primitives/StringValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringValidator.cs
@@ -22,27 +22,16 @@ internal class StringValidator
             return;
         }
 
-        if (!ValidateAgainstNulls(subject, expected))
+        comparisonStrategy.AssertNeitherIsNull(assertionChain, subject, expected);
+
+        if (assertionChain.Succeeded)
         {
-            return;
+            if (expected.IsLongOrMultiline() || subject.IsLongOrMultiline())
+            {
+                assertionChain = assertionChain.UsingLineBreaks;
+            }
+
+            comparisonStrategy.AssertForEquality(assertionChain, subject, expected);
         }
-
-        if (expected.IsLongOrMultiline() || subject.IsLongOrMultiline())
-        {
-            assertionChain = assertionChain.UsingLineBreaks;
-        }
-
-        comparisonStrategy.ValidateAgainstMismatch(assertionChain, subject, expected);
-    }
-
-    private bool ValidateAgainstNulls(string subject, string expected)
-    {
-        if (expected is null == subject is null)
-        {
-            return true;
-        }
-
-        assertionChain.FailWith($"{comparisonStrategy.ExpectationDescription}{{0}}{{reason}}, but found {{1}}.", expected, subject);
-        return false;
     }
 }

--- a/Src/FluentAssertions/Primitives/StringValidatorSupportingNull.cs
+++ b/Src/FluentAssertions/Primitives/StringValidatorSupportingNull.cs
@@ -24,6 +24,6 @@ internal class StringValidatorSupportingNull
             assertionChain = assertionChain.UsingLineBreaks;
         }
 
-        comparisonStrategy.ValidateAgainstMismatch(assertionChain, subject, expected);
+        comparisonStrategy.AssertForEquality(assertionChain, subject, expected);
     }
 }

--- a/Tests/FluentAssertions.Specs/Exceptions/OuterExceptionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/OuterExceptionSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using Bogus;
 using Xunit;
 using Xunit.Sdk;
 
@@ -38,6 +39,104 @@ public class OuterExceptionSpecs
             // Assert
             ex.Message.Should().Match(
                 "Expected exception message to match the equivalent of*\"some message\", but*\"some\" does not*");
+        }
+    }
+
+    [Fact]
+    public void Long_exception_messages_are_rendered_over_multiple_lines()
+    {
+        // Arrange
+        Does testSubject = Does.Throw(new InvalidOperationException("some"));
+
+        try
+        {
+            // Act
+            testSubject
+                .Invoking(x => x.Do())
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(new Faker().Random.String2(101));
+
+            throw new XunitException("This point should not be reached");
+        }
+        catch (XunitException ex)
+        {
+            // Assert
+            ex.Message.Should().Match(
+                """
+                Expected exception message to match the equivalent of
+
+                    "*",
+
+                but
+
+                    "some"
+
+                does not.
+
+                """);
+        }
+    }
+
+    [Fact]
+    public void Multiline_exception_messages_are_rendered_over_multiple_lines()
+    {
+        // Arrange
+        Does testSubject = Does.Throw(new InvalidOperationException("some"));
+
+        try
+        {
+            // Act
+            testSubject
+                .Invoking(x => x.Do())
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage("""
+                             line1*
+                             line2
+                             """);
+
+            throw new XunitException("This point should not be reached");
+        }
+        catch (XunitException ex)
+        {
+            // Assert
+            ex.Message.Should().Match(
+                """
+                Expected exception message to match the equivalent of
+
+                    "line1*
+                    line2",
+
+                but
+
+                    "some"
+
+                does not.
+
+                """);
+        }
+    }
+
+    [Fact]
+    public void Short_exception_messages_are_rendered_on_a_single_line()
+    {
+        // Arrange
+        Does testSubject = Does.Throw(new InvalidOperationException("some"));
+
+        try
+        {
+            // Act
+            testSubject
+                .Invoking(x => x.Do())
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(new Faker().Random.String2(50));
+
+            throw new XunitException("This point should not be reached");
+        }
+        catch (XunitException ex)
+        {
+            // Assert
+            ex.Message.Should().Match(
+                """Expected exception message to match the equivalent of "*", but "some" does not.""");
         }
     }
 
@@ -177,7 +276,7 @@ public class OuterExceptionSpecs
         {
             // Assert
             ex.Message.Should().Match(
-                "Expected exception message to match the equivalent of*\"message2\", but*message2*someParam*");
+                "Expected exception message to match the equivalent of*\"message2\",*but*message2*someParam*");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net47;net6.0;net8.0</TargetFrameworks>
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bogus" Version="35.6.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">


### PR DESCRIPTION
In a test like `When_one_of_the_types_does_not_match_the_generic_type_it_should_throw_with_a_clear_explanation`, a multi-line exception message like this

```
Expected exception message to match the equivalent of "Expected type to be "System.Int33" because they are of different type, but found "[System.Int32, System.String, System.Int32]".", but "Expected type to be "System.Int32" because they are of different type, but found "[System.Int32, System.String, System.Int32]"." does not.
```

after this PR, they will be rendered as 

```
Expected exception message to match the equivalent of

    "Expected type to be "System.Int33" because they are of different type, but found "[System.Int32, System.String, System.Int32]".",

but

    "Expected type to be "System.Int32" because they are of different type, but found "[System.Int32, System.String, System.Int32]"."

does not.
```

