### PR TITLE
Clean-up tests related to exceptions

### DIFF
--- a/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Xunit;
 using Xunit.Sdk;
 
@@ -148,84 +147,5 @@ public class ExceptionAssertionSpecs
 
         // Act / Assert
         act.Should().ThrowExactly<ArgumentNullException>();
-    }
-}
-
-public class SomeTestClass
-{
-    internal const string ExceptionMessage = "someMessage";
-
-    public IList<string> Strings = new List<string>();
-
-    public void Throw()
-    {
-        throw new ArgumentException(ExceptionMessage);
-    }
-}
-
-public abstract class Does
-{
-    public abstract void Do();
-
-    public abstract void Do(string someParam);
-
-    public abstract int Return();
-
-    public static Does Throw<TException>(TException exception)
-        where TException : Exception
-    {
-        return new DoesThrow<TException>(exception);
-    }
-
-    public static Does Throw<TException>()
-        where TException : Exception, new()
-    {
-        return Throw(new TException());
-    }
-
-    public static Does NotThrow() => new DoesNotThrow();
-
-    private class DoesThrow<TException> : Does
-        where TException : Exception
-    {
-        private readonly TException exception;
-
-        public DoesThrow(TException exception)
-        {
-            this.exception = exception;
-        }
-
-        public override void Do() => throw exception;
-
-        public override void Do(string someParam) => throw exception;
-
-        public override int Return() => throw exception;
-    }
-
-    private class DoesNotThrow : Does
-    {
-        public override void Do() { }
-
-        public override void Do(string someParam) { }
-
-        public override int Return() => 42;
-    }
-}
-
-internal class ExceptionWithProperties : Exception
-{
-    public ExceptionWithProperties(string propertyValue)
-    {
-        Property = propertyValue;
-    }
-
-    public string Property { get; set; }
-}
-
-internal class ExceptionWithEmptyToString : Exception
-{
-    public override string ToString()
-    {
-        return string.Empty;
     }
 }

--- a/Tests/FluentAssertions.Specs/Exceptions/InnerExceptionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/InnerExceptionSpecs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 using Xunit.Sdk;
 
@@ -10,11 +10,10 @@ public class InnerExceptionSpecs
     public void When_subject_throws_an_exception_with_the_expected_inner_exception_it_should_not_do_anything()
     {
         // Arrange
-        Does testSubject = Does.Throw(new Exception("", new ArgumentException()));
+        Action testSubject = () => throw new Exception("", new ArgumentException());
 
         // Act / Assert
         testSubject
-            .Invoking(x => x.Do())
             .Should().Throw<Exception>()
             .WithInnerException<ArgumentException>();
     }
@@ -23,11 +22,10 @@ public class InnerExceptionSpecs
     public void When_subject_throws_an_exception_with_the_expected_inner_base_exception_it_should_not_do_anything()
     {
         // Arrange
-        Does testSubject = Does.Throw(new Exception("", new ArgumentNullException()));
+        Action testSubject = () => throw new Exception("", new ArgumentNullException());
 
         // Act / Assert
         testSubject
-            .Invoking(x => x.Do())
             .Should().Throw<Exception>()
             .WithInnerException<ArgumentException>();
     }
@@ -36,11 +34,10 @@ public class InnerExceptionSpecs
     public void When_subject_throws_an_exception_with_the_expected_inner_exception_from_argument_it_should_not_do_anything()
     {
         // Arrange
-        Does testSubject = Does.Throw(new Exception("", new ArgumentException()));
+        Action testSubject = () => throw new Exception("", new ArgumentException());
 
         // Act / Assert
         testSubject
-            .Invoking(x => x.Do())
             .Should().Throw<Exception>()
             .WithInnerException(typeof(ArgumentException));
     }
@@ -186,15 +183,14 @@ public class InnerExceptionSpecs
         // Arrange
         var innerException = new NullReferenceException("InnerExceptionMessage");
 
-        Does testSubject = Does.Throw(new Exception("", innerException));
+        Action testSubject = () => throw new Exception("", innerException);
 
         try
         {
             // Act
             testSubject
-                .Invoking(x => x.Do())
                 .Should().Throw<Exception>()
-                .WithInnerException<ArgumentException>("because {0} should do just that", "Does.Do");
+                .WithInnerException<ArgumentException>("because {0} should do just that", "the action");
 
             throw new XunitException("This point should not be reached");
         }
@@ -202,7 +198,7 @@ public class InnerExceptionSpecs
         {
             // Assert
             exc.Message.Should().Match(
-                "Expected*ArgumentException*Does.Do should do just that*NullReferenceException*InnerExceptionMessage*");
+                "Expected*ArgumentException*the action should do just that*NullReferenceException*InnerExceptionMessage*");
         }
     }
 
@@ -211,17 +207,17 @@ public class InnerExceptionSpecs
     {
         try
         {
-            Does testSubject = Does.Throw<Exception>();
+            Action testSubject = () => throw new Exception();
 
-            testSubject.Invoking(x => x.Do()).Should().Throw<Exception>()
-                .WithInnerException<InvalidOperationException>("because {0} should do that", "Does.Do");
+            testSubject.Should().Throw<Exception>()
+                .WithInnerException<InvalidOperationException>("because {0} should do that", "the action");
 
             throw new XunitException("This point should not be reached");
         }
         catch (XunitException ex)
         {
             ex.Message.Should().Be(
-                "Expected inner System.InvalidOperationException because Does.Do should do that, but the thrown exception has no inner exception.");
+                "Expected inner System.InvalidOperationException because the action should do that, but the thrown exception has no inner exception.");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Exceptions/InvokingActionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/InvokingActionSpecs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 
 namespace FluentAssertions.Specs.Exceptions;
@@ -9,10 +9,10 @@ public class InvokingActionSpecs
     public void Invoking_on_null_is_not_allowed()
     {
         // Arrange
-        Does someClass = null;
+        Action someClass = null;
 
         // Act
-        Action act = () => someClass.Invoking(d => d.Do());
+        Action act = () => someClass.Invoking(d => d());
 
         // Assert
         act.Should().ThrowExactly<ArgumentNullException>()
@@ -23,7 +23,7 @@ public class InvokingActionSpecs
     public void Invoking_with_null_is_not_allowed()
     {
         // Arrange
-        Does someClass = Does.NotThrow();
+        Action someClass = () => { };
 
         // Act
         Action act = () => someClass.Invoking(null);

--- a/Tests/FluentAssertions.Specs/Exceptions/InvokingFunctionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/InvokingFunctionSpecs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 
 namespace FluentAssertions.Specs.Exceptions;
@@ -9,10 +9,10 @@ public class InvokingFunctionSpecs
     public void Invoking_on_null_is_not_allowed()
     {
         // Arrange
-        Does someClass = null;
+        Func<int> someClass = null;
 
         // Act
-        Action act = () => someClass.Invoking(d => d.Return());
+        Action act = () => someClass.Invoking(d => d());
 
         // Assert
         act.Should().ThrowExactly<ArgumentNullException>()
@@ -23,10 +23,10 @@ public class InvokingFunctionSpecs
     public void Invoking_with_null_is_not_allowed()
     {
         // Arrange
-        Does someClass = Does.NotThrow();
+        Action someClass = () => { };
 
         // Act
-        Action act = () => someClass.Invoking((Func<Does, object>)null);
+        Action act = () => someClass.Invoking((Func<Action, object>)null);
 
         // Assert
         act.Should().ThrowExactly<ArgumentNullException>()

--- a/Tests/FluentAssertions.Specs/Exceptions/MiscellaneousExceptionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/MiscellaneousExceptionSpecs.cs
@@ -1,9 +1,27 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Xunit;
 using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.Exceptions;
+
+internal class ExceptionWithEmptyToString : Exception
+{
+    public override string ToString()
+    {
+        return string.Empty;
+    }
+}
+
+internal class ExceptionWithProperties : Exception
+{
+    public ExceptionWithProperties(string propertyValue)
+    {
+        Property = propertyValue;
+    }
+
+    public string Property { get; set; }
+}
 
 public class MiscellaneousExceptionSpecs
 {
@@ -11,25 +29,25 @@ public class MiscellaneousExceptionSpecs
     public void When_getting_value_of_property_of_thrown_exception_it_should_return_value_of_property()
     {
         // Arrange
-        const string SomeParamNameValue = "param";
-        Does target = Does.Throw(new ExceptionWithProperties(SomeParamNameValue));
+        const string someParamNameValue = "param";
+        Action target = () => throw new ExceptionWithProperties(someParamNameValue);
 
         // Act
-        Action act = target.Do;
+        Action act = target;
 
         // Assert
-        act.Should().Throw<ExceptionWithProperties>().And.Property.Should().Be(SomeParamNameValue);
+        act.Should().Throw<ExceptionWithProperties>().And.Property.Should().Be(someParamNameValue);
     }
 
     [Fact]
     public void When_validating_a_subject_against_multiple_conditions_it_should_support_chaining()
     {
         // Arrange
-        Does testSubject = Does.Throw(new InvalidOperationException("message", new ArgumentException("inner message")));
+        Action testSubject = () => throw new InvalidOperationException("message", new ArgumentException("inner message"));
 
         // Act / Assert
         testSubject
-            .Invoking(x => x.Do())
+            
             .Should().Throw<InvalidOperationException>()
             .WithInnerException<ArgumentException>()
             .WithMessage("inner message");
@@ -126,8 +144,8 @@ public class MiscellaneousExceptionSpecs
     public void When_two_exceptions_are_thrown_and_the_assertion_assumes_there_can_only_be_one_it_should_fail()
     {
         // Arrange
-        Does testSubject = Does.Throw(new AggregateException(new Exception(), new Exception()));
-        Action throwingMethod = testSubject.Do;
+        Action testSubject = () => throw new AggregateException(new Exception(), new Exception());
+        Action throwingMethod = testSubject;
 
         // Act
         Action action = () => throwingMethod.Should().Throw<Exception>().And.Message.Should();

--- a/Tests/FluentAssertions.Specs/Exceptions/NotThrowSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/NotThrowSpecs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FluentAssertions.Execution;
 #if NET47
 using FluentAssertions.Specs.Common;
@@ -34,11 +34,11 @@ public class NotThrowSpecs
     public void When_a_specific_exception_should_not_be_thrown_but_it_was_it_should_throw()
     {
         // Arrange
-        Does foo = Does.Throw(new ArgumentException("An exception was forced"));
+        Action foo = () => throw new ArgumentException("An exception was forced");
 
         // Act
         Action action =
-            () => foo.Invoking(f => f.Do()).Should().NotThrow<ArgumentException>("we passed valid arguments");
+            () => foo.Should().NotThrow<ArgumentException>("we passed valid arguments");
 
         // Assert
         action
@@ -51,20 +51,20 @@ public class NotThrowSpecs
     public void When_a_specific_exception_should_not_be_thrown_but_another_was_it_should_succeed()
     {
         // Arrange
-        Does foo = Does.Throw<ArgumentException>();
+        Action foo = () => throw new ArgumentException();
 
         // Act / Assert
-        foo.Invoking(f => f.Do()).Should().NotThrow<InvalidOperationException>();
+        foo.Should().NotThrow<InvalidOperationException>();
     }
 
     [Fact]
     public void When_no_exception_should_be_thrown_but_it_was_it_should_throw()
     {
         // Arrange
-        Does foo = Does.Throw(new ArgumentException("An exception was forced"));
+        Action foo = () => throw new ArgumentException("An exception was forced");
 
         // Act
-        Action action = () => foo.Invoking(f => f.Do()).Should().NotThrow("we passed valid arguments");
+        Action action = () => foo.Should().NotThrow("we passed valid arguments");
 
         // Assert
         action
@@ -77,10 +77,10 @@ public class NotThrowSpecs
     public void When_no_exception_should_be_thrown_and_none_was_it_should_not_throw()
     {
         // Arrange
-        Does foo = Does.NotThrow();
+        Action foo = () => { };
 
         // Act / Assert
-        foo.Invoking(f => f.Do()).Should().NotThrow();
+        foo.Should().NotThrow();
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Exceptions/OuterExceptionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/OuterExceptionSpecs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Xunit;
 using Xunit.Sdk;
@@ -11,23 +11,23 @@ public class OuterExceptionSpecs
     public void When_subject_throws_expected_exception_with_an_expected_message_it_should_not_do_anything()
     {
         // Arrange
-        Does testSubject = Does.Throw(new InvalidOperationException("some message"));
+        Action testSubject = () => throw new InvalidOperationException("some message");
 
         // Act / Assert
-        testSubject.Invoking(x => x.Do()).Should().Throw<InvalidOperationException>().WithMessage("some message");
+        testSubject.Should().Throw<InvalidOperationException>().WithMessage("some message");
     }
 
     [Fact]
     public void When_subject_throws_expected_exception_but_with_unexpected_message_it_should_throw()
     {
         // Arrange
-        Does testSubject = Does.Throw(new InvalidOperationException("some"));
+        Action testSubject = () => throw new InvalidOperationException("some");
 
         try
         {
             // Act
             testSubject
-                .Invoking(x => x.Do())
+
                 .Should().Throw<InvalidOperationException>()
                 .WithMessage("some message");
 
@@ -45,13 +45,13 @@ public class OuterExceptionSpecs
     public void Long_exception_messages_are_rendered_over_multiple_lines()
     {
         // Arrange
-        Does testSubject = Does.Throw(new InvalidOperationException("some"));
+        Action testSubject = () => throw new InvalidOperationException("some");
 
         try
         {
             // Act
             testSubject
-                .Invoking(x => x.Do())
+
                 .Should().Throw<InvalidOperationException>()
                 .WithMessage(new string('#', 101));
 
@@ -80,13 +80,13 @@ public class OuterExceptionSpecs
     public void Multiline_exception_messages_are_rendered_over_multiple_lines()
     {
         // Arrange
-        Does testSubject = Does.Throw(new InvalidOperationException("some"));
+        Action testSubject = () => throw new InvalidOperationException("some");
 
         try
         {
             // Act
             testSubject
-                .Invoking(x => x.Do())
+
                 .Should().Throw<InvalidOperationException>()
                 .WithMessage("""
                              line1*
@@ -119,13 +119,13 @@ public class OuterExceptionSpecs
     public void Short_exception_messages_are_rendered_on_a_single_line()
     {
         // Arrange
-        Does testSubject = Does.Throw(new InvalidOperationException("some"));
+        Action testSubject = () => throw new InvalidOperationException("some");
 
         try
         {
             // Act
             testSubject
-                .Invoking(x => x.Do())
+
                 .Should().Throw<InvalidOperationException>()
                 .WithMessage(new string('#', 50));
 
@@ -143,10 +143,10 @@ public class OuterExceptionSpecs
     public void When_subject_throws_expected_exception_with_message_starting_with_expected_message_it_should_not_throw()
     {
         // Arrange
-        Does testSubject = Does.Throw(new InvalidOperationException("expected message"));
+        Action testSubject = () => throw new InvalidOperationException("expected message");
 
         // Act
-        Action action = testSubject.Do;
+        Action action = testSubject;
 
         // Assert
         action.Should().Throw<InvalidOperationException>()
@@ -158,11 +158,10 @@ public class OuterExceptionSpecs
     public void When_subject_throws_expected_exception_with_message_that_does_not_start_with_expected_message_it_should_throw()
     {
         // Arrange
-        Does testSubject = Does.Throw(new InvalidOperationException("OxpectOd message"));
+        Action testSubject = () => throw new InvalidOperationException("OxpectOd message");
 
         // Act
         Action action = () => testSubject
-            .Invoking(s => s.Do())
             .Should().Throw<InvalidOperationException>()
             .WithMessage("Expected mes");
 
@@ -177,10 +176,10 @@ public class OuterExceptionSpecs
         When_subject_throws_expected_exception_with_message_starting_with_expected_equivalent_message_it_should_not_throw()
     {
         // Arrange
-        Does testSubject = Does.Throw(new InvalidOperationException("Expected Message"));
+        Action testSubject = () => throw new InvalidOperationException("Expected Message");
 
         // Act
-        Action action = testSubject.Do;
+        Action action = testSubject;
 
         // Assert
         action.Should().Throw<InvalidOperationException>()
@@ -192,11 +191,10 @@ public class OuterExceptionSpecs
     public void When_subject_throws_expected_exception_with_message_that_does_not_start_with_equivalent_message_it_should_throw()
     {
         // Arrange
-        Does testSubject = Does.Throw(new InvalidOperationException("OxpectOd message"));
+        Action testSubject = () => throw new InvalidOperationException("OxpectOd message");
 
         // Act
         Action action = () => testSubject
-            .Invoking(s => s.Do())
             .Should().Throw<InvalidOperationException>()
             .WithMessage("expected mes");
 
@@ -210,13 +208,13 @@ public class OuterExceptionSpecs
     public void When_subject_throws_some_exception_with_unexpected_message_it_should_throw_with_clear_description()
     {
         // Arrange
-        Does subjectThatThrows = Does.Throw(new InvalidOperationException("message1"));
+        Action subjectThatThrows = () => throw new InvalidOperationException("message1");
 
         try
         {
             // Act
             subjectThatThrows
-                .Invoking(x => x.Do())
+
                 .Should().Throw<InvalidOperationException>()
                 .WithMessage("message2", "because we want to test the failure {0}", "message");
 
@@ -234,13 +232,13 @@ public class OuterExceptionSpecs
     public void When_subject_throws_some_exception_with_an_empty_message_it_should_throw_with_clear_description()
     {
         // Arrange
-        Does subjectThatThrows = Does.Throw(new InvalidOperationException(""));
+        Action subjectThatThrows = () => throw new InvalidOperationException("");
 
         try
         {
             // Act
             subjectThatThrows
-                .Invoking(x => x.Do())
+
                 .Should().Throw<InvalidOperationException>()
                 .WithMessage("message2");
 
@@ -259,13 +257,12 @@ public class OuterExceptionSpecs
         When_subject_throws_some_exception_with_message_which_contains_complete_expected_exception_and_more_it_should_throw()
     {
         // Arrange
-        Does subjectThatThrows = Does.Throw(new ArgumentNullException("someParam", "message2"));
+        Action subjectThatThrows = () => throw new ArgumentNullException("someParam", "message2");
 
         try
         {
             // Act
             subjectThatThrows
-                .Invoking(x => x.Do("something"))
                 .Should().Throw<ArgumentNullException>()
                 .WithMessage("message2");
 
@@ -285,10 +282,10 @@ public class OuterExceptionSpecs
         try
         {
             // Arrange
-            Does testSubject = Does.NotThrow();
+            Action testSubject = () => { };
 
             // Act
-            testSubject.Invoking(x => x.Do()).Should().Throw<Exception>("because {0} should do that", "Does.Do");
+            testSubject.Should().Throw<Exception>("because {0} should do that", "Does.Do");
 
             throw new XunitException("This point should not be reached");
         }
@@ -306,13 +303,13 @@ public class OuterExceptionSpecs
         // Arrange
         var actualException = new ArgumentException();
 
-        Does testSubject = Does.Throw(actualException);
+        Action testSubject = () => throw actualException;
 
         try
         {
             // Act
             testSubject
-                .Invoking(x => x.Do())
+
                 .Should().Throw<InvalidOperationException>("because {0} should throw that one", "Does.Do");
 
             throw new XunitException("This point should not be reached");
@@ -331,13 +328,12 @@ public class OuterExceptionSpecs
     public void When_subject_throws_exception_with_message_with_braces_but_a_different_message_is_expected_it_should_report_that()
     {
         // Arrange
-        Does subjectThatThrows = Does.Throw(new Exception("message with {}"));
+        Action subjectThatThrows = () => throw new Exception("message with {}");
 
         try
         {
             // Act
             subjectThatThrows
-                .Invoking(x => x.Do("something"))
                 .Should().Throw<Exception>()
                 .WithMessage("message without");
 
@@ -355,10 +351,10 @@ public class OuterExceptionSpecs
     public void When_asserting_with_an_aggregate_exception_type_the_asserts_should_occur_against_the_aggregate_exception()
     {
         // Arrange
-        Does testSubject = Does.Throw(new AggregateException("Outer Message", new Exception("Inner Message")));
+        Action testSubject = () => throw new AggregateException("Outer Message", new Exception("Inner Message"));
 
         // Act
-        Action act = testSubject.Do;
+        Action act = testSubject;
 
         // Assert
         act.Should().Throw<AggregateException>()
@@ -372,10 +368,10 @@ public class OuterExceptionSpecs
         When_asserting_with_an_aggregate_exception_and_inner_exception_type_from_argument_the_asserts_should_occur_against_the_aggregate_exception()
     {
         // Arrange
-        Does testSubject = Does.Throw(new AggregateException("Outer Message", new Exception("Inner Message")));
+        Action testSubject = () => throw new AggregateException("Outer Message", new Exception("Inner Message"));
 
         // Act
-        Action act = testSubject.Do;
+        Action act = testSubject;
 
         // Assert
         act.Should().Throw<AggregateException>()

--- a/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 using Xunit.Sdk;
 
@@ -10,40 +10,40 @@ public class ThrowAssertionsSpecs
     public void Succeeds_for_any_exception_thrown_by_subject()
     {
         // Arrange
-        Does testSubject = Does.Throw<InvalidOperationException>();
+        Action testSubject = () => throw new InvalidOperationException();
 
         // Act / Assert
-        testSubject.Invoking(x => x.Do()).Should().Throw();
+        testSubject.Should().Throw();
     }
 
     [Fact]
     public void Succeeds_for_expected_exception_thrown_by_subject()
     {
         // Arrange
-        Does testSubject = Does.Throw<InvalidOperationException>();
+        Action testSubject = () => throw new InvalidOperationException();
 
         // Act / Assert
-        testSubject.Invoking(x => x.Do()).Should().Throw<InvalidOperationException>();
+        testSubject.Should().Throw<InvalidOperationException>();
     }
 
     [Fact]
     public void Succeeds_for_any_exception_thrown_by_func()
     {
         // Arrange
-        Does testSubject = Does.Throw<InvalidOperationException>();
+        Func<int> testSubject = () => throw new InvalidOperationException();
 
         // Act / Assert
-        testSubject.Invoking(x => x.Return()).Should().Throw();
+        testSubject.Should().Throw();
     }
 
     [Fact]
     public void Succeeds_for_expected_exception_thrown_by_func()
     {
         // Arrange
-        Does testSubject = Does.Throw<InvalidOperationException>();
+        Func<int> testSubject = () => throw new InvalidOperationException();
 
         // Act / Assert
-        testSubject.Invoking(x => x.Return()).Should().Throw<InvalidOperationException>();
+        testSubject.Should().Throw<InvalidOperationException>();
     }
 
     [Fact]
@@ -71,9 +71,9 @@ public class ThrowAssertionsSpecs
     {
         try
         {
-            Does testSubject = Does.NotThrow();
+            Action testSubject = () => { };
 
-            testSubject.Invoking(x => x.Do()).Should().Throw<Exception>();
+            testSubject.Should().Throw<Exception>();
 
             throw new XunitException("Should().Throw() did not throw");
         }
@@ -89,9 +89,9 @@ public class ThrowAssertionsSpecs
     {
         try
         {
-            Does testSubject = Does.NotThrow();
+            Func<int> testSubject = () => 42;
 
-            testSubject.Invoking(x => x.Return()).Should().Throw<Exception>();
+            testSubject.Should().Throw<Exception>();
 
             throw new XunitException("Should().Throw() did not throw");
         }
@@ -106,10 +106,10 @@ public class ThrowAssertionsSpecs
     public void When_func_does_not_throw_it_should_be_chainable()
     {
         // Arrange
-        Does testSubject = Does.NotThrow();
+        Func<int> testSubject = () => 42;
 
         // Act / Assert
-        testSubject.Invoking(x => x.Return()).Should().NotThrow()
+        testSubject.Should().NotThrow()
             .Which.Should().Be(42);
     }
 


### PR DESCRIPTION
This PR cleans up the test code by removing unnecessary helper classes and simplifying test patterns. The main changes involved removing the `Does` abstract class and its implementations (`DoesThrow` and `DoesNotThrow`) that were used to create mock test subjects. Instead, the tests now use simple `Action` and `Func<int>` delegates directly with lambda expressions like `() => throw new Exception()` or `() => { }`. This eliminates the need for the `.Invoking(x => x.Do())` pattern and makes the test assertions more direct and readable. Additionally, some test helper classes like `SomeTestClass`, `ExceptionWithProperties`, and `ExceptionWithEmptyToString` were moved to more appropriate locations within the test files.
