### PR TITLE
Use `==` or `!=` when comparing Nullable<T> against constants

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -129,7 +129,7 @@ class Build : NukeBuild
             DotNetBuild(s => s
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
-                .When(_ => GenerateBinLog is true, c => c
+                .When(_ => GenerateBinLog == true, c => c
                     .SetBinaryLog(ArtifactsDirectory / $"{Solution.Core.FluentAssertions.Name}.binlog")
                 )
                 .EnableNoLogo()

--- a/Src/FluentAssertions/Equivalency/EqualityStrategyProvider.cs
+++ b/Src/FluentAssertions/Equivalency/EqualityStrategyProvider.cs
@@ -65,7 +65,7 @@ internal sealed class EqualityStrategyProvider
 
             if ((CompareRecordsByValue != null || defaultStrategy is null) && typeKey.IsRecord())
             {
-                return CompareRecordsByValue is true ? EqualityStrategy.ForceEquals : EqualityStrategy.ForceMembers;
+                return CompareRecordsByValue == true ? EqualityStrategy.ForceEquals : EqualityStrategy.ForceMembers;
             }
 
             if (defaultStrategy is not null)
@@ -105,7 +105,7 @@ internal sealed class EqualityStrategyProvider
     {
         var builder = new StringBuilder();
 
-        if (CompareRecordsByValue is true)
+        if (CompareRecordsByValue == true)
         {
             builder.AppendLine("- Compare records by value");
         }

--- a/Src/FluentAssertions/Execution/AssertionChain.cs
+++ b/Src/FluentAssertions/Execution/AssertionChain.cs
@@ -246,9 +246,9 @@ public sealed class AssertionChain
     {
         if (PreviousAssertionSucceeded)
         {
-            PreviousAssertionSucceeded = succeeded is true;
+            PreviousAssertionSucceeded = succeeded == true;
 
-            if (succeeded is not true)
+            if (succeeded != true)
             {
                 string failure = getFailureReason();
 

--- a/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
@@ -160,7 +160,7 @@ public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAsserti
     public AndConstraint<TAssertions> NotBeFalse([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         assertionChain
-            .ForCondition(Subject is not false)
+            .ForCondition(Subject != false)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:nullable boolean} not to be {0}{reason}, but found {1}.", false, Subject);
 
@@ -180,7 +180,7 @@ public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAsserti
     public AndConstraint<TAssertions> NotBeTrue([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         assertionChain
-            .ForCondition(Subject is not true)
+            .ForCondition(Subject != true)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:nullable boolean} not to be {0}{reason}, but found {1}.", true, Subject);
 


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
using `==` instead of `is` when comparing a `Nullable<T>` against a constant generates both better IL and assembly.
[SharpLab](https://sharplab.io/#v2:D4Iw9mA2AECyAMAKcUD80QEpoF4B8GuO0ALgE4CuApgNwCwAUCjLAIzISTpa4EjQBLAM6lKtRo2ZwATBzQZs+QgEJi5avSac4AZjlcFvQsOgA7MCVEagA===)

Roslyn has an open [issue](https://github.com/dotnet/roslyn/issues/66431) about this.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## CONTRIBUTOR LICENSE GRANT

By submitting this contribution, the contributor hereby irrevocably grants to the project owners and maintainers a perpetual, worldwide, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and create derivative works of the contribution for any purpose and under any terms, including proprietary licensing.

The contributor waives any moral rights in the contribution to the extent permitted by law and agrees not to assert any claim of authorship or control over the contribution. The contributor represents that they are the sole author of the contribution and that it is provided free of any third-party claims.

The contributor understands and agrees that the maintainers may, at their sole discretion, use, license, or redistribute the contribution as part of any work and under any terms they choose, without further permission or attribution.

* [ ] I have read the Contributor License Grant and accept the conditions
* [ ] I'm interested in a free license for Fluent Assertions and will share my email address through sales@xceed.com