### PR TITLE
Fix qodana warnings

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -3050,8 +3050,6 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
                         chain => chain
                             .FailWithPreFormatted(failureMessage));
             }
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Formatting/LineCollection.cs
+++ b/Src/FluentAssertions/Formatting/LineCollection.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions.Execution;

--- a/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
@@ -48,6 +48,6 @@ public class XElementValueFormatter : IValueFormatter
     private static string[] SplitIntoSeparateLines(XElement element)
     {
         string formattedXml = element.ToString();
-        return formattedXml.Split(Environment.NewLine, StringSplitOptions.None);
+        return formattedXml.Split(Environment.NewLine);
     }
 }

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingStrategy.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using FluentAssertions.Common;

--- a/Src/FluentAssertions/Streams/BufferedStreamAssertions.cs
+++ b/Src/FluentAssertions/Streams/BufferedStreamAssertions.cs
@@ -1,7 +1,9 @@
 ﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using FluentAssertions.Execution;
+#if NET6_0_OR_GREATER || NETSTANDARD2_1
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace FluentAssertions.Streams;
 

--- a/Tests/FluentAssertions.Specs/Xml/XmlNodeFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlNodeFormatterSpecs.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Xml;
+﻿using System.Xml;
 using FluentAssertions.Formatting;
 using Xunit;
 


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Since https://github.com/fluentassertions/fluentassertions/actions/runs/14577365118/job/40886331551 we have had a red Qodana pipeline.

The timestamps matches that Github [announced](https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts) a shutdown of an old(er) cache service.
![image](https://github.com/user-attachments/assets/08475d7a-d85d-4ffe-89e1-7c39cd7182e1)
![image](https://github.com/user-attachments/assets/b8a06ab1-2269-4bf3-8a90-5c311b90dba3)

That improved with #3044.
Now it's just 7 warnings, which this PR takes care of.

The removal of `StringSplitOptions.None` is a leftover from 0a649cb006744405050f0a72ad48442831b3c8cd where I introduced and started using `string.Split(string separator, StringSplitOptions options = StringSplitOptions.None)`.

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
