### PR TITLE
Fixed ambiguity when using Should on a JsonNode derived class

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -913,10 +913,10 @@ public static class AssertionExtensions
     /// Returns an object that provides various assertion APIs that act on a <see cref="JsonNode"/>.
     /// </summary>
     [Pure]
-    public static JsonNodeAssertions Should<T>([NotNull] this T jsonNode)
+    public static JsonNodeAssertions<T> Should<T>([NotNull] this T jsonNode)
         where T : JsonNode
     {
-        return new JsonNodeAssertions(jsonNode, AssertionChain.GetOrCreate());
+        return new JsonNodeAssertions<T>(jsonNode, AssertionChain.GetOrCreate());
     }
 
     /// <summary>

--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -23,11 +23,6 @@ using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 using FluentAssertions.Events;
 #endif
 
-#if NET6_0_OR_GREATER
-using System.Linq;
-using System.Text.Json.Nodes;
-#endif
-
 namespace FluentAssertions;
 
 /// <summary>
@@ -907,26 +902,6 @@ public static class AssertionExtensions
     public static TaskCompletionSourceAssertions Should(this TaskCompletionSource tcs)
     {
         return new TaskCompletionSourceAssertions(tcs, AssertionChain.GetOrCreate());
-    }
-
-    /// <summary>
-    /// Returns an object that provides various assertion APIs that act on a <see cref="JsonNode"/>.
-    /// </summary>
-    [Pure]
-    public static JsonNodeAssertions<T> Should<T>([NotNull] this T jsonNode)
-        where T : JsonNode
-    {
-        return new JsonNodeAssertions<T>(jsonNode, AssertionChain.GetOrCreate());
-    }
-
-    /// <summary>
-    /// Return an object that provides various assertion APIs that treat a <see cref="JsonArray"/>
-    /// as a collection of <see cref="JsonNode"/>s.
-    /// </summary>
-    [Pure]
-    public static GenericCollectionAssertions<JsonNode> Should([NotNull] this JsonArray jsonArray)
-    {
-        return new GenericCollectionAssertions<JsonNode>(jsonArray?.ToArray(), AssertionChain.GetOrCreate());
     }
 
 #endif

--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -913,7 +913,8 @@ public static class AssertionExtensions
     /// Returns an object that provides various assertion APIs that act on a <see cref="JsonNode"/>.
     /// </summary>
     [Pure]
-    public static JsonNodeAssertions Should([NotNull] this JsonNode jsonNode)
+    public static JsonNodeAssertions Should<T>([NotNull] this T jsonNode)
+        where T : JsonNode
     {
         return new JsonNodeAssertions(jsonNode, AssertionChain.GetOrCreate());
     }

--- a/Src/FluentAssertions/JsonAssertionExtensions.cs
+++ b/Src/FluentAssertions/JsonAssertionExtensions.cs
@@ -1,0 +1,41 @@
+﻿#if NET6_0_OR_GREATER
+
+using System.Diagnostics;
+using System.Linq;
+using System.Text.Json.Nodes;
+using FluentAssertions.Collections;
+using FluentAssertions.Execution;
+using FluentAssertions.Specialized;
+using JetBrains.Annotations;
+using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
+
+namespace FluentAssertions;
+
+/// <summary>
+/// Contains an extension method for custom assertions in unit tests related to System.Text.Json objects.
+/// </summary>
+[DebuggerNonUserCode]
+public static class JsonAssertionExtensions
+{
+    /// <summary>
+    /// Returns an object that provides various assertion APIs that act on a <see cref="JsonNode"/>.
+    /// </summary>
+    [Pure]
+    public static JsonNodeAssertions<T> Should<T>([NotNull] this T jsonNode)
+        where T : JsonNode
+    {
+        return new JsonNodeAssertions<T>(jsonNode, AssertionChain.GetOrCreate());
+    }
+
+    /// <summary>
+    /// Return an object that provides various assertion APIs that treat a <see cref="JsonArray"/>
+    /// as a collection of <see cref="JsonNode"/>s.
+    /// </summary>
+    [Pure]
+    public static GenericCollectionAssertions<JsonNode> Should([NotNull] this JsonArray jsonArray)
+    {
+        return new GenericCollectionAssertions<JsonNode>(jsonArray?.ToArray(), AssertionChain.GetOrCreate());
+    }
+}
+
+#endif

--- a/Src/FluentAssertions/Specialized/JsonNodeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/JsonNodeAssertions.cs
@@ -13,10 +13,11 @@ using FluentAssertions.Primitives;
 
 namespace FluentAssertions.Specialized;
 
-public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAssertions>
+public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertions<T>>
+    where T : JsonNode
 {
     /// <inheritdoc />
-    public JsonNodeAssertions(JsonNode subject, AssertionChain assertionChain)
+    public JsonNodeAssertions(T subject, AssertionChain assertionChain)
         : base(subject, assertionChain)
     {
     }
@@ -38,7 +39,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndWhichConstraint<JsonNodeAssertions, JsonNode> HaveProperty(string code,
+    public AndWhichConstraint<JsonNodeAssertions<T>, JsonNode> HaveProperty(string code,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -49,7 +50,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .ForCondition(Subject?[code] != null)
             .FailWith("Expected {context:JSON node} to have property {0}{reason}.", code);
 
-        return new AndWhichConstraint<JsonNodeAssertions, JsonNode>(this, Subject?[code]);
+        return new AndWhichConstraint<JsonNodeAssertions<T>, JsonNode>(this, Subject?[code]);
     }
 
     /// <summary>
@@ -63,7 +64,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<JsonNodeAssertions> NotHaveProperty(string code,
+    public AndConstraint<JsonNodeAssertions<T>> NotHaveProperty(string code,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -75,7 +76,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:JSON node} to have property {0}{reason}.", code);
 
-        return new AndConstraint<JsonNodeAssertions>(this);
+        return new AndConstraint<JsonNodeAssertions<T>>(this);
     }
 
     /// <summary>
@@ -88,7 +89,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndWhichConstraint<JsonNodeAssertions, IEnumerable<JsonNode>> BeAnArray(
+    public AndWhichConstraint<JsonNodeAssertions<T>, IEnumerable<JsonNode>> BeAnArray(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -96,7 +97,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:JSON node} to be an array{reason}, but {0} is not.", Subject);
 
-        return new AndWhichConstraint<JsonNodeAssertions, IEnumerable<JsonNode>>(this, (Subject as JsonArray)?.AsEnumerable());
+        return new AndWhichConstraint<JsonNodeAssertions<T>, IEnumerable<JsonNode>>(this, (Subject as JsonArray)?.AsEnumerable());
     }
 
     /// <summary>
@@ -109,7 +110,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<JsonNodeAssertions> NotBeAnArray(
+    public AndConstraint<JsonNodeAssertions<T>> NotBeAnArray(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -117,7 +118,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:JSON node} to be an array{reason}, but {0} is.", Subject);
 
-        return new AndConstraint<JsonNodeAssertions>(this);
+        return new AndConstraint<JsonNodeAssertions<T>>(this);
     }
 
     /// <summary>
@@ -130,7 +131,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndWhichConstraint<JsonNodeAssertions, long> BeNumeric(
+    public AndWhichConstraint<JsonNodeAssertions<T>, long> BeNumeric(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -139,7 +140,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .FailWith("Expected {context:JSON node} to be an Int32{reason}, but {0} is not.", Subject);
 
         var actualValue = Subject is JsonValue jsonValue && jsonValue.TryGetValue<long>(out var result) ? result : 0;
-        return new AndWhichConstraint<JsonNodeAssertions, long>(this, actualValue);
+        return new AndWhichConstraint<JsonNodeAssertions<T>, long>(this, actualValue);
     }
 
     /// <summary>
@@ -152,7 +153,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<JsonNodeAssertions> NotBeNumeric(
+    public AndConstraint<JsonNodeAssertions<T>> NotBeNumeric(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -160,7 +161,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:JSON node} to be an Int32{reason}, but {0} is.", Subject);
 
-        return new AndConstraint<JsonNodeAssertions>(this);
+        return new AndConstraint<JsonNodeAssertions<T>>(this);
     }
 
     /// <summary>
@@ -173,7 +174,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndWhichConstraint<JsonNodeAssertions, DateTime> BeLocalDate(
+    public AndWhichConstraint<JsonNodeAssertions<T>, DateTime> BeLocalDate(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -182,7 +183,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .FailWith("Expected {context:JSON node} to be a local date{reason}, but {0} is not.", Subject);
 
         var actualValue = Subject is JsonValue jsonValue && jsonValue.TryGetValue<DateTime>(out var result) ? result : default;
-        return new AndWhichConstraint<JsonNodeAssertions, DateTime>(this, actualValue);
+        return new AndWhichConstraint<JsonNodeAssertions<T>, DateTime>(this, actualValue);
     }
 
     /// <summary>
@@ -195,7 +196,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<JsonNodeAssertions> NotBeLocalDate(
+    public AndConstraint<JsonNodeAssertions<T>> NotBeLocalDate(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -203,7 +204,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:JSON node} to be a local date{reason}, but {0} is.", Subject);
 
-        return new AndConstraint<JsonNodeAssertions>(this);
+        return new AndConstraint<JsonNodeAssertions<T>>(this);
     }
 
     /// <summary>
@@ -216,7 +217,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndWhichConstraint<JsonNodeAssertions, DateTime> BeUtcDate(
+    public AndWhichConstraint<JsonNodeAssertions<T>, DateTime> BeUtcDate(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -225,7 +226,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .FailWith("Expected {context} to be a UTC date{reason}, but {0} is not.", Subject);
 
         var actualValue = Subject is JsonValue jsonValue && jsonValue.TryGetValue<DateTime>(out var result) ? result : default;
-        return new AndWhichConstraint<JsonNodeAssertions, DateTime>(this, actualValue);
+        return new AndWhichConstraint<JsonNodeAssertions<T>, DateTime>(this, actualValue);
     }
 
     /// <summary>
@@ -238,7 +239,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<JsonNodeAssertions> NotBeUtcDate(
+    public AndConstraint<JsonNodeAssertions<T>> NotBeUtcDate(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -246,7 +247,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context} to be a UTC date{reason}, but {0} is.", Subject);
 
-        return new AndConstraint<JsonNodeAssertions>(this);
+        return new AndConstraint<JsonNodeAssertions<T>>(this);
     }
 
     /// <summary>
@@ -259,7 +260,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndWhichConstraint<JsonNodeAssertions, bool> BeBool(
+    public AndWhichConstraint<JsonNodeAssertions<T>, bool> BeBool(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -268,7 +269,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .FailWith("Expected {context} to be a boolean{reason}, but {0} is not.", Subject);
 
         var actualValue = Subject is JsonValue jsonValue && jsonValue.TryGetValue<bool>(out var result) && result;
-        return new AndWhichConstraint<JsonNodeAssertions, bool>(this, actualValue);
+        return new AndWhichConstraint<JsonNodeAssertions<T>, bool>(this, actualValue);
     }
 
     /// <summary>
@@ -281,7 +282,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<JsonNodeAssertions> NotBeBool(
+    public AndConstraint<JsonNodeAssertions<T>> NotBeBool(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -289,7 +290,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:JSON node} to be a boolean{reason}, but {0} is.", Subject);
 
-        return new AndConstraint<JsonNodeAssertions>(this);
+        return new AndConstraint<JsonNodeAssertions<T>>(this);
     }
 
     /// <summary>
@@ -302,7 +303,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndWhichConstraint<JsonNodeAssertions, string> BeString(
+    public AndWhichConstraint<JsonNodeAssertions<T>, string> BeString(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -311,7 +312,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .FailWith("Expected {context:JSON node} to be a string{reason}, but {0} is not.", Subject);
 
         var actualValue = Subject is JsonValue jsonValue && jsonValue.TryGetValue<string>(out var result) ? result : null;
-        return new AndWhichConstraint<JsonNodeAssertions, string>(this, actualValue);
+        return new AndWhichConstraint<JsonNodeAssertions<T>, string>(this, actualValue);
     }
 
     /// <summary>
@@ -324,7 +325,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndConstraint<JsonNodeAssertions> NotBeString(
+    public AndConstraint<JsonNodeAssertions<T>> NotBeString(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
@@ -332,7 +333,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:JSON node} to be a string{reason}, but {0} is.", Subject);
 
-        return new AndConstraint<JsonNodeAssertions>(this);
+        return new AndConstraint<JsonNodeAssertions<T>>(this);
     }
 
     /// <summary>
@@ -355,7 +356,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<JsonNodeAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation,
+    public AndConstraint<JsonNodeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         return BeEquivalentTo(expectation, config => config, because, becauseArgs);
@@ -383,7 +384,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<JsonNodeAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation,
+    public AndConstraint<JsonNodeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation,
         Func<EquivalencyOptions<TExpectation>, EquivalencyOptions<TExpectation>> config,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
@@ -408,7 +409,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
 
         new EquivalencyValidator().AssertEquality(comparands, context);
 
-        return new AndConstraint<JsonNodeAssertions>(this);
+        return new AndConstraint<JsonNodeAssertions<T>>(this);
     }
 
     /// <summary>
@@ -431,7 +432,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<JsonNodeAssertions> NotBeEquivalentTo<TExpectation>(
+    public AndConstraint<JsonNodeAssertions<T>> NotBeEquivalentTo<TExpectation>(
         TExpectation unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
@@ -460,7 +461,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
-    public AndConstraint<JsonNodeAssertions> NotBeEquivalentTo<TExpectation>(
+    public AndConstraint<JsonNodeAssertions<T>> NotBeEquivalentTo<TExpectation>(
         TExpectation unexpected,
         Func<EquivalencyOptions<TExpectation>, EquivalencyOptions<TExpectation>> config,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
@@ -481,7 +482,7 @@ public class JsonNodeAssertions : ReferenceTypeAssertions<JsonNode, JsonNodeAsse
             .WithDefaultIdentifier(Identifier)
             .FailWith("Did not expect {context:JSON node} to be equivalent to {0}{reason}, but they are.", unexpected);
 
-        return new AndConstraint<JsonNodeAssertions>(this);
+        return new AndConstraint<JsonNodeAssertions<T>>(this);
     }
 }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -88,8 +88,6 @@ namespace FluentAssertions
         public static FluentAssertions.Types.ConstructorInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
         public static FluentAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
-        public static FluentAssertions.Collections.GenericCollectionAssertions<System.Text.Json.Nodes.JsonNode> Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Text.Json.Nodes.JsonArray jsonArray) { }
-        public static FluentAssertions.Specialized.JsonNodeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Text.Json.Nodes.JsonNode jsonNode) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions Should(this System.Threading.Tasks.TaskCompletionSource tcs) { }
         public static FluentAssertions.Primitives.TimeOnlyAssertions Should(this System.TimeOnly actualValue) { }
         public static FluentAssertions.Primitives.NullableTimeOnlyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.TimeOnly? actualValue) { }
@@ -271,6 +269,12 @@ namespace FluentAssertions
         public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
         public static System.Action Invoking(System.Action action) { }
         public static System.Func<T> Invoking<T>(System.Func<T> func) { }
+    }
+    public static class JsonAssertionExtensions
+    {
+        public static FluentAssertions.Collections.GenericCollectionAssertions<System.Text.Json.Nodes.JsonNode> Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Text.Json.Nodes.JsonArray jsonArray) { }
+        public static FluentAssertions.Specialized.JsonNodeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this T jsonNode)
+            where T : System.Text.Json.Nodes.JsonNode { }
     }
     public static class LessThan
     {
@@ -2344,28 +2348,29 @@ namespace FluentAssertions.Specialized
         System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
             where T : System.Exception;
     }
-    public class JsonNodeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Text.Json.Nodes.JsonNode, FluentAssertions.Specialized.JsonNodeAssertions>
+    public class JsonNodeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<T, FluentAssertions.Specialized.JsonNodeAssertions<T>>
+        where T : System.Text.Json.Nodes.JsonNode
     {
-        public JsonNodeAssertions(System.Text.Json.Nodes.JsonNode subject, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public JsonNodeAssertions(T subject, FluentAssertions.Execution.AssertionChain assertionChain) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions, System.Collections.Generic.IEnumerable<System.Text.Json.Nodes.JsonNode>> BeAnArray(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions, bool> BeBool(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions, System.DateTime> BeLocalDate(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions, long> BeNumeric(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions, string> BeString(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions, System.DateTime> BeUtcDate(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions, System.Text.Json.Nodes.JsonNode> HaveProperty(string code, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions> NotBeAnArray(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions> NotBeBool(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions> NotBeLocalDate(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions> NotBeNumeric(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions> NotBeString(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions> NotBeUtcDate(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions> NotHaveProperty(string code, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, System.Collections.Generic.IEnumerable<System.Text.Json.Nodes.JsonNode>> BeAnArray(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, bool> BeBool(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, System.DateTime> BeLocalDate(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, long> BeNumeric(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, string> BeString(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, System.DateTime> BeUtcDate(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, System.Text.Json.Nodes.JsonNode> HaveProperty(string code, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> NotBeAnArray(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> NotBeBool(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> NotBeLocalDate(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> NotBeNumeric(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> NotBeString(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> NotBeUtcDate(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> NotHaveProperty(string code, string because = "", params object[] becauseArgs) { }
     }
     public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
     {

--- a/Tests/FluentAssertions.Equivalency.Specs/JsonNodeSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/JsonNodeSpecs.cs
@@ -548,6 +548,26 @@ public class JsonNodeSpecs
     }
 
     [Fact]
+    public void Can_assert_json_node_instances()
+    {
+        // Arrange
+        JsonNode jsonNode = null;
+
+        // Act & Assert
+        jsonNode.Should().BeNull();
+    }
+
+    [Fact]
+    public void Can_assert_json_value_instances()
+    {
+        // Arrange
+        JsonValue jsonValue = null;
+
+        // Act & Assert
+        jsonValue.Should().BeNull();
+    }
+
+    [Fact]
     public void Can_assert_json_object_instances()
     {
         // Arrange

--- a/Tests/FluentAssertions.Equivalency.Specs/JsonNodeSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/JsonNodeSpecs.cs
@@ -546,6 +546,16 @@ public class JsonNodeSpecs
         // Act & Assert
         array.Should().BeNull();
     }
+
+    [Fact]
+    public void Can_assert_json_object_instances()
+    {
+        // Arrange
+        JsonObject jsonObject = null;
+
+        // Act & Assert
+        jsonObject.Should().BeNull();
+    }
 }
 
 #endif

--- a/docs/_pages/json.md
+++ b/docs/_pages/json.md
@@ -7,7 +7,7 @@ sidebar:
   nav: "sidebar"
 ---
 
-For projects targeting .NET 6 or later, there's built-in support for assertions on the types `JsonNode` and `JsonArray` from the `System.Text.Json` namespace.
+For projects targeting .NET 6 or later, there's built-in support for assertions on the types `JsonNode` and `JsonArray` (including `JsonNode` derived classes, e.g. `JsonValue` and `JsonObject`) from the `System.Text.Json` namespace.
 
 ```csharp
 var jsonNode = JsonNode.Parse("{ \"name\": \"John\" }");

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -7,6 +7,12 @@ sidebar:
   nav: "sidebar"
 ---
 
+## 8.7.1
+
+### Fixes
+
+* Fixed ambiguity when using `Should()` on a `JsonNode` derived class. - [#3102](https://github.com/fluentassertions/fluentassertions/pull/3102)
+
 ## 8.7.0
 
 ### What's new


### PR DESCRIPTION
The first commit demonstrates the issue; the second commit proposes a solution.

The third commit makes the `JsonNodeAssertions` generic, which propagates the type safety of the `Subject`.

Fixes #3103

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [X] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [X] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## CONTRIBUTOR LICENSE GRANT

By submitting this contribution, the contributor hereby irrevocably grants to the project owners and maintainers a perpetual, worldwide, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and create derivative works of the contribution for any purpose and under any terms, including proprietary licensing.

The contributor waives any moral rights in the contribution to the extent permitted by law and agrees not to assert any claim of authorship or control over the contribution. The contributor represents that they are the sole author of the contribution and that it is provided free of any third-party claims.

The contributor understands and agrees that the maintainers may, at their sole discretion, use, license, or redistribute the contribution as part of any work and under any terms they choose, without further permission or attribution.

* [X] I have read the Contributor License Grant and accept the conditions
* [x] I'm interested in a free license for Fluent Assertions and will share my email address through sales@xceed.com