### PR TITLE
Clarify the date/time type when comparing dates, times and combinations of those

### DIFF
--- a/Src/FluentAssertions/Equivalency/Comparands.cs
+++ b/Src/FluentAssertions/Equivalency/Comparands.cs
@@ -29,6 +29,9 @@ public class Comparands
     /// </summary>
     public object Expectation { get; set; }
 
+    /// <summary>
+    /// Gets the compile-time type of the expectation object.
+    /// </summary>
     public Type CompileTimeType
     {
         get

--- a/Src/FluentAssertions/Equivalency/EquivalencyPlan.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyPlan.cs
@@ -152,6 +152,7 @@ public class EquivalencyPlan : IEnumerable<IEquivalencyStep>
             new GenericEnumerableEquivalencyStep(),
             new EnumerableEquivalencyStep(),
             new StringEqualityEquivalencyStep(),
+            new DateAndTimeEquivalencyStep(),
             new EnumEqualityStep(),
             new ValueTypeEquivalencyStep(),
             new StructuralEqualityEquivalencyStep(),

--- a/Src/FluentAssertions/Equivalency/Steps/DateAndTimeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DateAndTimeEquivalencyStep.cs
@@ -1,0 +1,53 @@
+using System;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency.Steps;
+
+// AV1000: Type 'DateAndTimeEquivalencyStep' contains the word 'and', which suggests it has multiple purpose
+#pragma warning disable AV1000
+
+/// <summary>
+/// Specific equivalency step for handling date and time types where the types are different and the failure message
+/// should make that clear.
+/// </summary>
+public class DateAndTimeEquivalencyStep : IEquivalencyStep
+{
+    public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+        IValidateChildNodeEquivalency valueChildNodes)
+    {
+        object subject = comparands.Subject;
+        object expectation = comparands.Expectation;
+
+        Type expectedType = comparands.GetExpectedType(context.Options);
+        Type subjectType = subject?.GetType();
+
+        if (IsOfDateOrTimeType(expectedType) && IsOfDateOrTimeType(subjectType) && subjectType != expectedType)
+        {
+            AssertionChain.GetOrCreate()
+                .For(context)
+                .ForCondition(subject!.Equals(expectation))
+                .FailWith("Expected {context} to be {0} (of type {1}){reason}, but found {2} (of type {3}).", expectation,
+                    expectedType, subject, subjectType);
+
+            return EquivalencyResult.EquivalencyProven;
+        }
+
+        return EquivalencyResult.ContinueWithNext;
+    }
+
+#if NET6_0_OR_GREATER
+    private static bool IsOfDateOrTimeType(Type type) =>
+        type == typeof(DateTime) ||
+        type == typeof(DateTimeOffset) ||
+        type == typeof(TimeSpan) ||
+        type == typeof(TimeOnly) ||
+        type == typeof(DateOnly);
+#else
+    private static bool IsOfDateOrTimeType(Type type) =>
+        type == typeof(DateTime) ||
+        type == typeof(DateTimeOffset) ||
+        type == typeof(TimeSpan);
+#endif
+}
+
+#pragma warning restore AV1000

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -982,6 +982,11 @@ namespace FluentAssertions.Equivalency.Steps
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
         public override string ToString() { }
     }
+    public class DateAndTimeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DateAndTimeEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
+    }
     public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Collections.IDictionary>
     {
         public DictionaryEquivalencyStep() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -995,6 +995,11 @@ namespace FluentAssertions.Equivalency.Steps
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
         public override string ToString() { }
     }
+    public class DateAndTimeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DateAndTimeEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
+    }
     public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Collections.IDictionary>
     {
         public DictionaryEquivalencyStep() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -974,6 +974,11 @@ namespace FluentAssertions.Equivalency.Steps
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
         public override string ToString() { }
     }
+    public class DateAndTimeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DateAndTimeEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
+    }
     public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Collections.IDictionary>
     {
         public DictionaryEquivalencyStep() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -982,6 +982,11 @@ namespace FluentAssertions.Equivalency.Steps
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
         public override string ToString() { }
     }
+    public class DateAndTimeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DateAndTimeEquivalencyStep() { }
+        public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
+    }
     public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Collections.IDictionary>
     {
         public DictionaryEquivalencyStep() { }

--- a/Tests/FluentAssertions.Equivalency.Specs/DateTimePropertiesSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DateTimePropertiesSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
@@ -149,5 +150,160 @@ public class DateTimePropertiesSpecs
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
             "Expected*Time*to be <2013-12-09 15:58:00>, but found <null>.*");
+    }
+
+#if NET6_0_OR_GREATER
+    [Fact]
+    public void Clarifies_that_a_date_time_is_compared_with_a_date_only()
+    {
+        // Arrange
+        var subject = new
+        {
+            SomeDate = new DateOnly(2020, 1, 2)
+        };
+
+        // Act
+        var act = () => subject.Should().BeEquivalentTo(new
+        {
+            SomeDate = 2.January(2020)
+        });
+
+        // Assert
+        act.Should().Throw<XunitException>().WithMessage("*SomeDate*DateTime*found*DateOnly*");
+    }
+
+    [Fact]
+    public void Clarifies_that_a_date_only_is_compared_with_a_date_time()
+    {
+        // Arrange
+        var subject = new
+        {
+            SomeDate = 2.January(2020)
+        };
+
+        // Act
+        var act = () => subject.Should().BeEquivalentTo(new
+        {
+            SomeDate = new DateOnly(2020, 1, 2)
+        });
+
+        // Assert
+        act.Should().Throw<XunitException>().WithMessage("*SomeDate*DateOnly*found*DateTime*");
+    }
+
+    [Fact]
+    public void Clarifies_that_a_time_only_is_compared_with_a_date_time()
+    {
+        // Arrange
+        var subject = new
+        {
+            SomeDate = new DateTime(2020, 1, 2).At(9, 30)
+        };
+
+        // Act
+        var act = () => subject.Should().BeEquivalentTo(new
+        {
+            SomeDate = new TimeOnly(9, 30)
+        });
+
+        // Assert
+        act.Should().Throw<XunitException>().WithMessage("*SomeDate*TimeOnly*found*DateTime*");
+    }
+
+    [Fact]
+    public void Clarifies_that_a_date_time_is_compared_with_a_time_only()
+    {
+        // Arrange
+        var subject = new
+        {
+            SomeDate = new TimeOnly(9, 30)
+        };
+
+        // Act
+        var act = () => subject.Should().BeEquivalentTo(new
+        {
+            SomeDate = new DateTime(2020, 1, 2).At(9, 30)
+        });
+
+        // Assert
+        act.Should().Throw<XunitException>().WithMessage("*SomeDate*DateTime*found*TimeOnly*");
+    }
+
+    [Fact]
+    public void Clarifies_that_a_time_only_is_compared_with_a_time_span()
+    {
+        // Arrange
+        var subject = new
+        {
+            SomeTime = new TimeOnly(9, 30)
+        };
+
+        // Act
+        var act = () => subject.Should().BeEquivalentTo(new
+        {
+            SomeTime = new TimeSpan(9, 30, 0)
+        });
+
+        // Assert
+        act.Should().Throw<XunitException>().WithMessage("*SomeTime*TimeSpan*found*TimeOnly*");
+    }
+
+    [Fact]
+    public void Clarifies_that_a_time_span_is_compared_with_a_time_only()
+    {
+        // Arrange
+        var subject = new
+        {
+            SomeTime = new TimeSpan(9, 30, 0)
+        };
+
+        // Act
+        var act = () => subject.Should().BeEquivalentTo(new
+        {
+            SomeTime = new TimeOnly(9, 30)
+        });
+
+        // Assert
+        act.Should().Throw<XunitException>().WithMessage("*SomeTime*TimeOnly*found*TimeSpan*");
+    }
+
+#endif
+
+    [Fact]
+    public void Clarifies_that_a_date_time_is_compared_to_a_date_time_offset()
+    {
+        // Arrange
+        var subject = new
+        {
+            SomeDate = 2.January(2020)
+        };
+
+        // Act
+        var act = () => subject.Should().BeEquivalentTo(new
+        {
+            SomeDate = new DateTimeOffset(2.January(2020), TimeSpan.Zero)
+        });
+
+        // Assert
+        act.Should().Throw<XunitException>().WithMessage("*SomeDate*DateTimeOffset*found*DateTime*");
+    }
+
+    [Fact]
+    public void Clarifies_that_a_date_time_offset_is_compared_to_a_date_time()
+    {
+        // Arrange
+        var subject = new
+        {
+            SomeDate = new DateTimeOffset(2.January(2020), TimeSpan.Zero)
+        };
+
+        // Act
+        var act = () => subject.Should().BeEquivalentTo(new
+        {
+            SomeDate = 2.January(2020)
+        });
+
+        // Assert
+        act.Should().Throw<XunitException>().WithMessage("*SomeDate*DateTime*found*DateTimeOffset*");
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -7,6 +7,13 @@ sidebar:
   nav: "sidebar"
 ---
 
+## 8.3.0
+
+## Enhancements
+
+* Clarify the date/time type when comparing non-compatible dates and times in `BeEquivalentTo` - [3049](https://github.com/fluentassertions/fluentassertions/pull/3049)
+* Improve the rendering of exception messages when using `WithMessage` for better readability - [3039](https://github.com/fluentassertions/fluentassertions/pull/3039)
+
 ## 8.2.0
 
 ## Fixes


### PR DESCRIPTION
Introduces a new `DateAndTimeEquivalencyStep` for `BeEquivalentTo` that will include the type of the comparands in the failure message if the subject and expectation aren't of the same date/time type like this:

`Expected property subject.SomeDate to be <2020-01-02> (of type System.DateTime), but found <2020-01-02> (of type System.DateOnly`

#3048 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
