### PR TITLE
Allow excluding properties by name anywhere in the graph

### DIFF
--- a/Src/FluentAssertions/Equivalency/Selection/ExcludeMembersByNameSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/ExcludeMembersByNameSelectionRule.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FluentAssertions.Equivalency.Selection;
+
+/// <summary>
+/// Represents a member selection rule that excludes certain fields or properties from being considered during
+/// structural equality checks based on their names.
+/// </summary>
+internal class ExcludeMembersByNameSelectionRule : IMemberSelectionRule
+{
+    private readonly string[] membersToExclude;
+    private readonly string description;
+
+    /// <summary>
+    /// Initializes the rule with a list of filed or property names to exclude from the structural equality check.
+    /// </summary>
+    public ExcludeMembersByNameSelectionRule(string[] membersToExclude)
+    {
+        this.membersToExclude = membersToExclude;
+        description = string.Join(", ", membersToExclude);
+    }
+
+    public bool IncludesMembers => false;
+
+    public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
+        MemberSelectionContext context)
+    {
+        return selectedMembers.Where(m => !membersToExclude.Contains(m.Expectation.Name)).ToArray();
+    }
+
+    /// <inheritdoc />
+    /// <filterpriority>2</filterpriority>
+    public override string ToString()
+    {
+        return "Exclude members named: " + description;
+    }
+}

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -275,6 +275,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     {
         includedProperties = MemberVisibility.Public | MemberVisibility.ExplicitlyImplemented |
             MemberVisibility.DefaultInterfaceProperties;
+
         return (TSelf)this;
     }
 
@@ -285,6 +286,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     {
         includedProperties = MemberVisibility.Public | MemberVisibility.Internal | MemberVisibility.ExplicitlyImplemented |
             MemberVisibility.DefaultInterfaceProperties;
+
         return (TSelf)this;
     }
 
@@ -297,6 +299,18 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     public TSelf ExcludingProperties()
     {
         includedProperties = MemberVisibility.None;
+        return (TSelf)this;
+    }
+
+    /// <summary>
+    /// Excludes the specified member(s) from the structural equality check anywhere in the object graph.
+    /// </summary>
+    public TSelf ExcludingMembersNamed(params string[] memberNames)
+    {
+        Guard.ThrowIfArgumentIsNull(memberNames, nameof(memberNames), "Member names cannot be null.");
+        Guard.ThrowIfArgumentIsEmpty(memberNames, nameof(memberNames), "At least one member name must be specified.");
+
+        AddSelectionRule(new ExcludeMembersByNameSelectionRule(memberNames));
         return (TSelf)this;
     }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -911,6 +911,7 @@ namespace FluentAssertions.Equivalency
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
+        public TSelf ExcludingMembersNamed(params string[] memberNames) { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -924,6 +924,7 @@ namespace FluentAssertions.Equivalency
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
+        public TSelf ExcludingMembersNamed(params string[] memberNames) { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -903,6 +903,7 @@ namespace FluentAssertions.Equivalency
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
+        public TSelf ExcludingMembersNamed(params string[] memberNames) { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -911,6 +911,7 @@ namespace FluentAssertions.Equivalency
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
+        public TSelf ExcludingMembersNamed(params string[] memberNames) { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNonBrowsableMembers() { }
         public TSelf ExcludingProperties() { }

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -123,6 +123,13 @@ orderDto.Should().BeEquivalentTo(order, options => options
     .Excluding(ctx => ctx.Path == "Level.Level.Text"));
 ```
 
+And if you want to exclude one or more specific properties everywhere in the object graph just by their names, use `ExcludingMembersNamed` like this:
+
+```csharp
+orderDto.Should().BeEquivalentTo(order, options => options 
+    .ExcludingMembersNamed("ID", "Version"));
+```
+
 Maybe far-fetched, but you may even decide to exclude a member on a particular nested object by its index.
 
 ```csharp

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -7,6 +7,12 @@ sidebar:
   nav: "sidebar"
 ---
 
+## 8.4.0
+
+## Enhancements
+
+* Added `ExcludingMembersNamed` to `BeEquivalentTo` to exclude fields and properties anywhere in the graph - [3062](https://github.com/fluentassertions/fluentassertions/pull/3062)
+
 ## 8.3.0
 
 ## Enhancements


### PR DESCRIPTION
Adds a new convenience option

```csharp
  subject.Should().BeEquivalentTo(expectation, options => options
      .ExcludingMembersNamed("LastName", "Age"));
```

Closes #3052 


