### PR TITLE
Added Should().Throw(), ThrowAsync() and ThrowWithinAsync() flavors that don’t require a specific exception type.

### DIFF
--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -113,6 +113,25 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     }
 
     /// <summary>
+    /// Asserts that the current <see cref="Func{Task}"/> throws any exception.
+    /// </summary>
+    /// <param name="because">
+    /// (Optional) A formatted phrase as is supported by <see cref="string.Format(string,object[])"/>  explaining why the assertion is
+    /// needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because"/> .
+    /// </param>
+    /// <returns>
+    /// A Task&lt;ExceptionAssertions&lt;Exception&gt;&gt; object.
+    /// </returns>
+    public async Task<ExceptionAssertions<Exception>> ThrowAsync(
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        return await ThrowAsync<Exception>(because, becauseArgs);
+    }
+
+    /// <summary>
     /// Asserts that the current <see cref="Func{Task}"/> throws an exception of type <typeparamref name="TException"/>.
     /// </summary>
     /// <typeparam name="TException">The type of exception expected to be thrown.</typeparam>
@@ -139,6 +158,29 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         }
 
         return new ExceptionAssertions<TException>([], assertionChain);
+    }
+
+    /// <summary>
+    /// Asserts that the current <see cref="Func{Task}"/> throws any exception within a specific timeout.
+    /// </summary>
+    /// <param name="timeSpan">
+    /// The allowed time span for the operation.
+    /// </param>
+    /// <param name="because">
+    /// (Optional)
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion is needed. If
+    /// the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <returns>
+    /// A Task&lt;ExceptionAssertions&lt;Exception&gt;&gt; object.
+    /// </returns>
+    public async Task<ExceptionAssertions<Exception>> ThrowWithinAsync(TimeSpan timeSpan,
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        return await ThrowWithinAsync(timeSpan, because, becauseArgs);
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -31,6 +31,25 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
     }
 
     /// <summary>
+    /// Asserts that the current <see cref="Delegate" /> throws any exception.
+    /// </summary>
+    /// <param name="because">
+    /// (Optional)
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion is needed. If
+    /// the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <returns>
+    /// An ExceptionAssertions&lt;Exception&gt; object.
+    /// </returns>
+    public ExceptionAssertions<Exception> Throw([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        return this.Throw<Exception>(because, becauseArgs);
+    }
+
+    /// <summary>
     /// Asserts that the current <see cref="Delegate" /> throws an exception of type <typeparamref name="TException"/>.
     /// </summary>
     /// <param name="because">

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2090,10 +2090,12 @@ namespace FluentAssertions.Specialized
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -2115,6 +2117,7 @@ namespace FluentAssertions.Specialized
         protected abstract void InvokeSubject();
         public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<System.Exception> Throw(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2211,10 +2211,12 @@ namespace FluentAssertions.Specialized
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -2236,6 +2238,7 @@ namespace FluentAssertions.Specialized
         protected abstract void InvokeSubject();
         public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<System.Exception> Throw(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2034,10 +2034,12 @@ namespace FluentAssertions.Specialized
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -2059,6 +2061,7 @@ namespace FluentAssertions.Specialized
         protected abstract void InvokeSubject();
         public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<System.Exception> Throw(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2090,10 +2090,12 @@ namespace FluentAssertions.Specialized
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowAsync(string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<System.Exception>> ThrowWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -2115,6 +2117,7 @@ namespace FluentAssertions.Specialized
         protected abstract void InvokeSubject();
         public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<System.Exception> Throw(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -936,6 +936,20 @@ public class AsyncFunctionExceptionAssertionSpecs
     }
 
     [Fact]
+    public async Task When_async_method_throws_any_exception_it_should_succeed()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async<InvalidOperationException>();
+
+        // Act
+        Func<Task> action = () => task
+            .Should().ThrowAsync();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
     public async Task When_async_method_throws_the_expected_exception_it_should_succeed()
     {
         // Arrange
@@ -944,6 +958,20 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => task
             .Should().ThrowAsync<InvalidOperationException>();
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task When_async_method_throws_any_exception_within_timespan_it_should_succeed()
+    {
+        // Arrange
+        Func<Task> task = () => Throw.Async<InvalidOperationException>();
+
+        // Act
+        Func<Task> action = () => task.Should().ThrowWithinAsync(
+            100.Milliseconds());
 
         // Assert
         await action.Should().NotThrowAsync();

--- a/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
@@ -7,6 +7,16 @@ namespace FluentAssertions.Specs.Exceptions;
 public class ThrowAssertionsSpecs
 {
     [Fact]
+    public void When_subject_throws_any_exception_it_should_not_do_anything()
+    {
+        // Arrange
+        Does testSubject = Does.Throw<InvalidOperationException>();
+
+        // Act / Assert
+        testSubject.Invoking(x => x.Do()).Should().Throw();
+    }
+
+    [Fact]
     public void When_subject_throws_expected_exception_it_should_not_do_anything()
     {
         // Arrange
@@ -17,6 +27,16 @@ public class ThrowAssertionsSpecs
     }
 
     [Fact]
+    public void When_func_throws_any_exception_it_should_not_do_anything()
+    {
+        // Arrange
+        Does testSubject = Does.Throw<InvalidOperationException>();
+
+        // Act / Assert
+        testSubject.Invoking(x => x.Return()).Should().Throw();
+    }
+
+    [Fact]
     public void When_func_throws_expected_exception_it_should_not_do_anything()
     {
         // Arrange
@@ -24,6 +44,16 @@ public class ThrowAssertionsSpecs
 
         // Act / Assert
         testSubject.Invoking(x => x.Return()).Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void When_action_throws_any_exception_it_should_not_do_anything()
+    {
+        // Arrange
+        var act = new Action(() => throw new InvalidOperationException("Some exception"));
+
+        // Act / Assert
+        act.Should().Throw();
     }
 
     [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,12 +13,13 @@ sidebar:
 
 * Clarify the date/time type when comparing non-compatible dates and times in `BeEquivalentTo` - [3049](https://github.com/fluentassertions/fluentassertions/pull/3049)
 * Improve the rendering of exception messages when using `WithMessage` for better readability - [3039](https://github.com/fluentassertions/fluentassertions/pull/3039)
+* Added `Should().Throw()`, `ThrowAsync()` and `ThrowWithinAsync()` flavors that don’t require a specific exception type - [3056](https://github.com/fluentassertions/fluentassertions/issues/3056)
 
 ## 8.2.0
 
 ## Fixes
 
-* Fixed a regression from 8.1.0 where a `NullReferenceException` was thrown during subject identification - [#3036](https://github.com/fluentassertions/fluentassertions/pull/3036
+* Fixed a regression from 8.1.0 where a `NullReferenceException` was thrown during subject identification - [#3036](https://github.com/fluentassertions/fluentassertions/pull/3036)
 
 ## Enhancements
 


### PR DESCRIPTION
This implements issue #3056

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## CONTRIBUTOR LICENSE GRANT

By submitting this contribution, the contributor hereby irrevocably grants to the project owners and maintainers a perpetual, worldwide, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and create derivative works of the contribution for any purpose and under any terms, including proprietary licensing.

The contributor waives any moral rights in the contribution to the extent permitted by law and agrees not to assert any claim of authorship or control over the contribution. The contributor represents that they are the sole author of the contribution and that it is provided free of any third-party claims.

The contributor understands and agrees that the maintainers may, at their sole discretion, use, license, or redistribute the contribution as part of any work and under any terms they choose, without further permission or attribution.

* [ ] I have read the Contributor License Grant and accept the conditions
* [ ] I'm interested in a free license for Fluent Assertions and will share my email address through sales@xceed.com