### PR TITLE
Create polyfill for `string.Create`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -265,6 +265,10 @@ dotnet_diagnostic.MA0006.severity = none
 # Rationale: See https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0009.md
 dotnet_diagnostic.MA0009.severity = suggestion
 
+# Purpose: Use string.Create instead of FormattableString.Invariant
+# Rationale: See https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0111.md
+dotnet_diagnostic.MA0111.severity = error
+
 # Purpose: Use an overload of 'System.ArgumentException' with the parameter name
 # Rationale: We don't want to force this
 dotnet_diagnostic.MA0015.severity = suggestion

--- a/Src/FluentAssertions/Equivalency/Comparands.cs
+++ b/Src/FluentAssertions/Equivalency/Comparands.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.Globalization;
 using FluentAssertions.Common;
-using static System.FormattableString;
 
 namespace FluentAssertions.Equivalency;
 
@@ -72,6 +72,6 @@ public class Comparands
 
     public override string ToString()
     {
-        return Invariant($"{{Subject={Subject}, Expectation={Expectation}}}");
+        return string.Create(CultureInfo.InvariantCulture, $"{{Subject={Subject}, Expectation={Expectation}}}");
     }
 }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -1,7 +1,10 @@
+#if !NET6_0_OR_GREATER
+using System;
+#endif
+using System.Globalization;
 using FluentAssertions.Equivalency.Execution;
 using FluentAssertions.Equivalency.Tracing;
 using FluentAssertions.Execution;
-using static System.FormattableString;
 
 namespace FluentAssertions.Equivalency;
 
@@ -98,6 +101,6 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
 
     public override string ToString()
     {
-        return Invariant($"{{Path=\"{CurrentNode.Subject.PathAndName}\"}}");
+        return string.Create(CultureInfo.InvariantCulture, $"{{Path=\"{CurrentNode.Subject.PathAndName}\"}}");
     }
 }

--- a/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs
@@ -1,8 +1,8 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using FluentAssertions.Common;
-using static System.FormattableString;
 
 namespace FluentAssertions.Equivalency.Execution;
 
@@ -76,7 +76,7 @@ internal class ObjectReference
 
     public override string ToString()
     {
-        return Invariant($"{{\"{path}\", {@object}}}");
+        return string.Create(CultureInfo.InvariantCulture, $"{{\"{path}\", {@object}}}");
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Globalization;
 using FluentAssertions.Common;
-using static System.FormattableString;
 
 namespace FluentAssertions.Equivalency.Steps;
 
@@ -37,14 +36,15 @@ public class AutoConversionStep : IEquivalencyStep
         if (TryChangeType(comparands.Subject, expectationType, out object convertedSubject))
         {
             context.Tracer.WriteLine(member =>
-                Invariant($"Converted subject {comparands.Subject} at {member.Subject} to {expectationType}"));
+                string.Create(CultureInfo.InvariantCulture, $"Converted subject {comparands.Subject} at {member.Subject} to {expectationType}"));
 
             comparands.Subject = convertedSubject;
         }
         else
         {
             context.Tracer.WriteLine(member =>
-                Invariant($"Subject {comparands.Subject} at {member.Subject} could not be converted to {expectationType}"));
+                string.Create(CultureInfo.InvariantCulture,
+                    $"Subject {comparands.Subject} at {member.Subject} could not be converted to {expectationType}"));
         }
 
         return EquivalencyResult.ContinueWithNext;

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
@@ -1,8 +1,11 @@
+#if !NET6_0_OR_GREATER
+using System;
+#endif
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
-using static System.FormattableString;
 
 namespace FluentAssertions.Equivalency.Steps;
 
@@ -25,14 +28,14 @@ public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
                 if (context.Options.IsRecursive)
                 {
                     context.Tracer.WriteLine(member =>
-                        Invariant($"Recursing into dictionary item {key} at {member.Expectation}"));
+                        string.Create(CultureInfo.InvariantCulture, $"Recursing into dictionary item {key} at {member.Expectation}"));
 
                     nestedValidator.AssertEquivalencyOf(new Comparands(subject[key], expectation[key], typeof(object)), context.AsDictionaryItem<object, IDictionary>(key));
                 }
                 else
                 {
                     context.Tracer.WriteLine(member =>
-                        Invariant(
+                        string.Create(CultureInfo.InvariantCulture,
                             $"Comparing dictionary item {key} at {member.Expectation} between subject and expectation"));
 
                     assertionChain.WithCallerPostfix($"[{key.ToFormattedString()}]").ReuseOnce();

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -1,9 +1,12 @@
+#if !NET6_0_OR_GREATER
+using System;
+#endif
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using FluentAssertions.Equivalency.Execution;
 using FluentAssertions.Equivalency.Tracing;
 using FluentAssertions.Execution;
-using static System.FormattableString;
 
 namespace FluentAssertions.Equivalency.Steps;
 
@@ -42,14 +45,15 @@ internal class EnumerableEquivalencyValidator
             if (Recursive)
             {
                 using var _ = context.Tracer.WriteBlock(member =>
-                    Invariant($"Structurally comparing {subject} and expectation {expectation} at {member.Expectation}"));
+                    string.Create(CultureInfo.InvariantCulture,
+                        $"Structurally comparing {subject} and expectation {expectation} at {member.Expectation}"));
 
                 AssertElementGraphEquivalency(subject, expectation, context.CurrentNode);
             }
             else
             {
                 using var _ = context.Tracer.WriteBlock(member =>
-                    Invariant(
+                    string.Create(CultureInfo.InvariantCulture,
                         $"Comparing subject {subject} and expectation {expectation} at {member.Expectation} using simple value equality"));
 
                 subject.Should().BeEquivalentTo(expectation);
@@ -101,7 +105,7 @@ internal class EnumerableEquivalencyValidator
             T expectation = expectations[index];
 
             using var _ = context.Tracer.WriteBlock(member =>
-                Invariant(
+                string.Create(CultureInfo.InvariantCulture,
                     $"Strictly comparing expectation {expectation} at {member.Expectation} to item with index {index} in {subjects}"));
 
             bool succeeded = StrictlyMatchAgainst(subjects, expectation, index);
@@ -128,7 +132,7 @@ internal class EnumerableEquivalencyValidator
             T expectation = expectations[index];
 
             using var _ = context.Tracer.WriteBlock(member =>
-                Invariant(
+                string.Create(CultureInfo.InvariantCulture,
                     $"Finding the best match of {expectation} within all items in {subjects} at {member.Expectation}[{index}]"));
 
             bool succeeded = LooselyMatchAgainst(subjects, expectation, index);

--- a/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using static System.FormattableString;
+using System.Globalization;
 
 namespace FluentAssertions.Formatting;
 
@@ -29,7 +29,7 @@ public class AggregateExceptionValueFormatter : IValueFormatter
         }
         else
         {
-            formattedGraph.AddLine(Invariant($"{exception.InnerExceptions.Count} (aggregated) exceptions:"));
+            formattedGraph.AddLine(string.Create(CultureInfo.InvariantCulture, $"{exception.InnerExceptions.Count} (aggregated) exceptions:"));
 
             foreach (Exception innerException in exception.InnerExceptions)
             {

--- a/Src/FluentAssertions/Polyfill/StringExtensions.cs
+++ b/Src/FluentAssertions/Polyfill/StringExtensions.cs
@@ -1,0 +1,15 @@
+﻿#if !NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace System;
+
+internal static class StringExtensions
+{
+    extension(string)
+    {
+        public static string Create(IFormatProvider _, FormattableString formattable) => FormattableString.Invariant(formattable);
+    }
+}
+#endif


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->

`string.Create` is better than `FormattableString.Invariant`.
See [MA0111](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0111.md) for a benchmark

With C# 14's extension members, we can now polyfill this static method, by creating an extension member directly on the type `string`.

Note that this isn't a 1:1 polyfill since `string.Create` uses `DefaultInterpolatedStringHandler` which isn't available for older TFMs.
So the polyfill just continues using `FormattableString.Invariant` for older targets.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## CONTRIBUTOR LICENSE GRANT

By submitting this contribution, the contributor hereby irrevocably grants to the project owners and maintainers a perpetual, worldwide, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and create derivative works of the contribution for any purpose and under any terms, including proprietary licensing.

The contributor waives any moral rights in the contribution to the extent permitted by law and agrees not to assert any claim of authorship or control over the contribution. The contributor represents that they are the sole author of the contribution and that it is provided free of any third-party claims.

The contributor understands and agrees that the maintainers may, at their sole discretion, use, license, or redistribute the contribution as part of any work and under any terms they choose, without further permission or attribution.

* [ ] I have read the Contributor License Grant and accept the conditions
* [ ] I'm interested in a free license for Fluent Assertions and will share my email address through sales@xceed.com