### PR TITLE
JSON assertions did not properly handle floats, doubles and unsigned …

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/JsonConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/JsonConversionStep.cs
@@ -14,9 +14,13 @@ public class JsonConversionStep : IEquivalencyStep
     {
         if (comparands.Subject is JsonValue json)
         {
-            if (json.TryGetValue(out int intValue))
+            if (json.TryGetValue(out long longValue))
             {
-                comparands.Subject = intValue;
+                comparands.Subject = longValue;
+            }
+            else if (json.TryGetValue(out ulong ulongValue))
+            {
+                comparands.Subject = ulongValue;
             }
             else if (json.TryGetValue(out double doubleValue))
             {

--- a/Src/FluentAssertions/Specialized/JsonNodeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/JsonNodeAssertions.cs
@@ -122,7 +122,7 @@ public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertio
     }
 
     /// <summary>
-    /// Asserts that the current <see cref="JsonNode"/> represents a 32-bit signed integer.
+    /// Asserts that the current <see cref="JsonNode"/> represents a numeric value.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -131,20 +131,43 @@ public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertio
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public AndWhichConstraint<JsonNodeAssertions<T>, long> BeNumeric(
+    public AndWhichConstraint<JsonNodeAssertions<T>, string> BeNumeric(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
-            .ForCondition(Subject is JsonValue value && value.TryGetValue<int>(out _))
+            .ForCondition(Subject is JsonValue value && value.IsNumeric())
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:JSON node} to be an Int32{reason}, but {0} is not.", Subject);
+            .FailWith("Expected {context:JSON node} to be a numeric value{reason}, but {0} is not.", Subject);
 
-        var actualValue = Subject is JsonValue jsonValue && jsonValue.TryGetValue<long>(out var result) ? result : 0;
-        return new AndWhichConstraint<JsonNodeAssertions<T>, long>(this, actualValue);
+        return new AndWhichConstraint<JsonNodeAssertions<T>, string>(this, (Subject as JsonValue)?.ToString() ?? string.Empty);
     }
 
     /// <summary>
-    /// Asserts that the current <see cref="JsonNode"/> does not represent a 32-bit signed integer.
+    /// Asserts that the current <see cref="JsonNode"/> represents a numeric value and returns
+    /// the actual value provided it can be converted to <typeparamref name="TValue"/>.
+    /// </summary>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public AndWhichConstraint<JsonNodeAssertions<T>, TValue> BeNumeric<TValue>(
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        TValue actualValue = default;
+
+        CurrentAssertionChain
+            .ForCondition(Subject is JsonValue value && value.IsNumeric() && value.TryGetValue(out actualValue))
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:JSON node} to be a numeric value{reason}, but {0} is not.", Subject);
+
+        return new AndWhichConstraint<JsonNodeAssertions<T>, TValue>(this, actualValue);
+    }
+
+    /// <summary>
+    /// Asserts that the current <see cref="JsonNode"/> does not represent a numeric value.
     /// </summary>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -157,9 +180,9 @@ public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertio
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
-            .ForCondition(!(Subject is JsonValue value && value.TryGetValue<long>(out _)))
+            .ForCondition(Subject is not JsonValue value || !value.IsNumeric())
             .BecauseOf(because, becauseArgs)
-            .FailWith("Did not expect {context:JSON node} to be an Int32{reason}, but {0} is.", Subject);
+            .FailWith("Did not expect {context:JSON node} to be a numeric value{reason}, but {0} is.", Subject);
 
         return new AndConstraint<JsonNodeAssertions<T>>(this);
     }
@@ -200,7 +223,8 @@ public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertio
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
-            .ForCondition(Subject is not JsonValue value || !value.TryGetValue<DateTime>(out _) || Subject.ToString().EndsWith('Z'))
+            .ForCondition(Subject is not JsonValue value || !value.TryGetValue<DateTime>(out _) ||
+                          Subject.ToString().EndsWith('Z'))
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:JSON node} to be a local date{reason}, but {0} is.", Subject);
 
@@ -243,7 +267,8 @@ public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertio
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         CurrentAssertionChain
-            .ForCondition(Subject is not JsonValue value || !value.TryGetValue<DateTime>(out _) || !Subject.ToString().EndsWith('Z'))
+            .ForCondition(Subject is not JsonValue value || !value.TryGetValue<DateTime>(out _) ||
+                          !Subject.ToString().EndsWith('Z'))
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context} to be a UTC date{reason}, but {0} is.", Subject);
 

--- a/Src/FluentAssertions/Specialized/JsonValueExtensions.cs
+++ b/Src/FluentAssertions/Specialized/JsonValueExtensions.cs
@@ -1,0 +1,16 @@
+#if NET6_0_OR_GREATER
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace FluentAssertions.Specialized;
+
+internal static class JsonValueExtensions
+{
+    public static bool IsNumeric(this JsonValue value)
+    {
+        return value.GetValue<JsonElement>().ValueKind == JsonValueKind.Number;
+    }
+}
+
+#endif

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2355,7 +2355,8 @@ namespace FluentAssertions.Specialized
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, System.DateTime> BeLocalDate(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, long> BeNumeric(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, string> BeNumeric(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, TValue> BeNumeric<TValue>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, string> BeString(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, System.DateTime> BeUtcDate(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>, System.Text.Json.Nodes.JsonNode> HaveProperty(string code, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Equivalency.Specs/JsonNodeSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/JsonNodeSpecs.cs
@@ -17,20 +17,30 @@ public class JsonNodeSpecs
         var node = JsonNode.Parse(
             """
             {
-            "number" : 1,
-            "floatingpoint": 1.0
+            "signedInt" : -2147483647,
+            "unsignedInt": 4294967295,
+            "signedLong" : -9223372036854775808,
+            "unsignedLong" : 18446744073709551615,
+            "floatingPoint": 1.0,
+            "largeDouble": 1.0E+20,
+            "money": 2.0
             }
             """);
 
         // Act
         var act = () => node.Should().BeEquivalentTo(new
         {
-            number = 2,
-            floatingpoint = 2.0
+            signedInt = int.MinValue,
+            unsignedInt = uint.MaxValue,
+            signedLong = long.MinValue,
+            unsignedLong = ulong.MaxValue,
+            floatingPoint = 1.0F,
+            largeDouble = 1E+20F,
+            money = 2.0M
         });
 
         // Assert
-        act.Should().Throw<XunitException>().WithMessage("*$.number*2*1*$.floatingpoint*2.0*1.0*");
+        act.Should().Throw<XunitException>().WithMessage("*$.signedInt to be -2147483648, but found -2147483647*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/JsonNodeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/JsonNodeSpecs.cs
@@ -1,6 +1,7 @@
 #if NET6_0_OR_GREATER
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json.Nodes;
 using FluentAssertions.Extensions;
 using Xunit;
@@ -171,13 +172,73 @@ public class JsonNodeSpecs
     public class BeNumeric
     {
         [Fact]
-        public void Returns_the_integer_for_chaining_purposes()
+        public void The_minimal_double_value_is_numeric()
+        {
+            // Arrange
+            var jsonNode = JsonNode.Parse(double.MinValue.ToString(CultureInfo.InvariantCulture));
+
+            // Act & Assert
+            jsonNode.Should().BeNumeric();
+        }
+
+        [Fact]
+        public void The_maximum_double_value_is_numeric()
+        {
+            // Arrange
+            var jsonNode = JsonNode.Parse(double.MaxValue.ToString(CultureInfo.InvariantCulture));
+
+            // Act & Assert
+            jsonNode.Should().BeNumeric();
+        }
+
+        [Fact]
+        public void The_minimal_long_value_is_numeric()
+        {
+            // Arrange
+            var jsonNode = JsonNode.Parse(long.MinValue.ToString(CultureInfo.InvariantCulture));
+
+            // Act & Assert
+            jsonNode.Should().BeNumeric();
+        }
+
+        [Fact]
+        public void The_maximum_long_value_is_numeric()
+        {
+            // Arrange
+            var jsonNode = JsonNode.Parse(long.MaxValue.ToString(CultureInfo.InvariantCulture));
+
+            // Act & Assert
+            jsonNode.Should().BeNumeric();
+        }
+
+        [Fact]
+        public void The_maximum_unsigned_long_value_is_numeric()
+        {
+            // Arrange
+            var jsonNode = JsonNode.Parse(ulong.MaxValue.ToString(CultureInfo.InvariantCulture));
+
+            // Act & Assert
+            jsonNode.Should().BeNumeric();
+        }
+
+        [Fact]
+        public void Can_return_the_actual_value()
         {
             // Arrange
             var jsonNode = JsonNode.Parse("42");
 
             // Act & Assert
-            jsonNode.Should().BeNumeric().Which.Should().Be(42);
+            jsonNode.Should().BeNumeric().Which.Should().Be("42");
+        }
+
+        [Fact]
+        public void Can_return_the_actual_numeric_value_as_a_specific_type()
+        {
+            // Arrange
+            var jsonNode = JsonNode.Parse("42");
+
+            // Act & Assert
+            jsonNode.Should().BeNumeric<int>().Which.Should().Be(42);
         }
 
         [Fact]
@@ -191,17 +252,43 @@ public class JsonNodeSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected jsonNode to be an Int32 because we expect an int, but \"not a number\" is not.");
+                .WithMessage("Expected jsonNode to be a numeric value because we expect an int, but \"not a number\" is not.");
         }
 
         [Fact]
-        public void Can_ensure_a_node_is_not_a_number()
+        public void Can_ensure_a_string_is_not_a_number()
         {
             // Arrange
             var jsonNode = JsonNode.Parse("\"not a number\"");
 
             // Act & Assert
             jsonNode.Should().NotBeNumeric();
+        }
+
+        [Fact]
+        public void Can_ensure_a_ulong_is_a_number()
+        {
+            // Arrange
+            var jsonNode = JsonNode.Parse(ulong.MaxValue.ToString(CultureInfo.InvariantCulture));
+
+            // Act
+            var act = () => jsonNode.Should().NotBeNumeric();
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Can_ensure_a_double_is_a_number()
+        {
+            // Arrange
+            var jsonNode = JsonNode.Parse(double.MaxValue.ToString(CultureInfo.InvariantCulture));
+
+            // Act
+            var act = () => jsonNode.Should().NotBeNumeric();
+
+            // Assert
+            act.Should().Throw<XunitException>();
         }
 
         [Fact]
@@ -215,7 +302,7 @@ public class JsonNodeSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect jsonNode to be an Int32 because we expect something else, but 42 is.");
+                .WithMessage("Did not expect jsonNode to be a numeric value because we expect something else, but 42 is.");
         }
 
         [Fact]
@@ -228,7 +315,7 @@ public class JsonNodeSpecs
             var act = () => jsonNode.Should().BeNumeric();
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected jsonNode to be an Int32*");
+            act.Should().Throw<XunitException>().WithMessage("Expected jsonNode to be a numeric value*");
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,7 +11,8 @@ sidebar:
 
 ### Fixes
 
-* Fixed ambiguity when using `Should()` on a `JsonNode` derived class. - [#3102](https://github.com/fluentassertions/fluentassertions/pull/3102)
+* Fixed ambiguity when using `Should()` on a `JsonNode` derived class - [#3102](https://github.com/fluentassertions/fluentassertions/pull/3102)
+* JSON assertions did not properly handle floats, doubles and unsigned int/long - [#3105](https://github.com/fluentassertions/fluentassertions/pull/3105)
 
 ## 8.7.0
 


### PR DESCRIPTION
This PR fixes a bug in JSON assertions where the library wasn't properly handling certain numeric types during comparisons. The core issue was that the JSON conversion logic only checked for `int` and `double` values, but missed other important numeric types like unsigned integers (`uint`, `ulong`), signed long integers (), and floats (`float`). `long`

The fix adds support for these missing numeric types by extending the conversion step to handle `uint`, , `ulong`, and `float` values. Additionally, it introduces a new `IsNumeric()` helper method that properly identifies all numeric JSON values by checking for , `ulong`, or `double` types. `long``long`

Thanks to @jnyrup for the discovery.