### PR TITLE
Use compiler-generated `paramName` parameter

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -884,7 +884,7 @@ public static class AssertionExtensions
     /// <exception cref="ArgumentNullException"><paramref name="eventSource"/> is <see langword="null"/>.</exception>
     public static IMonitor<T> Monitor<T>(this T eventSource, Action<EventMonitorOptions> configureOptions)
     {
-        Guard.ThrowIfArgumentIsNull(configureOptions, nameof(configureOptions));
+        Guard.ThrowIfArgumentIsNull(configureOptions);
 
         var options = new EventMonitorOptions();
         configureOptions(options);

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -364,7 +364,7 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
     public AndConstraint<XDocumentAssertions> NotHaveElement(string unexpectedElement,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpectedElement, nameof(unexpectedElement));
+        Guard.ThrowIfArgumentIsNull(unexpectedElement);
 
         return NotHaveElement(XNamespace.None + unexpectedElement, because, becauseArgs);
     }
@@ -385,7 +385,7 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
     public AndConstraint<XDocumentAssertions> NotHaveElement(XName unexpectedElement,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpectedElement, nameof(unexpectedElement));
+        Guard.ThrowIfArgumentIsNull(unexpectedElement);
 
         assertionChain
             .BecauseOf(because, becauseArgs)
@@ -420,8 +420,8 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
     public AndWhichConstraint<XDocumentAssertions, XElement> HaveElementWithValue(string expectedElement,
         string expectedValue, [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(expectedElement, nameof(expectedElement));
-        Guard.ThrowIfArgumentIsNull(expectedValue, nameof(expectedValue));
+        Guard.ThrowIfArgumentIsNull(expectedElement);
+        Guard.ThrowIfArgumentIsNull(expectedValue);
 
         return HaveElementWithValue(XNamespace.None + expectedElement, expectedValue, because, becauseArgs);
     }
@@ -446,8 +446,8 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
     public AndWhichConstraint<XDocumentAssertions, XElement> HaveElementWithValue(XName expectedElement,
         string expectedValue, [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(expectedElement, nameof(expectedElement));
-        Guard.ThrowIfArgumentIsNull(expectedValue, nameof(expectedValue));
+        Guard.ThrowIfArgumentIsNull(expectedElement);
+        Guard.ThrowIfArgumentIsNull(expectedValue);
 
         IEnumerable<XElement> xElements = [];
 
@@ -495,8 +495,8 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
     public AndConstraint<XDocumentAssertions> NotHaveElementWithValue(string unexpectedElement,
         string unexpectedValue, [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpectedElement, nameof(unexpectedElement));
-        Guard.ThrowIfArgumentIsNull(unexpectedValue, nameof(unexpectedValue));
+        Guard.ThrowIfArgumentIsNull(unexpectedElement);
+        Guard.ThrowIfArgumentIsNull(unexpectedValue);
 
         return NotHaveElementWithValue(XNamespace.None + unexpectedElement, unexpectedValue, because, becauseArgs);
     }
@@ -521,8 +521,8 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
     public AndConstraint<XDocumentAssertions> NotHaveElementWithValue(XName unexpectedElement,
         string unexpectedValue, [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpectedElement, nameof(unexpectedElement));
-        Guard.ThrowIfArgumentIsNull(unexpectedValue, nameof(unexpectedValue));
+        Guard.ThrowIfArgumentIsNull(unexpectedElement);
+        Guard.ThrowIfArgumentIsNull(unexpectedValue);
 
         assertionChain
             .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -367,8 +367,8 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     public AndConstraint<XElementAssertions> NotHaveAttributeWithValue(string unexpectedName, string unexpectedValue,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNullOrEmpty(unexpectedName, nameof(unexpectedName));
-        Guard.ThrowIfArgumentIsNull(unexpectedValue, nameof(unexpectedValue));
+        Guard.ThrowIfArgumentIsNullOrEmpty(unexpectedName);
+        Guard.ThrowIfArgumentIsNull(unexpectedValue);
 
         return NotHaveAttributeWithValue(XNamespace.None + unexpectedName, unexpectedValue, because, becauseArgs);
     }
@@ -390,8 +390,8 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     public AndConstraint<XElementAssertions> NotHaveAttributeWithValue(XName unexpectedName, string unexpectedValue,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpectedName, nameof(unexpectedName));
-        Guard.ThrowIfArgumentIsNull(unexpectedValue, nameof(unexpectedValue));
+        Guard.ThrowIfArgumentIsNull(unexpectedName);
+        Guard.ThrowIfArgumentIsNull(unexpectedValue);
 
         string unexpectedText = unexpectedName.ToString();
 
@@ -574,7 +574,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     public AndConstraint<XElementAssertions> NotHaveElement(string unexpectedElement,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpectedElement, nameof(unexpectedElement));
+        Guard.ThrowIfArgumentIsNull(unexpectedElement);
 
         return NotHaveElement(XNamespace.None + unexpectedElement, because, becauseArgs);
     }
@@ -595,7 +595,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     public AndConstraint<XElementAssertions> NotHaveElement(XName unexpectedElement,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpectedElement, nameof(unexpectedElement));
+        Guard.ThrowIfArgumentIsNull(unexpectedElement);
 
         assertionChain
             .ForCondition(Subject is not null)
@@ -636,8 +636,8 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     public AndWhichConstraint<XElementAssertions, XElement> HaveElementWithValue(string expectedElement,
         string expectedValue, [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(expectedElement, nameof(expectedElement));
-        Guard.ThrowIfArgumentIsNull(expectedValue, nameof(expectedValue));
+        Guard.ThrowIfArgumentIsNull(expectedElement);
+        Guard.ThrowIfArgumentIsNull(expectedValue);
 
         return HaveElementWithValue(XNamespace.None + expectedElement, expectedValue, because, becauseArgs);
     }
@@ -662,8 +662,8 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     public AndWhichConstraint<XElementAssertions, XElement> HaveElementWithValue(XName expectedElement,
         string expectedValue, [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(expectedElement, nameof(expectedElement));
-        Guard.ThrowIfArgumentIsNull(expectedValue, nameof(expectedValue));
+        Guard.ThrowIfArgumentIsNull(expectedElement);
+        Guard.ThrowIfArgumentIsNull(expectedValue);
 
         IEnumerable<XElement> xElements = [];
 
@@ -713,8 +713,8 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     public AndConstraint<XElementAssertions> NotHaveElementWithValue(string unexpectedElement,
         string unexpectedValue, [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpectedElement, nameof(unexpectedElement));
-        Guard.ThrowIfArgumentIsNull(unexpectedValue, nameof(unexpectedValue));
+        Guard.ThrowIfArgumentIsNull(unexpectedElement);
+        Guard.ThrowIfArgumentIsNull(unexpectedValue);
 
         return NotHaveElementWithValue(XNamespace.None + unexpectedElement, unexpectedValue, because, becauseArgs);
     }
@@ -739,8 +739,8 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     public AndConstraint<XElementAssertions> NotHaveElementWithValue(XName unexpectedElement,
         string unexpectedValue, [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        Guard.ThrowIfArgumentIsNull(unexpectedElement, nameof(unexpectedElement));
-        Guard.ThrowIfArgumentIsNull(unexpectedValue, nameof(unexpectedValue));
+        Guard.ThrowIfArgumentIsNull(unexpectedElement);
+        Guard.ThrowIfArgumentIsNull(unexpectedValue);
 
         assertionChain
             .WithExpectation("Did not expect {context:subject} to have an element {0} with value {1}{reason}, ",


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->

After [upgrading Qodana](https://github.com/fluentassertions/fluentassertions/pull/3142) "The parameter 'paramName' has 'CallerArgumentExpression' attribute applied, so argument could be omitted" is now [triggered](https://qodana.cloud/projects/AgRgk/reports/b8jgDK?openedProblem=AwIwLMDGIKwEwHYBsBGBkVxUgnCAhjACb4qQCmICK%2BIAzHdfguSjABwhxFEygBmkfnnb8Udcr2aogA).
This PR fixes that.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## CONTRIBUTOR LICENSE GRANT

By submitting this contribution, the contributor hereby irrevocably grants to the project owners and maintainers a perpetual, worldwide, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and create derivative works of the contribution for any purpose and under any terms, including proprietary licensing.

The contributor waives any moral rights in the contribution to the extent permitted by law and agrees not to assert any claim of authorship or control over the contribution. The contributor represents that they are the sole author of the contribution and that it is provided free of any third-party claims.

The contributor understands and agrees that the maintainers may, at their sole discretion, use, license, or redistribute the contribution as part of any work and under any terms they choose, without further permission or attribution.

* [ ] I have read the Contributor License Grant and accept the conditions
* [ ] I'm interested in a free license for Fluent Assertions and will share my email address through sales@xceed.com