### PR TITLE
Added Should().Throw(), ThrowAsync() and ThrowWithinAsync() flavors that don’t require a specific exception type

### DIFF
--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -113,6 +113,25 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     }
 
     /// <summary>
+    /// Asserts that the current <see cref="Func{Task}"/> throws any exception.
+    /// </summary>
+    /// <param name="because">
+    /// (Optional) A formatted phrase as is supported by <see cref="string.Format(string,object[])"/>  explaining why the assertion is
+    /// needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because"/> .
+    /// </param>
+    /// <returns>
+    /// A Task&lt;ExceptionAssertions&lt;Exception&gt;&gt; object.
+    /// </returns>
+    public async Task<ExceptionAssertions<Exception>> ThrowAsync(
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        return await ThrowAsync<Exception>(because, becauseArgs);
+    }
+
+    /// <summary>
     /// Asserts that the current <see cref="Func{Task}"/> throws an exception of type <typeparamref name="TException"/>.
     /// </summary>
     /// <typeparam name="TException">The type of exception expected to be thrown.</typeparam>
@@ -139,6 +158,29 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         }
 
         return new ExceptionAssertions<TException>([], assertionChain);
+    }
+
+    /// <summary>
+    /// Asserts that the current <see cref="Func{Task}"/> throws any exception within a specific timeout.
+    /// </summary>
+    /// <param name="timeSpan">
+    /// The allowed time span for the operation.
+    /// </param>
+    /// <param name="because">
+    /// (Optional)
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion is needed. If
+    /// the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <returns>
+    /// A Task&lt;ExceptionAssertions&lt;Exception&gt;&gt; object.
+    /// </returns>
+    public async Task<ExceptionAssertions<Exception>> ThrowWithinAsync(TimeSpan timeSpan,
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        return await ThrowWithinAsync(timeSpan, because, becauseArgs);
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -122,9 +122,6 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/> .
     /// </param>
-    /// <returns>
-    /// A Task&lt;ExceptionAssertions&lt;Exception&gt;&gt; object.
-    /// </returns>
     public async Task<ExceptionAssertions<Exception>> ThrowAsync(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
@@ -174,9 +171,6 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <returns>
-    /// A Task&lt;ExceptionAssertions&lt;Exception&gt;&gt; object.
-    /// </returns>
     public async Task<ExceptionAssertions<Exception>> ThrowWithinAsync(TimeSpan timeSpan,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -180,7 +180,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     public async Task<ExceptionAssertions<Exception>> ThrowWithinAsync(TimeSpan timeSpan,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        return await ThrowWithinAsync(timeSpan, because, becauseArgs);
+        return await ThrowWithinAsync<Exception>(timeSpan, because, becauseArgs);
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -31,6 +31,25 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
     }
 
     /// <summary>
+    /// Asserts that the current <see cref="Delegate" /> throws any exception.
+    /// </summary>
+    /// <param name="because">
+    /// (Optional)
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion is needed. If
+    /// the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <returns>
+    /// An ExceptionAssertions&lt;Exception&gt; object.
+    /// </returns>
+    public ExceptionAssertions<Exception> Throw([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        return this.Throw<Exception>(because, becauseArgs);
+    }
+
+    /// <summary>
     /// Asserts that the current <see cref="Delegate" /> throws an exception of type <typeparamref name="TException"/>.
     /// </summary>
     /// <param name="because">

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -41,9 +41,6 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    /// <returns>
-    /// An ExceptionAssertions&lt;Exception&gt; object.
-    /// </returns>
     public ExceptionAssertions<Exception> Throw([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         return Throw<Exception>(because, becauseArgs);

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -46,7 +46,7 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
     /// </returns>
     public ExceptionAssertions<Exception> Throw([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        return this.Throw<Exception>(because, becauseArgs);
+        return Throw<Exception>(because, becauseArgs);
     }
 
     /// <summary>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2090,10 +2090,12 @@ namespace FluentAssertions.Specialized
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -2115,6 +2117,7 @@ namespace FluentAssertions.Specialized
         protected abstract void InvokeSubject();
         public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<System.Exception> Throw(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2211,10 +2211,12 @@ namespace FluentAssertions.Specialized
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -2236,6 +2238,7 @@ namespace FluentAssertions.Specialized
         protected abstract void InvokeSubject();
         public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<System.Exception> Throw(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2034,10 +2034,12 @@ namespace FluentAssertions.Specialized
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -2059,6 +2061,7 @@ namespace FluentAssertions.Specialized
         protected abstract void InvokeSubject();
         public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<System.Exception> Throw(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2090,10 +2090,12 @@ namespace FluentAssertions.Specialized
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -2115,6 +2117,7 @@ namespace FluentAssertions.Specialized
         protected abstract void InvokeSubject();
         public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<System.Exception> Throw(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -14,93 +14,87 @@ namespace FluentAssertions.Specs.Exceptions;
 
 public class AsyncFunctionExceptionAssertionSpecs
 {
-    public partial class ActionAssertions
+    [Fact]
+    public void When_getting_the_subject_it_should_remain_unchanged()
     {
-        [Fact]
-        public void When_getting_the_subject_it_should_remain_unchanged()
-        {
-            // Arrange
-            Func<Task> subject = () => Task.FromResult(42);
+        // Arrange
+        Func<Task> subject = () => Task.FromResult(42);
 
-            // Act
-            Action action = () => subject.Should().Subject.As<object>().Should().BeSameAs(subject);
+        // Act
+        Action action = () => subject.Should().Subject.As<object>().Should().BeSameAs(subject);
 
-            // Assert
-            action.Should().NotThrow("the Subject should remain the same");
-        }
+        // Assert
+        action.Should().NotThrow("the Subject should remain the same");
     }
 
-    public partial class NonGenericAsyncFunctionAssertions
+    [Fact]
+    public async Task When_subject_is_null_when_expecting_an_exception_it_should_throw()
     {
-        [Fact]
-        public async Task When_subject_is_null_when_expecting_an_exception_it_should_throw()
+        // Arrange
+        Func<Task> action = null;
+
+        // Act
+        Func<Task> testAction = async () =>
         {
-            // Arrange
-            Func<Task> action = null;
+            using var _ = new AssertionScope();
+            await action.Should().ThrowAsync<ArgumentException>("because we want to test the failure {0}", "message");
+        };
 
-            // Act
-            Func<Task> testAction = async () =>
-            {
-                using var _ = new AssertionScope();
-                await action.Should().ThrowAsync<ArgumentException>("because we want to test the failure {0}", "message");
-            };
+        // Assert
+        await testAction.Should().ThrowAsync<XunitException>()
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
+    }
 
-            // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
-                .WithMessage("*because we want to test the failure message*found <null>*")
-                .Where(e => !e.Message.Contains("NullReferenceException"));
-        }
+    [Fact]
+    public async Task When_subject_is_null_when_not_expecting_a_generic_exception_it_should_throw()
+    {
+        // Arrange
+        Func<Task> action = null;
 
-        [Fact]
-        public async Task When_subject_is_null_when_not_expecting_a_generic_exception_it_should_throw()
+        // Act
+        Func<Task> testAction = async () =>
         {
-            // Arrange
-            Func<Task> action = null;
+            using var _ = new AssertionScope();
+            await action.Should().NotThrowAsync<ArgumentException>("because we want to test the failure {0}", "message");
+        };
 
-            // Act
-            Func<Task> testAction = async () =>
-            {
-                using var _ = new AssertionScope();
-                await action.Should().NotThrowAsync<ArgumentException>("because we want to test the failure {0}", "message");
-            };
+        // Assert
+        await testAction.Should().ThrowAsync<XunitException>()
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
+    }
 
-            // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
-                .WithMessage("*because we want to test the failure message*found <null>*")
-                .Where(e => !e.Message.Contains("NullReferenceException"));
-        }
+    [Fact]
+    public async Task When_subject_is_null_when_not_expecting_an_exception_it_should_throw()
+    {
+        // Arrange
+        Func<Task> action = null;
 
-        [Fact]
-        public async Task When_subject_is_null_when_not_expecting_an_exception_it_should_throw()
+        // Act
+        Func<Task> testAction = async () =>
         {
-            // Arrange
-            Func<Task> action = null;
+            using var _ = new AssertionScope();
+            await action.Should().NotThrowAsync("because we want to test the failure {0}", "message");
+        };
 
-            // Act
-            Func<Task> testAction = async () =>
-            {
-                using var _ = new AssertionScope();
-                await action.Should().NotThrowAsync("because we want to test the failure {0}", "message");
-            };
+        // Assert
+        await testAction.Should().ThrowAsync<XunitException>()
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
+    }
 
-            // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
-                .WithMessage("*because we want to test the failure message*found <null>*")
-                .Where(e => !e.Message.Contains("NullReferenceException"));
-        }
+    [Fact]
+    public async Task When_async_method_throws_an_empty_AggregateException_it_should_fail()
+    {
+        // Arrange
+        Func<Task> act = () => throw new AggregateException();
 
-        [Fact]
-        public async Task When_async_method_throws_an_empty_AggregateException_it_should_fail()
-        {
-            // Arrange
-            Func<Task> act = () => throw new AggregateException();
+        // Act
+        Func<Task> act2 = () => act.Should().NotThrowAsync();
 
-            // Act
-            Func<Task> act2 = () => act.Should().NotThrowAsync();
-
-            // Assert
-            await act2.Should().ThrowAsync<XunitException>();
-        }
+        // Assert
+        await act2.Should().ThrowAsync<XunitException>();
     }
 
     [Collection("UIFacts")]
@@ -120,17 +114,14 @@ public class AsyncFunctionExceptionAssertionSpecs
         }
     }
 
-    public partial class NonGenericAsyncFunctionAssertions
+    [Fact]
+    public async Task When_async_method_throws_a_nested_AggregateException_it_should_provide_the_message()
     {
-        [Fact]
-        public async Task When_async_method_throws_a_nested_AggregateException_it_should_provide_the_message()
-        {
-            // Arrange
-            Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
+        // Arrange
+        Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
 
-            // Act & Assert
-            await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
-        }
+        // Act & Assert
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
     }
 
     public partial class UIFacts
@@ -146,39 +137,36 @@ public class AsyncFunctionExceptionAssertionSpecs
         }
     }
 
-    public partial class NonGenericAsyncFunctionAssertions
+    [Fact]
+    public async Task When_async_method_throws_a_flat_AggregateException_it_should_provide_the_message()
     {
-        [Fact]
-        public async Task When_async_method_throws_a_flat_AggregateException_it_should_provide_the_message()
-        {
-            // Arrange
-            Func<Task> act = () => throw new AggregateException("That was wrong as well.");
+        // Arrange
+        Func<Task> act = () => throw new AggregateException("That was wrong as well.");
 
-            // Act & Assert
-            await act.Should().ThrowAsync<AggregateException>().WithMessage("That was wrong as well.");
-        }
+        // Act & Assert
+        await act.Should().ThrowAsync<AggregateException>().WithMessage("That was wrong as well.");
+    }
 
-        [Fact]
-        public async Task When_async_method_throws_a_nested_AggregateException_it_should_provide_unwrapped_exception_to_predicate()
-        {
-            // Arrange
-            Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
+    [Fact]
+    public async Task When_async_method_throws_a_nested_AggregateException_it_should_provide_unwrapped_exception_to_predicate()
+    {
+        // Arrange
+        Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
 
-            // Act & Assert
-            await act.Should().ThrowAsync<ArgumentException>()
-                .Where(i => i.Message == "That was wrong.");
-        }
+        // Act & Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .Where(i => i.Message == "That was wrong.");
+    }
 
-        [Fact]
-        public async Task When_async_method_throws_a_flat_AggregateException_it_should_provide_it_to_predicate()
-        {
-            // Arrange
-            Func<Task> act = () => throw new AggregateException("That was wrong as well.");
+    [Fact]
+    public async Task When_async_method_throws_a_flat_AggregateException_it_should_provide_it_to_predicate()
+    {
+        // Arrange
+        Func<Task> act = () => throw new AggregateException("That was wrong as well.");
 
-            // Act & Assert
-            await act.Should().ThrowAsync<AggregateException>()
-                .Where(i => i.Message == "That was wrong as well.");
-        }
+        // Act & Assert
+        await act.Should().ThrowAsync<AggregateException>()
+            .Where(i => i.Message == "That was wrong as well.");
     }
 
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters
@@ -283,267 +271,264 @@ public class AsyncFunctionExceptionAssertionSpecs
         return Task.FromException(exception);
     }
 
-    public partial class NonGenericAsyncFunctionAssertions
+    [Fact]
+    public async Task When_subject_throws_subclass_of_expected_exact_exception_it_should_fail()
     {
-        [Fact]
-        public async Task When_subject_throws_subclass_of_expected_exact_exception_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
-                .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
+            .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage(
-                    "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
-        }
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage(
+                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
+    }
 
-        [Fact]
-        public async Task When_subject_ValueTask_throws_subclass_of_expected_exact_exception_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_subject_ValueTask_throws_subclass_of_expected_exact_exception_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentNullException>())
-                .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentNullException>())
+            .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage(
-                    "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
-        }
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage(
+                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
+    }
 
-        [Fact]
-        public async Task When_subject_throws_aggregate_exception_and_not_expected_exact_exception_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_subject_throws_aggregate_exception_and_not_expected_exact_exception_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAggregateExceptionAsync<ArgumentException>())
-                .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAggregateExceptionAsync<ArgumentException>())
+            .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage(
-                    "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
-        }
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage(
+                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
+    }
 
-        [Fact]
-        public async Task When_subject_throws_aggregate_exception_and_not_expected_exact_exception_through_ValueTask_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_subject_throws_aggregate_exception_and_not_expected_exact_exception_through_ValueTask_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAggregateExceptionAsyncValueTask<ArgumentException>())
-                .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAggregateExceptionAsyncValueTask<ArgumentException>())
+            .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage(
-                    "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
-        }
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage(
+                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
+    }
 
-        [Fact]
-        public async Task When_subject_throws_the_expected_exact_exception_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_subject_throws_the_expected_exact_exception_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act / Assert
-            await asyncObject
-                .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
-                .Should().ThrowExactlyAsync<ArgumentNullException>();
-        }
+        // Act / Assert
+        await asyncObject
+            .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
+            .Should().ThrowExactlyAsync<ArgumentNullException>();
+    }
 
-        [Fact]
-        public async Task When_subject_throws_the_expected_exact_exception_through_ValueTask_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_subject_throws_the_expected_exact_exception_through_ValueTask_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act / Assert
-            await asyncObject
-                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentNullException>())
-                .Should().ThrowExactlyAsync<ArgumentNullException>();
-        }
+        // Act / Assert
+        await asyncObject
+            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentNullException>())
+            .Should().ThrowExactlyAsync<ArgumentNullException>();
+    }
 
-        [Fact]
-        public async Task When_async_method_throws_expected_exception_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_async_method_throws_expected_exception_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAsync<ArgumentException>())
-                .Should().ThrowAsync<ArgumentException>();
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAsync<ArgumentException>())
+            .Should().ThrowAsync<ArgumentException>();
 
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
 
-        [Fact]
-        public async Task When_async_method_throws_expected_exception_through_ValueTask_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_async_method_throws_expected_exception_through_ValueTask_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-                .Should().ThrowAsync<ArgumentException>();
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
+            .Should().ThrowAsync<ArgumentException>();
 
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
 
-        [Fact]
-        public async Task When_subject_is_null_it_should_be_null()
-        {
-            // Arrange
-            Func<Task> subject = null;
+    [Fact]
+    public async Task When_subject_is_null_it_should_be_null()
+    {
+        // Arrange
+        Func<Task> subject = null;
 
-            // Act
-            Func<Task> action = () => subject.Should().NotThrowAsync();
+        // Act
+        Func<Task> action = () => subject.Should().NotThrowAsync();
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("*found <null>*");
-        }
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage("*found <null>*");
+    }
 
-        [Fact]
-        public async Task When_async_method_throws_async_expected_exception_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_async_method_throws_async_expected_exception_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
+        // Act
+        Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
 
-            // Assert
-            await action.Should().ThrowAsync<ArgumentException>();
-        }
+        // Assert
+        await action.Should().ThrowAsync<ArgumentException>();
+    }
 
-        [Fact]
-        public async Task When_async_method_does_not_throw_expected_exception_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_async_method_does_not_throw_expected_exception_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.SucceedAsync())
-                .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.SucceedAsync())
+            .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage(
-                    "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
-        }
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage(
+                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
+    }
 
-        [Fact]
-        public async Task When_async_method_does_not_throw_expected_exception_through_ValueTask_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_async_method_does_not_throw_expected_exception_through_ValueTask_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.SucceedAsyncValueTask())
-                .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.SucceedAsyncValueTask())
+            .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage(
-                    "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
-        }
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage(
+                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
+    }
 
-        [Fact]
-        public async Task When_async_method_throws_unexpected_exception_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_async_method_throws_unexpected_exception_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAsync<ArgumentException>())
-                .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAsync<ArgumentException>())
+            .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage(
-                    "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
-        }
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage(
+                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
+    }
 
-        [Fact]
-        public async Task When_async_method_throws_unexpected_exception_through_ValueTask_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_async_method_throws_unexpected_exception_through_ValueTask_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-                .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
+            .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage(
-                    "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
-        }
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage(
+                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
+    }
 
-        [Fact]
-        public async Task When_async_method_does_not_throw_exception_and_that_was_expected_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_async_method_does_not_throw_exception_and_that_was_expected_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.SucceedAsync())
-                .Should().NotThrowAsync();
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.SucceedAsync())
+            .Should().NotThrowAsync();
 
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
 
-        [Fact]
-        public async Task When_async_method_does_not_throw_exception_through_ValueTask_and_that_was_expected_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_async_method_does_not_throw_exception_through_ValueTask_and_that_was_expected_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.SucceedAsyncValueTask())
-                .Should().NotThrowAsync();
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.SucceedAsyncValueTask())
+            .Should().NotThrowAsync();
 
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
 
-        [Fact]
-        public async Task When_async_method_does_not_throw_async_exception_and_that_was_expected_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+    [Fact]
+    public async Task When_async_method_does_not_throw_async_exception_and_that_was_expected_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject.SucceedAsync();
+        // Act
+        Func<Task> action = () => asyncObject.SucceedAsync();
 
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
+        // Assert
+        await action.Should().NotThrowAsync();
     }
 
     public partial class UIFacts
@@ -562,110 +547,101 @@ public class AsyncFunctionExceptionAssertionSpecs
         }
     }
 
-    public partial class NonGenericAsyncFunctionAssertions
+    [Fact]
+    public async Task When_subject_throws_subclass_of_expected_async_exception_it_should_succeed()
     {
-        [Fact]
-        public async Task When_subject_throws_subclass_of_expected_async_exception_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject.ThrowAsync<ArgumentNullException>();
+        // Act
+        Func<Task> action = () => asyncObject.ThrowAsync<ArgumentNullException>();
 
-            // Assert
-            await action.Should().ThrowAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
-        }
+        // Assert
+        await action.Should().ThrowAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
     }
 
-    public partial class GenericAsyncFunctionAssertions
+    [Fact]
+    public async Task When_function_of_task_int_in_async_method_throws_the_expected_exception_it_should_succeed()
     {
-        [Fact]
-        public async Task When_function_of_task_int_in_async_method_throws_the_expected_exception_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-            Func<Task<int>> f = () => asyncObject.ThrowTaskIntAsync<ArgumentNullException>(true);
+        // Arrange
+        var asyncObject = new AsyncClass();
+        Func<Task<int>> f = () => asyncObject.ThrowTaskIntAsync<ArgumentNullException>(true);
 
-            // Act / Assert
-            await f.Should().ThrowAsync<ArgumentNullException>();
-        }
-
-        [Fact]
-        public async Task When_function_of_task_int_in_async_method_throws_not_excepted_exception_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-            Func<Task<int>> f = () => asyncObject.ThrowTaskIntAsync<InvalidOperationException>(true);
-
-            // Act / Assert
-            await f.Should().NotThrowAsync<ArgumentNullException>();
-        }
+        // Act / Assert
+        await f.Should().ThrowAsync<ArgumentNullException>();
     }
 
-    public partial class NonGenericAsyncFunctionAssertions
+    [Fact]
+    public async Task When_function_of_task_int_in_async_method_throws_not_excepted_exception_it_should_succeed()
     {
-        [Fact]
-        public async Task When_subject_is_null_when_expecting_an_exact_exception_it_should_throw()
+        // Arrange
+        var asyncObject = new AsyncClass();
+        Func<Task<int>> f = () => asyncObject.ThrowTaskIntAsync<InvalidOperationException>(true);
+
+        // Act / Assert
+        await f.Should().NotThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task When_subject_is_null_when_expecting_an_exact_exception_it_should_throw()
+    {
+        // Arrange
+        Func<Task> action = null;
+
+        // Act
+        Func<Task> testAction = async () =>
         {
-            // Arrange
-            Func<Task> action = null;
+            using var _ = new AssertionScope();
+            await action.Should().ThrowExactlyAsync<ArgumentException>("because we want to test the failure {0}", "message");
+        };
 
-            // Act
-            Func<Task> testAction = async () =>
-            {
-                using var _ = new AssertionScope();
-                await action.Should().ThrowExactlyAsync<ArgumentException>("because we want to test the failure {0}", "message");
-            };
+        // Assert
+        await testAction.Should().ThrowAsync<XunitException>()
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
+    }
 
-            // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
-                .WithMessage("*because we want to test the failure message*found <null>*")
-                .Where(e => !e.Message.Contains("NullReferenceException"));
-        }
+    [Fact]
+    public async Task When_subject_throws_subclass_of_expected_async_exact_exception_it_should_throw()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-        [Fact]
-        public async Task When_subject_throws_subclass_of_expected_async_exact_exception_it_should_throw()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+        // Act
+        Func<Task> action = () => asyncObject.ThrowAsync<ArgumentNullException>();
+        Func<Task> testAction = () => action.Should().ThrowExactlyAsync<ArgumentException>("ABCDE");
 
-            // Act
-            Func<Task> action = () => asyncObject.ThrowAsync<ArgumentNullException>();
-            Func<Task> testAction = () => action.Should().ThrowExactlyAsync<ArgumentException>("ABCDE");
+        // Assert
+        await testAction.Should().ThrowAsync<XunitException>()
+            .WithMessage("*ArgumentException*ABCDE*ArgumentNullException*");
+    }
 
-            // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
-                .WithMessage("*ArgumentException*ABCDE*ArgumentNullException*");
-        }
+    [Fact]
+    public async Task When_subject_throws_aggregate_exception_instead_of_exact_exception_it_should_throw()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-        [Fact]
-        public async Task When_subject_throws_aggregate_exception_instead_of_exact_exception_it_should_throw()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+        // Act
+        Func<Task> action = () => asyncObject.ThrowAggregateExceptionAsync<ArgumentException>();
+        Func<Task> testAction = () => action.Should().ThrowExactlyAsync<ArgumentException>("ABCDE");
 
-            // Act
-            Func<Task> action = () => asyncObject.ThrowAggregateExceptionAsync<ArgumentException>();
-            Func<Task> testAction = () => action.Should().ThrowExactlyAsync<ArgumentException>("ABCDE");
+        // Assert
+        await testAction.Should().ThrowAsync<XunitException>()
+            .WithMessage("*ArgumentException*ABCDE*AggregateException*");
+    }
 
-            // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
-                .WithMessage("*ArgumentException*ABCDE*AggregateException*");
-        }
+    [Fact]
+    public async Task When_subject_throws_expected_async_exact_exception_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-        [Fact]
-        public async Task When_subject_throws_expected_async_exact_exception_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+        // Act
+        Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
 
-            // Act
-            Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
-
-            // Assert
-            await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
-        }
+        // Assert
+        await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
     }
 
     public partial class UIFacts
@@ -684,647 +660,632 @@ public class AsyncFunctionExceptionAssertionSpecs
         }
     }
 
-    public partial class NonGenericAsyncFunctionAssertions
+    [Fact]
+    public async Task When_async_method_throws_exception_and_no_exception_was_expected_it_should_fail()
     {
-        [Fact]
-        public async Task When_async_method_throws_exception_and_no_exception_was_expected_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAsync<ArgumentException>())
-                .Should().NotThrowAsync();
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAsync<ArgumentException>())
+            .Should().NotThrowAsync();
 
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect any exception, but found System.ArgumentException*");
-        }
-
-        [Fact]
-        public async Task When_async_method_throws_exception_through_ValueTask_and_no_exception_was_expected_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-                .Should().NotThrowAsync();
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect any exception, but found System.ArgumentException*");
-        }
-
-        [Fact]
-        public async Task When_async_method_throws_exception_and_expected_not_to_throw_another_one_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAsync<ArgumentException>())
-                .Should().NotThrowAsync<InvalidOperationException>();
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task
-            When_async_method_throws_exception_through_ValueTask_and_expected_not_to_throw_another_one_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-                .Should().NotThrowAsync<InvalidOperationException>();
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task When_async_method_throws_exception_and_expected_not_to_throw_async_another_one_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-
-            // Act
-            Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
-
-            // Assert
-            await action.Should().NotThrowAsync<InvalidOperationException>();
-        }
-
-        [Fact]
-        public async Task When_async_method_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(_ => asyncObject.SucceedAsync())
-                .Should().NotThrowAsync<InvalidOperationException>();
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task
-            When_async_method_succeeds_and_expected_not_to_throw_particular_exception_through_ValueTask_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(_ => asyncObject.SucceedAsyncValueTask())
-                .Should().NotThrowAsync<InvalidOperationException>();
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task When_async_method_throws_exception_expected_not_to_be_thrown_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAsync<ArgumentException>())
-                .Should().NotThrowAsync<ArgumentException>();
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect System.ArgumentException, but found*");
-        }
-
-        [Fact]
-        public async Task When_async_method_throws_exception_expected_through_ValueTask_not_to_be_thrown_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-                .Should().NotThrowAsync<ArgumentException>();
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect System.ArgumentException, but found*");
-        }
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage("Did not expect any exception, but found System.ArgumentException*");
     }
 
-    public partial class GenericAsyncFunctionAssertions
+    [Fact]
+    public async Task When_async_method_throws_exception_through_ValueTask_and_no_exception_was_expected_it_should_fail()
     {
-        [Fact]
-        public async Task When_async_method_of_T_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(_ => asyncObject.ReturnTaskInt())
-                .Should().NotThrowAsync<InvalidOperationException>();
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
+            .Should().NotThrowAsync();
 
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task When_ValueTask_async_method_of_T_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(_ => asyncObject.ReturnValueTaskInt())
-                .Should().NotThrowAsync<InvalidOperationException>();
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task When_async_method_of_T_throws_exception_expected_not_to_be_thrown_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowTaskIntAsync<ArgumentException>(true))
-                .Should().NotThrowAsync<ArgumentException>();
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect System.ArgumentException, but found System.ArgumentException*");
-        }
-
-        [Fact]
-        public async Task When_ValueTask_async_method_of_T_throws_exception_expected_not_to_be_thrown_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-
-            // Act
-            Func<Task> action = () => asyncObject
-                .Awaiting(x => x.ThrowValueTaskIntAsync<ArgumentException>(true))
-                .Should().NotThrowAsync<ArgumentException>();
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect System.ArgumentException, but found System.ArgumentException*");
-        }
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage("Did not expect any exception, but found System.ArgumentException*");
     }
 
-    public partial class NonGenericAsyncFunctionAssertions
+    [Fact]
+    public async Task When_async_method_throws_exception_and_expected_not_to_throw_another_one_it_should_succeed()
     {
-        [Fact]
-        public async Task When_async_method_throws_the_expected_inner_exception_it_should_succeed()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+        // Arrange
+        var asyncObject = new AsyncClass();
 
-            // Act
-            Func<Task> action = () => task
-                .Should().ThrowAsync<AggregateException>()
-                .WithInnerException<AggregateException, InvalidOperationException>();
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAsync<ArgumentException>())
+            .Should().NotThrowAsync<InvalidOperationException>();
 
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task When_async_method_throws_the_expected_inner_exception_from_argument_it_should_succeed()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async(new AggregateException(new InvalidOperationException()));
-
-            // Act
-            Func<Task> action = () => task
-                .Should().ThrowAsync<AggregateException>()
-                .WithInnerException(typeof(InvalidOperationException));
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task When_async_method_throws_the_expected_inner_exception_exactly_it_should_succeed()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
-
-            // Act
-            Func<Task> action = () => task
-                .Should().ThrowAsync<AggregateException>()
-                .WithInnerExceptionExactly<AggregateException, ArgumentException>();
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task When_async_method_throws_the_expected_inner_exception_exactly_defined_in_arguments_it_should_succeed()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
-
-            // Act
-            Func<Task> action = () => task
-                .Should().ThrowAsync<AggregateException>()
-                .WithInnerExceptionExactly(typeof(ArgumentException));
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task When_async_method_throws_aggregate_exception_containing_expected_exception_it_should_succeed()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async(new AggregateException(new InvalidOperationException()));
-
-            // Act
-            Func<Task> action = () => task
-                .Should().ThrowAsync<InvalidOperationException>();
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task Succeeds_for_any_exception_thrown_by_async_method()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async<InvalidOperationException>();
-
-            // Act
-            Func<Task> action = () => task
-                .Should().ThrowAsync();
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task Succeeds_for_expected_exception_thrown_by_async_method()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async<InvalidOperationException>();
-
-            // Act
-            Func<Task> action = () => task
-                .Should().ThrowAsync<InvalidOperationException>();
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task Succeeds_for_any_exception_thrown_within_timespan_by_async_method()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async<InvalidOperationException>();
-
-            // Act
-            Func<Task> action = () => task.Should().ThrowWithinAsync(
-                100.Milliseconds());
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task When_async_method_does_not_throw_the_expected_inner_exception_it_should_fail()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
-
-            // Act
-            Func<Task> action = () => task
-                .Should().ThrowAsync<AggregateException>()
-                .WithInnerException<AggregateException, InvalidOperationException>();
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
-        }
-
-        [Fact]
-        public async Task When_async_method_does_not_throw_the_expected_inner_exception_from_argument_it_should_fail()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
-
-            // Act
-            Func<Task> action = () => task
-                .Should().ThrowAsync<AggregateException>()
-                .WithInnerException(typeof(InvalidOperationException));
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
-        }
-
-        [Fact]
-        public async Task When_async_method_does_not_throw_the_expected_inner_exception_exactly_it_should_fail()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentNullException()));
-
-            // Act
-            Func<Task> action = () => task
-                .Should().ThrowAsync<AggregateException>()
-                .WithInnerExceptionExactly<AggregateException, ArgumentException>();
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>().WithMessage("*ArgumentException*ArgumentNullException*");
-        }
-
-        [Fact]
-        public async Task
-            When_async_method_does_not_throw_the_expected_inner_exception_exactly_defined_in_arguments_it_should_fail()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentNullException()));
-
-            // Act
-            Func<Task> action = () => task
-                .Should().ThrowAsync<AggregateException>()
-                .WithInnerExceptionExactly(typeof(ArgumentException));
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>().WithMessage("*ArgumentException*ArgumentNullException*");
-        }
-
-        [Fact]
-        public async Task When_async_method_does_not_throw_the_expected_exception_it_should_fail()
-        {
-            // Arrange
-            Func<Task> task = () => Throw.Async<ArgumentException>();
-
-            // Act
-            Func<Task> action = () => task
-                .Should().ThrowAsync<InvalidOperationException>();
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
-        }
+        // Assert
+        await action.Should().NotThrowAsync();
     }
 
-    public partial class ActionAssertions
+    [Fact]
+    public async Task
+        When_async_method_throws_exception_through_ValueTask_and_expected_not_to_throw_another_one_it_should_succeed()
     {
+        // Arrange
+        var asyncObject = new AsyncClass();
+
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
+            .Should().NotThrowAsync<InvalidOperationException>();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_async_method_throws_exception_and_expected_not_to_throw_async_another_one_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
+
+        // Act
+        Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
+
+        // Assert
+        await action.Should().NotThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task When_async_method_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
+
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(_ => asyncObject.SucceedAsync())
+            .Should().NotThrowAsync<InvalidOperationException>();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task
+        When_async_method_succeeds_and_expected_not_to_throw_particular_exception_through_ValueTask_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
+
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(_ => asyncObject.SucceedAsyncValueTask())
+            .Should().NotThrowAsync<InvalidOperationException>();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_async_method_throws_exception_expected_not_to_be_thrown_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
+
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAsync<ArgumentException>())
+            .Should().NotThrowAsync<ArgumentException>();
+
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage("Did not expect System.ArgumentException, but found*");
+    }
+
+    [Fact]
+    public async Task When_async_method_throws_exception_expected_through_ValueTask_not_to_be_thrown_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
+
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
+            .Should().NotThrowAsync<ArgumentException>();
+
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage("Did not expect System.ArgumentException, but found*");
+    }
+
+    [Fact]
+    public async Task When_async_method_of_T_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
+
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(_ => asyncObject.ReturnTaskInt())
+            .Should().NotThrowAsync<InvalidOperationException>();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_ValueTask_async_method_of_T_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
+
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(_ => asyncObject.ReturnValueTaskInt())
+            .Should().NotThrowAsync<InvalidOperationException>();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_async_method_of_T_throws_exception_expected_not_to_be_thrown_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
+
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowTaskIntAsync<ArgumentException>(true))
+            .Should().NotThrowAsync<ArgumentException>();
+
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage("Did not expect System.ArgumentException, but found System.ArgumentException*");
+    }
+
+    [Fact]
+    public async Task When_ValueTask_async_method_of_T_throws_exception_expected_not_to_be_thrown_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
+
+        // Act
+        Func<Task> action = () => asyncObject
+            .Awaiting(x => x.ThrowValueTaskIntAsync<ArgumentException>(true))
+            .Should().NotThrowAsync<ArgumentException>();
+
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage("Did not expect System.ArgumentException, but found System.ArgumentException*");
+    }
+
+    [Fact]
+    public async Task When_async_method_throws_the_expected_inner_exception_it_should_succeed()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync<AggregateException>()
+            .WithInnerException<AggregateException, InvalidOperationException>();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_async_method_throws_the_expected_inner_exception_from_argument_it_should_succeed()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync<AggregateException>()
+            .WithInnerException(typeof(InvalidOperationException));
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_async_method_throws_the_expected_inner_exception_exactly_it_should_succeed()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync<AggregateException>()
+            .WithInnerExceptionExactly<AggregateException, ArgumentException>();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_async_method_throws_the_expected_inner_exception_exactly_defined_in_arguments_it_should_succeed()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync<AggregateException>()
+            .WithInnerExceptionExactly(typeof(ArgumentException));
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_async_method_throws_aggregate_exception_containing_expected_exception_it_should_succeed()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync<InvalidOperationException>();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Succeeds_for_any_exception_thrown_by_async_method()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async<InvalidOperationException>();
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Succeeds_for_expected_exception_thrown_by_async_method()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async<InvalidOperationException>();
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync<InvalidOperationException>();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Succeeds_for_any_exception_thrown_within_timespan_by_async_method()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async<InvalidOperationException>();
+
+        // Act
+        Func<Task> action = () => task.Should().ThrowWithinAsync(
+            100.Milliseconds());
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_async_method_does_not_throw_the_expected_inner_exception_it_should_fail()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync<AggregateException>()
+            .WithInnerException<AggregateException, InvalidOperationException>();
+
+        // Assert
+        await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
+    }
+
+    [Fact]
+    public async Task When_async_method_does_not_throw_the_expected_inner_exception_from_argument_it_should_fail()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync<AggregateException>()
+            .WithInnerException(typeof(InvalidOperationException));
+
+        // Assert
+        await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
+    }
+
+    [Fact]
+    public async Task When_async_method_does_not_throw_the_expected_inner_exception_exactly_it_should_fail()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentNullException()));
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync<AggregateException>()
+            .WithInnerExceptionExactly<AggregateException, ArgumentException>();
+
+        // Assert
+        await action.Should().ThrowAsync<XunitException>().WithMessage("*ArgumentException*ArgumentNullException*");
+    }
+
+    [Fact]
+    public async Task
+        When_async_method_does_not_throw_the_expected_inner_exception_exactly_defined_in_arguments_it_should_fail()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentNullException()));
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync<AggregateException>()
+            .WithInnerExceptionExactly(typeof(ArgumentException));
+
+        // Assert
+        await action.Should().ThrowAsync<XunitException>().WithMessage("*ArgumentException*ArgumentNullException*");
+    }
+
+    [Fact]
+    public async Task When_async_method_does_not_throw_the_expected_exception_it_should_fail()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async<ArgumentException>();
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync<InvalidOperationException>();
+
+        // Assert
+        await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
+    }
+
 #pragma warning disable MA0147
-        [Fact]
-        public void When_asserting_async_void_method_should_throw_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-            Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
+    [Fact]
+    public void When_asserting_async_void_method_should_throw_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
+        Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
 
-            // Act
-            Action action = () => asyncVoidMethod.Should().Throw<ArgumentException>();
+        // Act
+        Action action = () => asyncVoidMethod.Should().Throw<ArgumentException>();
 
-            // Assert
-            action.Should().Throw<InvalidOperationException>("*async*void*");
-        }
-
-        [Fact]
-        public void When_asserting_async_void_method_should_throw_exactly_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-            Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
-
-            // Act
-            Action action = () => asyncVoidMethod.Should().ThrowExactly<ArgumentException>();
-
-            // Assert
-            action.Should().Throw<InvalidOperationException>("*async*void*");
-        }
-
-        [Fact]
-        public void When_asserting_async_void_method_should_not_throw_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-            Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
-
-            // Act
-            Action action = () => asyncVoidMethod.Should().NotThrow();
-
-            // Assert
-            action.Should().Throw<InvalidOperationException>("*async*void*");
-        }
-
-        [Fact]
-        public void When_asserting_async_void_method_should_not_throw_specific_exception_it_should_fail()
-        {
-            // Arrange
-            var asyncObject = new AsyncClass();
-            Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
-
-            // Act
-            Action action = () => asyncVoidMethod.Should().NotThrow<ArgumentException>();
-
-            // Assert
-            action.Should().Throw<InvalidOperationException>("*async*void*");
-        }
-#pragma warning restore MA0147
+        // Assert
+        action.Should().Throw<InvalidOperationException>("*async*void*");
     }
 
-    public partial class NonGenericAsyncFunctionAssertions
+    [Fact]
+    public void When_asserting_async_void_method_should_throw_exactly_it_should_fail()
     {
-        [Fact]
-        public async Task When_a_method_throws_with_a_matching_parameter_name_it_should_succeed()
+        // Arrange
+        var asyncObject = new AsyncClass();
+        Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
+
+        // Act
+        Action action = () => asyncVoidMethod.Should().ThrowExactly<ArgumentException>();
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>("*async*void*");
+    }
+
+    [Fact]
+    public void When_asserting_async_void_method_should_not_throw_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
+        Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
+
+        // Act
+        Action action = () => asyncVoidMethod.Should().NotThrow();
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>("*async*void*");
+    }
+
+    [Fact]
+    public void When_asserting_async_void_method_should_not_throw_specific_exception_it_should_fail()
+    {
+        // Arrange
+        var asyncObject = new AsyncClass();
+        Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
+
+        // Act
+        Action action = () => asyncVoidMethod.Should().NotThrow<ArgumentException>();
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>("*async*void*");
+    }
+#pragma warning restore MA0147
+
+    [Fact]
+    public async Task When_a_method_throws_with_a_matching_parameter_name_it_should_succeed()
+    {
+        // Arrange
+        Func<Task> task = () => new AsyncClass().ThrowAsync(new ArgumentNullException("someParameter"));
+
+        // Act
+        Func<Task> act = () =>
+            task.Should().ThrowAsync<ArgumentException>()
+                .WithParameterName("someParameter");
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_a_method_throws_with_a_non_matching_parameter_name_it_should_fail_with_a_descriptive_message()
+    {
+        // Arrange
+        Func<Task> task = () => new AsyncClass().ThrowAsync(new ArgumentNullException("someOtherParameter"));
+
+        // Act
+        Func<Task> act = () =>
+            task.Should().ThrowAsync<ArgumentException>()
+                .WithParameterName("someParameter", "we want to test the failure {0}", "message");
+
+        // Assert
+        await act.Should().ThrowAsync<XunitException>()
+            .WithMessage("*with parameter name \"someParameter\"*we want to test the failure message*\"someOtherParameter\"*");
+    }
+
+    #region NotThrowAfterAsync
+
+    [Fact]
+    public async Task When_wait_time_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
+    {
+        // Arrange
+        var waitTime = 0.Milliseconds();
+        var pollInterval = 10.Milliseconds();
+
+        var clock = new FakeClock();
+        var asyncObject = new AsyncClass();
+        Func<Task> someFunc = () => asyncObject.SucceedAsync();
+
+        // Act
+        Func<Task> act = () => someFunc.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_poll_interval_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
+    {
+        // Arrange
+        var waitTime = 10.Milliseconds();
+        var pollInterval = 0.Milliseconds();
+
+        var clock = new FakeClock();
+        var asyncObject = new AsyncClass();
+        Func<Task> someFunc = () => asyncObject.SucceedAsync();
+
+        // Act
+        Func<Task> act = () => someFunc.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_subject_is_null_for_async_func_it_should_throw()
+    {
+        // Arrange
+        var waitTime = 0.Milliseconds();
+        var pollInterval = 0.Milliseconds();
+        Func<Task> action = null;
+
+        // Act
+        Func<Task> testAction = async () =>
         {
-            // Arrange
-            Func<Task> task = () => new AsyncClass().ThrowAsync(new ArgumentNullException("someParameter"));
+            using var _ = new AssertionScope();
 
-            // Act
-            Func<Task> act = () =>
-                task.Should().ThrowAsync<ArgumentException>()
-                    .WithParameterName("someParameter");
+            await action.Should().NotThrowAfterAsync(waitTime, pollInterval,
+                "because we want to test the failure {0}", "message");
+        };
 
-            // Assert
-            await act.Should().NotThrowAsync();
-        }
+        // Assert
+        await testAction.Should().ThrowAsync<XunitException>()
+            .WithMessage("*because we want to test the failure message*found <null>*")
+            .Where(e => !e.Message.Contains("NullReferenceException"));
+    }
 
-        [Fact]
-        public async Task When_a_method_throws_with_a_non_matching_parameter_name_it_should_fail_with_a_descriptive_message()
+    [Fact]
+    public async Task When_wait_time_is_negative_for_async_func_it_should_throw()
+    {
+        // Arrange
+        var waitTime = -1.Milliseconds();
+        var pollInterval = 10.Milliseconds();
+
+        var asyncObject = new AsyncClass();
+        Func<Task> someFunc = () => asyncObject.SucceedAsync();
+
+        // Act
+        Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
+            .WithParameterName("waitTime")
+            .WithMessage("*must be non-negative*");
+    }
+
+    [Fact]
+    public async Task When_poll_interval_is_negative_for_async_func_it_should_throw()
+    {
+        // Arrange
+        var waitTime = 10.Milliseconds();
+        var pollInterval = -1.Milliseconds();
+
+        var asyncObject = new AsyncClass();
+        Func<Task> someFunc = () => asyncObject.SucceedAsync();
+
+        // Act
+        Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
+            .WithParameterName("pollInterval")
+            .WithMessage("*must be non-negative*");
+    }
+
+    [Fact]
+    public async Task When_no_exception_should_be_thrown_for_null_async_func_after_wait_time_it_should_throw()
+    {
+        // Arrange
+        var waitTime = 2.Seconds();
+        var pollInterval = 10.Milliseconds();
+
+        Func<Task> func = null;
+
+        // Act
+        Func<Task> action = () => func.Should()
+            .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage("*but found <null>*");
+    }
+
+    [Fact]
+    public async Task When_no_exception_should_be_thrown_for_async_func_after_wait_time_but_it_was_it_should_throw()
+    {
+        // Arrange
+        var waitTime = 2.Seconds();
+        var pollInterval = 10.Milliseconds();
+
+        var clock = new FakeClock();
+        var timer = clock.StartTimer();
+        clock.CompleteAfter(waitTime);
+
+        Func<Task> throwLongerThanWaitTime = async () =>
         {
-            // Arrange
-            Func<Task> task = () => new AsyncClass().ThrowAsync(new ArgumentNullException("someOtherParameter"));
-
-            // Act
-            Func<Task> act = () =>
-                task.Should().ThrowAsync<ArgumentException>()
-                    .WithParameterName("someParameter", "we want to test the failure {0}", "message");
-
-            // Assert
-            await act.Should().ThrowAsync<XunitException>()
-                .WithMessage("*with parameter name \"someParameter\"*we want to test the failure message*\"someOtherParameter\"*");
-        }
-
-        #region NotThrowAfterAsync
-
-        [Fact]
-        public async Task When_wait_time_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
-        {
-            // Arrange
-            var waitTime = 0.Milliseconds();
-            var pollInterval = 10.Milliseconds();
-
-            var clock = new FakeClock();
-            var asyncObject = new AsyncClass();
-            Func<Task> someFunc = () => asyncObject.SucceedAsync();
-
-            // Act
-            Func<Task> act = () => someFunc.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
-
-            // Assert
-            await act.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task When_poll_interval_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
-        {
-            // Arrange
-            var waitTime = 10.Milliseconds();
-            var pollInterval = 0.Milliseconds();
-
-            var clock = new FakeClock();
-            var asyncObject = new AsyncClass();
-            Func<Task> someFunc = () => asyncObject.SucceedAsync();
-
-            // Act
-            Func<Task> act = () => someFunc.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
-
-            // Assert
-            await act.Should().NotThrowAsync();
-        }
-
-        [Fact]
-        public async Task When_subject_is_null_for_async_func_it_should_throw()
-        {
-            // Arrange
-            var waitTime = 0.Milliseconds();
-            var pollInterval = 0.Milliseconds();
-            Func<Task> action = null;
-
-            // Act
-            Func<Task> testAction = async () =>
+            if (timer.Elapsed <= waitTime.Multiply(1.5))
             {
-                using var _ = new AssertionScope();
+                throw new ArgumentException("An exception was forced");
+            }
 
-                await action.Should().NotThrowAfterAsync(waitTime, pollInterval,
-                    "because we want to test the failure {0}", "message");
-            };
+            await Task.Yield();
+        };
 
-            // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
-                .WithMessage("*because we want to test the failure message*found <null>*")
-                .Where(e => !e.Message.Contains("NullReferenceException"));
-        }
+        // Act
+        Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
+            .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
 
-        [Fact]
-        public async Task When_wait_time_is_negative_for_async_func_it_should_throw()
-        {
-            // Arrange
-            var waitTime = -1.Milliseconds();
-            var pollInterval = 10.Milliseconds();
-
-            var asyncObject = new AsyncClass();
-            Func<Task> someFunc = () => asyncObject.SucceedAsync();
-
-            // Act
-            Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
-
-            // Assert
-            await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
-                .WithParameterName("waitTime")
-                .WithMessage("*must be non-negative*");
-        }
-
-        [Fact]
-        public async Task When_poll_interval_is_negative_for_async_func_it_should_throw()
-        {
-            // Arrange
-            var waitTime = 10.Milliseconds();
-            var pollInterval = -1.Milliseconds();
-
-            var asyncObject = new AsyncClass();
-            Func<Task> someFunc = () => asyncObject.SucceedAsync();
-
-            // Act
-            Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
-
-            // Assert
-            await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
-                .WithParameterName("pollInterval")
-                .WithMessage("*must be non-negative*");
-        }
-
-        [Fact]
-        public async Task When_no_exception_should_be_thrown_for_null_async_func_after_wait_time_it_should_throw()
-        {
-            // Arrange
-            var waitTime = 2.Seconds();
-            var pollInterval = 10.Milliseconds();
-
-            Func<Task> func = null;
-
-            // Act
-            Func<Task> action = () => func.Should()
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("*but found <null>*");
-        }
-
-        [Fact]
-        public async Task When_no_exception_should_be_thrown_for_async_func_after_wait_time_but_it_was_it_should_throw()
-        {
-            // Arrange
-            var waitTime = 2.Seconds();
-            var pollInterval = 10.Milliseconds();
-
-            var clock = new FakeClock();
-            var timer = clock.StartTimer();
-            clock.CompleteAfter(waitTime);
-
-            Func<Task> throwLongerThanWaitTime = async () =>
-            {
-                if (timer.Elapsed <= waitTime.Multiply(1.5))
-                {
-                    throw new ArgumentException("An exception was forced");
-                }
-
-                await Task.Yield();
-            };
-
-            // Act
-            Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
-
-            // Assert
-            await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
-        }
+        // Assert
+        await action.Should().ThrowAsync<XunitException>()
+            .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
     }
 
     public partial class UIFacts
@@ -1361,35 +1322,32 @@ public class AsyncFunctionExceptionAssertionSpecs
         }
     }
 
-    public partial class NonGenericAsyncFunctionAssertions
+    [Fact]
+    public async Task When_no_exception_should_be_thrown_for_async_func_after_wait_time_and_none_was_it_should_not_throw()
     {
-        [Fact]
-        public async Task When_no_exception_should_be_thrown_for_async_func_after_wait_time_and_none_was_it_should_not_throw()
+        // Arrange
+        var waitTime = 6.Seconds();
+        var pollInterval = 10.Milliseconds();
+
+        var clock = new FakeClock();
+        var timer = clock.StartTimer();
+        clock.Delay(waitTime);
+
+        Func<Task> throwShorterThanWaitTime = async () =>
         {
-            // Arrange
-            var waitTime = 6.Seconds();
-            var pollInterval = 10.Milliseconds();
-
-            var clock = new FakeClock();
-            var timer = clock.StartTimer();
-            clock.Delay(waitTime);
-
-            Func<Task> throwShorterThanWaitTime = async () =>
+            if (timer.Elapsed <= waitTime.Divide(12))
             {
-                if (timer.Elapsed <= waitTime.Divide(12))
-                {
-                    throw new ArgumentException("An exception was forced");
-                }
+                throw new ArgumentException("An exception was forced");
+            }
 
-                await Task.Yield();
-            };
+            await Task.Yield();
+        };
 
-            // Act
-            Func<Task> act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
+        // Act
+        Func<Task> act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
 
-            // Assert
-            await act.Should().NotThrowAsync();
-        }
+        // Assert
+        await act.Should().NotThrowAsync();
     }
 
     public partial class UIFacts

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -14,94 +14,83 @@ namespace FluentAssertions.Specs.Exceptions;
 
 public class AsyncFunctionExceptionAssertionSpecs
 {
-    [Fact]
-    public void When_getting_the_subject_it_should_remain_unchanged()
+    public partial class ActionAssertions
     {
-        // Arrange
-        Func<Task> subject = () => Task.FromResult(42);
-
-        // Act
-        Action action = () => subject.Should().Subject.As<object>().Should().BeSameAs(subject);
-
-        // Assert
-        action.Should().NotThrow("the Subject should remain the same");
-    }
-
-    [Fact]
-    public async Task When_subject_is_null_when_expecting_an_exception_it_should_throw()
-    {
-        // Arrange
-        Func<Task> action = null;
-
-        // Act
-        Func<Task> testAction = async () =>
+        [Fact]
+        public void When_getting_the_subject_it_should_remain_unchanged()
         {
-            using var _ = new AssertionScope();
-            await action.Should().ThrowAsync<ArgumentException>("because we want to test the failure {0}", "message");
-        };
+            // Arrange
+            Func<Task> subject = () => Task.FromResult(42);
 
-        // Assert
-        await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*")
-            .Where(e => !e.Message.Contains("NullReferenceException"));
+            // Act
+            Action action = () => subject.Should().Subject.As<object>().Should().BeSameAs(subject);
+
+            // Assert
+            action.Should().NotThrow("the Subject should remain the same");
+        }
     }
 
-    [Fact]
-    public async Task When_subject_is_null_when_not_expecting_a_generic_exception_it_should_throw()
+    public partial class NonGenericAsyncFunctionAssertions
     {
-        // Arrange
-        Func<Task> action = null;
-
-        // Act
-        Func<Task> testAction = async () =>
+        [Fact]
+        public async Task When_subject_is_null_when_expecting_an_exception_it_should_throw()
         {
-            using var _ = new AssertionScope();
-            await action.Should().NotThrowAsync<ArgumentException>("because we want to test the failure {0}", "message");
-        };
+            // Arrange
+            Func<Task> action = null;
 
-        // Assert
-        await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*")
-            .Where(e => !e.Message.Contains("NullReferenceException"));
-    }
+            // Act
+            Func<Task> testAction = async () =>
+            {
+                using var _ = new AssertionScope();
+                await action.Should().ThrowAsync<ArgumentException>("because we want to test the failure {0}", "message");
+            };
 
-    [Fact]
-    public async Task When_subject_is_null_when_not_expecting_an_exception_it_should_throw()
-    {
-        // Arrange
-        Func<Task> action = null;
+            // Assert
+            await testAction.Should().ThrowAsync<XunitException>()
+                .WithMessage("*because we want to test the failure message*found <null>*")
+                .Where(e => !e.Message.Contains("NullReferenceException"));
+        }
 
-        // Act
-        Func<Task> testAction = async () =>
+        [Fact]
+        public async Task When_subject_is_null_when_not_expecting_a_generic_exception_it_should_throw()
         {
-            using var _ = new AssertionScope();
-            await action.Should().NotThrowAsync("because we want to test the failure {0}", "message");
-        };
+            // Arrange
+            Func<Task> action = null;
 
-        // Assert
-        await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*")
-            .Where(e => !e.Message.Contains("NullReferenceException"));
-    }
+            // Act
+            Func<Task> testAction = async () =>
+            {
+                using var _ = new AssertionScope();
+                await action.Should().NotThrowAsync<ArgumentException>("because we want to test the failure {0}", "message");
+            };
 
-    [Fact]
-    public async Task When_async_method_throws_an_empty_AggregateException_it_should_fail()
-    {
-        // Arrange
-        Func<Task> act = () => throw new AggregateException();
+            // Assert
+            await testAction.Should().ThrowAsync<XunitException>()
+                .WithMessage("*because we want to test the failure message*found <null>*")
+                .Where(e => !e.Message.Contains("NullReferenceException"));
+        }
 
-        // Act
-        Func<Task> act2 = () => act.Should().NotThrowAsync();
+        [Fact]
+        public async Task When_subject_is_null_when_not_expecting_an_exception_it_should_throw()
+        {
+            // Arrange
+            Func<Task> action = null;
 
-        // Assert
-        await act2.Should().ThrowAsync<XunitException>();
-    }
+            // Act
+            Func<Task> testAction = async () =>
+            {
+                using var _ = new AssertionScope();
+                await action.Should().NotThrowAsync("because we want to test the failure {0}", "message");
+            };
 
-    [Collection("UIFacts")]
-    public partial class UIFacts
-    {
-        [UIFact]
-        public async Task When_async_method_throws_an_empty_AggregateException_on_UI_thread_it_should_fail()
+            // Assert
+            await testAction.Should().ThrowAsync<XunitException>()
+                .WithMessage("*because we want to test the failure message*found <null>*")
+                .Where(e => !e.Message.Contains("NullReferenceException"));
+        }
+
+        [Fact]
+        public async Task When_async_method_throws_an_empty_AggregateException_it_should_fail()
         {
             // Arrange
             Func<Task> act = () => throw new AggregateException();
@@ -112,22 +101,26 @@ public class AsyncFunctionExceptionAssertionSpecs
             // Assert
             await act2.Should().ThrowAsync<XunitException>();
         }
-    }
 
-    [Fact]
-    public async Task When_async_method_throws_a_nested_AggregateException_it_should_provide_the_message()
-    {
-        // Arrange
-        Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
+        [Collection("UIFacts")]
+        public partial class UIFacts
+        {
+            [UIFact]
+            public async Task When_async_method_throws_an_empty_AggregateException_on_UI_thread_it_should_fail()
+            {
+                // Arrange
+                Func<Task> act = () => throw new AggregateException();
 
-        // Act & Assert
-        await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
-    }
+                // Act
+                Func<Task> act2 = () => act.Should().NotThrowAsync();
 
-    public partial class UIFacts
-    {
-        [UIFact]
-        public async Task When_async_method_throws_a_nested_AggregateException_on_UI_thread_it_should_provide_the_message()
+                // Assert
+                await act2.Should().ThrowAsync<XunitException>();
+            }
+        }
+
+        [Fact]
+        public async Task When_async_method_throws_a_nested_AggregateException_it_should_provide_the_message()
         {
             // Arrange
             Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
@@ -135,38 +128,51 @@ public class AsyncFunctionExceptionAssertionSpecs
             // Act & Assert
             await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
         }
-    }
 
-    [Fact]
-    public async Task When_async_method_throws_a_flat_AggregateException_it_should_provide_the_message()
-    {
-        // Arrange
-        Func<Task> act = () => throw new AggregateException("That was wrong as well.");
+        public partial class UIFacts
+        {
+            [UIFact]
+            public async Task When_async_method_throws_a_nested_AggregateException_on_UI_thread_it_should_provide_the_message()
+            {
+                // Arrange
+                Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
 
-        // Act & Assert
-        await act.Should().ThrowAsync<AggregateException>().WithMessage("That was wrong as well.");
-    }
+                // Act & Assert
+                await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
+            }
+        }
 
-    [Fact]
-    public async Task When_async_method_throws_a_nested_AggregateException_it_should_provide_unwrapped_exception_to_predicate()
-    {
-        // Arrange
-        Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
+        [Fact]
+        public async Task When_async_method_throws_a_flat_AggregateException_it_should_provide_the_message()
+        {
+            // Arrange
+            Func<Task> act = () => throw new AggregateException("That was wrong as well.");
 
-        // Act & Assert
-        await act.Should().ThrowAsync<ArgumentException>()
-            .Where(i => i.Message == "That was wrong.");
-    }
+            // Act & Assert
+            await act.Should().ThrowAsync<AggregateException>().WithMessage("That was wrong as well.");
+        }
 
-    [Fact]
-    public async Task When_async_method_throws_a_flat_AggregateException_it_should_provide_it_to_predicate()
-    {
-        // Arrange
-        Func<Task> act = () => throw new AggregateException("That was wrong as well.");
+        [Fact]
+        public async Task When_async_method_throws_a_nested_AggregateException_it_should_provide_unwrapped_exception_to_predicate()
+        {
+            // Arrange
+            Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
 
-        // Act & Assert
-        await act.Should().ThrowAsync<AggregateException>()
-            .Where(i => i.Message == "That was wrong as well.");
+            // Act & Assert
+            await act.Should().ThrowAsync<ArgumentException>()
+                .Where(i => i.Message == "That was wrong.");
+        }
+
+        [Fact]
+        public async Task When_async_method_throws_a_flat_AggregateException_it_should_provide_it_to_predicate()
+        {
+            // Arrange
+            Func<Task> act = () => throw new AggregateException("That was wrong as well.");
+
+            // Act & Assert
+            await act.Should().ThrowAsync<AggregateException>()
+                .Where(i => i.Message == "That was wrong as well.");
+        }
     }
 
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters
@@ -271,264 +277,267 @@ public class AsyncFunctionExceptionAssertionSpecs
         return Task.FromException(exception);
     }
 
-    [Fact]
-    public async Task When_subject_throws_subclass_of_expected_exact_exception_it_should_fail()
+    public partial class NonGenericAsyncFunctionAssertions
     {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_subject_throws_subclass_of_expected_exact_exception_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
-            .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
+                .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage(
-                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage(
+                    "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
+        }
 
-    [Fact]
-    public async Task When_subject_ValueTask_throws_subclass_of_expected_exact_exception_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_subject_ValueTask_throws_subclass_of_expected_exact_exception_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentNullException>())
-            .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentNullException>())
+                .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage(
-                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage(
+                    "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
+        }
 
-    [Fact]
-    public async Task When_subject_throws_aggregate_exception_and_not_expected_exact_exception_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_subject_throws_aggregate_exception_and_not_expected_exact_exception_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAggregateExceptionAsync<ArgumentException>())
-            .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAggregateExceptionAsync<ArgumentException>())
+                .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage(
-                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage(
+                    "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
+        }
 
-    [Fact]
-    public async Task When_subject_throws_aggregate_exception_and_not_expected_exact_exception_through_ValueTask_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_subject_throws_aggregate_exception_and_not_expected_exact_exception_through_ValueTask_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAggregateExceptionAsyncValueTask<ArgumentException>())
-            .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAggregateExceptionAsyncValueTask<ArgumentException>())
+                .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage(
-                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage(
+                    "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
+        }
 
-    [Fact]
-    public async Task When_subject_throws_the_expected_exact_exception_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_subject_throws_the_expected_exact_exception_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act / Assert
-        await asyncObject
-            .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
-            .Should().ThrowExactlyAsync<ArgumentNullException>();
-    }
+            // Act / Assert
+            await asyncObject
+                .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
+                .Should().ThrowExactlyAsync<ArgumentNullException>();
+        }
 
-    [Fact]
-    public async Task When_subject_throws_the_expected_exact_exception_through_ValueTask_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_subject_throws_the_expected_exact_exception_through_ValueTask_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act / Assert
-        await asyncObject
-            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentNullException>())
-            .Should().ThrowExactlyAsync<ArgumentNullException>();
-    }
+            // Act / Assert
+            await asyncObject
+                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentNullException>())
+                .Should().ThrowExactlyAsync<ArgumentNullException>();
+        }
 
-    [Fact]
-    public async Task When_async_method_throws_expected_exception_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_async_method_throws_expected_exception_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAsync<ArgumentException>())
-            .Should().ThrowAsync<ArgumentException>();
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAsync<ArgumentException>())
+                .Should().ThrowAsync<ArgumentException>();
 
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
 
-    [Fact]
-    public async Task When_async_method_throws_expected_exception_through_ValueTask_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_async_method_throws_expected_exception_through_ValueTask_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-            .Should().ThrowAsync<ArgumentException>();
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
+                .Should().ThrowAsync<ArgumentException>();
 
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
 
-    [Fact]
-    public async Task When_subject_is_null_it_should_be_null()
-    {
-        // Arrange
-        Func<Task> subject = null;
+        [Fact]
+        public async Task When_subject_is_null_it_should_be_null()
+        {
+            // Arrange
+            Func<Task> subject = null;
 
-        // Act
-        Func<Task> action = () => subject.Should().NotThrowAsync();
+            // Act
+            Func<Task> action = () => subject.Should().NotThrowAsync();
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("*found <null>*");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("*found <null>*");
+        }
 
-    [Fact]
-    public async Task When_async_method_throws_async_expected_exception_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_async_method_throws_async_expected_exception_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
+            // Act
+            Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
 
-        // Assert
-        await action.Should().ThrowAsync<ArgumentException>();
-    }
+            // Assert
+            await action.Should().ThrowAsync<ArgumentException>();
+        }
 
-    [Fact]
-    public async Task When_async_method_does_not_throw_expected_exception_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_async_method_does_not_throw_expected_exception_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.SucceedAsync())
-            .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.SucceedAsync())
+                .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage(
-                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage(
+                    "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
+        }
 
-    [Fact]
-    public async Task When_async_method_does_not_throw_expected_exception_through_ValueTask_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_async_method_does_not_throw_expected_exception_through_ValueTask_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.SucceedAsyncValueTask())
-            .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.SucceedAsyncValueTask())
+                .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage(
-                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage(
+                    "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
+        }
 
-    [Fact]
-    public async Task When_async_method_throws_unexpected_exception_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_async_method_throws_unexpected_exception_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAsync<ArgumentException>())
-            .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAsync<ArgumentException>())
+                .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage(
-                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage(
+                    "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
+        }
 
-    [Fact]
-    public async Task When_async_method_throws_unexpected_exception_through_ValueTask_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_async_method_throws_unexpected_exception_through_ValueTask_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-            .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
+                .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage(
-                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
-    }
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage(
+                    "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
+        }
 
-    [Fact]
-    public async Task When_async_method_does_not_throw_exception_and_that_was_expected_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_async_method_does_not_throw_exception_and_that_was_expected_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.SucceedAsync())
-            .Should().NotThrowAsync();
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.SucceedAsync())
+                .Should().NotThrowAsync();
 
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
 
-    [Fact]
-    public async Task When_async_method_does_not_throw_exception_through_ValueTask_and_that_was_expected_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_async_method_does_not_throw_exception_through_ValueTask_and_that_was_expected_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.SucceedAsyncValueTask())
-            .Should().NotThrowAsync();
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.SucceedAsyncValueTask())
+                .Should().NotThrowAsync();
 
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
 
-    [Fact]
-    public async Task When_async_method_does_not_throw_async_exception_and_that_was_expected_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_async_method_does_not_throw_async_exception_and_that_was_expected_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject.SucceedAsync();
+            // Act
+            Func<Task> action = () => asyncObject.SucceedAsync();
 
-        // Assert
-        await action.Should().NotThrowAsync();
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
     }
 
     public partial class UIFacts
@@ -547,107 +556,100 @@ public class AsyncFunctionExceptionAssertionSpecs
         }
     }
 
-    [Fact]
-    public async Task When_subject_throws_subclass_of_expected_async_exception_it_should_succeed()
+    public partial class NonGenericAsyncFunctionAssertions
     {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject.ThrowAsync<ArgumentNullException>();
-
-        // Assert
-        await action.Should().ThrowAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
-    }
-
-    [Fact]
-    public async Task When_function_of_task_int_in_async_method_throws_the_expected_exception_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-        Func<Task<int>> f = () => asyncObject.ThrowTaskIntAsync<ArgumentNullException>(true);
-
-        // Act / Assert
-        await f.Should().ThrowAsync<ArgumentNullException>();
-    }
-
-    [Fact]
-    public async Task When_function_of_task_int_in_async_method_throws_not_excepted_exception_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-        Func<Task<int>> f = () => asyncObject.ThrowTaskIntAsync<InvalidOperationException>(true);
-
-        // Act / Assert
-        await f.Should().NotThrowAsync<ArgumentNullException>();
-    }
-
-    [Fact]
-    public async Task When_subject_is_null_when_expecting_an_exact_exception_it_should_throw()
-    {
-        // Arrange
-        Func<Task> action = null;
-
-        // Act
-        Func<Task> testAction = async () =>
+        [Fact]
+        public async Task When_subject_throws_subclass_of_expected_async_exception_it_should_succeed()
         {
-            using var _ = new AssertionScope();
-            await action.Should().ThrowExactlyAsync<ArgumentException>("because we want to test the failure {0}", "message");
-        };
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Assert
-        await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*")
-            .Where(e => !e.Message.Contains("NullReferenceException"));
+            // Act
+            Func<Task> action = () => asyncObject.ThrowAsync<ArgumentNullException>();
+
+            // Assert
+            await action.Should().ThrowAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+        }
     }
 
-    [Fact]
-    public async Task When_subject_throws_subclass_of_expected_async_exact_exception_it_should_throw()
+    public partial class GenericAsyncFunctionAssertions
     {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_function_of_task_int_in_async_method_throws_the_expected_exception_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+            Func<Task<int>> f = () => asyncObject.ThrowTaskIntAsync<ArgumentNullException>(true);
 
-        // Act
-        Func<Task> action = () => asyncObject.ThrowAsync<ArgumentNullException>();
-        Func<Task> testAction = () => action.Should().ThrowExactlyAsync<ArgumentException>("ABCDE");
+            // Act / Assert
+            await f.Should().ThrowAsync<ArgumentNullException>();
+        }
 
-        // Assert
-        await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*ArgumentException*ABCDE*ArgumentNullException*");
+        [Fact]
+        public async Task When_function_of_task_int_in_async_method_throws_not_excepted_exception_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+            Func<Task<int>> f = () => asyncObject.ThrowTaskIntAsync<InvalidOperationException>(true);
+
+            // Act / Assert
+            await f.Should().NotThrowAsync<ArgumentNullException>();
+        }
     }
 
-    [Fact]
-    public async Task When_subject_throws_aggregate_exception_instead_of_exact_exception_it_should_throw()
+    public partial class NonGenericAsyncFunctionAssertions
     {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_subject_is_null_when_expecting_an_exact_exception_it_should_throw()
+        {
+            // Arrange
+            Func<Task> action = null;
 
-        // Act
-        Func<Task> action = () => asyncObject.ThrowAggregateExceptionAsync<ArgumentException>();
-        Func<Task> testAction = () => action.Should().ThrowExactlyAsync<ArgumentException>("ABCDE");
+            // Act
+            Func<Task> testAction = async () =>
+            {
+                using var _ = new AssertionScope();
+                await action.Should().ThrowExactlyAsync<ArgumentException>("because we want to test the failure {0}", "message");
+            };
 
-        // Assert
-        await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*ArgumentException*ABCDE*AggregateException*");
-    }
+            // Assert
+            await testAction.Should().ThrowAsync<XunitException>()
+                .WithMessage("*because we want to test the failure message*found <null>*")
+                .Where(e => !e.Message.Contains("NullReferenceException"));
+        }
 
-    [Fact]
-    public async Task When_subject_throws_expected_async_exact_exception_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
+        [Fact]
+        public async Task When_subject_throws_subclass_of_expected_async_exact_exception_it_should_throw()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
+            // Act
+            Func<Task> action = () => asyncObject.ThrowAsync<ArgumentNullException>();
+            Func<Task> testAction = () => action.Should().ThrowExactlyAsync<ArgumentException>("ABCDE");
 
-        // Assert
-        await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
-    }
+            // Assert
+            await testAction.Should().ThrowAsync<XunitException>()
+                .WithMessage("*ArgumentException*ABCDE*ArgumentNullException*");
+        }
 
-    public partial class UIFacts
-    {
-        [UIFact]
-        public async Task When_subject_throws_on_UI_thread_expected_async_exact_exception_it_should_succeed()
+        [Fact]
+        public async Task When_subject_throws_aggregate_exception_instead_of_exact_exception_it_should_throw()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject.ThrowAggregateExceptionAsync<ArgumentException>();
+            Func<Task> testAction = () => action.Should().ThrowExactlyAsync<ArgumentException>("ABCDE");
+
+            // Assert
+            await testAction.Should().ThrowAsync<XunitException>()
+                .WithMessage("*ArgumentException*ABCDE*AggregateException*");
+        }
+
+        [Fact]
+        public async Task When_subject_throws_expected_async_exact_exception_it_should_succeed()
         {
             // Arrange
             var asyncObject = new AsyncClass();
@@ -658,634 +660,662 @@ public class AsyncFunctionExceptionAssertionSpecs
             // Assert
             await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
         }
-    }
 
-    [Fact]
-    public async Task When_async_method_throws_exception_and_no_exception_was_expected_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAsync<ArgumentException>())
-            .Should().NotThrowAsync();
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Did not expect any exception, but found System.ArgumentException*");
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_exception_through_ValueTask_and_no_exception_was_expected_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-            .Should().NotThrowAsync();
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Did not expect any exception, but found System.ArgumentException*");
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_exception_and_expected_not_to_throw_another_one_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAsync<ArgumentException>())
-            .Should().NotThrowAsync<InvalidOperationException>();
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task
-        When_async_method_throws_exception_through_ValueTask_and_expected_not_to_throw_another_one_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-            .Should().NotThrowAsync<InvalidOperationException>();
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_exception_and_expected_not_to_throw_async_another_one_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
-
-        // Assert
-        await action.Should().NotThrowAsync<InvalidOperationException>();
-    }
-
-    [Fact]
-    public async Task When_async_method_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(_ => asyncObject.SucceedAsync())
-            .Should().NotThrowAsync<InvalidOperationException>();
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task
-        When_async_method_succeeds_and_expected_not_to_throw_particular_exception_through_ValueTask_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(_ => asyncObject.SucceedAsyncValueTask())
-            .Should().NotThrowAsync<InvalidOperationException>();
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_exception_expected_not_to_be_thrown_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAsync<ArgumentException>())
-            .Should().NotThrowAsync<ArgumentException>();
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Did not expect System.ArgumentException, but found*");
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_exception_expected_through_ValueTask_not_to_be_thrown_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-            .Should().NotThrowAsync<ArgumentException>();
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Did not expect System.ArgumentException, but found*");
-    }
-
-    [Fact]
-    public async Task When_async_method_of_T_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(_ => asyncObject.ReturnTaskInt())
-            .Should().NotThrowAsync<InvalidOperationException>();
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_ValueTask_async_method_of_T_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(_ => asyncObject.ReturnValueTaskInt())
-            .Should().NotThrowAsync<InvalidOperationException>();
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_async_method_of_T_throws_exception_expected_not_to_be_thrown_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowTaskIntAsync<ArgumentException>(true))
-            .Should().NotThrowAsync<ArgumentException>();
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Did not expect System.ArgumentException, but found System.ArgumentException*");
-    }
-
-    [Fact]
-    public async Task When_ValueTask_async_method_of_T_throws_exception_expected_not_to_be_thrown_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-
-        // Act
-        Func<Task> action = () => asyncObject
-            .Awaiting(x => x.ThrowValueTaskIntAsync<ArgumentException>(true))
-            .Should().NotThrowAsync<ArgumentException>();
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Did not expect System.ArgumentException, but found System.ArgumentException*");
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_the_expected_inner_exception_it_should_succeed()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async(new AggregateException(new InvalidOperationException()));
-
-        // Act
-        Func<Task> action = () => task
-            .Should().ThrowAsync<AggregateException>()
-            .WithInnerException<AggregateException, InvalidOperationException>();
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_the_expected_inner_exception_from_argument_it_should_succeed()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async(new AggregateException(new InvalidOperationException()));
-
-        // Act
-        Func<Task> action = () => task
-            .Should().ThrowAsync<AggregateException>()
-            .WithInnerException(typeof(InvalidOperationException));
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_the_expected_inner_exception_exactly_it_should_succeed()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
-
-        // Act
-        Func<Task> action = () => task
-            .Should().ThrowAsync<AggregateException>()
-            .WithInnerExceptionExactly<AggregateException, ArgumentException>();
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_the_expected_inner_exception_exactly_defined_in_arguments_it_should_succeed()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
-
-        // Act
-        Func<Task> action = () => task
-            .Should().ThrowAsync<AggregateException>()
-            .WithInnerExceptionExactly(typeof(ArgumentException));
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_aggregate_exception_containing_expected_exception_it_should_succeed()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async(new AggregateException(new InvalidOperationException()));
-
-        // Act
-        Func<Task> action = () => task
-            .Should().ThrowAsync<InvalidOperationException>();
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_any_exception_it_should_succeed()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async<InvalidOperationException>();
-
-        // Act
-        Func<Task> action = () => task
-            .Should().ThrowAsync();
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_the_expected_exception_it_should_succeed()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async<InvalidOperationException>();
-
-        // Act
-        Func<Task> action = () => task
-            .Should().ThrowAsync<InvalidOperationException>();
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_async_method_throws_any_exception_within_timespan_it_should_succeed()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async<InvalidOperationException>();
-
-        // Act
-        Func<Task> action = () => task.Should().ThrowWithinAsync(
-            100.Milliseconds());
-
-        // Assert
-        await action.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_async_method_does_not_throw_the_expected_inner_exception_it_should_fail()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
-
-        // Act
-        Func<Task> action = () => task
-            .Should().ThrowAsync<AggregateException>()
-            .WithInnerException<AggregateException, InvalidOperationException>();
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
-    }
-
-    [Fact]
-    public async Task When_async_method_does_not_throw_the_expected_inner_exception_from_argument_it_should_fail()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
-
-        // Act
-        Func<Task> action = () => task
-            .Should().ThrowAsync<AggregateException>()
-            .WithInnerException(typeof(InvalidOperationException));
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
-    }
-
-    [Fact]
-    public async Task When_async_method_does_not_throw_the_expected_inner_exception_exactly_it_should_fail()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentNullException()));
-
-        // Act
-        Func<Task> action = () => task
-            .Should().ThrowAsync<AggregateException>()
-            .WithInnerExceptionExactly<AggregateException, ArgumentException>();
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>().WithMessage("*ArgumentException*ArgumentNullException*");
-    }
-
-    [Fact]
-    public async Task
-        When_async_method_does_not_throw_the_expected_inner_exception_exactly_defined_in_arguments_it_should_fail()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentNullException()));
-
-        // Act
-        Func<Task> action = () => task
-            .Should().ThrowAsync<AggregateException>()
-            .WithInnerExceptionExactly(typeof(ArgumentException));
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>().WithMessage("*ArgumentException*ArgumentNullException*");
-    }
-
-    [Fact]
-    public async Task When_async_method_does_not_throw_the_expected_exception_it_should_fail()
-    {
-        // Arrange
-        Func<Task> task = () => Throw.Async<ArgumentException>();
-
-        // Act
-        Func<Task> action = () => task
-            .Should().ThrowAsync<InvalidOperationException>();
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
-    }
-
-#pragma warning disable MA0147
-    [Fact]
-    public void When_asserting_async_void_method_should_throw_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-        Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
-
-        // Act
-        Action action = () => asyncVoidMethod.Should().Throw<ArgumentException>();
-
-        // Assert
-        action.Should().Throw<InvalidOperationException>("*async*void*");
-    }
-
-    [Fact]
-    public void When_asserting_async_void_method_should_throw_exactly_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-        Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
-
-        // Act
-        Action action = () => asyncVoidMethod.Should().ThrowExactly<ArgumentException>();
-
-        // Assert
-        action.Should().Throw<InvalidOperationException>("*async*void*");
-    }
-
-    [Fact]
-    public void When_asserting_async_void_method_should_not_throw_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-        Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
-
-        // Act
-        Action action = () => asyncVoidMethod.Should().NotThrow();
-
-        // Assert
-        action.Should().Throw<InvalidOperationException>("*async*void*");
-    }
-
-    [Fact]
-    public void When_asserting_async_void_method_should_not_throw_specific_exception_it_should_fail()
-    {
-        // Arrange
-        var asyncObject = new AsyncClass();
-        Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
-
-        // Act
-        Action action = () => asyncVoidMethod.Should().NotThrow<ArgumentException>();
-
-        // Assert
-        action.Should().Throw<InvalidOperationException>("*async*void*");
-    }
-#pragma warning restore MA0147
-
-    [Fact]
-    public async Task When_a_method_throws_with_a_matching_parameter_name_it_should_succeed()
-    {
-        // Arrange
-        Func<Task> task = () => new AsyncClass().ThrowAsync(new ArgumentNullException("someParameter"));
-
-        // Act
-        Func<Task> act = () =>
-            task.Should().ThrowAsync<ArgumentException>()
-                .WithParameterName("someParameter");
-
-        // Assert
-        await act.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_a_method_throws_with_a_non_matching_parameter_name_it_should_fail_with_a_descriptive_message()
-    {
-        // Arrange
-        Func<Task> task = () => new AsyncClass().ThrowAsync(new ArgumentNullException("someOtherParameter"));
-
-        // Act
-        Func<Task> act = () =>
-            task.Should().ThrowAsync<ArgumentException>()
-                .WithParameterName("someParameter", "we want to test the failure {0}", "message");
-
-        // Assert
-        await act.Should().ThrowAsync<XunitException>()
-            .WithMessage("*with parameter name \"someParameter\"*we want to test the failure message*\"someOtherParameter\"*");
-    }
-
-    #region NotThrowAfterAsync
-
-    [Fact]
-    public async Task When_wait_time_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
-    {
-        // Arrange
-        var waitTime = 0.Milliseconds();
-        var pollInterval = 10.Milliseconds();
-
-        var clock = new FakeClock();
-        var asyncObject = new AsyncClass();
-        Func<Task> someFunc = () => asyncObject.SucceedAsync();
-
-        // Act
-        Func<Task> act = () => someFunc.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
-
-        // Assert
-        await act.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_poll_interval_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
-    {
-        // Arrange
-        var waitTime = 10.Milliseconds();
-        var pollInterval = 0.Milliseconds();
-
-        var clock = new FakeClock();
-        var asyncObject = new AsyncClass();
-        Func<Task> someFunc = () => asyncObject.SucceedAsync();
-
-        // Act
-        Func<Task> act = () => someFunc.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
-
-        // Assert
-        await act.Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task When_subject_is_null_for_async_func_it_should_throw()
-    {
-        // Arrange
-        var waitTime = 0.Milliseconds();
-        var pollInterval = 0.Milliseconds();
-        Func<Task> action = null;
-
-        // Act
-        Func<Task> testAction = async () =>
+        public partial class UIFacts
         {
-            using var _ = new AssertionScope();
-
-            await action.Should().NotThrowAfterAsync(waitTime, pollInterval,
-                "because we want to test the failure {0}", "message");
-        };
-
-        // Assert
-        await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*")
-            .Where(e => !e.Message.Contains("NullReferenceException"));
-    }
-
-    [Fact]
-    public async Task When_wait_time_is_negative_for_async_func_it_should_throw()
-    {
-        // Arrange
-        var waitTime = -1.Milliseconds();
-        var pollInterval = 10.Milliseconds();
-
-        var asyncObject = new AsyncClass();
-        Func<Task> someFunc = () => asyncObject.SucceedAsync();
-
-        // Act
-        Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
-
-        // Assert
-        await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
-            .WithParameterName("waitTime")
-            .WithMessage("*must be non-negative*");
-    }
-
-    [Fact]
-    public async Task When_poll_interval_is_negative_for_async_func_it_should_throw()
-    {
-        // Arrange
-        var waitTime = 10.Milliseconds();
-        var pollInterval = -1.Milliseconds();
-
-        var asyncObject = new AsyncClass();
-        Func<Task> someFunc = () => asyncObject.SucceedAsync();
-
-        // Act
-        Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
-
-        // Assert
-        await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
-            .WithParameterName("pollInterval")
-            .WithMessage("*must be non-negative*");
-    }
-
-    [Fact]
-    public async Task When_no_exception_should_be_thrown_for_null_async_func_after_wait_time_it_should_throw()
-    {
-        // Arrange
-        var waitTime = 2.Seconds();
-        var pollInterval = 10.Milliseconds();
-
-        Func<Task> func = null;
-
-        // Act
-        Func<Task> action = () => func.Should()
-            .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
-
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("*but found <null>*");
-    }
-
-    [Fact]
-    public async Task When_no_exception_should_be_thrown_for_async_func_after_wait_time_but_it_was_it_should_throw()
-    {
-        // Arrange
-        var waitTime = 2.Seconds();
-        var pollInterval = 10.Milliseconds();
-
-        var clock = new FakeClock();
-        var timer = clock.StartTimer();
-        clock.CompleteAfter(waitTime);
-
-        Func<Task> throwLongerThanWaitTime = async () =>
-        {
-            if (timer.Elapsed <= waitTime.Multiply(1.5))
+            [UIFact]
+            public async Task When_subject_throws_on_UI_thread_expected_async_exact_exception_it_should_succeed()
             {
-                throw new ArgumentException("An exception was forced");
+                // Arrange
+                var asyncObject = new AsyncClass();
+
+                // Act
+                Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
+
+                // Assert
+                await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
             }
+        }
 
-            await Task.Yield();
-        };
+        [Fact]
+        public async Task When_async_method_throws_exception_and_no_exception_was_expected_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-        // Act
-        Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-            .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAsync<ArgumentException>())
+                .Should().NotThrowAsync();
 
-        // Assert
-        await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Did not expect any exception, but found System.ArgumentException*");
+        }
+
+        [Fact]
+        public async Task When_async_method_throws_exception_through_ValueTask_and_no_exception_was_expected_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
+                .Should().NotThrowAsync();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Did not expect any exception, but found System.ArgumentException*");
+        }
+
+        [Fact]
+        public async Task When_async_method_throws_exception_and_expected_not_to_throw_another_one_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAsync<ArgumentException>())
+                .Should().NotThrowAsync<InvalidOperationException>();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task
+            When_async_method_throws_exception_through_ValueTask_and_expected_not_to_throw_another_one_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
+                .Should().NotThrowAsync<InvalidOperationException>();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_async_method_throws_exception_and_expected_not_to_throw_async_another_one_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
+
+            // Assert
+            await action.Should().NotThrowAsync<InvalidOperationException>();
+        }
+
+        [Fact]
+        public async Task When_async_method_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(_ => asyncObject.SucceedAsync())
+                .Should().NotThrowAsync<InvalidOperationException>();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task
+            When_async_method_succeeds_and_expected_not_to_throw_particular_exception_through_ValueTask_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(_ => asyncObject.SucceedAsyncValueTask())
+                .Should().NotThrowAsync<InvalidOperationException>();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_async_method_throws_exception_expected_not_to_be_thrown_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAsync<ArgumentException>())
+                .Should().NotThrowAsync<ArgumentException>();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Did not expect System.ArgumentException, but found*");
+        }
+
+        [Fact]
+        public async Task When_async_method_throws_exception_expected_through_ValueTask_not_to_be_thrown_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
+                .Should().NotThrowAsync<ArgumentException>();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Did not expect System.ArgumentException, but found*");
+        }
+    }
+
+    public partial class GenericAsyncFunctionAssertions
+    {
+        [Fact]
+        public async Task When_async_method_of_T_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(_ => asyncObject.ReturnTaskInt())
+                .Should().NotThrowAsync<InvalidOperationException>();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_ValueTask_async_method_of_T_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(_ => asyncObject.ReturnValueTaskInt())
+                .Should().NotThrowAsync<InvalidOperationException>();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_async_method_of_T_throws_exception_expected_not_to_be_thrown_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowTaskIntAsync<ArgumentException>(true))
+                .Should().NotThrowAsync<ArgumentException>();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Did not expect System.ArgumentException, but found System.ArgumentException*");
+        }
+
+        [Fact]
+        public async Task When_ValueTask_async_method_of_T_throws_exception_expected_not_to_be_thrown_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Func<Task> action = () => asyncObject
+                .Awaiting(x => x.ThrowValueTaskIntAsync<ArgumentException>(true))
+                .Should().NotThrowAsync<ArgumentException>();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Did not expect System.ArgumentException, but found System.ArgumentException*");
+        }
+    }
+
+    public partial class NonGenericAsyncFunctionAssertions
+    {
+        [Fact]
+        public async Task When_async_method_throws_the_expected_inner_exception_it_should_succeed()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<AggregateException>()
+                .WithInnerException<AggregateException, InvalidOperationException>();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_async_method_throws_the_expected_inner_exception_from_argument_it_should_succeed()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<AggregateException>()
+                .WithInnerException(typeof(InvalidOperationException));
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_async_method_throws_the_expected_inner_exception_exactly_it_should_succeed()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly<AggregateException, ArgumentException>();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_async_method_throws_the_expected_inner_exception_exactly_defined_in_arguments_it_should_succeed()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly(typeof(ArgumentException));
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_async_method_throws_aggregate_exception_containing_expected_exception_it_should_succeed()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<InvalidOperationException>();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Succeeds_for_any_exception_thrown_by_async_method()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async<InvalidOperationException>();
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Succeeds_for_expected_exception_thrown_by_async_method()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async<InvalidOperationException>();
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<InvalidOperationException>();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Succeeds_for_any_exception_thrown_within_timespan_by_async_method()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async<InvalidOperationException>();
+
+            // Act
+            Func<Task> action = () => task.Should().ThrowWithinAsync(
+                100.Milliseconds());
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_async_method_does_not_throw_the_expected_inner_exception_it_should_fail()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<AggregateException>()
+                .WithInnerException<AggregateException, InvalidOperationException>();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
+        }
+
+        [Fact]
+        public async Task When_async_method_does_not_throw_the_expected_inner_exception_from_argument_it_should_fail()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<AggregateException>()
+                .WithInnerException(typeof(InvalidOperationException));
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
+        }
+
+        [Fact]
+        public async Task When_async_method_does_not_throw_the_expected_inner_exception_exactly_it_should_fail()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentNullException()));
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly<AggregateException, ArgumentException>();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>().WithMessage("*ArgumentException*ArgumentNullException*");
+        }
+
+        [Fact]
+        public async Task
+            When_async_method_does_not_throw_the_expected_inner_exception_exactly_defined_in_arguments_it_should_fail()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentNullException()));
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly(typeof(ArgumentException));
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>().WithMessage("*ArgumentException*ArgumentNullException*");
+        }
+
+        [Fact]
+        public async Task When_async_method_does_not_throw_the_expected_exception_it_should_fail()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async<ArgumentException>();
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<InvalidOperationException>();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
+        }
+    }
+
+    public partial class ActionAssertions
+    {
+#pragma warning disable MA0147
+        [Fact]
+        public void When_asserting_async_void_method_should_throw_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+            Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
+
+            // Act
+            Action action = () => asyncVoidMethod.Should().Throw<ArgumentException>();
+
+            // Assert
+            action.Should().Throw<InvalidOperationException>("*async*void*");
+        }
+
+        [Fact]
+        public void When_asserting_async_void_method_should_throw_exactly_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+            Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
+
+            // Act
+            Action action = () => asyncVoidMethod.Should().ThrowExactly<ArgumentException>();
+
+            // Assert
+            action.Should().Throw<InvalidOperationException>("*async*void*");
+        }
+
+        [Fact]
+        public void When_asserting_async_void_method_should_not_throw_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+            Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
+
+            // Act
+            Action action = () => asyncVoidMethod.Should().NotThrow();
+
+            // Assert
+            action.Should().Throw<InvalidOperationException>("*async*void*");
+        }
+
+        [Fact]
+        public void When_asserting_async_void_method_should_not_throw_specific_exception_it_should_fail()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+            Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
+
+            // Act
+            Action action = () => asyncVoidMethod.Should().NotThrow<ArgumentException>();
+
+            // Assert
+            action.Should().Throw<InvalidOperationException>("*async*void*");
+        }
+#pragma warning restore MA0147
+    }
+
+    public partial class NonGenericAsyncFunctionAssertions
+    {
+        [Fact]
+        public async Task When_a_method_throws_with_a_matching_parameter_name_it_should_succeed()
+        {
+            // Arrange
+            Func<Task> task = () => new AsyncClass().ThrowAsync(new ArgumentNullException("someParameter"));
+
+            // Act
+            Func<Task> act = () =>
+                task.Should().ThrowAsync<ArgumentException>()
+                    .WithParameterName("someParameter");
+
+            // Assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_a_method_throws_with_a_non_matching_parameter_name_it_should_fail_with_a_descriptive_message()
+        {
+            // Arrange
+            Func<Task> task = () => new AsyncClass().ThrowAsync(new ArgumentNullException("someOtherParameter"));
+
+            // Act
+            Func<Task> act = () =>
+                task.Should().ThrowAsync<ArgumentException>()
+                    .WithParameterName("someParameter", "we want to test the failure {0}", "message");
+
+            // Assert
+            await act.Should().ThrowAsync<XunitException>()
+                .WithMessage("*with parameter name \"someParameter\"*we want to test the failure message*\"someOtherParameter\"*");
+        }
+
+        #region NotThrowAfterAsync
+
+        [Fact]
+        public async Task When_wait_time_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
+        {
+            // Arrange
+            var waitTime = 0.Milliseconds();
+            var pollInterval = 10.Milliseconds();
+
+            var clock = new FakeClock();
+            var asyncObject = new AsyncClass();
+            Func<Task> someFunc = () => asyncObject.SucceedAsync();
+
+            // Act
+            Func<Task> act = () => someFunc.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
+
+            // Assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_poll_interval_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
+        {
+            // Arrange
+            var waitTime = 10.Milliseconds();
+            var pollInterval = 0.Milliseconds();
+
+            var clock = new FakeClock();
+            var asyncObject = new AsyncClass();
+            Func<Task> someFunc = () => asyncObject.SucceedAsync();
+
+            // Act
+            Func<Task> act = () => someFunc.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
+
+            // Assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_subject_is_null_for_async_func_it_should_throw()
+        {
+            // Arrange
+            var waitTime = 0.Milliseconds();
+            var pollInterval = 0.Milliseconds();
+            Func<Task> action = null;
+
+            // Act
+            Func<Task> testAction = async () =>
+            {
+                using var _ = new AssertionScope();
+
+                await action.Should().NotThrowAfterAsync(waitTime, pollInterval,
+                    "because we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            await testAction.Should().ThrowAsync<XunitException>()
+                .WithMessage("*because we want to test the failure message*found <null>*")
+                .Where(e => !e.Message.Contains("NullReferenceException"));
+        }
+
+        [Fact]
+        public async Task When_wait_time_is_negative_for_async_func_it_should_throw()
+        {
+            // Arrange
+            var waitTime = -1.Milliseconds();
+            var pollInterval = 10.Milliseconds();
+
+            var asyncObject = new AsyncClass();
+            Func<Task> someFunc = () => asyncObject.SucceedAsync();
+
+            // Act
+            Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
+                .WithParameterName("waitTime")
+                .WithMessage("*must be non-negative*");
+        }
+
+        [Fact]
+        public async Task When_poll_interval_is_negative_for_async_func_it_should_throw()
+        {
+            // Arrange
+            var waitTime = 10.Milliseconds();
+            var pollInterval = -1.Milliseconds();
+
+            var asyncObject = new AsyncClass();
+            Func<Task> someFunc = () => asyncObject.SucceedAsync();
+
+            // Act
+            Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
+                .WithParameterName("pollInterval")
+                .WithMessage("*must be non-negative*");
+        }
+
+        [Fact]
+        public async Task When_no_exception_should_be_thrown_for_null_async_func_after_wait_time_it_should_throw()
+        {
+            // Arrange
+            var waitTime = 2.Seconds();
+            var pollInterval = 10.Milliseconds();
+
+            Func<Task> func = null;
+
+            // Act
+            Func<Task> action = () => func.Should()
+                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("*but found <null>*");
+        }
+
+        [Fact]
+        public async Task When_no_exception_should_be_thrown_for_async_func_after_wait_time_but_it_was_it_should_throw()
+        {
+            // Arrange
+            var waitTime = 2.Seconds();
+            var pollInterval = 10.Milliseconds();
+
+            var clock = new FakeClock();
+            var timer = clock.StartTimer();
+            clock.CompleteAfter(waitTime);
+
+            Func<Task> throwLongerThanWaitTime = async () =>
+            {
+                if (timer.Elapsed <= waitTime.Multiply(1.5))
+                {
+                    throw new ArgumentException("An exception was forced");
+                }
+
+                await Task.Yield();
+            };
+
+            // Act
+            Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
+                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+        }
     }
 
     public partial class UIFacts
@@ -1322,32 +1352,35 @@ public class AsyncFunctionExceptionAssertionSpecs
         }
     }
 
-    [Fact]
-    public async Task When_no_exception_should_be_thrown_for_async_func_after_wait_time_and_none_was_it_should_not_throw()
+    public partial class NonGenericAsyncFunctionAssertions
     {
-        // Arrange
-        var waitTime = 6.Seconds();
-        var pollInterval = 10.Milliseconds();
-
-        var clock = new FakeClock();
-        var timer = clock.StartTimer();
-        clock.Delay(waitTime);
-
-        Func<Task> throwShorterThanWaitTime = async () =>
+        [Fact]
+        public async Task When_no_exception_should_be_thrown_for_async_func_after_wait_time_and_none_was_it_should_not_throw()
         {
-            if (timer.Elapsed <= waitTime.Divide(12))
+            // Arrange
+            var waitTime = 6.Seconds();
+            var pollInterval = 10.Milliseconds();
+
+            var clock = new FakeClock();
+            var timer = clock.StartTimer();
+            clock.Delay(waitTime);
+
+            Func<Task> throwShorterThanWaitTime = async () =>
             {
-                throw new ArgumentException("An exception was forced");
-            }
+                if (timer.Elapsed <= waitTime.Divide(12))
+                {
+                    throw new ArgumentException("An exception was forced");
+                }
 
-            await Task.Yield();
-        };
+                await Task.Yield();
+            };
 
-        // Act
-        Func<Task> act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
+            // Act
+            Func<Task> act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
 
-        // Assert
-        await act.Should().NotThrowAsync();
+            // Assert
+            await act.Should().NotThrowAsync();
+        }
     }
 
     public partial class UIFacts

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -936,6 +936,20 @@ public class AsyncFunctionExceptionAssertionSpecs
     }
 
     [Fact]
+    public async Task When_async_method_throws_any_exception_it_should_succeed()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async<InvalidOperationException>();
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
     public async Task When_async_method_throws_the_expected_exception_it_should_succeed()
     {
         // Arrange

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -101,24 +101,27 @@ public class AsyncFunctionExceptionAssertionSpecs
             // Assert
             await act2.Should().ThrowAsync<XunitException>();
         }
+    }
 
-        [Collection("UIFacts")]
-        public partial class UIFacts
+    [Collection("UIFacts")]
+    public partial class UIFacts
+    {
+        [UIFact]
+        public async Task When_async_method_throws_an_empty_AggregateException_on_UI_thread_it_should_fail()
         {
-            [UIFact]
-            public async Task When_async_method_throws_an_empty_AggregateException_on_UI_thread_it_should_fail()
-            {
-                // Arrange
-                Func<Task> act = () => throw new AggregateException();
+            // Arrange
+            Func<Task> act = () => throw new AggregateException();
 
-                // Act
-                Func<Task> act2 = () => act.Should().NotThrowAsync();
+            // Act
+            Func<Task> act2 = () => act.Should().NotThrowAsync();
 
-                // Assert
-                await act2.Should().ThrowAsync<XunitException>();
-            }
+            // Assert
+            await act2.Should().ThrowAsync<XunitException>();
         }
+    }
 
+    public partial class NonGenericAsyncFunctionAssertions
+    {
         [Fact]
         public async Task When_async_method_throws_a_nested_AggregateException_it_should_provide_the_message()
         {
@@ -128,20 +131,23 @@ public class AsyncFunctionExceptionAssertionSpecs
             // Act & Assert
             await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
         }
+    }
 
-        public partial class UIFacts
+    public partial class UIFacts
+    {
+        [UIFact]
+        public async Task When_async_method_throws_a_nested_AggregateException_on_UI_thread_it_should_provide_the_message()
         {
-            [UIFact]
-            public async Task When_async_method_throws_a_nested_AggregateException_on_UI_thread_it_should_provide_the_message()
-            {
-                // Arrange
-                Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
+            // Arrange
+            Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
 
-                // Act & Assert
-                await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
-            }
+            // Act & Assert
+            await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
         }
+    }
 
+    public partial class NonGenericAsyncFunctionAssertions
+    {
         [Fact]
         public async Task When_async_method_throws_a_flat_AggregateException_it_should_provide_the_message()
         {
@@ -660,23 +666,26 @@ public class AsyncFunctionExceptionAssertionSpecs
             // Assert
             await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
         }
+    }
 
-        public partial class UIFacts
+    public partial class UIFacts
+    {
+        [UIFact]
+        public async Task When_subject_throws_on_UI_thread_expected_async_exact_exception_it_should_succeed()
         {
-            [UIFact]
-            public async Task When_subject_throws_on_UI_thread_expected_async_exact_exception_it_should_succeed()
-            {
-                // Arrange
-                var asyncObject = new AsyncClass();
+            // Arrange
+            var asyncObject = new AsyncClass();
 
-                // Act
-                Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
+            // Act
+            Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
 
-                // Assert
-                await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
-            }
+            // Assert
+            await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
         }
+    }
 
+    public partial class NonGenericAsyncFunctionAssertions
+    {
         [Fact]
         public async Task When_async_method_throws_exception_and_no_exception_was_expected_it_should_fail()
         {

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -964,6 +964,20 @@ public class AsyncFunctionExceptionAssertionSpecs
     }
 
     [Fact]
+    public async Task When_async_method_throws_any_exception_within_timespan_it_should_succeed()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async<InvalidOperationException>();
+
+        // Act
+        Func<Task> action = () => task.Should().ThrowWithinAsync(
+            100.Milliseconds());
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
     public async Task When_async_method_does_not_throw_the_expected_inner_exception_it_should_fail()
     {
         // Arrange

--- a/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
@@ -6,134 +6,128 @@ namespace FluentAssertions.Specs.Exceptions;
 
 public class ThrowAssertionsSpecs
 {
-    public class ActionsAssertions
+    [Fact]
+    public void Succeeds_for_any_exception_thrown_by_subject()
     {
-        [Fact]
-        public void Succeeds_for_any_exception_thrown_by_subject()
-        {
-            // Arrange
-            Does testSubject = Does.Throw<InvalidOperationException>();
+        // Arrange
+        Does testSubject = Does.Throw<InvalidOperationException>();
 
-            // Act / Assert
-            testSubject.Invoking(x => x.Do()).Should().Throw();
+        // Act / Assert
+        testSubject.Invoking(x => x.Do()).Should().Throw();
+    }
+
+    [Fact]
+    public void Succeeds_for_expected_exception_thrown_by_subject()
+    {
+        // Arrange
+        Does testSubject = Does.Throw<InvalidOperationException>();
+
+        // Act / Assert
+        testSubject.Invoking(x => x.Do()).Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Succeeds_for_any_exception_thrown_by_func()
+    {
+        // Arrange
+        Does testSubject = Does.Throw<InvalidOperationException>();
+
+        // Act / Assert
+        testSubject.Invoking(x => x.Return()).Should().Throw();
+    }
+
+    [Fact]
+    public void Succeeds_for_expected_exception_thrown_by_func()
+    {
+        // Arrange
+        Does testSubject = Does.Throw<InvalidOperationException>();
+
+        // Act / Assert
+        testSubject.Invoking(x => x.Return()).Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Succeeds_for_any_exception_thrown_by_action()
+    {
+        // Arrange
+        var act = new Action(() => throw new InvalidOperationException("Some exception"));
+
+        // Act / Assert
+        act.Should().Throw();
+    }
+
+    [Fact]
+    public void Succeeds_for_any_exception_thrown_by_action()
+    {
+        // Arrange
+        var act = new Action(() => throw new InvalidOperationException("Some exception"));
+
+        // Act / Assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void When_subject_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
+    {
+        try
+        {
+            Does testSubject = Does.NotThrow();
+
+            testSubject.Invoking(x => x.Do()).Should().Throw<Exception>();
+
+            throw new XunitException("Should().Throw() did not throw");
         }
-
-        [Fact]
-        public void Succeeds_for_expected_exception_thrown_by_subject()
+        catch (XunitException ex)
         {
-            // Arrange
-            Does testSubject = Does.Throw<InvalidOperationException>();
-
-            // Act / Assert
-            testSubject.Invoking(x => x.Do()).Should().Throw<InvalidOperationException>();
-        }
-
-        [Fact]
-        public void When_subject_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
-        {
-            try
-            {
-                Does testSubject = Does.NotThrow();
-
-                testSubject.Invoking(x => x.Do()).Should().Throw<Exception>();
-
-                throw new XunitException("Should().Throw() did not throw");
-            }
-            catch (XunitException ex)
-            {
-                ex.Message.Should().Be(
-                    "Expected a <System.Exception> to be thrown, but no exception was thrown.");
-            }
-        }
-
-        [Fact]
-        public void Succeeds_for_any_exception_thrown_by_action()
-        {
-            // Arrange
-            var act = new Action(() => throw new InvalidOperationException("Some exception"));
-
-            // Act / Assert
-            act.Should().Throw();
-        }
-
-        [Fact]
-        public void Succeeds_for_expected_exception_thrown_by_action()
-        {
-            // Arrange
-            var act = new Action(() => throw new InvalidOperationException("Some exception"));
-
-            // Act / Assert
-            act.Should().Throw<InvalidOperationException>();
-        }
-
-        [Fact]
-        public void When_action_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
-        {
-            try
-            {
-                var act = new Action(() => { });
-
-                act.Should().Throw<Exception>();
-
-                throw new XunitException("Should().Throw() did not throw");
-            }
-            catch (XunitException ex)
-            {
-                ex.Message.Should().Be(
-                    "Expected a <System.Exception> to be thrown, but no exception was thrown.");
-            }
+            ex.Message.Should().Be(
+                "Expected a <System.Exception> to be thrown, but no exception was thrown.");
         }
     }
 
-    public class FunctionAssertions
+    [Fact]
+    public void When_func_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
     {
-        [Fact]
-        public void Succeeds_for_any_exception_thrown_by_func()
+        try
         {
-            // Arrange
-            Does testSubject = Does.Throw<InvalidOperationException>();
-
-            // Act / Assert
-            testSubject.Invoking(x => x.Return()).Should().Throw();
-        }
-
-        [Fact]
-        public void Succeeds_for_expected_exception_thrown_by_func()
-        {
-            // Arrange
-            Does testSubject = Does.Throw<InvalidOperationException>();
-
-            // Act / Assert
-            testSubject.Invoking(x => x.Return()).Should().Throw<InvalidOperationException>();
-        }
-
-        [Fact]
-        public void When_func_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
-        {
-            try
-            {
-                Does testSubject = Does.NotThrow();
-
-                testSubject.Invoking(x => x.Return()).Should().Throw<Exception>();
-
-                throw new XunitException("Should().Throw() did not throw");
-            }
-            catch (XunitException ex)
-            {
-                ex.Message.Should().Be(
-                    "Expected a <System.Exception> to be thrown, but no exception was thrown.");
-            }
-        }
-
-        [Fact]
-        public void When_func_does_not_throw_it_should_be_chainable()
-        {
-            // Arrange
             Does testSubject = Does.NotThrow();
 
-            // Act / Assert
-            testSubject.Invoking(x => x.Return()).Should().NotThrow()
-                .Which.Should().Be(42);
+            testSubject.Invoking(x => x.Return()).Should().Throw<Exception>();
+
+            throw new XunitException("Should().Throw() did not throw");
+        }
+        catch (XunitException ex)
+        {
+            ex.Message.Should().Be(
+                "Expected a <System.Exception> to be thrown, but no exception was thrown.");
+        }
+    }
+
+    [Fact]
+    public void When_func_does_not_throw_it_should_be_chainable()
+    {
+        // Arrange
+        Does testSubject = Does.NotThrow();
+
+        // Act / Assert
+        testSubject.Invoking(x => x.Return()).Should().NotThrow()
+            .Which.Should().Be(42);
+    }
+
+    [Fact]
+    public void When_action_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
+    {
+        try
+        {
+            var act = new Action(() => { });
+
+            act.Should().Throw<Exception>();
+
+            throw new XunitException("Should().Throw() did not throw");
+        }
+        catch (XunitException ex)
+        {
+            ex.Message.Should().Be(
+                "Expected a <System.Exception> to be thrown, but no exception was thrown.");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
@@ -6,128 +6,134 @@ namespace FluentAssertions.Specs.Exceptions;
 
 public class ThrowAssertionsSpecs
 {
-    [Fact]
-    public void When_subject_throws_any_exception_it_should_not_do_anything()
+    public class ActionsAssertions
     {
-        // Arrange
-        Does testSubject = Does.Throw<InvalidOperationException>();
-
-        // Act / Assert
-        testSubject.Invoking(x => x.Do()).Should().Throw();
-    }
-
-    [Fact]
-    public void When_subject_throws_expected_exception_it_should_not_do_anything()
-    {
-        // Arrange
-        Does testSubject = Does.Throw<InvalidOperationException>();
-
-        // Act / Assert
-        testSubject.Invoking(x => x.Do()).Should().Throw<InvalidOperationException>();
-    }
-
-    [Fact]
-    public void When_func_throws_any_exception_it_should_not_do_anything()
-    {
-        // Arrange
-        Does testSubject = Does.Throw<InvalidOperationException>();
-
-        // Act / Assert
-        testSubject.Invoking(x => x.Return()).Should().Throw();
-    }
-
-    [Fact]
-    public void When_func_throws_expected_exception_it_should_not_do_anything()
-    {
-        // Arrange
-        Does testSubject = Does.Throw<InvalidOperationException>();
-
-        // Act / Assert
-        testSubject.Invoking(x => x.Return()).Should().Throw<InvalidOperationException>();
-    }
-
-    [Fact]
-    public void When_action_throws_any_exception_it_should_not_do_anything()
-    {
-        // Arrange
-        var act = new Action(() => throw new InvalidOperationException("Some exception"));
-
-        // Act / Assert
-        act.Should().Throw();
-    }
-
-    [Fact]
-    public void When_action_throws_expected_exception_it_should_not_do_anything()
-    {
-        // Arrange
-        var act = new Action(() => throw new InvalidOperationException("Some exception"));
-
-        // Act / Assert
-        act.Should().Throw<InvalidOperationException>();
-    }
-
-    [Fact]
-    public void When_subject_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
-    {
-        try
+        [Fact]
+        public void Succeeds_for_any_exception_thrown_by_subject()
         {
+            // Arrange
+            Does testSubject = Does.Throw<InvalidOperationException>();
+
+            // Act / Assert
+            testSubject.Invoking(x => x.Do()).Should().Throw();
+        }
+
+        [Fact]
+        public void Succeeds_for_expected_exception_thrown_by_subject()
+        {
+            // Arrange
+            Does testSubject = Does.Throw<InvalidOperationException>();
+
+            // Act / Assert
+            testSubject.Invoking(x => x.Do()).Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void When_subject_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
+        {
+            try
+            {
+                Does testSubject = Does.NotThrow();
+
+                testSubject.Invoking(x => x.Do()).Should().Throw<Exception>();
+
+                throw new XunitException("Should().Throw() did not throw");
+            }
+            catch (XunitException ex)
+            {
+                ex.Message.Should().Be(
+                    "Expected a <System.Exception> to be thrown, but no exception was thrown.");
+            }
+        }
+
+        [Fact]
+        public void Succeeds_for_any_exception_thrown_by_action()
+        {
+            // Arrange
+            var act = new Action(() => throw new InvalidOperationException("Some exception"));
+
+            // Act / Assert
+            act.Should().Throw();
+        }
+
+        [Fact]
+        public void Succeeds_for_expected_exception_thrown_by_action()
+        {
+            // Arrange
+            var act = new Action(() => throw new InvalidOperationException("Some exception"));
+
+            // Act / Assert
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void When_action_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
+        {
+            try
+            {
+                var act = new Action(() => { });
+
+                act.Should().Throw<Exception>();
+
+                throw new XunitException("Should().Throw() did not throw");
+            }
+            catch (XunitException ex)
+            {
+                ex.Message.Should().Be(
+                    "Expected a <System.Exception> to be thrown, but no exception was thrown.");
+            }
+        }
+    }
+
+    public class FunctionAssertions
+    {
+        [Fact]
+        public void Succeeds_for_any_exception_thrown_by_func()
+        {
+            // Arrange
+            Does testSubject = Does.Throw<InvalidOperationException>();
+
+            // Act / Assert
+            testSubject.Invoking(x => x.Return()).Should().Throw();
+        }
+
+        [Fact]
+        public void Succeeds_for_expected_exception_thrown_by_func()
+        {
+            // Arrange
+            Does testSubject = Does.Throw<InvalidOperationException>();
+
+            // Act / Assert
+            testSubject.Invoking(x => x.Return()).Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void When_func_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
+        {
+            try
+            {
+                Does testSubject = Does.NotThrow();
+
+                testSubject.Invoking(x => x.Return()).Should().Throw<Exception>();
+
+                throw new XunitException("Should().Throw() did not throw");
+            }
+            catch (XunitException ex)
+            {
+                ex.Message.Should().Be(
+                    "Expected a <System.Exception> to be thrown, but no exception was thrown.");
+            }
+        }
+
+        [Fact]
+        public void When_func_does_not_throw_it_should_be_chainable()
+        {
+            // Arrange
             Does testSubject = Does.NotThrow();
 
-            testSubject.Invoking(x => x.Do()).Should().Throw<Exception>();
-
-            throw new XunitException("Should().Throw() did not throw");
-        }
-        catch (XunitException ex)
-        {
-            ex.Message.Should().Be(
-                "Expected a <System.Exception> to be thrown, but no exception was thrown.");
-        }
-    }
-
-    [Fact]
-    public void When_func_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
-    {
-        try
-        {
-            Does testSubject = Does.NotThrow();
-
-            testSubject.Invoking(x => x.Return()).Should().Throw<Exception>();
-
-            throw new XunitException("Should().Throw() did not throw");
-        }
-        catch (XunitException ex)
-        {
-            ex.Message.Should().Be(
-                "Expected a <System.Exception> to be thrown, but no exception was thrown.");
-        }
-    }
-
-    [Fact]
-    public void When_func_does_not_throw_it_should_be_chainable()
-    {
-        // Arrange
-        Does testSubject = Does.NotThrow();
-
-        // Act / Assert
-        testSubject.Invoking(x => x.Return()).Should().NotThrow()
-            .Which.Should().Be(42);
-    }
-
-    [Fact]
-    public void When_action_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
-    {
-        try
-        {
-            var act = new Action(() => { });
-
-            act.Should().Throw<Exception>();
-
-            throw new XunitException("Should().Throw() did not throw");
-        }
-        catch (XunitException ex)
-        {
-            ex.Message.Should().Be(
-                "Expected a <System.Exception> to be thrown, but no exception was thrown.");
+            // Act / Assert
+            testSubject.Invoking(x => x.Return()).Should().NotThrow()
+                .Which.Should().Be(42);
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
@@ -57,7 +57,7 @@ public class ThrowAssertionsSpecs
     }
 
     [Fact]
-    public void Succeeds_for_any_exception_thrown_by_action()
+    public void Succeeds_for_expected_exception_thrown_by_action()
     {
         // Arrange
         var act = new Action(() => throw new InvalidOperationException("Some exception"));

--- a/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
@@ -7,6 +7,16 @@ namespace FluentAssertions.Specs.Exceptions;
 public class ThrowAssertionsSpecs
 {
     [Fact]
+    public void When_subject_throws_any_exception_it_should_not_do_anything()
+    {
+        // Arrange
+        Does testSubject = Does.Throw<InvalidOperationException>();
+
+        // Act / Assert
+        testSubject.Invoking(x => x.Do()).Should().Throw();
+    }
+
+    [Fact]
     public void When_subject_throws_expected_exception_it_should_not_do_anything()
     {
         // Arrange
@@ -17,6 +27,16 @@ public class ThrowAssertionsSpecs
     }
 
     [Fact]
+    public void When_func_throws_any_exception_it_should_not_do_anything()
+    {
+        // Arrange
+        Does testSubject = Does.Throw<InvalidOperationException>();
+
+        // Act / Assert
+        testSubject.Invoking(x => x.Return()).Should().Throw();
+    }
+
+    [Fact]
     public void When_func_throws_expected_exception_it_should_not_do_anything()
     {
         // Arrange
@@ -24,6 +44,16 @@ public class ThrowAssertionsSpecs
 
         // Act / Assert
         testSubject.Invoking(x => x.Return()).Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void When_action_throws_any_exception_it_should_not_do_anything()
+    {
+        // Arrange
+        var act = new Action(() => throw new InvalidOperationException("Some exception"));
+
+        // Act / Assert
+        act.Should().Throw();
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -468,6 +468,27 @@ public static class TaskAssertionSpecs
         }
 
         [Fact]
+        public async Task When_task_throws_any_asynchronous_it_should_succeed()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<bool>();
+
+            // Act
+            Func<Task> action = () =>
+            {
+                return Awaiting(() => (Task)taskFactory.Task)
+                    .Should(timer).ThrowWithinAsync(1.Seconds());
+            };
+
+            _ = action.Invoke();
+            taskFactory.SetException(new InvalidOperationException("foo"));
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
         public async Task When_task_throws_asynchronous_it_should_succeed()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -468,27 +468,6 @@ public static class TaskAssertionSpecs
         }
 
         [Fact]
-        public async Task When_task_throws_any_asynchronous_it_should_succeed()
-        {
-            // Arrange
-            var timer = new FakeClock();
-            var taskFactory = new TaskCompletionSource<bool>();
-
-            // Act
-            Func<Task> action = () =>
-            {
-                return Awaiting(() => (Task)taskFactory.Task)
-                    .Should(timer).ThrowWithinAsync(1.Seconds());
-            };
-
-            _ = action.Invoke();
-            taskFactory.SetException(new InvalidOperationException("foo"));
-
-            // Assert
-            await action.Should().NotThrowAsync();
-        }
-
-        [Fact]
         public async Task When_task_throws_asynchronous_it_should_succeed()
         {
             // Arrange

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -9,11 +9,10 @@ sidebar:
 
 ## 8.4.0
 
-* Added `Should().Throw()`, `ThrowAsync()` and `ThrowWithinAsync()` flavors that don’t require a specific exception type - [3059](https://github.com/fluentassertions/fluentassertions/pull/3059)
-
 ## Enhancements
 
 * Added `ExcludingMembersNamed` to `BeEquivalentTo` to exclude fields and properties anywhere in the graph - [3062](https://github.com/fluentassertions/fluentassertions/pull/3062)
+* Added `Should().Throw()`, `ThrowAsync()` and `ThrowWithinAsync()` flavors that don’t require a specific exception type - [3059](https://github.com/fluentassertions/fluentassertions/pull/3059)
 
 ## 8.3.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -9,6 +9,8 @@ sidebar:
 
 ## 8.4.0
 
+* Added `Should().Throw()`, `ThrowAsync()` and `ThrowWithinAsync()` flavors that don’t require a specific exception type - [3059](https://github.com/fluentassertions/fluentassertions/pull/3059)
+
 ## Enhancements
 
 * Added `ExcludingMembersNamed` to `BeEquivalentTo` to exclude fields and properties anywhere in the graph - [3062](https://github.com/fluentassertions/fluentassertions/pull/3062)
@@ -19,7 +21,6 @@ sidebar:
 
 * Clarify the date/time type when comparing non-compatible dates and times in `BeEquivalentTo` - [3049](https://github.com/fluentassertions/fluentassertions/pull/3049)
 * Improve the rendering of exception messages when using `WithMessage` for better readability - [3039](https://github.com/fluentassertions/fluentassertions/pull/3039)
-* Added `Should().Throw()`, `ThrowAsync()` and `ThrowWithinAsync()` flavors that don’t require a specific exception type - [3056](https://github.com/fluentassertions/fluentassertions/issues/3056)
 
 ## 8.2.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,12 +13,13 @@ sidebar:
 
 * Clarify the date/time type when comparing non-compatible dates and times in `BeEquivalentTo` - [3049](https://github.com/fluentassertions/fluentassertions/pull/3049)
 * Improve the rendering of exception messages when using `WithMessage` for better readability - [3039](https://github.com/fluentassertions/fluentassertions/pull/3039)
+* Added `Should().Throw()`, `ThrowAsync()` and `ThrowWithinAsync()` flavors that don’t require a specific exception type - [3056](https://github.com/fluentassertions/fluentassertions/issues/3056)
 
 ## 8.2.0
 
 ## Fixes
 
-* Fixed a regression from 8.1.0 where a `NullReferenceException` was thrown during subject identification - [#3036](https://github.com/fluentassertions/fluentassertions/pull/3036
+* Fixed a regression from 8.1.0 where a `NullReferenceException` was thrown during subject identification - [#3036](https://github.com/fluentassertions/fluentassertions/pull/3036)
 
 ## Enhancements
 


### PR DESCRIPTION
This implements issue #3056

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## CONTRIBUTOR LICENSE GRANT

By submitting this contribution, the contributor hereby irrevocably grants to the project owners and maintainers a perpetual, worldwide, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and create derivative works of the contribution for any purpose and under any terms, including proprietary licensing.

The contributor waives any moral rights in the contribution to the extent permitted by law and agrees not to assert any claim of authorship or control over the contribution. The contributor represents that they are the sole author of the contribution and that it is provided free of any third-party claims.

The contributor understands and agrees that the maintainers may, at their sole discretion, use, license, or redistribute the contribution as part of any work and under any terms they choose, without further permission or attribution.

* [ ] I have read the Contributor License Grant and accept the conditions
* [ ] I'm interested in a free license for Fluent Assertions and will share my email address through sales@xceed.com