### PR TITLE
Fix links to test suites in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -13,7 +13,7 @@ body:
           * Checked existing open *and* closed [issues](https://github.com/fluentassertions/fluentassertions/issues?utf8=%E2%9C%93&q=is%3Aissue), to see if the issue has already been reported?
           * Tried reproducing your problem in a new isolated project?
           * Read the [documentation](https://fluentassertions.com/introduction)?
-          * Searched the two [test](https://github.com/fluentassertions/fluentassertions/tree/develop/Tests/FluentAssertions.Specs) [suites](https://github.com/fluentassertions/fluentassertions/tree/develop/Tests/FluentAssertions.Equivalency.Specs) if there is a test documenting the expected behavior?
+          * Searched the two [test](https://github.com/fluentassertions/fluentassertions/tree/main/Tests/FluentAssertions.Specs) [suites](https://github.com/fluentassertions/fluentassertions/tree/main/Tests/FluentAssertions.Equivalency.Specs) if there is a test documenting the expected behavior?
           * Considered if this is a general question and not a bug? For general questions please use [Stack Overflow](https://stackoverflow.com/questions/tagged/fluent-assertions?mixed=1).
   - type: textarea
     id: background


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
