### PR TITLE
Expose the target type for inline assertions

### DIFF
--- a/Tests/ExampleExtensions/ExampleExtensions.csproj
+++ b/Tests/ExampleExtensions/ExampleExtensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <IsPackable>false</IsPackable>
@@ -9,7 +9,7 @@
         <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
       <ProjectReference Include="..\..\Src\FluentAssertions\FluentAssertions.csproj" />
     </ItemGroup>
 

--- a/Tests/ExampleExtensions/HttpResponseMessageAssertions.cs
+++ b/Tests/ExampleExtensions/HttpResponseMessageAssertions.cs
@@ -1,0 +1,31 @@
+#if NETCOREAPP3_1_OR_GREATER
+
+using System.Text.Json;
+using FluentAssertions;
+
+namespace ExampleExtensions;
+
+public static class HttpResponseMessageExtensions
+{
+    public static HttpResponseMessageAssertions Should(this HttpResponseMessage response)
+    {
+        return new HttpResponseMessageAssertions(response);
+    }
+}
+
+public class HttpResponseMessageAssertions(HttpResponseMessage response)
+{
+    public async Task BeEquivalentTo<T>(T expectation)
+    {
+        string body = await response.Content.ReadAsStringAsync();
+
+        object actual = JsonSerializer.Deserialize(body, expectation.GetType(), new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        });
+
+        actual.Should().BeEquivalentTo(expectation);
+    }
+}
+
+#endif

--- a/Tests/FluentAssertions.Extensibility.Specs/ExtensibilitySpecs.cs
+++ b/Tests/FluentAssertions.Extensibility.Specs/ExtensibilitySpecs.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using ExampleExtensions;
-using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs;
+namespace FluentAssertions.Extensibility.Specs;
 
 public class ExtensibilitySpecs
 {

--- a/Tests/FluentAssertions.Extensibility.Specs/FluentAssertions.Extensibility.Specs.csproj
+++ b/Tests/FluentAssertions.Extensibility.Specs/FluentAssertions.Extensibility.Specs.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Src\FluentAssertions\FluentAssertions.csproj" />
+    <ProjectReference Include="..\ExampleExtensions\ExampleExtensions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tests/FluentAssertions.Extensibility.Specs/JsonWithInlineAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Extensibility.Specs/JsonWithInlineAssertionsSpecs.cs
@@ -1,0 +1,92 @@
+#if NET8_0_OR_GREATER
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using ExampleExtensions;
+namespace FluentAssertions.Extensibility.Specs;
+
+public class JsonWithInlineAssertionsSpecs
+{
+    [Fact]
+    public async Task Can_use_inline_predicates_during_json_assertions()
+    {
+        // Arrange
+        string json =
+            """
+            {
+                "Id": "TestPackage",
+                "Versions": [
+                    {
+                        "Version": "1.0.0",
+                        "Description": "Test package description",
+                        "RepositoryUrl": "https://github.com/test/package",
+                        "Owner": "testowner"
+                    }
+                ]
+            }
+            """;
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+        response.Content = new StringContent(json);
+
+        // Act
+        await HttpResponseMessageExtensions.Should(response).BeEquivalentTo(new
+        {
+            Id = "Pathy",
+            Versions = new[]
+            {
+                new
+                {
+                    Description = Value.ThatMatches<string>(s => s.Contains("paths")),
+                    Owner = "dennisdoomen",
+                    RepositoryUrl = "https://github.com/dennisdoomen/pathy",
+                    Version = "1.5.0"
+                }
+            }
+        });
+
+        // Assert
+    }
+
+    [Fact]
+    public async Task Can_use_inline_assertions_during_json_assertions()
+    {
+        // Arrange
+        string json =
+            """
+            {
+                "Id": "TestPackage",
+                "Versions": [
+                    {
+                        "Version": "1.0.0",
+                        "Description": "Test package description",
+                        "RepositoryUrl": "https://github.com/test/package",
+                        "Owner": "testowner"
+                    }
+                ]
+            }
+            """;
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+        response.Content = new StringContent(json);
+
+        // Act
+        await HttpResponseMessageExtensions.Should(response).BeEquivalentTo(new
+        {
+            Id = "Pathy",
+            Versions = new[]
+            {
+                new
+                {
+                    Description = Value.ThatSatisfies<string>(s => s.Should().Contain("paths")),
+                    Owner = "dennisdoomen",
+                    RepositoryUrl = "https://github.com/dennisdoomen/pathy",
+                    Version = "1.5.0"
+                }
+            }
+        });
+
+        // Assert
+    }
+}
+#endif

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -41,7 +41,6 @@
     <ProjectReference Include="..\..\Src\FluentAssertions\FluentAssertions.csproj" />
     <ProjectReference Include="..\AssemblyA\AssemblyA.csproj" />
     <ProjectReference Include="..\AssemblyB\AssemblyB.csproj" />
-    <ProjectReference Include="..\ExampleExtensions\ExampleExtensions.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION


<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

Closes #3089