### PR TITLE
Clean-up the stack trace when throwing an assertion failure

### DIFF
--- a/Src/FluentAssertions/AggregateExceptionExtractor.cs
+++ b/Src/FluentAssertions/AggregateExceptionExtractor.cs
@@ -6,6 +6,7 @@ using FluentAssertions.Specialized;
 
 namespace FluentAssertions;
 
+[System.Diagnostics.StackTraceHidden]
 public class AggregateExceptionExtractor : IExtractExceptions
 {
     public IEnumerable<T> OfType<T>(Exception actualException)

--- a/Src/FluentAssertions/AndConstraint.cs
+++ b/Src/FluentAssertions/AndConstraint.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 
 namespace FluentAssertions;
 
+[StackTraceHidden]
 [DebuggerNonUserCode]
 public class AndConstraint<TParent>
 {

--- a/Src/FluentAssertions/AndWhichConstraint.cs
+++ b/Src/FluentAssertions/AndWhichConstraint.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Execution;
 using FluentAssertions.Formatting;
@@ -10,6 +11,8 @@ namespace FluentAssertions;
 /// Provides a <see cref="Which"/> property that can be used in chained assertions where the prior assertions returns a
 /// single object that the assertion continues on.
 /// </summary>
+[StackTraceHidden]
+[DebuggerNonUserCode]
 public class AndWhichConstraint<TParent, TSubject> : AndConstraint<TParent>
 {
     private readonly AssertionChain assertionChain;
@@ -98,7 +101,7 @@ public class AndWhichConstraint<TParent, TSubject> : AndConstraint<TParent>
                 matchedElements.Select(ele => "\t" + Formatter.ToString(ele)));
 
             string message = "More than one object found.  FluentAssertions cannot determine which object is meant."
-                + $"  Found objects:{Environment.NewLine}{foundObjects}";
+                             + $"  Found objects:{Environment.NewLine}{foundObjects}";
 
             AssertionEngine.TestFramework.Throw(message);
         }

--- a/Src/FluentAssertions/AssertionConfiguration.cs
+++ b/Src/FluentAssertions/AssertionConfiguration.cs
@@ -1,10 +1,11 @@
-﻿using FluentAssertions.Configuration;
+using FluentAssertions.Configuration;
 
 namespace FluentAssertions;
 
 /// <summary>
 /// Provides access to the global configuration and options to customize the behavior of FluentAssertions.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public static class AssertionConfiguration
 {
     public static GlobalConfiguration Current => AssertionEngine.Configuration;

--- a/Src/FluentAssertions/AssertionEngine.cs
+++ b/Src/FluentAssertions/AssertionEngine.cs
@@ -12,6 +12,7 @@ namespace FluentAssertions;
 /// <summary>
 /// Represents the run-time configuration of the assertion library.
 /// </summary>
+[StackTraceHidden]
 public static class AssertionEngine
 {
     private static readonly object Lockable = new();
@@ -148,3 +149,4 @@ public static class AssertionEngine
 #endif
     }
 }
+

--- a/Src/FluentAssertions/AtLeast.cs
+++ b/Src/FluentAssertions/AtLeast.cs
@@ -1,5 +1,6 @@
-﻿namespace FluentAssertions;
+namespace FluentAssertions;
 
+[System.Diagnostics.StackTraceHidden]
 public static class AtLeast
 {
     public static OccurrenceConstraint Once() => new AtLeastTimesConstraint(1);

--- a/Src/FluentAssertions/AtMost.cs
+++ b/Src/FluentAssertions/AtMost.cs
@@ -1,5 +1,6 @@
-﻿namespace FluentAssertions;
+namespace FluentAssertions;
 
+[System.Diagnostics.StackTraceHidden]
 public static class AtMost
 {
     public static OccurrenceConstraint Once() => new AtMostTimesConstraint(1);

--- a/Src/FluentAssertions/CallerIdentification/IParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/IParsingStrategy.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 
 namespace FluentAssertions.CallerIdentification;
 

--- a/Src/FluentAssertions/CallerIdentification/MultiLineCommentParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/MultiLineCommentParsingStrategy.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 
 namespace FluentAssertions.CallerIdentification;
 

--- a/Src/FluentAssertions/CallerIdentification/ParsingState.cs
+++ b/Src/FluentAssertions/CallerIdentification/ParsingState.cs
@@ -1,4 +1,4 @@
-﻿namespace FluentAssertions.CallerIdentification;
+namespace FluentAssertions.CallerIdentification;
 
 internal enum ParsingState
 {

--- a/Src/FluentAssertions/CallerIdentification/QuotesParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/QuotesParsingStrategy.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 
 namespace FluentAssertions.CallerIdentification;
 

--- a/Src/FluentAssertions/CallerIdentification/SemicolonParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/SemicolonParsingStrategy.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 
 namespace FluentAssertions.CallerIdentification;
 

--- a/Src/FluentAssertions/CallerIdentification/ShouldCallParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/ShouldCallParsingStrategy.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 
 namespace FluentAssertions.CallerIdentification;
 

--- a/Src/FluentAssertions/CallerIdentification/SingleLineCommentParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/SingleLineCommentParsingStrategy.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 
 namespace FluentAssertions.CallerIdentification;
 

--- a/Src/FluentAssertions/CallerIdentification/StatementParser.cs
+++ b/Src/FluentAssertions/CallerIdentification/StatementParser.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -16,6 +16,7 @@ namespace FluentAssertions;
 /// Tries to extract the name of the variable or invocation on which the assertion is executed.
 /// </summary>
 // REFACTOR: Should be internal and treated as an implementation detail of the AssertionScope
+[StackTraceHidden]
 public static class CallerIdentifier
 {
     public static Action<string> Logger { get; set; } = _ => { };
@@ -290,3 +291,4 @@ public static class CallerIdentifier
             .ToArray();
     }
 }
+

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -36,7 +36,6 @@ public class GenericCollectionAssertions<TCollection, T>
 
 #pragma warning disable CS0659, S1206 // Ignore not overriding Object.GetHashCode()
 #pragma warning disable CA1065 // Ignore throwing NotSupportedException from Equals
-
 [DebuggerNonUserCode]
 public class GenericCollectionAssertions<TCollection, T, TAssertions> : ReferenceTypeAssertions<TCollection, TAssertions>
     where TCollection : IEnumerable<T>
@@ -1186,28 +1185,28 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             switch (actualItems.Count)
             {
                 case 0: // Fail, Collection is empty
-                {
-                    assertionChain
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} to contain a single item{reason}, but the collection is empty.");
+                    {
+                        assertionChain
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} to contain a single item{reason}, but the collection is empty.");
 
-                    break;
-                }
+                        break;
+                    }
 
                 case 1: // Success Condition
-                {
-                    match = actualItems.Single();
-                    break;
-                }
+                    {
+                        match = actualItems.Single();
+                        break;
+                    }
 
                 default: // Fail, Collection contains more than a single item
-                {
-                    assertionChain
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} to contain a single item{reason}, but found {0}.", Subject);
+                    {
+                        assertionChain
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} to contain a single item{reason}, but found {0}.", Subject);
 
-                    break;
-                }
+                        break;
+                    }
             }
         }
 

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingProblem.cs
+++ b/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingProblem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolution.cs
+++ b/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolution.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace FluentAssertions.Collections.MaximumMatching;

--- a/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolver.cs
+++ b/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolver.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Src/FluentAssertions/Collections/MaximumMatching/Predicate.cs
+++ b/Src/FluentAssertions/Collections/MaximumMatching/Predicate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq.Expressions;
 using FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -135,7 +135,8 @@ public class StringCollectionAssertions<TCollection, TAssertions> : GenericColle
             options = config(AssertionConfiguration.Current.Equivalency.CloneDefaults<string>()).AsCollection();
 
         var context =
-            new EquivalencyValidationContext(Node.From<IEnumerable<string>>(() => CurrentAssertionChain.CallerIdentifier), options)
+            new EquivalencyValidationContext(Node.From<IEnumerable<string>>(() => CurrentAssertionChain.CallerIdentifier),
+                options)
             {
                 Reason = new Reason(because, becauseArgs),
                 TraceWriter = options.TraceWriter

--- a/Src/FluentAssertions/Collections/WhoseValueConstraint.cs
+++ b/Src/FluentAssertions/Collections/WhoseValueConstraint.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 
 namespace FluentAssertions.Collections;
 
+[System.Diagnostics.StackTraceHidden]
 public class WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> : AndConstraint<TAssertions>
     where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
     where TAssertions : GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>

--- a/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
+++ b/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Reflection;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class CSharpAccessModifierExtensions
 {
     internal static CSharpAccessModifier GetCSharpAccessModifier(this MethodBase methodBase)
@@ -105,3 +106,4 @@ internal static class CSharpAccessModifierExtensions
         return CSharpAccessModifier.InvalidForCSharp;
     }
 }
+

--- a/Src/FluentAssertions/Common/Clock.cs
+++ b/Src/FluentAssertions/Common/Clock.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,6 +7,7 @@ namespace FluentAssertions.Common;
 /// <summary>
 /// Default implementation for <see cref="IClock"/> for production use.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class Clock : IClock
 {
     public void Delay(TimeSpan timeToDelay) => Task.Delay(timeToDelay).GetAwaiter().GetResult();

--- a/Src/FluentAssertions/Common/DateTimeExtensions.cs
+++ b/Src/FluentAssertions/Common/DateTimeExtensions.cs
@@ -18,3 +18,4 @@ public static class DateTimeExtensions
         return new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified), offset);
     }
 }
+

--- a/Src/FluentAssertions/Common/EnumerableExtensions.cs
+++ b/Src/FluentAssertions/Common/EnumerableExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class EnumerableExtensions
 {
     public static ICollection<T> ConvertOrCastToCollection<T>(this IEnumerable<T> source)

--- a/Src/FluentAssertions/Common/ExceptionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExceptionExtensions.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class ExceptionExtensions
 {
     public static ExceptionDispatchInfo Unwrap(this TargetInvocationException exception)
@@ -18,3 +19,4 @@ internal static class ExceptionExtensions
         return ExceptionDispatchInfo.Capture(result);
     }
 }
+

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class ExpressionExtensions
 {
     /// <summary>
@@ -56,79 +57,79 @@ internal static class ExpressionExtensions
 #pragma warning restore IDE0010
             {
                 case ExpressionType.Lambda:
-                {
-                    node = ((LambdaExpression)node).Body;
-                    break;
-                }
+                    {
+                        node = ((LambdaExpression)node).Body;
+                        break;
+                    }
 
                 case ExpressionType.Convert:
                 case ExpressionType.ConvertChecked:
-                {
-                    var unaryExpression = (UnaryExpression)node;
-                    node = unaryExpression.Operand;
-                    break;
-                }
+                    {
+                        var unaryExpression = (UnaryExpression)node;
+                        node = unaryExpression.Operand;
+                        break;
+                    }
 
                 case ExpressionType.MemberAccess:
-                {
-                    var memberExpression = (MemberExpression)node;
-                    node = memberExpression.Expression;
+                    {
+                        var memberExpression = (MemberExpression)node;
+                        node = memberExpression.Expression;
 
-                    singlePath = $"{memberExpression.Member.Name}.{singlePath}";
-                    declaringTypes.Add(memberExpression.Member.DeclaringType);
-                    break;
-                }
+                        singlePath = $"{memberExpression.Member.Name}.{singlePath}";
+                        declaringTypes.Add(memberExpression.Member.DeclaringType);
+                        break;
+                    }
 
                 case ExpressionType.ArrayIndex:
-                {
-                    var binaryExpression = (BinaryExpression)node;
-                    var indexExpression = (ConstantExpression)binaryExpression.Right;
-                    node = binaryExpression.Left;
+                    {
+                        var binaryExpression = (BinaryExpression)node;
+                        var indexExpression = (ConstantExpression)binaryExpression.Right;
+                        node = binaryExpression.Left;
 
-                    singlePath = $"[{indexExpression.Value}].{singlePath}";
-                    break;
-                }
+                        singlePath = $"[{indexExpression.Value}].{singlePath}";
+                        break;
+                    }
 
                 case ExpressionType.Parameter:
-                {
-                    node = null;
-                    break;
-                }
+                    {
+                        node = null;
+                        break;
+                    }
 
                 case ExpressionType.Call:
-                {
-                    var methodCallExpression = (MethodCallExpression)node;
+                    {
+                        var methodCallExpression = (MethodCallExpression)node;
 
-                    if (methodCallExpression is not
-                        { Method.Name: "get_Item", Arguments: [ConstantExpression argumentExpression] })
+                        if (methodCallExpression is not
+                            { Method.Name: "get_Item", Arguments: [ConstantExpression argumentExpression] })
+                        {
+                            throw new ArgumentException(GetUnsupportedExpressionMessage(expression.Body), nameof(expression));
+                        }
+
+                        node = methodCallExpression.Object;
+                        singlePath = $"[{argumentExpression.Value}].{singlePath}";
+                        break;
+                    }
+
+                case ExpressionType.New:
+                    {
+                        var newExpression = (NewExpression)node;
+
+                        foreach (Expression member in newExpression.Arguments)
+                        {
+                            var expr = member.ToString();
+                            selectors.Add(expr[expr.IndexOf('.', StringComparison.Ordinal)..]);
+                            declaringTypes.Add(((MemberExpression)member).Member.DeclaringType);
+                        }
+
+                        node = null;
+                        break;
+                    }
+
+                default:
                     {
                         throw new ArgumentException(GetUnsupportedExpressionMessage(expression.Body), nameof(expression));
                     }
-
-                    node = methodCallExpression.Object;
-                    singlePath = $"[{argumentExpression.Value}].{singlePath}";
-                    break;
-                }
-
-                case ExpressionType.New:
-                {
-                    var newExpression = (NewExpression)node;
-
-                    foreach (Expression member in newExpression.Arguments)
-                    {
-                        var expr = member.ToString();
-                        selectors.Add(expr[expr.IndexOf('.', StringComparison.Ordinal)..]);
-                        declaringTypes.Add(((MemberExpression)member).Member.DeclaringType);
-                    }
-
-                    node = null;
-                    break;
-                }
-
-                default:
-                {
-                    throw new ArgumentException(GetUnsupportedExpressionMessage(expression.Body), nameof(expression));
-                }
             }
         }
 
@@ -183,58 +184,58 @@ internal static class ExpressionExtensions
 #pragma warning restore IDE0010
             {
                 case ExpressionType.Lambda:
-                {
-                    node = ((LambdaExpression)node).Body;
-                    break;
-                }
+                    {
+                        node = ((LambdaExpression)node).Body;
+                        break;
+                    }
 
                 case ExpressionType.Convert:
                 case ExpressionType.ConvertChecked:
-                {
-                    var unaryExpression = (UnaryExpression)node;
-                    node = unaryExpression.Operand;
-                    break;
-                }
+                    {
+                        var unaryExpression = (UnaryExpression)node;
+                        node = unaryExpression.Operand;
+                        break;
+                    }
 
                 case ExpressionType.MemberAccess:
-                {
-                    var memberExpression = (MemberExpression)node;
-                    node = memberExpression.Expression;
+                    {
+                        var memberExpression = (MemberExpression)node;
+                        node = memberExpression.Expression;
 
-                    break;
-                }
+                        break;
+                    }
 
                 case ExpressionType.ArrayIndex:
-                {
-                    var binaryExpression = (BinaryExpression)node;
-                    node = binaryExpression.Left;
+                    {
+                        var binaryExpression = (BinaryExpression)node;
+                        node = binaryExpression.Left;
 
-                    break;
-                }
+                        break;
+                    }
 
                 case ExpressionType.Parameter:
-                {
-                    node = null;
-                    break;
-                }
+                    {
+                        node = null;
+                        break;
+                    }
 
                 case ExpressionType.Call:
-                {
-                    var methodCallExpression = (MethodCallExpression)node;
+                    {
+                        var methodCallExpression = (MethodCallExpression)node;
 
-                    if (methodCallExpression is not { Method.Name: "get_Item", Arguments: [ConstantExpression] })
+                        if (methodCallExpression is not { Method.Name: "get_Item", Arguments: [ConstantExpression] })
+                        {
+                            throw new ArgumentException(GetUnsupportedExpressionMessage(expression.Body), nameof(expression));
+                        }
+
+                        node = methodCallExpression.Object;
+                        break;
+                    }
+
+                default:
                     {
                         throw new ArgumentException(GetUnsupportedExpressionMessage(expression.Body), nameof(expression));
                     }
-
-                    node = methodCallExpression.Object;
-                    break;
-                }
-
-                default:
-                {
-                    throw new ArgumentException(GetUnsupportedExpressionMessage(expression.Body), nameof(expression));
-                }
             }
         }
     }
@@ -242,3 +243,4 @@ internal static class ExpressionExtensions
     private static string GetUnsupportedExpressionMessage(Expression expression) =>
         $"Expression <{expression}> cannot be used to select a member.";
 }
+

--- a/Src/FluentAssertions/Common/Guard.cs
+++ b/Src/FluentAssertions/Common/Guard.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class Guard
 {
     public static void ThrowIfArgumentIsNull<T>([ValidatedNotNull][NoEnumeration] T obj,

--- a/Src/FluentAssertions/Common/IClock.cs
+++ b/Src/FluentAssertions/Common/IClock.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Src/FluentAssertions/Common/ITimer.cs
+++ b/Src/FluentAssertions/Common/ITimer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace FluentAssertions.Common;
 

--- a/Src/FluentAssertions/Common/IntegerExtensions.cs
+++ b/Src/FluentAssertions/Common/IntegerExtensions.cs
@@ -1,8 +1,9 @@
-﻿namespace FluentAssertions.Common;
+namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class IntegerExtensions
 {
     public static string Times(this int count) => count == 1 ? "1 time" : $"{count} times";
 
-    internal static bool IsConsecutiveTo(this int startNumber, int endNumber) => endNumber == (startNumber + 1);
+    internal static bool IsConsecutiveTo(this int startNumber, int endNumber) => endNumber == startNumber + 1;
 }

--- a/Src/FluentAssertions/Common/Iterator.cs
+++ b/Src/FluentAssertions/Common/Iterator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -8,6 +8,7 @@ namespace FluentAssertions.Common;
 /// A smarter enumerator that can provide information about the relative location (current, first, last)
 /// of the current item within the collection without unnecessarily iterating the collection.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal sealed class Iterator<T> : IEnumerator<T>
 {
     private const int InitialIndex = -1;
@@ -137,3 +138,4 @@ internal sealed class Iterator<T> : IEnumerator<T>
         enumerator.Dispose();
     }
 }
+

--- a/Src/FluentAssertions/Common/KeyValuePairCollectionExtensions.cs
+++ b/Src/FluentAssertions/Common/KeyValuePairCollectionExtensions.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class KeyValuePairCollectionExtensions
 {
     public static IEnumerable<TKey> GetKeys<TCollection, TKey, TValue>(this TCollection collection)
@@ -81,3 +82,4 @@ internal static class KeyValuePairCollectionExtensions
         };
     }
 }
+

--- a/Src/FluentAssertions/Common/MemberPath.cs
+++ b/Src/FluentAssertions/Common/MemberPath.cs
@@ -9,6 +9,7 @@ namespace FluentAssertions.Common;
 /// Encapsulates a dotted candidate to a (nested) member of a type as well as the
 /// declaring type of the deepest member.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class MemberPath
 {
     private readonly string dottedPath;
@@ -136,3 +137,4 @@ internal class MemberPath
         return dottedPath;
     }
 }
+

--- a/Src/FluentAssertions/Common/MemberPathSegmentEqualityComparer.cs
+++ b/Src/FluentAssertions/Common/MemberPathSegmentEqualityComparer.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER || NETSTANDARD2_1
+#if NET6_0_OR_GREATER || NETSTANDARD2_1
 using System;
 #endif
 using System.Collections.Generic;
@@ -11,6 +11,7 @@ namespace FluentAssertions.Common;
 /// Sets the <see cref="AnyIndexQualifier"/> equal with any numeric index qualifier.
 /// All other comparisons are default string equality.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class MemberPathSegmentEqualityComparer : IEqualityComparer<string>
 {
     private const string AnyIndexQualifier = "*";
@@ -49,3 +50,4 @@ internal class MemberPathSegmentEqualityComparer : IEqualityComparer<string>
 #endif
     }
 }
+

--- a/Src/FluentAssertions/Common/MethodInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/MethodInfoExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class MethodInfoExtensions
 {
     /// <summary>
@@ -66,3 +67,4 @@ internal static class MethodInfoExtensions
         return (false, null);
     }
 }
+

--- a/Src/FluentAssertions/Common/ObjectExtensions.cs
+++ b/Src/FluentAssertions/Common/ObjectExtensions.cs
@@ -5,6 +5,7 @@ using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class ObjectExtensions
 {
     public static Func<T, T, bool> GetComparer<T>()
@@ -87,3 +88,4 @@ internal static class ObjectExtensions
         return Formatter.ToString(source);
     }
 }
+

--- a/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
@@ -1,7 +1,8 @@
-﻿using System.Reflection;
+using System.Reflection;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class PropertyInfoExtensions
 {
     internal static bool IsVirtual(this PropertyInfo property)
@@ -22,3 +23,4 @@ internal static class PropertyInfoExtensions
         return methodInfo.IsAbstract;
     }
 }
+

--- a/Src/FluentAssertions/Common/StartTimer.cs
+++ b/Src/FluentAssertions/Common/StartTimer.cs
@@ -1,4 +1,4 @@
-﻿namespace FluentAssertions.Common;
+namespace FluentAssertions.Common;
 
 /// <summary>
 /// Factory for starting a timer on demand.

--- a/Src/FluentAssertions/Common/StopwatchTimer.cs
+++ b/Src/FluentAssertions/Common/StopwatchTimer.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 
 namespace FluentAssertions.Common;
 
+[StackTraceHidden]
 internal sealed class StopwatchTimer : ITimer
 {
     private readonly Stopwatch stopwatch = Stopwatch.StartNew();
@@ -19,3 +20,4 @@ internal sealed class StopwatchTimer : ITimer
         }
     }
 }
+

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -7,6 +7,7 @@ using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class StringExtensions
 {
     /// <summary>
@@ -179,3 +180,4 @@ internal static class StringExtensions
         return "    \"" + string.Join(Environment.NewLine + "    ", wrappedLines) + "\"";
     }
 }
+

--- a/Src/FluentAssertions/Common/TimeOnlyExtensions.cs
+++ b/Src/FluentAssertions/Common/TimeOnlyExtensions.cs
@@ -3,6 +3,7 @@ using System;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class TimeOnlyExtensions
 {
     /// <summary>
@@ -27,3 +28,4 @@ internal static class TimeOnlyExtensions
 }
 
 #endif
+

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -11,6 +11,7 @@ using Reflectify;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class TypeExtensions
 {
     private const BindingFlags PublicInstanceMembersFlag =
@@ -482,3 +483,4 @@ internal static class TypeExtensions
         return type;
     }
 }
+

--- a/Src/FluentAssertions/Common/TypeReflector.cs
+++ b/Src/FluentAssertions/Common/TypeReflector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,6 +6,7 @@ using System.Reflection;
 
 namespace FluentAssertions.Common;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class TypeReflector
 {
     public static IEnumerable<Type> GetAllTypesFromAppDomain(Func<Assembly, bool> predicate)
@@ -56,3 +57,4 @@ internal static class TypeReflector
         }
     }
 }
+

--- a/Src/FluentAssertions/Common/ValueFormatterDetectionMode.cs
+++ b/Src/FluentAssertions/Common/ValueFormatterDetectionMode.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions.Configuration;
+using FluentAssertions.Configuration;
 
 namespace FluentAssertions.Common;
 

--- a/Src/FluentAssertions/Configuration/GlobalConfiguration.cs
+++ b/Src/FluentAssertions/Configuration/GlobalConfiguration.cs
@@ -1,5 +1,6 @@
 namespace FluentAssertions.Configuration;
 
+[System.Diagnostics.StackTraceHidden]
 public class GlobalConfiguration
 {
     /// <summary>

--- a/Src/FluentAssertions/Configuration/GlobalEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Configuration/GlobalEquivalencyOptions.cs
@@ -1,10 +1,12 @@
 using System;
+
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 using JetBrains.Annotations;
 
 namespace FluentAssertions.Configuration;
 
+[System.Diagnostics.StackTraceHidden]
 public class GlobalEquivalencyOptions
 {
     private EquivalencyOptions defaults = new();
@@ -49,3 +51,4 @@ public class GlobalEquivalencyOptions
         return new EquivalencyOptions<T>(defaults);
     }
 }
+

--- a/Src/FluentAssertions/Configuration/GlobalFormattingOptions.cs
+++ b/Src/FluentAssertions/Configuration/GlobalFormattingOptions.cs
@@ -4,6 +4,7 @@ using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Configuration;
 
+[System.Diagnostics.StackTraceHidden]
 public class GlobalFormattingOptions : FormattingOptions
 {
     public string ValueFormatterAssembly
@@ -32,3 +33,4 @@ public class GlobalFormattingOptions : FormattingOptions
         };
     }
 }
+

--- a/Src/FluentAssertions/CustomAssertionAttribute.cs
+++ b/Src/FluentAssertions/CustomAssertionAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace FluentAssertions;
 
@@ -8,4 +8,6 @@ namespace FluentAssertions;
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
 #pragma warning disable CA1813 // Avoid unsealed attributes. This type has shipped.
+[System.Diagnostics.StackTraceHidden]
 public class CustomAssertionAttribute : Attribute;
+

--- a/Src/FluentAssertions/CustomAssertionsAssemblyAttribute.cs
+++ b/Src/FluentAssertions/CustomAssertionsAssemblyAttribute.cs
@@ -7,4 +7,6 @@ namespace FluentAssertions;
 /// internally, or directly uses <c>AssertionChain</c>.
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly)]
+[System.Diagnostics.StackTraceHidden]
 public sealed class CustomAssertionsAssemblyAttribute : Attribute;
+

--- a/Src/FluentAssertions/Disposable.cs
+++ b/Src/FluentAssertions/Disposable.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 
 namespace FluentAssertions;
 
+[System.Diagnostics.StackTraceHidden]
 internal sealed class Disposable : IDisposable
 {
     private readonly Action action;
@@ -16,3 +17,4 @@ internal sealed class Disposable : IDisposable
         action();
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/AssertionChainExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionChainExtensions.cs
@@ -2,6 +2,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class AssertionChainExtensions
 {
     /// <summary>
@@ -17,3 +18,4 @@ internal static class AssertionChainExtensions
             .BecauseOf(context.Reason);
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Comparands.cs
+++ b/Src/FluentAssertions/Equivalency/Comparands.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
+
 using System.Globalization;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 public class Comparands
 {
     public Comparands()
@@ -75,3 +77,4 @@ public class Comparands
         return string.Create(CultureInfo.InvariantCulture, $"{{Subject={Subject}, Expectation={Expectation}}}");
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/ConversionSelector.cs
+++ b/Src/FluentAssertions/Equivalency/ConversionSelector.cs
@@ -11,6 +11,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Collects the members that need to be converted by the <see cref="AutoConversionStep"/>.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class ConversionSelector
 {
     private sealed class ConversionSelectorRule
@@ -112,3 +113,4 @@ public class ConversionSelector
         return new ConversionSelector(new List<ConversionSelectorRule>(inclusions), new List<ConversionSelectorRule>(exclusions));
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Digit.cs
+++ b/Src/FluentAssertions/Equivalency/Digit.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 
 namespace FluentAssertions.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 internal class Digit
 {
     private readonly int length;
@@ -49,3 +50,4 @@ internal class Digit
         return success;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/EqualityStrategyProvider.cs
+++ b/Src/FluentAssertions/Equivalency/EqualityStrategyProvider.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 
 namespace FluentAssertions.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 internal sealed class EqualityStrategyProvider
 {
     private readonly List<Type> referenceTypes = [];
@@ -127,3 +128,4 @@ internal sealed class EqualityStrategyProvider
         return builder.ToString();
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/EquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyOptions.cs
@@ -12,6 +12,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Represents the run-time type-specific behavior of a structural equivalency assertion.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class EquivalencyOptions<TExpectation>
     : SelfReferenceEquivalencyOptions<EquivalencyOptions<TExpectation>>
 {
@@ -208,3 +209,4 @@ public class EquivalencyOptions : SelfReferenceEquivalencyOptions<EquivalencyOpt
         PreferringDeclaredMemberTypes();
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/EquivalencyPlan.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyPlan.cs
@@ -1,5 +1,3 @@
-﻿#region
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -7,14 +5,13 @@ using System.Linq;
 using FluentAssertions.Equivalency.Inlining;
 using FluentAssertions.Equivalency.Steps;
 
-#endregion
-
 namespace FluentAssertions.Equivalency;
 
 /// <summary>
 /// Represents a mutable collection of equivalency steps that can be reordered and/or amended with additional
 /// custom equivalency steps.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class EquivalencyPlan : IEnumerable<IEquivalencyStep>
 {
     private List<IEquivalencyStep> steps = GetDefaultSteps();
@@ -166,3 +163,4 @@ public class EquivalencyPlan : IEnumerable<IEquivalencyStep>
         ];
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/EquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyStep.cs
@@ -1,8 +1,9 @@
-﻿namespace FluentAssertions.Equivalency;
+namespace FluentAssertions.Equivalency;
 
 /// <summary>
 ///  Convenient implementation of <see cref="IEquivalencyStep"/> that will only invoke
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public abstract class EquivalencyStep<T> : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -1,6 +1,7 @@
 #if !NET6_0_OR_GREATER
 using System;
 #endif
+
 using System.Globalization;
 using FluentAssertions.Equivalency.Execution;
 using FluentAssertions.Equivalency.Tracing;
@@ -11,6 +12,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Provides information on a particular property during an assertion for structural equality of two object graphs.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class EquivalencyValidationContext : IEquivalencyValidationContext
 {
     private Tracer tracer;
@@ -104,3 +106,4 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
         return string.Create(CultureInfo.InvariantCulture, $"{{Path=\"{CurrentNode.Subject.PathAndName}\"}}");
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -7,6 +7,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Is responsible for validating the equivalency of a subject with another object.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class EquivalencyValidator : IValidateChildNodeEquivalency
 {
     private const int MaxDepth = 10;

--- a/Src/FluentAssertions/Equivalency/Execution/CollectionMemberOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CollectionMemberOptionsDecorator.cs
@@ -11,6 +11,7 @@ namespace FluentAssertions.Equivalency.Execution;
 /// <summary>
 /// Ensures that all the rules remove the collection index from the path before processing it further.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class CollectionMemberOptionsDecorator : IEquivalencyOptions, IContainTypingRules
 {
     private readonly IEquivalencyOptions inner;
@@ -93,3 +94,4 @@ internal class CollectionMemberOptionsDecorator : IEquivalencyOptions, IContainT
 
     public ITraceWriter TraceWriter => inner.TraceWriter;
 }
+

--- a/Src/FluentAssertions/Equivalency/Execution/CyclicReferenceDetector.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CyclicReferenceDetector.cs
@@ -7,6 +7,7 @@ namespace FluentAssertions.Equivalency.Execution;
 /// Keeps track of objects and their location within an object graph so that cyclic references can be detected
 /// and handled upon.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class CyclicReferenceDetector : ICloneable2
 {
     #region Private Definitions
@@ -45,3 +46,4 @@ internal class CyclicReferenceDetector : ICloneable2
         };
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Execution/ObjectInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/ObjectInfo.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace FluentAssertions.Equivalency.Execution;
 
+[System.Diagnostics.StackTraceHidden]
 internal class ObjectInfo : IObjectInfo
 {
     public ObjectInfo(Comparands comparands, INode currentNode)
@@ -23,3 +24,4 @@ internal class ObjectInfo : IObjectInfo
 
     public Type RuntimeType { get; }
 }
+

--- a/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs
@@ -9,6 +9,7 @@ namespace FluentAssertions.Equivalency.Execution;
 /// <summary>
 /// Represents  an object tracked by the <see cref="CyclicReferenceDetector"/> including it's location within an object graph.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class ObjectReference
 {
     private readonly object @object;
@@ -90,3 +91,4 @@ internal class ObjectReference
     /// </remarks>
     public bool CompareByMembers { get; }
 }
+

--- a/Src/FluentAssertions/Equivalency/Field.cs
+++ b/Src/FluentAssertions/Equivalency/Field.cs
@@ -8,6 +8,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// A specialized type of <see cref="INode"/> that represents a field of an object in a structural equivalency assertion.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class Field : Node, IMember
 {
     private readonly FieldInfo fieldInfo;
@@ -42,3 +43,4 @@ internal class Field : Node, IMember
     public bool IsBrowsable =>
         isBrowsable ??= fieldInfo.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
 }
+

--- a/Src/FluentAssertions/Equivalency/Inlining/ActionBasedInlineAssertion.cs
+++ b/Src/FluentAssertions/Equivalency/Inlining/ActionBasedInlineAssertion.cs
@@ -9,6 +9,7 @@ namespace FluentAssertions.Equivalency.Inlining;
 /// of the assertion APIs provided by Fluent Assertions.
 /// </summary>
 /// <typeparam name="T">The expected type of the subject to which the assertion is applied.</typeparam>
+[System.Diagnostics.StackTraceHidden]
 internal class ActionBasedInlineAssertion<T>(Action<T> assertion) : IInlineEquivalencyAssertion
 {
     /// <inheritdoc />
@@ -24,3 +25,4 @@ internal class ActionBasedInlineAssertion<T>(Action<T> assertion) : IInlineEquiv
         }
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Inlining/ConditionBasedInlineAssertion.cs
+++ b/Src/FluentAssertions/Equivalency/Inlining/ConditionBasedInlineAssertion.cs
@@ -8,6 +8,7 @@ namespace FluentAssertions.Equivalency.Inlining;
 /// Represents a condition-based inline equivalency assertion that evaluates a specified condition against a subject during object equivalency checks.
 /// </summary>
 /// <typeparam name="T">The expected type of the subject being asserted.</typeparam>
+[System.Diagnostics.StackTraceHidden]
 internal class ConditionBasedInlineAssertion<T>(Expression<Func<T, bool>> condition) : IInlineEquivalencyAssertion
 {
     /// <inheritdoc />
@@ -22,3 +23,4 @@ internal class ConditionBasedInlineAssertion<T>(Expression<Func<T, bool>> condit
             .FailWith("Expected {context:subject} to meet condition {0}, but it did not.", condition);
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Inlining/InlineEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Inlining/InlineEquivalencyStep.cs
@@ -13,6 +13,7 @@ namespace FluentAssertions.Equivalency.Inlining;
 /// This step allows users to define custom equivalency behaviors inline during assertion
 /// execution.
 /// </remarks>
+[System.Diagnostics.StackTraceHidden]
 public class InlineEquivalencyStep : IEquivalencyStep
 {
     /// <inheritdoc />
@@ -31,3 +32,4 @@ public class InlineEquivalencyStep : IEquivalencyStep
         return EquivalencyResult.ContinueWithNext;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/JsonProperty.cs
+++ b/Src/FluentAssertions/Equivalency/JsonProperty.cs
@@ -12,6 +12,7 @@ namespace FluentAssertions.Equivalency;
 /// information about a specific JSON property, its parent object, and its counterpart in an expectation object
 /// when performing comparisons.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class JsonProperty(JsonNode property, JsonObject parent, INode expectationParent) : IMember
 {
     // SMELL: A lot of properties are required by the IMember interface, but they are not used. In the future
@@ -145,3 +146,4 @@ internal class JsonProperty(JsonNode property, JsonObject parent, INode expectat
 }
 
 #endif
+

--- a/Src/FluentAssertions/Equivalency/MemberFactory.cs
+++ b/Src/FluentAssertions/Equivalency/MemberFactory.cs
@@ -1,9 +1,11 @@
 using System;
+
 using System.Reflection;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 public static class MemberFactory
 {
     public static IMember Create(MemberInfo memberInfo, INode parent)
@@ -29,3 +31,4 @@ public static class MemberFactory
         return field is not null ? new Field(field, parent) : null;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/MemberSelectionContext.cs
+++ b/Src/FluentAssertions/Equivalency/MemberSelectionContext.cs
@@ -6,6 +6,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Provides contextual information to an <see cref="IMemberSelectionRule"/>.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class MemberSelectionContext
 {
     private readonly Type compileTimeType;
@@ -42,3 +43,4 @@ public class MemberSelectionContext
         }
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/MemberVisibility.cs
+++ b/Src/FluentAssertions/Equivalency/MemberVisibility.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 #pragma warning disable CA1714
 namespace FluentAssertions.Equivalency;

--- a/Src/FluentAssertions/Equivalency/MemberVisibilityExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/MemberVisibilityExtensions.cs
@@ -4,6 +4,7 @@ using Reflectify;
 
 namespace FluentAssertions.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class MemberVisibilityExtensions
 {
     private static readonly ConcurrentDictionary<MemberVisibility, MemberKind> Cache = new();
@@ -41,3 +42,4 @@ internal static class MemberVisibilityExtensions
         });
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using FluentAssertions.Execution;
 
@@ -8,6 +8,7 @@ namespace FluentAssertions.Equivalency;
 /// Supports recursively comparing two multi-dimensional arrays for equivalency using strict order for the array items
 /// themselves.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class MultiDimensionalArrayEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
@@ -105,3 +106,4 @@ internal class MultiDimensionalArrayEquivalencyStep : IEquivalencyStep
         return assertionChain.Succeeded;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/NestedExclusionOptionBuilder.cs
+++ b/Src/FluentAssertions/Equivalency/NestedExclusionOptionBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
@@ -6,6 +6,7 @@ using FluentAssertions.Equivalency.Selection;
 
 namespace FluentAssertions.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
 {
     /// <summary>
@@ -49,3 +50,4 @@ public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
         return new NestedExclusionOptionBuilder<TExpectation, TNext>(capturedOptions, currentPathSelectionRule);
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Equivalency/Node.cs
@@ -7,6 +7,7 @@ using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 internal class Node : INode
 {
     private static readonly Regex MatchFirstIndex = new(@"^\[[0-9]+\]$");
@@ -151,3 +152,4 @@ internal class Node : INode
 
     public override string ToString() => Subject.Description;
 }
+

--- a/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
+++ b/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
@@ -7,6 +7,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Collection of <see cref="PathBasedOrderingRule"/>s.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class OrderingRuleCollection : IEnumerable<IOrderingRule>
 {
     private readonly List<IOrderingRule> rules = [];
@@ -70,3 +71,4 @@ public class OrderingRuleCollection : IEnumerable<IOrderingRule>
         return results.Contains(OrderStrictness.Strict) && !results.Contains(OrderStrictness.NotStrict);
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Property.cs
+++ b/Src/FluentAssertions/Equivalency/Property.cs
@@ -9,6 +9,7 @@ namespace FluentAssertions.Equivalency;
 /// A specialized type of <see cref="INode  "/> that represents a property of an object in a structural equivalency assertion.
 /// </summary>
 #pragma warning disable CA1716
+[System.Diagnostics.StackTraceHidden]
 internal class Property : Node, IMember
 {
     private readonly PropertyInfo propertyInfo;
@@ -48,3 +49,4 @@ internal class Property : Node, IMember
     public bool IsBrowsable =>
         isBrowsable ??= propertyInfo.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
 }
+

--- a/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByPredicateSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByPredicateSelectionRule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/Src/FluentAssertions/Equivalency/Selection/ExcludeNonBrowsableMembersRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/ExcludeNonBrowsableMembersRule.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace FluentAssertions.Equivalency.Selection;

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -21,6 +21,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Represents the run-time behavior of a structural equivalency assertion.
 /// </summary>
+[StackTraceHidden]
 public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptions, IContainTypingRules
     where TSelf : SelfReferenceEquivalencyOptions<TSelf>
 {
@@ -449,7 +450,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     /// <para>
     /// For open generic types, this excludes all closed generics and types deriving from them. For example,
     /// <c>Excluding(typeof(Nullable&lt;&gt;))</c> excludes all nullable value types like <c>int?</c>, <c>double?</c>, etc.
-    /// Similarly, <c>Excluding(typeof(List&lt;&gt;))</c> excludes <c>List&lt;int&gt;</c>, <c>List&lt;string&gt;</c>, 
+    /// Similarly, <c>Excluding(typeof(List&lt;&gt;))</c> excludes <c>List&lt;int&gt;</c>, <c>List&lt;string&gt;</c>,
     /// and any types deriving from those closed generics.
     /// </para>
     /// </remarks>
@@ -1066,3 +1067,4 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
 
     #endregion
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionContext.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionContext.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 internal sealed class AssertionContext<TSubject> : IAssertionContext<TSubject>
 {
     private AssertionContext(INode currentNode, TSubject subject, TSubject expectation,
@@ -34,3 +35,4 @@ internal sealed class AssertionContext<TSubject> : IAssertionContext<TSubject>
             context.Reason.Arguments);
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionResultSet.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionResultSet.cs
@@ -8,6 +8,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// <summary>
 /// Represents a collection of assertion results obtained through a <see cref="AssertionScope"/>.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class AssertionResultSet
 {
     private readonly Dictionary<object, string[]> set = [];
@@ -68,3 +69,4 @@ internal class AssertionResultSet
     /// </summary>
     public bool ContainsSuccessfulSet() => set.Values.Any(v => v.Length == 0);
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
@@ -1,4 +1,5 @@
 using System;
+
 using System.Linq.Expressions;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency.Execution;
@@ -6,6 +7,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
 {
     private readonly Func<IObjectInfo, bool> predicate;
@@ -115,3 +117,4 @@ public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
         return "Invoke Action<" + typeof(TSubject).Name + "> when " + description;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
@@ -10,6 +10,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// <remarks>
 /// Whether or not the conversion is attempted depends on the <see cref="ConversionSelector"/>.
 /// </remarks>
+[System.Diagnostics.StackTraceHidden]
 public class AutoConversionStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
@@ -85,3 +86,4 @@ public class AutoConversionStep : IEquivalencyStep
         return string.Empty;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/DateAndTimeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DateAndTimeEquivalencyStep.cs
@@ -10,6 +10,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// Specific equivalency step for handling date and time types where the types are different and the failure message
 /// should make that clear.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class DateAndTimeEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
@@ -51,3 +52,4 @@ public class DateAndTimeEquivalencyStep : IEquivalencyStep
 }
 
 #pragma warning restore AV1000
+

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
@@ -9,6 +9,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
 {
     [SuppressMessage("ReSharper", "PossibleNullReferenceException")]
@@ -28,9 +29,11 @@ public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
                 if (context.Options.IsRecursive)
                 {
                     context.Tracer.WriteLine(member =>
-                        string.Create(CultureInfo.InvariantCulture, $"Recursing into dictionary item {key} at {member.Expectation}"));
+                        string.Create(CultureInfo.InvariantCulture,
+                            $"Recursing into dictionary item {key} at {member.Expectation}"));
 
-                    nestedValidator.AssertEquivalencyOf(new Comparands(subject[key], expectation[key], typeof(object)), context.AsDictionaryItem<object, IDictionary>(key));
+                    nestedValidator.AssertEquivalencyOf(new Comparands(subject[key], expectation[key], typeof(object)),
+                        context.AsDictionaryItem<object, IDictionary>(key));
                 }
                 else
                 {
@@ -50,8 +53,8 @@ public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
     private static bool PreconditionsAreMet(IDictionary expectation, IDictionary subject, AssertionChain assertionChain)
     {
         return AssertIsDictionary(subject, assertionChain)
-            && AssertEitherIsNotNull(expectation, subject, assertionChain)
-            && AssertSameLength(expectation, subject, assertionChain);
+               && AssertEitherIsNotNull(expectation, subject, assertionChain)
+               && AssertSameLength(expectation, subject, assertionChain);
     }
 
     private static bool AssertEitherIsNotNull(IDictionary expectation, IDictionary subject, AssertionChain assertionChain)

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +10,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// <summary>
 /// Provides Reflection-backed meta-data information about a type implementing the <see cref="IDictionary{TKey,TValue}"/> interface.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal sealed class DictionaryInterfaceInfo
 {
     // ReSharper disable once PossibleNullReferenceException
@@ -135,3 +136,4 @@ internal sealed class DictionaryInterfaceInfo
 
     public override string ToString() => $"IDictionary<{Key}, {Value}>";
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumEqualityStep.cs
@@ -8,6 +8,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class EnumEqualityStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
@@ -39,21 +40,21 @@ public class EnumEqualityStep : IEquivalencyStep
             switch (context.Options.EnumEquivalencyHandling)
             {
                 case EnumEquivalencyHandling.ByValue:
-                {
-                    HandleByValue(assertionChain, comparands, context.Reason);
-                    break;
-                }
+                    {
+                        HandleByValue(assertionChain, comparands, context.Reason);
+                        break;
+                    }
 
                 case EnumEquivalencyHandling.ByName:
-                {
-                    HandleByName(assertionChain, comparands, context.Reason);
-                    break;
-                }
+                    {
+                        HandleByName(assertionChain, comparands, context.Reason);
+                        break;
+                    }
 
                 default:
-                {
-                    throw new InvalidOperationException($"Do not know how to handle {context.Options.EnumEquivalencyHandling}");
-                }
+                    {
+                        throw new InvalidOperationException($"Do not know how to handle {context.Options.EnumEquivalencyHandling}");
+                    }
             }
         }
 
@@ -119,3 +120,4 @@ public class EnumEqualityStep : IEquivalencyStep
         return o is not null ? Convert.ToDecimal(o, CultureInfo.InvariantCulture) : null;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -1,10 +1,12 @@
 using System;
+
 using System.Collections;
 using System.Linq;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class EnumerableEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
@@ -77,3 +79,4 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
             (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ArraySegment<>));
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -13,6 +13,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// <summary>
 /// Executes a single equivalency assertion on two collections, optionally recursive and with or without strict ordering.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class EnumerableEquivalencyValidator
 {
     private const int FailedItemsFastFailThreshold = 10;
@@ -217,3 +218,4 @@ internal class EnumerableEquivalencyValidator
         return !failed;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidatorExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidatorExtensions.cs
@@ -4,6 +4,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class EnumerableEquivalencyValidatorExtensions
 {
     public static Continuation AssertEitherCollectionIsNotEmpty<T>(this AssertionChain assertionChain,
@@ -49,3 +50,4 @@ internal static class EnumerableEquivalencyValidatorExtensions
                         expectation));
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
+
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class EqualityComparerEquivalencyStep<T> : IEquivalencyStep
 {
     private readonly IEqualityComparer<T> comparer;
@@ -49,3 +51,4 @@ public class EqualityComparerEquivalencyStep<T> : IEquivalencyStep
         return $"Use {comparer} for objects of type {typeof(T)}";
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/EquivalencyValidationContextExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EquivalencyValidationContextExtensions.cs
@@ -1,10 +1,12 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class EquivalencyValidationContextExtensions
 {
     public static IEquivalencyValidationContext AsCollectionItem<TItem>(this IEquivalencyValidationContext context,
         int index) =>
         context.AsCollectionItem<TItem>(index.ToString(CultureInfo.InvariantCulture));
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
@@ -8,6 +9,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class GenericDictionaryEquivalencyStep : IEquivalencyStep
 {
 #pragma warning disable SA1110 // Allow opening parenthesis on new line to reduce line length
@@ -225,3 +227,4 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
         public List<TSubjectKey> AdditionalKeys { get; }
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -8,6 +9,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class GenericEnumerableEquivalencyStep : IEquivalencyStep
 {
 #pragma warning disable SA1110 // Allow opening parenthesis on new line to reduce line length
@@ -125,3 +127,4 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
         }
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/JsonConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/JsonConversionStep.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class JsonConversionStep : IEquivalencyStep
 {
     /// <inheritdoc />
@@ -63,3 +64,4 @@ public class JsonConversionStep : IEquivalencyStep
 }
 
 #endif
+

--- a/Src/FluentAssertions/Equivalency/Steps/ReferenceEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ReferenceEqualityEquivalencyStep.cs
@@ -1,5 +1,6 @@
-﻿namespace FluentAssertions.Equivalency.Steps;
+namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class ReferenceEqualityEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/RunAllUserStepsEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/RunAllUserStepsEquivalencyStep.cs
@@ -1,9 +1,10 @@
-﻿namespace FluentAssertions.Equivalency.Steps;
+namespace FluentAssertions.Equivalency.Steps;
 
 /// <summary>
 /// Represents a composite equivalency step that passes the execution to all user-supplied steps that can handle the
 /// current context.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class RunAllUserStepsEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/SimpleEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/SimpleEqualityEquivalencyStep.cs
@@ -2,6 +2,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class SimpleEqualityEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
@@ -21,3 +22,4 @@ public class SimpleEqualityEquivalencyStep : IEquivalencyStep
         return EquivalencyResult.ContinueWithNext;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -3,6 +3,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class StringEqualityEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
@@ -106,3 +107,4 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         return assertionChain.Succeeded;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
@@ -5,6 +5,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class StructuralEqualityEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
@@ -108,3 +109,4 @@ public class StructuralEqualityEquivalencyStep : IEquivalencyStep
         return members;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/TypeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/TypeEquivalencyStep.cs
@@ -13,6 +13,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// This differs from the default equivalency assertion which states that two objects are equivalent if they have the
 /// same properties and values, regardless of their type.
 /// </remarks>
+[System.Diagnostics.StackTraceHidden]
 public class TypeEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
@@ -57,3 +58,4 @@ public class TypeEquivalencyStep : IEquivalencyStep
         return EquivalencyResult.ContinueWithNext;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
@@ -6,6 +6,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// <summary>
 /// Ensures that types that are marked as value types are treated as such.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class ValueTypeEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
@@ -39,3 +40,4 @@ public class ValueTypeEquivalencyStep : IEquivalencyStep
         return EquivalencyResult.ContinueWithNext;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Steps/XAttributeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/XAttributeEquivalencyStep.cs
@@ -1,8 +1,9 @@
-﻿using System.Xml.Linq;
+using System.Xml.Linq;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class XAttributeEquivalencyStep : EquivalencyStep<XAttribute>
 {
     protected override EquivalencyResult OnHandle(Comparands comparands,

--- a/Src/FluentAssertions/Equivalency/Steps/XDocumentEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/XDocumentEquivalencyStep.cs
@@ -1,8 +1,9 @@
-﻿using System.Xml.Linq;
+using System.Xml.Linq;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class XDocumentEquivalencyStep : EquivalencyStep<XDocument>
 {
     protected override EquivalencyResult OnHandle(Comparands comparands,

--- a/Src/FluentAssertions/Equivalency/Steps/XElementEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/XElementEquivalencyStep.cs
@@ -1,8 +1,9 @@
-﻿using System.Xml.Linq;
+using System.Xml.Linq;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
+[System.Diagnostics.StackTraceHidden]
 public class XElementEquivalencyStep : EquivalencyStep<XElement>
 {
     protected override EquivalencyResult OnHandle(Comparands comparands,

--- a/Src/FluentAssertions/Equivalency/SubjectInfoExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/SubjectInfoExtensions.cs
@@ -1,7 +1,8 @@
-﻿using FluentAssertions.Common;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 public static class SubjectInfoExtensions
 {
     /// <summary>
@@ -48,3 +49,4 @@ public static class SubjectInfoExtensions
         return memberInfo.GetterAccessibility != accessModifier;
     }
 }
+

--- a/Src/FluentAssertions/Equivalency/Typing/AlwaysBeStrictTypingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Typing/AlwaysBeStrictTypingRule.cs
@@ -3,6 +3,7 @@ namespace FluentAssertions.Equivalency.Typing;
 /// <summary>
 /// An implementation of <see cref="ITypingRule"/> that applies strict typing to all objects.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class AlwaysBeStrictTypingRule : ITypingRule
 {
     /// <inheritdoc />

--- a/Src/FluentAssertions/Equivalency/Typing/PredicateBasedTypingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Typing/PredicateBasedTypingRule.cs
@@ -8,6 +8,7 @@ namespace FluentAssertions.Equivalency.Typing;
 /// An implementation of <see cref="ITypingRule"/> that uses a predicate to determine
 /// whether strict typing should be applied during equivalency comparison.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class PredicateBasedTypingRule : ITypingRule
 {
     private readonly Func<IObjectInfo, bool> predicate;
@@ -37,3 +38,4 @@ internal class PredicateBasedTypingRule : ITypingRule
         return $"Use strict typing when {description}";
     }
 }
+

--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -177,3 +177,4 @@ public static class EventRaisingExtensions
         return new FilteredEventRecording(eventRecording, eventsForPropertyName);
     }
 }
+

--- a/Src/FluentAssertions/Events/EventAssertions.cs
+++ b/Src/FluentAssertions/Events/EventAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -174,3 +174,4 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
 
     protected override string Identifier => "subject";
 }
+

--- a/Src/FluentAssertions/Events/EventHandlerFactory.cs
+++ b/Src/FluentAssertions/Events/EventHandlerFactory.cs
@@ -7,6 +7,7 @@ namespace FluentAssertions.Events;
 /// <summary>
 /// Static methods that aid in generic event subscription
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal static class EventHandlerFactory
 {
     /// <summary>
@@ -146,3 +147,4 @@ internal static class EventHandlerFactory
         return invoke;
     }
 }
+

--- a/Src/FluentAssertions/Events/EventMetadata.cs
+++ b/Src/FluentAssertions/Events/EventMetadata.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 
 namespace FluentAssertions.Events;
 
 /// <summary>
 /// Provides the metadata of a monitored event.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class EventMetadata
 {
     /// <summary>
@@ -23,3 +24,4 @@ public class EventMetadata
         HandlerType = handlerType;
     }
 }
+

--- a/Src/FluentAssertions/Events/EventMonitor.cs
+++ b/Src/FluentAssertions/Events/EventMonitor.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 
 using System;
 using System.Collections.Concurrent;
@@ -13,6 +13,7 @@ namespace FluentAssertions.Events;
 /// <summary>
 /// Tracks the events an object raises.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal sealed class EventMonitor<T> : IMonitor<T>
 {
     private readonly WeakReference subject;
@@ -165,3 +166,4 @@ internal sealed class EventMonitor<T> : IMonitor<T>
 }
 
 #endif
+

--- a/Src/FluentAssertions/Events/EventMonitorOptions.cs
+++ b/Src/FluentAssertions/Events/EventMonitorOptions.cs
@@ -5,6 +5,7 @@ namespace FluentAssertions.Events;
 /// <summary>
 /// Settings for the EventMonitor.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class EventMonitorOptions
 {
     /// <summary>
@@ -54,3 +55,4 @@ public class EventMonitorOptions
         return this;
     }
 }
+

--- a/Src/FluentAssertions/Events/EventRecorder.cs
+++ b/Src/FluentAssertions/Events/EventRecorder.cs
@@ -12,6 +12,7 @@ namespace FluentAssertions.Events;
 /// Records activity for a single event.
 /// </summary>
 [DebuggerNonUserCode]
+[StackTraceHidden]
 internal sealed class EventRecorder : IEventRecording, IDisposable
 {
     private readonly Func<DateTime> utcNow;

--- a/Src/FluentAssertions/Events/FilteredEventRecording.cs
+++ b/Src/FluentAssertions/Events/FilteredEventRecording.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace FluentAssertions.Events;
 
+[System.Diagnostics.StackTraceHidden]
 internal class FilteredEventRecording : IEventRecording
 {
     private readonly OccurredEvent[] occurredEvents;
@@ -42,3 +43,4 @@ internal class FilteredEventRecording : IEventRecording
         }
     }
 }
+

--- a/Src/FluentAssertions/Events/IMonitor.cs
+++ b/Src/FluentAssertions/Events/IMonitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace FluentAssertions.Events;
 

--- a/Src/FluentAssertions/Events/OccurredEvent.cs
+++ b/Src/FluentAssertions/Events/OccurredEvent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Linq;
 
@@ -7,6 +7,7 @@ namespace FluentAssertions.Events;
 /// <summary>
 /// Represents an occurrence of a particular event.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class OccurredEvent
 {
     /// <summary>
@@ -44,3 +45,4 @@ public class OccurredEvent
                          .Any(e => string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == propertyName);
     }
 }
+

--- a/Src/FluentAssertions/Events/RecordedEvent.cs
+++ b/Src/FluentAssertions/Events/RecordedEvent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 
 namespace FluentAssertions.Events;
@@ -7,6 +7,7 @@ namespace FluentAssertions.Events;
 /// This class is used to store data about an intercepted event
 /// </summary>
 [DebuggerNonUserCode]
+[StackTraceHidden]
 internal class RecordedEvent
 {
     /// <summary>

--- a/Src/FluentAssertions/Events/ThreadSafeSequenceGenerator.cs
+++ b/Src/FluentAssertions/Events/ThreadSafeSequenceGenerator.cs
@@ -5,6 +5,7 @@ namespace FluentAssertions.Events;
 /// <summary>
 /// Generates a sequence in a thread-safe manner.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal sealed class ThreadSafeSequenceGenerator
 {
     private int sequence = -1;
@@ -17,3 +18,4 @@ internal sealed class ThreadSafeSequenceGenerator
         return Interlocked.Increment(ref sequence);
     }
 }
+

--- a/Src/FluentAssertions/Exactly.cs
+++ b/Src/FluentAssertions/Exactly.cs
@@ -1,5 +1,6 @@
-﻿namespace FluentAssertions;
+namespace FluentAssertions;
 
+[System.Diagnostics.StackTraceHidden]
 public static class Exactly
 {
     public static OccurrenceConstraint Once() => new ExactlyTimesConstraint(1);

--- a/Src/FluentAssertions/ExceptionAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ExceptionAssertionsExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -224,3 +225,4 @@ public static class ExceptionAssertionsExtensions
 
 #pragma warning restore AV1755
 }
+

--- a/Src/FluentAssertions/Execution/AssertionChain.cs
+++ b/Src/FluentAssertions/Execution/AssertionChain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -14,6 +14,7 @@ namespace FluentAssertions.Execution;
 /// This is the core engine of many of the assertion APIs in this library. When combined with <see cref="AssertionScope"/>,
 /// you can run multiple assertions which failure messages will be collected until the scope is disposed.
 /// </remarks>
+[System.Diagnostics.StackTraceHidden]
 public sealed class AssertionChain
 {
     private readonly Func<AssertionScope> getCurrentScope;

--- a/Src/FluentAssertions/Execution/AssertionFailedException.cs
+++ b/Src/FluentAssertions/Execution/AssertionFailedException.cs
@@ -7,7 +7,9 @@ namespace FluentAssertions.Execution;
 /// </summary>
 /// <param name="message">The <em>mandatory</em> exception message</param>
 #pragma warning disable CA1032, RCS1194 // AssertionFailedException should never be constructed with an empty message
+[System.Diagnostics.StackTraceHidden]
 public class AssertionFailedException(string message) : Exception(message), IAssertionException
 #pragma warning restore CA1032, RCS1194
 {
 }
+

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -15,6 +15,7 @@ namespace FluentAssertions.Execution;
 /// such as when using <see langword="async"/> or <see langword="await"/>.
 /// </remarks>
 // Remove all assertion logic from this class since it is superseded by the Assertion class
+[System.Diagnostics.StackTraceHidden]
 public sealed class AssertionScope : IDisposable
 {
     private readonly IAssertionStrategy assertionStrategy;

--- a/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 namespace FluentAssertions.Execution;
 
+[System.Diagnostics.StackTraceHidden]
 internal class CollectingAssertionStrategy : IAssertionStrategy
 {
     private readonly List<string> failureMessages = [];

--- a/Src/FluentAssertions/Execution/ContextDataDictionary.cs
+++ b/Src/FluentAssertions/Execution/ContextDataDictionary.cs
@@ -8,6 +8,7 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Represents a collection of data items that are associated with an <see cref="AssertionScope"/>.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class ContextDataDictionary
 {
     private readonly List<DataItem> items = [];
@@ -78,3 +79,4 @@ internal class ContextDataDictionary
         }
     }
 }
+

--- a/Src/FluentAssertions/Execution/Continuation.cs
+++ b/Src/FluentAssertions/Execution/Continuation.cs
@@ -1,8 +1,9 @@
-﻿namespace FluentAssertions.Execution;
+namespace FluentAssertions.Execution;
 
 /// <summary>
 /// Enables chaining multiple assertions on an <see cref="AssertionScope"/>.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class Continuation
 {
     internal Continuation(AssertionChain parent)

--- a/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
+++ b/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
@@ -1,8 +1,9 @@
-﻿namespace FluentAssertions.Execution;
+namespace FluentAssertions.Execution;
 
 /// <summary>
 /// Enables chaining multiple assertions from a <see cref="AssertionChain.Given{T}"/> call.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class ContinuationOfGiven<TSubject>
 {
     internal ContinuationOfGiven(GivenSelector<TSubject> parent)
@@ -17,3 +18,4 @@ public class ContinuationOfGiven<TSubject>
 
     public bool Succeeded => Then.Succeeded;
 }
+

--- a/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace FluentAssertions.Execution;
 
 [ExcludeFromCodeCoverage]
+[System.Diagnostics.StackTraceHidden]
 internal class DefaultAssertionStrategy : IAssertionStrategy
 {
     /// <summary>

--- a/Src/FluentAssertions/Execution/FailReason.cs
+++ b/Src/FluentAssertions/Execution/FailReason.cs
@@ -19,6 +19,7 @@ namespace FluentAssertions.Execution;
 /// Note that only 10 <c>args</c> are supported in combination with a <em>{reason}</em>.
 /// </para>
 /// </remarks>
+[System.Diagnostics.StackTraceHidden]
 public class FailReason
 {
     /// <summary>

--- a/Src/FluentAssertions/Execution/FailureMessageFormatter.cs
+++ b/Src/FluentAssertions/Execution/FailureMessageFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -10,6 +10,7 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Encapsulates expanding the various placeholders supported in a failure message.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class FailureMessageFormatter(FormattingOptions formattingOptions)
 {
     private static readonly char[] Blanks = ['\r', '\n', ' ', '\t'];
@@ -152,3 +153,4 @@ internal class FailureMessageFormatter(FormattingOptions formattingOptions)
         }
     }
 }
+

--- a/Src/FluentAssertions/Execution/FallbackTestFramework.cs
+++ b/Src/FluentAssertions/Execution/FallbackTestFramework.cs
@@ -5,6 +5,7 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Throws a generic exception in case no other test harness is detected.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class FallbackTestFramework : ITestFramework
 {
     /// <summary>

--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using FluentAssertions.Common;
 
@@ -8,6 +8,7 @@ namespace FluentAssertions.Execution;
 /// Represents a chaining object returned from <see cref="AssertionChain"/> to continue the assertion using
 /// an object returned by a selector.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class GivenSelector<T>
 {
     private readonly AssertionChain assertionChain;
@@ -74,3 +75,4 @@ public class GivenSelector<T>
         return new ContinuationOfGiven<T>(this);
     }
 }
+

--- a/Src/FluentAssertions/Execution/GivenSelectorExtensions.cs
+++ b/Src/FluentAssertions/Execution/GivenSelectorExtensions.cs
@@ -1,10 +1,12 @@
-﻿using System;
+using System;
+
 using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Execution;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class GivenSelectorExtensions
 {
     public static ContinuationOfGiven<IEnumerable<T>> AssertCollectionIsNotNull<T>(
@@ -104,3 +106,4 @@ internal static class GivenSelectorExtensions
         IEnumerator IEnumerable.GetEnumerator() => Items.GetEnumerator();
     }
 }
+

--- a/Src/FluentAssertions/Execution/IAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/IAssertionStrategy.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Execution/ITestFramework.cs
+++ b/Src/FluentAssertions/Execution/ITestFramework.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 namespace FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 
 namespace FluentAssertions.Execution;
 
+[System.Diagnostics.StackTraceHidden]
 internal abstract class LateBoundTestFramework : ITestFramework
 {
     private Func<string, Exception> exceptionFactory =

--- a/Src/FluentAssertions/Execution/MSTestFrameworkV2.cs
+++ b/Src/FluentAssertions/Execution/MSTestFrameworkV2.cs
@@ -1,5 +1,6 @@
-﻿namespace FluentAssertions.Execution;
+namespace FluentAssertions.Execution;
 
+[System.Diagnostics.StackTraceHidden]
 internal class MSTestFrameworkV2 : LateBoundTestFramework
 {
     protected override string ExceptionFullName => "Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException";

--- a/Src/FluentAssertions/Execution/MSTestFrameworkV4.cs
+++ b/Src/FluentAssertions/Execution/MSTestFrameworkV4.cs
@@ -1,5 +1,6 @@
-﻿namespace FluentAssertions.Execution;
+namespace FluentAssertions.Execution;
 
+[System.Diagnostics.StackTraceHidden]
 internal sealed class MSTestFrameworkV4 : LateBoundTestFramework
 {
     protected override string ExceptionFullName => "Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException";

--- a/Src/FluentAssertions/Execution/MSpecFramework.cs
+++ b/Src/FluentAssertions/Execution/MSpecFramework.cs
@@ -1,5 +1,6 @@
-﻿namespace FluentAssertions.Execution;
+namespace FluentAssertions.Execution;
 
+[System.Diagnostics.StackTraceHidden]
 internal class MSpecFramework : LateBoundTestFramework
 {
     protected internal override string AssemblyName => "Machine.Specifications";

--- a/Src/FluentAssertions/Execution/NUnitTestFramework.cs
+++ b/Src/FluentAssertions/Execution/NUnitTestFramework.cs
@@ -1,5 +1,6 @@
-﻿namespace FluentAssertions.Execution;
+namespace FluentAssertions.Execution;
 
+[System.Diagnostics.StackTraceHidden]
 internal class NUnitTestFramework : LateBoundTestFramework
 {
     protected internal override string AssemblyName => "nunit.framework";

--- a/Src/FluentAssertions/Execution/Reason.cs
+++ b/Src/FluentAssertions/Execution/Reason.cs
@@ -5,6 +5,7 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Represents the reason for a structural equivalency assertion.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class Reason
 {
     public Reason([StringSyntax("CompositeFormat")] string formattedMessage, object[] arguments)
@@ -24,3 +25,4 @@ public class Reason
     /// </summary>
     public object[] Arguments { get; set; }
 }
+

--- a/Src/FluentAssertions/Execution/StringExtensions.cs
+++ b/Src/FluentAssertions/Execution/StringExtensions.cs
@@ -1,5 +1,6 @@
 namespace FluentAssertions.Execution;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class StringExtensions
 {
     /// <summary>

--- a/Src/FluentAssertions/Execution/SubjectIdentificationBuilder.cs
+++ b/Src/FluentAssertions/Execution/SubjectIdentificationBuilder.cs
@@ -12,6 +12,7 @@ namespace FluentAssertions.Execution;
 /// (nested) instances of <see cref="AssertionScope"/> and modifications made by the
 /// <see cref="AndWhichConstraint{TParent,TSubject}"/>.
 /// </remarks>
+[System.Diagnostics.StackTraceHidden]
 internal class SubjectIdentificationBuilder
 {
     private readonly Func<string> getScopeName;
@@ -100,3 +101,4 @@ internal class SubjectIdentificationBuilder
         return identifiersExtractedFromTheCode.Value.Length > index ? identifiersExtractedFromTheCode.Value[index] : null;
     }
 }
+

--- a/Src/FluentAssertions/Execution/TUnitFramework.cs
+++ b/Src/FluentAssertions/Execution/TUnitFramework.cs
@@ -1,5 +1,6 @@
-﻿namespace FluentAssertions.Execution;
+namespace FluentAssertions.Execution;
 
+[System.Diagnostics.StackTraceHidden]
 internal class TUnitFramework : LateBoundTestFramework
 {
     public TUnitFramework()

--- a/Src/FluentAssertions/Execution/TestFrameworkFactory.cs
+++ b/Src/FluentAssertions/Execution/TestFrameworkFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions.Configuration;
@@ -9,6 +9,7 @@ namespace FluentAssertions.Execution;
 /// Determines the test framework, either by scanning the current app domain for known test framework assemblies or by
 /// passing the framework name directly.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal static class TestFrameworkFactory
 {
     private static readonly Dictionary<TestFramework, ITestFramework> Frameworks = new()
@@ -73,3 +74,4 @@ internal static class TestFrameworkFactory
         return Frameworks.Values.FirstOrDefault(framework => framework.IsAvailable);
     }
 }
+

--- a/Src/FluentAssertions/Execution/WithoutFormattingWrapper.cs
+++ b/Src/FluentAssertions/Execution/WithoutFormattingWrapper.cs
@@ -5,7 +5,9 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Wrapper to tell the <see cref="Formatter"/> not to apply any value formatters on this string.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class WithoutFormattingWrapper(string value)
 {
     public override string ToString() => value;
 }
+

--- a/Src/FluentAssertions/Execution/XUnitTestFramework.cs
+++ b/Src/FluentAssertions/Execution/XUnitTestFramework.cs
@@ -3,6 +3,7 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Implements the xUnit (version 2 and 3) test framework adapter.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class XUnitTestFramework : LateBoundTestFramework
 {
     private readonly string assemblyName;

--- a/Src/FluentAssertions/Extensibility/AssertionEngineInitializerAttribute.cs
+++ b/Src/FluentAssertions/Extensibility/AssertionEngineInitializerAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 
 namespace FluentAssertions.Extensibility;
@@ -7,6 +7,7 @@ namespace FluentAssertions.Extensibility;
 /// Can be added to an assembly so it gets a change to initialize Fluent Assertions before the first assertion happens.
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+[System.Diagnostics.StackTraceHidden]
 public sealed class AssertionEngineInitializerAttribute : Attribute
 {
     private readonly string methodName;
@@ -28,3 +29,4 @@ public sealed class AssertionEngineInitializerAttribute : Attribute
         type?.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static)?.Invoke(obj: null, parameters: null);
     }
 }
+

--- a/Src/FluentAssertions/Extensions/FluentTimeSpanExtensions.cs
+++ b/Src/FluentAssertions/Extensions/FluentTimeSpanExtensions.cs
@@ -248,3 +248,4 @@ public static class FluentTimeSpanExtensions
         return sourceTime.Add(offset);
     }
 }
+

--- a/Src/FluentAssertions/Extensions/OccurrenceConstraintExtensions.cs
+++ b/Src/FluentAssertions/Extensions/OccurrenceConstraintExtensions.cs
@@ -34,3 +34,4 @@ public static class OccurrenceConstraintExtensions
         return AtLeast.Times(times);
     }
 }
+

--- a/Src/FluentAssertions/FluentActions.cs
+++ b/Src/FluentAssertions/FluentActions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -10,6 +10,7 @@ namespace FluentAssertions;
 /// <summary>
 /// Contains static methods to help with exception assertions on actions.
 /// </summary>
+[StackTraceHidden]
 [DebuggerNonUserCode]
 public static class FluentActions
 {

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -47,11 +47,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reflectify" Version="1.6.0">
+    <PackageReference Include="Reflectify" Version="1.7.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
+  <PropertyGroup Label="PolySharp">
+    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+  </PropertyGroup>
 
   <ItemGroup Label="Analyzers">
     <AdditionalFiles Include="BannedSymbols.txt" />

--- a/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using FluentAssertions.Common;

--- a/Src/FluentAssertions/Formatting/DecimalValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DecimalValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/DictionaryValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DictionaryValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;

--- a/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 
 namespace FluentAssertions.Formatting;

--- a/Src/FluentAssertions/Formatting/EnumValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 
 namespace FluentAssertions.Formatting;

--- a/Src/FluentAssertions/Formatting/EnumerableExtensions.cs
+++ b/Src/FluentAssertions/Formatting/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Text;
 
 namespace FluentAssertions.Formatting;

--- a/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;

--- a/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/ExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExpressionValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq.Expressions;
 
 namespace FluentAssertions.Formatting;

--- a/Src/FluentAssertions/Formatting/FormatChild.cs
+++ b/Src/FluentAssertions/Formatting/FormatChild.cs
@@ -1,4 +1,4 @@
-﻿namespace FluentAssertions.Formatting;
+namespace FluentAssertions.Formatting;
 
 /// <summary>
 /// Represents a method that can be used to format child values from inside an <see cref="IValueFormatter"/>.

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/Src/FluentAssertions/Formatting/FormattingContext.cs
+++ b/Src/FluentAssertions/Formatting/FormattingContext.cs
@@ -1,4 +1,4 @@
-﻿namespace FluentAssertions.Formatting;
+namespace FluentAssertions.Formatting;
 
 /// <summary>
 /// Provides information about the current formatting action.

--- a/Src/FluentAssertions/Formatting/FormattingOptions.cs
+++ b/Src/FluentAssertions/Formatting/FormattingOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Formatting;

--- a/Src/FluentAssertions/Formatting/IValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/IValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿namespace FluentAssertions.Formatting;
+namespace FluentAssertions.Formatting;
 
 /// <summary>
 /// Represents a strategy for formatting an arbitrary value into a human-readable string representation.

--- a/Src/FluentAssertions/Formatting/Int16ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/Int16ValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/Int32ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/Int32ValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/Int64ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/Int64ValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/MaxLinesExceededException.cs
+++ b/Src/FluentAssertions/Formatting/MaxLinesExceededException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
+++ b/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/Src/FluentAssertions/Formatting/NullValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/NullValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿namespace FluentAssertions.Formatting;
+namespace FluentAssertions.Formatting;
 
 public class NullValueFormatter : IValueFormatter
 {

--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/Src/FluentAssertions/Formatting/PropertyInfoFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PropertyInfoFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/SByteValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/SByteValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/SingleValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/SingleValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 
 namespace FluentAssertions.Formatting;

--- a/Src/FluentAssertions/Formatting/StringValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/StringValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿namespace FluentAssertions.Formatting;
+namespace FluentAssertions.Formatting;
 
 public class StringValueFormatter : IValueFormatter
 {

--- a/Src/FluentAssertions/Formatting/TaskFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TaskFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/Src/FluentAssertions/Formatting/UInt16ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/UInt16ValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/UInt32ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/UInt32ValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/UInt64ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/UInt64ValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/XDocumentValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XDocumentValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Xml.Linq;
+using System.Xml.Linq;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Xml.Linq;
 using FluentAssertions.Common;
 

--- a/Src/FluentAssertions/Formatting/XmlReaderValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XmlReaderValueFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Xml;
+using System.Xml;
 
 namespace FluentAssertions.Formatting;
 

--- a/Src/FluentAssertions/JsonAssertionExtensions.cs
+++ b/Src/FluentAssertions/JsonAssertionExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
 
 using System.Diagnostics;
 using System.Linq;

--- a/Src/FluentAssertions/LessThan.cs
+++ b/Src/FluentAssertions/LessThan.cs
@@ -1,5 +1,6 @@
-﻿namespace FluentAssertions;
+namespace FluentAssertions;
 
+[System.Diagnostics.StackTraceHidden]
 public static class LessThan
 {
     public static OccurrenceConstraint Twice() => new LessThanTimesConstraint(2);

--- a/Src/FluentAssertions/License.cs
+++ b/Src/FluentAssertions/License.cs
@@ -3,6 +3,7 @@ namespace FluentAssertions;
 /// <summary>
 /// Provides access to the licensing state of Fluent Assertions
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public static class License
 {
     /// <summary>

--- a/Src/FluentAssertions/MoreThan.cs
+++ b/Src/FluentAssertions/MoreThan.cs
@@ -1,5 +1,6 @@
-﻿namespace FluentAssertions;
+namespace FluentAssertions;
 
+[System.Diagnostics.StackTraceHidden]
 public static class MoreThan
 {
     public static OccurrenceConstraint Once() => new MoreThanTimesConstraint(1);

--- a/Src/FluentAssertions/Numeric/ByteAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ByteAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/DecimalAssertions.cs
+++ b/Src/FluentAssertions/Numeric/DecimalAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;

--- a/Src/FluentAssertions/Numeric/DoubleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/DoubleAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/Int16Assertions.cs
+++ b/Src/FluentAssertions/Numeric/Int16Assertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/Int32Assertions.cs
+++ b/Src/FluentAssertions/Numeric/Int32Assertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/Int64Assertions.cs
+++ b/Src/FluentAssertions/Numeric/Int64Assertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/NullableByteAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableByteAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/NullableDecimalAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableDecimalAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;

--- a/Src/FluentAssertions/Numeric/NullableInt16Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableInt16Assertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/NullableInt32Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableInt32Assertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/NullableInt64Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableInt64Assertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/NullableSByteAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableSByteAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/NullableSingleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableSingleAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/NullableUInt16Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableUInt16Assertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/NullableUInt32Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableUInt32Assertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/NullableUInt64Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableUInt64Assertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/NumericAssertionsBase.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertionsBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
@@ -10,6 +11,7 @@ namespace FluentAssertions.Numeric;
 
 #pragma warning disable CS0659, S1206 // Ignore not overriding Object.GetHashCode()
 #pragma warning disable CA1065 // Ignore throwing NotSupportedException from Equals
+[DebuggerNonUserCode]
 public abstract class NumericAssertionsBase<T, TSubject, TAssertions>
     where T : struct, IComparable<T>
     where TAssertions : NumericAssertionsBase<T, TSubject, TAssertions>

--- a/Src/FluentAssertions/Numeric/SByteAssertions.cs
+++ b/Src/FluentAssertions/Numeric/SByteAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 
@@ -21,3 +21,4 @@ internal class SByteAssertions : NumericAssertions<sbyte>
         return difference != 0 ? difference.ToString(CultureInfo.InvariantCulture) : null;
     }
 }
+

--- a/Src/FluentAssertions/Numeric/SingleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/SingleAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 
@@ -23,3 +23,4 @@ internal class SingleAssertions : NumericAssertions<float>
         return difference != 0 ? difference.ToString("R", CultureInfo.InvariantCulture) : null;
     }
 }
+

--- a/Src/FluentAssertions/Numeric/UInt16Assertions.cs
+++ b/Src/FluentAssertions/Numeric/UInt16Assertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/UInt32Assertions.cs
+++ b/Src/FluentAssertions/Numeric/UInt32Assertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/Numeric/UInt64Assertions.cs
+++ b/Src/FluentAssertions/Numeric/UInt64Assertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -1796,3 +1796,4 @@ public static class NumericAssertionsExtensions
         return maxValue;
     }
 }
+

--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+
 using System.IO;
 using System.Runtime.Serialization;
 using System.Xml.Serialization;
@@ -199,3 +200,4 @@ public static class ObjectAssertionsExtensions
         return serializer.Deserialize(stream);
     }
 }
+

--- a/Src/FluentAssertions/OccurrenceConstraint.cs
+++ b/Src/FluentAssertions/OccurrenceConstraint.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using FluentAssertions.Common;
 
 namespace FluentAssertions;
 
+[System.Diagnostics.StackTraceHidden]
 public abstract class OccurrenceConstraint
 {
     protected OccurrenceConstraint(int expectedCount)
@@ -26,3 +27,4 @@ public abstract class OccurrenceConstraint
         register("expectedOccurrence", $"{Mode} {ExpectedCount.Times()}");
     }
 }
+

--- a/Src/FluentAssertions/Polyfill/StringBuilderExtensions.cs
+++ b/Src/FluentAssertions/Polyfill/StringBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NET47 || NETSTANDARD2_0 || NETSTANDARD2_1
+#if NET47 || NETSTANDARD2_0 || NETSTANDARD2_1
 
 using System.Collections.Generic;
 

--- a/Src/FluentAssertions/Polyfill/StringExtensions.cs
+++ b/Src/FluentAssertions/Polyfill/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if !NET6_0_OR_GREATER
+#if !NET6_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 

--- a/Src/FluentAssertions/Polyfill/SystemExtensions.cs
+++ b/Src/FluentAssertions/Polyfill/SystemExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NET47 || NETSTANDARD2_0
+#if NET47 || NETSTANDARD2_0
 
 // ReSharper disable once CheckNamespace
 namespace System;

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Execution;

--- a/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
 
 using System;
 using System.Collections.Generic;

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -138,3 +138,4 @@ public class DateTimeOffsetRangeAssertions<TAssertions>
     public override bool Equals(object obj) =>
         throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean Before() or After() instead?");
 }
+

--- a/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -140,3 +140,4 @@ public class DateTimeRangeAssertions<TAssertions>
     public override bool Equals(object obj) =>
         throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean Before() or After() instead?");
 }
+

--- a/Src/FluentAssertions/Primitives/EnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/EnumAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -460,3 +460,4 @@ public class EnumAssertions<TEnum, TAssertions>
     public override bool Equals(object obj) =>
         throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
 }
+

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Execution;

--- a/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Execution;
 
@@ -187,3 +187,4 @@ public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAsserti
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 }
+

--- a/Src/FluentAssertions/Primitives/NullableDateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateOnlyAssertions.cs
@@ -106,3 +106,4 @@ public class NullableDateOnlyAssertions<TAssertions> : DateOnlyAssertions<TAsser
 }
 
 #endif
+

--- a/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Execution;
@@ -109,3 +109,4 @@ public class NullableDateTimeAssertions<TAssertions> : DateTimeAssertions<TAsser
         return NotHaveValue(because, becauseArgs);
     }
 }
+

--- a/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Execution;
@@ -112,3 +112,4 @@ public class NullableDateTimeOffsetAssertions<TAssertions> : DateTimeOffsetAsser
         return NotHaveValue(because, becauseArgs);
     }
 }
+

--- a/Src/FluentAssertions/Primitives/NullableEnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableEnumAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Execution;
 
@@ -101,3 +101,4 @@ public class NullableEnumAssertions<TEnum, TAssertions> : EnumAssertions<TEnum, 
         return NotHaveValue(because, becauseArgs);
     }
 }
+

--- a/Src/FluentAssertions/Primitives/NullableGuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableGuidAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Execution;
@@ -123,3 +123,4 @@ public class NullableGuidAssertions<TAssertions> : GuidAssertions<TAssertions>
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 }
+

--- a/Src/FluentAssertions/Primitives/NullableSimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableSimpleTimeSpanAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Execution;
@@ -132,3 +132,4 @@ public class NullableSimpleTimeSpanAssertions<TAssertions> : SimpleTimeSpanAsser
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 }
+

--- a/Src/FluentAssertions/Primitives/NullableTimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableTimeOnlyAssertions.cs
@@ -106,3 +106,4 @@ public class NullableTimeOnlyAssertions<TAssertions> : TimeOnlyAssertions<TAsser
 }
 
 #endif
+

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Common;
@@ -302,3 +302,4 @@ public class SimpleTimeSpanAssertions<TAssertions>
     public override bool Equals(object obj) =>
         throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
 }
+

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/Src/FluentAssertions/Primitives/StringContainsStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringContainsStrategy.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
+
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
+[System.Diagnostics.StackTraceHidden]
 internal class StringContainsStrategy : IStringComparisonStrategy
 {
     private readonly IEqualityComparer<string> comparer;
@@ -34,3 +36,4 @@ internal class StringContainsStrategy : IStringComparisonStrategy
         }
     }
 }
+

--- a/Src/FluentAssertions/Primitives/StringEndStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEndStrategy.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
+
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
+[System.Diagnostics.StackTraceHidden]
 internal class StringEndStrategy : IStringComparisonStrategy
 {
     private readonly IEqualityComparer<string> comparer;
@@ -49,3 +51,4 @@ internal class StringEndStrategy : IStringComparisonStrategy
 
     private string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} {{0}}{{reason}}";
 }
+

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -8,6 +8,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
+[System.Diagnostics.StackTraceHidden]
 internal class StringEqualityStrategy : IStringComparisonStrategy
 {
     private readonly IEqualityComparer<string> comparer;

--- a/Src/FluentAssertions/Primitives/StringStartStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringStartStrategy.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
+
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
+[System.Diagnostics.StackTraceHidden]
 internal class StringStartStrategy : IStringComparisonStrategy
 {
     private readonly IEqualityComparer<string> comparer;
@@ -49,3 +51,4 @@ internal class StringStartStrategy : IStringComparisonStrategy
 
     private string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} ";
 }
+

--- a/Src/FluentAssertions/Primitives/StringValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringValidator.cs
@@ -3,6 +3,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
+[System.Diagnostics.StackTraceHidden]
 internal class StringValidator
 {
     private readonly IStringComparisonStrategy comparisonStrategy;

--- a/Src/FluentAssertions/Primitives/StringValidatorSupportingNull.cs
+++ b/Src/FluentAssertions/Primitives/StringValidatorSupportingNull.cs
@@ -4,6 +4,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
+[System.Diagnostics.StackTraceHidden]
 internal class StringValidatorSupportingNull
 {
     private readonly IStringComparisonStrategy comparisonStrategy;
@@ -27,3 +28,4 @@ internal class StringValidatorSupportingNull
         comparisonStrategy.AssertForEquality(assertionChain, subject, expected);
     }
 }
+

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingStrategy.cs
@@ -6,6 +6,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
+[System.Diagnostics.StackTraceHidden]
 internal class StringWildcardMatchingStrategy : IStringComparisonStrategy
 {
     public void AssertForEquality(AssertionChain assertionChain, string subject, string expected)
@@ -39,7 +40,7 @@ internal class StringWildcardMatchingStrategy : IStringComparisonStrategy
         else
         {
             assertionChain.FailWith($"{ExpectationDescription} {{0}}{{reason}}, but {{1}} {OutcomeDescription}.", expected,
-                    subject);
+                subject);
         }
     }
 
@@ -67,10 +68,10 @@ internal class StringWildcardMatchingStrategy : IStringComparisonStrategy
     private static string ConvertWildcardToRegEx(string wildcardExpression)
     {
         return "^"
-            + Regex.Escape(wildcardExpression)
-                .Replace("\\*", ".*", StringComparison.Ordinal)
-                .Replace("\\?", ".", StringComparison.Ordinal)
-            + "$";
+               + Regex.Escape(wildcardExpression)
+                   .Replace("\\*", ".*", StringComparison.Ordinal)
+                   .Replace("\\?", ".", StringComparison.Ordinal)
+               + "$";
     }
 
     private static bool IsLongOrMultiline(string message)

--- a/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
 
 using System;
 using System.Collections.Generic;

--- a/Src/FluentAssertions/Primitives/TimeSpanPredicate.cs
+++ b/Src/FluentAssertions/Primitives/TimeSpanPredicate.cs
@@ -5,6 +5,7 @@ namespace FluentAssertions.Primitives;
 /// <summary>
 /// Provides the logic and the display text for a <see cref="TimeSpanCondition"/>.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 internal class TimeSpanPredicate
 {
     private readonly Func<TimeSpan, TimeSpan, bool> lambda;
@@ -22,3 +23,4 @@ internal class TimeSpanPredicate
         return lambda(actual, expected) && actual >= TimeSpan.Zero;
     }
 }
+

--- a/Src/FluentAssertions/Specialized/ActionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ActionAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Common;

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;

--- a/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/Src/FluentAssertions/Specialized/ExecutionTime.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTime.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
+
 using System.Threading.Tasks;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Specialized;
 
+[System.Diagnostics.StackTraceHidden]
 public class ExecutionTime
 {
     private ITimer timer;
@@ -114,3 +116,4 @@ public class ExecutionTime
 
     internal Exception Exception { get; private set; }
 }
+

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
@@ -10,6 +11,7 @@ namespace FluentAssertions.Specialized;
 /// <summary>
 /// Provides methods for asserting that the execution time of an <see cref="Action"/> satisfies certain conditions.
 /// </summary>
+[DebuggerNonUserCode]
 public class ExecutionTimeAssertions
 {
     private readonly ExecutionTime execution;

--- a/Src/FluentAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Common;

--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,6 +12,7 @@ namespace FluentAssertions.Specialized;
 /// Contains a number of methods to assert that an asynchronous method yields the expected result.
 /// </summary>
 /// <typeparam name="TResult">The type returned in the <see cref="Task{T}"/>.</typeparam>
+[DebuggerNonUserCode]
 public class GenericAsyncFunctionAssertions<TResult>
     : AsyncFunctionAssertions<Task<TResult>, GenericAsyncFunctionAssertions<TResult>>
 {

--- a/Src/FluentAssertions/Specialized/JsonNodeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/JsonNodeAssertions.cs
@@ -524,3 +524,4 @@ public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertio
 }
 
 #endif
+

--- a/Src/FluentAssertions/Specialized/JsonValueExtensions.cs
+++ b/Src/FluentAssertions/Specialized/JsonValueExtensions.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Nodes;
 
 namespace FluentAssertions.Specialized;
 
+[System.Diagnostics.StackTraceHidden]
 internal static class JsonValueExtensions
 {
     public static bool IsNumeric(this JsonValue value)
@@ -14,3 +15,4 @@ internal static class JsonValueExtensions
 }
 
 #endif
+

--- a/Src/FluentAssertions/Specialized/MemberExecutionTime.cs
+++ b/Src/FluentAssertions/Specialized/MemberExecutionTime.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
+
 using System.Linq.Expressions;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Specialized;
 
+[System.Diagnostics.StackTraceHidden]
 public class MemberExecutionTime<T> : ExecutionTime
 {
     /// <summary>
@@ -18,3 +20,4 @@ public class MemberExecutionTime<T> : ExecutionTime
     {
     }
 }
+

--- a/Src/FluentAssertions/Specialized/NonGenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/NonGenericAsyncFunctionAssertions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ namespace FluentAssertions.Specialized;
 /// <summary>
 /// Contains a number of methods to assert that an asynchronous method yields the expected result.
 /// </summary>
+[DebuggerNonUserCode]
 public class NonGenericAsyncFunctionAssertions : AsyncFunctionAssertions<Task, NonGenericAsyncFunctionAssertions>
 {
     private readonly AssertionChain assertionChain;

--- a/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
+++ b/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using FluentAssertions.Common;
@@ -10,6 +11,7 @@ namespace FluentAssertions.Specialized;
 #pragma warning disable CA1065 // Ignore throwing NotSupportedException from Equals
 
 #if NET6_0_OR_GREATER
+[DebuggerNonUserCode]
 public class TaskCompletionSourceAssertions : TaskCompletionSourceAssertionsBase
 {
     private readonly AssertionChain assertionChain;
@@ -90,8 +92,10 @@ public class TaskCompletionSourceAssertions : TaskCompletionSourceAssertionsBase
         return new AndConstraint<TaskCompletionSourceAssertions>(this);
     }
 }
+
 #endif
 
+[DebuggerNonUserCode]
 public class TaskCompletionSourceAssertions<T> : TaskCompletionSourceAssertionsBase
 {
     private readonly AssertionChain assertionChain;

--- a/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertionsBase.cs
+++ b/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertionsBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ namespace FluentAssertions.Specialized;
 /// <summary>
 /// Implements base functionality for assertions on TaskCompletionSource.
 /// </summary>
+[DebuggerNonUserCode]
 public class TaskCompletionSourceAssertionsBase
 {
     protected TaskCompletionSourceAssertionsBase(IClock clock)

--- a/Src/FluentAssertions/Streams/BufferedStreamAssertions.cs
+++ b/Src/FluentAssertions/Streams/BufferedStreamAssertions.cs
@@ -1,9 +1,9 @@
-﻿using System.Diagnostics;
-using System.IO;
-using FluentAssertions.Execution;
-#if NET6_0_OR_GREATER || NETSTANDARD2_1
+using System.Diagnostics;
+#if NETSTANDARD2_1 || NETCOREAPP2_1_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
+using System.IO;
+using FluentAssertions.Execution;
 
 namespace FluentAssertions.Streams;
 
@@ -105,3 +105,4 @@ public class BufferedStreamAssertions<TAssertions> : StreamAssertions<BufferedSt
 
     protected override string Identifier => "buffered stream";
 }
+

--- a/Src/FluentAssertions/Streams/StreamAssertions.cs
+++ b/Src/FluentAssertions/Streams/StreamAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -22,6 +22,7 @@ public class StreamAssertions : StreamAssertions<Stream, StreamAssertions>
 /// <summary>
 /// Contains a number of methods to assert that a <typeparamref name="TSubject"/> is in the expected state.
 /// </summary>
+[DebuggerNonUserCode]
 public class StreamAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<TSubject, TAssertions>
     where TSubject : Stream
     where TAssertions : StreamAssertions<TSubject, TAssertions>
@@ -516,3 +517,4 @@ public class StreamAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 }
+

--- a/Src/FluentAssertions/TypeEnumerableExtensions.cs
+++ b/Src/FluentAssertions/TypeEnumerableExtensions.cs
@@ -134,3 +134,4 @@ public static class TypeEnumerableExtensions
         return new TypeSelector(types).UnwrapEnumerableTypes();
     }
 }
+

--- a/Src/FluentAssertions/TypeExtensions.cs
+++ b/Src/FluentAssertions/TypeExtensions.cs
@@ -78,3 +78,4 @@ public static class TypeExtensions
         return new PropertyInfoSelector(typeSelector.ToList());
     }
 }
+

--- a/Src/FluentAssertions/Types/AllTypes.cs
+++ b/Src/FluentAssertions/Types/AllTypes.cs
@@ -11,6 +11,7 @@ namespace FluentAssertions.Types;
 /// .Should()<br />
 /// .BeDecoratedWith&lt;SomeAttribute&gt;()
 /// </example>
+[System.Diagnostics.StackTraceHidden]
 public static class AllTypes
 {
     /// <summary>
@@ -23,3 +24,4 @@ public static class AllTypes
         return assembly.Types();
     }
 }
+

--- a/Src/FluentAssertions/Types/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Types/AssemblyAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -224,3 +224,4 @@ public class AssemblyAssertions : ReferenceTypeAssertions<Assembly, AssemblyAsse
     /// </summary>
     protected override string Identifier => "assembly";
 }
+

--- a/Src/FluentAssertions/Types/ConstructorInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/ConstructorInfoAssertions.cs
@@ -28,3 +28,4 @@ public class ConstructorInfoAssertions : MethodBaseAssertions<ConstructorInfo, C
         return $"{constructorInfo.DeclaringType}({GetParameterString(constructorInfo)})";
     }
 }
+

--- a/Src/FluentAssertions/Types/MemberInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MemberInfoAssertions.cs
@@ -155,3 +155,4 @@ public abstract class MemberInfoAssertions<TSubject, TAssertions> : ReferenceTyp
 
     private protected virtual string SubjectDescription => $"{Subject.DeclaringType}.{Subject.Name}";
 }
+

--- a/Src/FluentAssertions/Types/MethodBaseAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodBaseAssertions.cs
@@ -120,3 +120,4 @@ public abstract class MethodBaseAssertions<TSubject, TAssertions> : MemberInfoAs
         return string.Join(", ", parameterTypes.Select(p => p.FullName));
     }
 }
+

--- a/Src/FluentAssertions/Types/MethodInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoAssertions.cs
@@ -311,3 +311,4 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
 
     protected override string Identifier => "method";
 }
+

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -11,6 +11,7 @@ namespace FluentAssertions.Types;
 /// <summary>
 /// Allows for fluent selection of methods of a type through reflection.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class MethodInfoSelector : IEnumerable<MethodInfo>
 {
     private IEnumerable<MethodInfo> selectedMethods;
@@ -256,3 +257,4 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
         return GetEnumerator();
     }
 }
+

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -348,3 +348,4 @@ public class MethodInfoSelectorAssertions
     public override bool Equals(object obj) =>
         throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
 }
+

--- a/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
@@ -397,3 +397,4 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
     /// </summary>
     protected override string Identifier => "property";
 }
+

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -10,6 +10,7 @@ namespace FluentAssertions.Types;
 /// <summary>
 /// Allows for fluent selection of properties of a type through reflection.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class PropertyInfoSelector : IEnumerable<PropertyInfo>
 {
     private IEnumerable<PropertyInfo> selectedProperties;
@@ -228,3 +229,4 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
         return GetEnumerator();
     }
 }
+

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -238,3 +238,4 @@ public class PropertyInfoSelectorAssertions
     public override bool Equals(object obj) =>
         throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
 }
+

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1916,3 +1916,4 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
         }
     }
 }
+

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -10,6 +10,7 @@ namespace FluentAssertions.Types;
 /// <summary>
 /// Allows for fluent filtering a list of types.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public class TypeSelector : IEnumerable<Type>
 {
     private List<Type> types;
@@ -368,3 +369,4 @@ public class TypeSelector : IEnumerable<Type>
         return GetEnumerator();
     }
 }
+

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -489,3 +489,4 @@ public class TypeSelectorAssertions
         throw new NotSupportedException(
             "Equals is not part of Fluent Assertions. Did you mean BeInNamespace() or BeDecoratedWith() instead?");
 }
+

--- a/Src/FluentAssertions/Value.cs
+++ b/Src/FluentAssertions/Value.cs
@@ -8,6 +8,7 @@ namespace FluentAssertions;
 /// <summary>
 /// Provides a fluent API for defining inline assertions.
 /// </summary>
+[System.Diagnostics.StackTraceHidden]
 public static class Value
 {
     /// <summary>
@@ -34,3 +35,4 @@ public static class Value
         return new ActionBasedInlineAssertion<T>(assertion);
     }
 }
+

--- a/Src/FluentAssertions/Xml/Equivalency/AttributeData.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/AttributeData.cs
@@ -1,5 +1,6 @@
 namespace FluentAssertions.Xml.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 internal class AttributeData
 {
     public AttributeData(string namespaceUri, string localName, string value, string prefix)

--- a/Src/FluentAssertions/Xml/Equivalency/Failure.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/Failure.cs
@@ -1,5 +1,6 @@
 namespace FluentAssertions.Xml.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 internal class Failure
 {
     public Failure(string formatString, params object[] formatParams)

--- a/Src/FluentAssertions/Xml/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/Node.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 namespace FluentAssertions.Xml.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 internal sealed class Node
 {
     private readonly List<Node> children = [];
@@ -78,3 +79,4 @@ internal sealed class Node
         return node;
     }
 }
+

--- a/Src/FluentAssertions/Xml/Equivalency/XmlIterator.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/XmlIterator.cs
@@ -3,6 +3,7 @@ using System.Xml;
 
 namespace FluentAssertions.Xml.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 internal class XmlIterator
 {
     private readonly XmlReader reader;
@@ -76,3 +77,4 @@ internal class XmlIterator
         return attributes;
     }
 }
+

--- a/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -7,6 +7,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Xml.Equivalency;
 
+[System.Diagnostics.StackTraceHidden]
 internal class XmlReaderValidator
 {
     private readonly AssertionChain assertionChain;

--- a/Src/FluentAssertions/Xml/XAttributeAssertions.cs
+++ b/Src/FluentAssertions/Xml/XAttributeAssertions.cs
@@ -104,3 +104,4 @@ public class XAttributeAssertions : ReferenceTypeAssertions<XAttribute, XAttribu
     /// </summary>
     protected override string Identifier => "XML attribute";
 }
+

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -543,3 +543,4 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
     /// </summary>
     protected override string Identifier => "XML document";
 }
+

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -762,3 +762,4 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     /// </summary>
     protected override string Identifier => "XML element";
 }
+

--- a/Src/FluentAssertions/Xml/XmlElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlElementAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Xml;
 using FluentAssertions.Common;
@@ -172,3 +172,4 @@ public class XmlElementAssertions : XmlNodeAssertions<XmlElement, XmlElementAsse
 
     protected override string Identifier => "XML element";
 }
+

--- a/Src/FluentAssertions/Xml/XmlNodeAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Xml;
 using FluentAssertions.Execution;
@@ -89,3 +89,4 @@ public class XmlNodeAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<
     /// </summary>
     protected override string Identifier => "XML node";
 }
+

--- a/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
@@ -1,9 +1,10 @@
-﻿using System.Xml;
+using System.Xml;
 using FluentAssertions.Common;
 using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Xml;
 
+[System.Diagnostics.StackTraceHidden]
 public class XmlNodeFormatter : IValueFormatter
 {
     public bool CanHandle(object value)
@@ -25,3 +26,4 @@ public class XmlNodeFormatter : IValueFormatter
         formattedGraph.AddLine(outerXml.EscapePlaceholders());
     }
 }
+

--- a/Src/FluentAssertions/XmlAssertionExtensions.cs
+++ b/Src/FluentAssertions/XmlAssertionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Xml;
 using FluentAssertions.Execution;
@@ -19,3 +19,4 @@ public static class XmlAssertionExtensions
         return new XmlElementAssertions(actualValue, AssertionChain.GetOrCreate());
     }
 }
+

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -4,17 +4,20 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 namespace FluentAssertions
 {
+    [System.Diagnostics.StackTraceHidden]
     public class AggregateExceptionExtractor : FluentAssertions.Specialized.IExtractExceptions
     {
         public AggregateExceptionExtractor() { }
         public System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
             where T : System.Exception { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class AndConstraint<TParent>
     {
         public AndConstraint(TParent parent) { }
         public TParent And { get; }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class AndWhichConstraint<TParent, TSubject> : FluentAssertions.AndConstraint<TParent>
     {
         public AndWhichConstraint(TParent parent, System.Collections.Generic.IEnumerable<TSubject> subjects) { }
@@ -25,10 +28,12 @@ namespace FluentAssertions
         public TSubject Subject { get; }
         public TSubject Which { get; }
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class AssertionConfiguration
     {
         public static FluentAssertions.Configuration.GlobalConfiguration Current { get; }
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class AssertionEngine
     {
         public static FluentAssertions.Configuration.GlobalConfiguration Configuration { get; }
@@ -188,6 +193,7 @@ namespace FluentAssertions
         public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
         public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class AtLeast
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }
@@ -195,6 +201,7 @@ namespace FluentAssertions
         public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
         public static FluentAssertions.OccurrenceConstraint Twice() { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class AtMost
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }
@@ -202,6 +209,7 @@ namespace FluentAssertions
         public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
         public static FluentAssertions.OccurrenceConstraint Twice() { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class CallerIdentifier
     {
         public static System.Action<string> Logger { get; set; }
@@ -209,11 +217,13 @@ namespace FluentAssertions
         public static string DetermineCallerIdentity() { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method)]
+    [System.Diagnostics.StackTraceHidden]
     public class CustomAssertionAttribute : System.Attribute
     {
         public CustomAssertionAttribute() { }
     }
     [System.AttributeUsage(System.AttributeTargets.Assembly)]
+    [System.Diagnostics.StackTraceHidden]
     public sealed class CustomAssertionsAssemblyAttribute : System.Attribute
     {
         public CustomAssertionsAssemblyAttribute() { }
@@ -231,6 +241,7 @@ namespace FluentAssertions
         public static FluentAssertions.Events.IEventRecording WithArgs<T>(this FluentAssertions.Events.IEventRecording eventRecording, params System.Linq.Expressions.Expression<System.Func<T, bool>>[] predicates) { }
         public static FluentAssertions.Events.IEventRecording WithSender(this FluentAssertions.Events.IEventRecording eventRecording, object expectedSender) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class Exactly
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }
@@ -261,6 +272,7 @@ namespace FluentAssertions
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithoutMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string wildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class FluentActions
     {
         public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
@@ -276,16 +288,19 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.JsonNodeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this T jsonNode)
             where T : System.Text.Json.Nodes.JsonNode { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class LessThan
     {
         public static FluentAssertions.OccurrenceConstraint Thrice() { }
         public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
         public static FluentAssertions.OccurrenceConstraint Twice() { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class License
     {
         public static bool Accepted { get; set; }
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class MoreThan
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }
@@ -347,6 +362,7 @@ namespace FluentAssertions
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<object>, FluentAssertions.Equivalency.EquivalencyOptions<object>> options, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<T>, FluentAssertions.Equivalency.EquivalencyOptions<T>> options, string because = "", params object[] becauseArgs) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public abstract class OccurrenceConstraint
     {
         protected OccurrenceConstraint(int expectedCount) { }
@@ -383,6 +399,7 @@ namespace FluentAssertions
         public static FluentAssertions.Types.TypeSelector Types(this System.Reflection.Assembly assembly) { }
         public static FluentAssertions.Types.TypeSelector Types(this System.Type type) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class Value
     {
         public static FluentAssertions.Equivalency.Inlining.IInlineEquivalencyAssertion ThatMatches<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> condition) { }
@@ -581,6 +598,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
         where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
@@ -626,6 +644,7 @@ namespace FluentAssertions.Common
 }
 namespace FluentAssertions.Configuration
 {
+    [System.Diagnostics.StackTraceHidden]
     public class GlobalConfiguration
     {
         public GlobalConfiguration() { }
@@ -633,6 +652,7 @@ namespace FluentAssertions.Configuration
         public FluentAssertions.Configuration.GlobalFormattingOptions Formatting { get; set; }
         public FluentAssertions.Configuration.TestFramework? TestFramework { get; set; }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class GlobalEquivalencyOptions
     {
         public GlobalEquivalencyOptions() { }
@@ -640,6 +660,7 @@ namespace FluentAssertions.Configuration
         public FluentAssertions.Equivalency.EquivalencyOptions<T> CloneDefaults<T>() { }
         public void Modify(System.Func<FluentAssertions.Equivalency.EquivalencyOptions, FluentAssertions.Equivalency.EquivalencyOptions> configureOptions) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class GlobalFormattingOptions : FluentAssertions.Formatting.FormattingOptions
     {
         public GlobalFormattingOptions() { }
@@ -659,6 +680,7 @@ namespace FluentAssertions.Configuration
 }
 namespace FluentAssertions.Equivalency
 {
+    [System.Diagnostics.StackTraceHidden]
     public class Comparands
     {
         public Comparands() { }
@@ -670,6 +692,7 @@ namespace FluentAssertions.Equivalency
         public System.Type GetExpectedType(FluentAssertions.Equivalency.IEquivalencyOptions options) { }
         public override string ToString() { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class ConversionSelector
     {
         public ConversionSelector() { }
@@ -701,6 +724,7 @@ namespace FluentAssertions.Equivalency
     {
         public EquivalencyOptions() { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class EquivalencyOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyOptions<FluentAssertions.Equivalency.EquivalencyOptions<TExpectation>>
     {
         public EquivalencyOptions() { }
@@ -716,6 +740,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.EquivalencyOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
         public FluentAssertions.Equivalency.EquivalencyOptions<TExpectation> WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class EquivalencyPlan : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
     {
         public EquivalencyPlan() { }
@@ -738,12 +763,14 @@ namespace FluentAssertions.Equivalency
         ContinueWithNext = 0,
         EquivalencyProven = 1,
     }
+    [System.Diagnostics.StackTraceHidden]
     public abstract class EquivalencyStep<T> : FluentAssertions.Equivalency.IEquivalencyStep
     {
         protected EquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
         protected abstract FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency nestedValidator);
     }
+    [System.Diagnostics.StackTraceHidden]
     public class EquivalencyValidationContext : FluentAssertions.Equivalency.IEquivalencyValidationContext
     {
         public EquivalencyValidationContext(FluentAssertions.Equivalency.INode root, FluentAssertions.Equivalency.IEquivalencyOptions options) { }
@@ -866,10 +893,12 @@ namespace FluentAssertions.Equivalency
     {
         void AssertEquivalencyOf(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context);
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class MemberFactory
     {
         public static FluentAssertions.Equivalency.IMember Create(System.Reflection.MemberInfo memberInfo, FluentAssertions.Equivalency.INode parent) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class MemberSelectionContext
     {
         public MemberSelectionContext(System.Type compileTimeType, System.Type runtimeType, FluentAssertions.Equivalency.IEquivalencyOptions options) { }
@@ -886,6 +915,7 @@ namespace FluentAssertions.Equivalency
         ExplicitlyImplemented = 4,
         DefaultInterfaceProperties = 8,
     }
+    [System.Diagnostics.StackTraceHidden]
     public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
     {
         public FluentAssertions.Equivalency.EquivalencyOptions<TExpectation> Exclude(System.Linq.Expressions.Expression<System.Func<TCurrent, object>> expression) { }
@@ -897,6 +927,7 @@ namespace FluentAssertions.Equivalency
         NotStrict = 1,
         Irrelevant = 2,
     }
+    [System.Diagnostics.StackTraceHidden]
     public class OrderingRuleCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule>, System.Collections.IEnumerable
     {
         public OrderingRuleCollection() { }
@@ -916,6 +947,7 @@ namespace FluentAssertions.Equivalency
         public override string ToString() { }
         public delegate string GetDescription(string pathAndName);
     }
+    [System.Diagnostics.StackTraceHidden]
     public abstract class SelfReferenceEquivalencyOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyOptions
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyOptions<TSelf>
     {
@@ -1002,6 +1034,7 @@ namespace FluentAssertions.Equivalency
                 where TMemberType : TMember { }
         }
     }
+    [System.Diagnostics.StackTraceHidden]
     public static class SubjectInfoExtensions
     {
         public static bool WhichGetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
@@ -1016,6 +1049,7 @@ namespace FluentAssertions.Equivalency.Inlining
     {
         void Execute(FluentAssertions.Execution.AssertionChain assertionChain, FluentAssertions.Equivalency.Comparands comparands);
     }
+    [System.Diagnostics.StackTraceHidden]
     public class InlineEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public InlineEquivalencyStep() { }
@@ -1024,104 +1058,124 @@ namespace FluentAssertions.Equivalency.Inlining
 }
 namespace FluentAssertions.Equivalency.Steps
 {
+    [System.Diagnostics.StackTraceHidden]
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> assertionAction) { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
         public override string ToString() { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class AutoConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public AutoConversionStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
         public override string ToString() { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class DateAndTimeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public DateAndTimeEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Collections.IDictionary>
     {
         public DictionaryEquivalencyStep() { }
         protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency nestedValidator) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class EnumEqualityStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public EnumEqualityStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class EnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public EnumerableEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class EqualityComparerEquivalencyStep<T> : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public EqualityComparerEquivalencyStep(System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
         public override string ToString() { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class GenericDictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public GenericDictionaryEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class GenericEnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public GenericEnumerableEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class JsonConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public JsonConversionStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class ReferenceEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public ReferenceEqualityEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class RunAllUserStepsEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public RunAllUserStepsEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public SimpleEqualityEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class StringEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public StringEqualityEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class StructuralEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public StructuralEqualityEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class TypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public TypeEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {
         public ValueTypeEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency valueChildNodes) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class XAttributeEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Xml.Linq.XAttribute>
     {
         public XAttributeEquivalencyStep() { }
         protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency nestedValidator) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class XDocumentEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Xml.Linq.XDocument>
     {
         public XDocumentEquivalencyStep() { }
         protected override FluentAssertions.Equivalency.EquivalencyResult OnHandle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IValidateChildNodeEquivalency nestedValidator) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class XElementEquivalencyStep : FluentAssertions.Equivalency.EquivalencyStep<System.Xml.Linq.XElement>
     {
         public XElementEquivalencyStep() { }
@@ -1163,12 +1217,14 @@ namespace FluentAssertions.Events
         public FluentAssertions.Events.IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Events.IEventRecording RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class EventMetadata
     {
         public EventMetadata(string eventName, System.Type handlerType) { }
         public string EventName { get; }
         public System.Type HandlerType { get; }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class EventMonitorOptions
     {
         public EventMonitorOptions() { }
@@ -1190,6 +1246,7 @@ namespace FluentAssertions.Events
         FluentAssertions.Events.IEventRecording GetRecordingFor(string eventName);
         FluentAssertions.Events.EventAssertions<T> Should();
     }
+    [System.Diagnostics.StackTraceHidden]
     public class OccurredEvent
     {
         public OccurredEvent() { }
@@ -1201,6 +1258,7 @@ namespace FluentAssertions.Events
 }
 namespace FluentAssertions.Execution
 {
+    [System.Diagnostics.StackTraceHidden]
     public sealed class AssertionChain
     {
         public string CallerIdentifier { get; }
@@ -1228,10 +1286,12 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionChain WithReportable(string name, System.Func<string> content) { }
         public static FluentAssertions.Execution.AssertionChain GetOrCreate() { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class AssertionFailedException : System.Exception
     {
         public AssertionFailedException(string message) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public sealed class AssertionScope : System.IDisposable
     {
         public AssertionScope() { }
@@ -1247,21 +1307,25 @@ namespace FluentAssertions.Execution
         public void Dispose() { }
         public bool HasFailures() { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class Continuation
     {
         public FluentAssertions.Execution.AssertionChain Then { get; }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class ContinuationOfGiven<TSubject>
     {
         public bool Succeeded { get; }
         public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class FailReason
     {
         public FailReason(string message, params object[] args) { }
         public object[] Args { get; }
         public string Message { get; }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class GivenSelector<T>
     {
         public bool Succeeded { get; }
@@ -1288,6 +1352,7 @@ namespace FluentAssertions.Execution
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         void Throw(string message);
     }
+    [System.Diagnostics.StackTraceHidden]
     public class Reason
     {
         public Reason(string formattedMessage, object[] arguments) { }
@@ -1298,6 +1363,7 @@ namespace FluentAssertions.Execution
 namespace FluentAssertions.Extensibility
 {
     [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple=true)]
+    [System.Diagnostics.StackTraceHidden]
     public sealed class AssertionEngineInitializerAttribute : System.Attribute
     {
         public AssertionEngineInitializerAttribute(System.Type type, string methodName) { }
@@ -2318,6 +2384,7 @@ namespace FluentAssertions.Specialized
         public virtual FluentAssertions.Specialized.ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
         public virtual FluentAssertions.Specialized.ExceptionAssertions<TException> WithoutMessage(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class ExecutionTime
     {
         public ExecutionTime(System.Action action, FluentAssertions.Common.StartTimer createTimer) { }
@@ -2382,6 +2449,7 @@ namespace FluentAssertions.Specialized
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> NotBeUtcDate(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.JsonNodeAssertions<T>> NotHaveProperty(string code, string because = "", params object[] becauseArgs) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
     {
         public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action, FluentAssertions.Common.StartTimer createTimer) { }
@@ -2456,6 +2524,7 @@ namespace FluentAssertions.Streams
 }
 namespace FluentAssertions.Types
 {
+    [System.Diagnostics.StackTraceHidden]
     public static class AllTypes
     {
         public static FluentAssertions.Types.TypeSelector From(System.Reflection.Assembly assembly) { }
@@ -2513,6 +2582,7 @@ namespace FluentAssertions.Types
         public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class MethodInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, System.Collections.IEnumerable
     {
         public MethodInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
@@ -2580,6 +2650,7 @@ namespace FluentAssertions.Types
         public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return(System.Type propertyType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return<TReturn>(string because = "", params object[] becauseArgs) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class PropertyInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo>, System.Collections.IEnumerable
     {
         public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
@@ -2700,6 +2771,7 @@ namespace FluentAssertions.Types
         public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs)
             where TInterface :  class { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class TypeSelector : System.Collections.Generic.IEnumerable<System.Type>, System.Collections.IEnumerable
     {
         public TypeSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
@@ -2849,6 +2921,7 @@ namespace FluentAssertions.Xml
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected, string because = "", params object[] becauseArgs) { }
     }
+    [System.Diagnostics.StackTraceHidden]
     public class XmlNodeFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public XmlNodeFormatter() { }

--- a/Tests/FluentAssertions.Specs/Exceptions/OuterExceptionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/OuterExceptionSpecs.cs
@@ -51,7 +51,6 @@ public class OuterExceptionSpecs
         {
             // Act
             testSubject
-
                 .Should().Throw<InvalidOperationException>()
                 .WithMessage(new string('#', 101));
 

--- a/Tests/FluentAssertions.Specs/StackTraceHiddenSpecs.cs
+++ b/Tests/FluentAssertions.Specs/StackTraceHiddenSpecs.cs
@@ -1,0 +1,88 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using FluentAssertions.Equivalency;
+using FluentAssertions.Types;
+using Reflectify;
+using Xunit;
+
+namespace FluentAssertions.Specs;
+
+public class StackTraceHiddenSpecs
+{
+    [Fact]
+    public void All_non_assertion_classes_have_their_stack_trace_hidden()
+    {
+        // Arrange / Act
+        var allFluentAssertionsClasses = GetAnnotatableTypes()
+            .Except(ShouldNotBeAnnotated())
+            .Types();
+
+        // Assert
+        allFluentAssertionsClasses.Should().BeDecoratedWith<StackTraceHiddenAttribute>(
+            "because all \"internal\" code should be hidden from the stacktrace to improve the debugging experience");
+    }
+
+    [Fact]
+    public void Assertion_classes_do_not_have_their_stack_trace_hidden()
+    {
+        // Arrange / Act
+        var allFluentAssertionsClasses = ShouldNotBeAnnotated();
+
+        // Assert
+        allFluentAssertionsClasses.Should().NotBeDecoratedWith<StackTraceHiddenAttribute>(
+            "because we do want to see the actual assertion method being used");
+    }
+
+    private static TypeSelector GetAnnotatableTypes()
+    {
+        return AllTypes
+            .From(typeof(FluentAssertions.AssertionExtensions).Assembly)
+            .ThatAreUnderNamespace("FluentAssertions")
+            .ThatAreClasses()
+            .ThatSatisfy(t => !t.IsNested)
+            .ThatSatisfy(t => !t.IsSameOrInherits<Delegate>())
+            .ThatSatisfy(t => !t.IsCompilerGenerated() && !t.HasAttribute<CompilerGeneratedAttribute>());
+    }
+
+    private static TypeSelector ShouldNotBeAnnotated()
+    {
+        string[] typeNameSuffixes =
+        [
+            "Assertions",
+            "AssertionsBase",
+            "AssertionExtensions",
+            "AssertionsExtensions",
+            "DateTimeExtensions",
+            "EventRaisingExtensions",
+            "FluentDateTimeExtensions",
+            "FluentTimeSpanExtensions",
+            "OccurrenceConstraintExtensions",
+            "Common.TypeExtensions",
+            "TypeEnumerableExtensions",
+            "FluentAssertions.TypeExtensions",
+        ];
+
+        string[] namespaces =
+        [
+            "FluentAssertions.CallerIdentification",
+            "FluentAssertions.Collections.MaximumMatching",
+            "FluentAssertions.Equivalency.Matching",
+            "FluentAssertions.Equivalency.Ordering",
+            "FluentAssertions.Equivalency.Selection",
+            "FluentAssertions.Equivalency.Tracing",
+            "FluentAssertions.Formatting",
+        ];
+
+        return GetAnnotatableTypes()
+              .ThatSatisfy(t =>
+                  t == typeof(EquivalencyOptions) ||
+                  typeNameSuffixes.Any(bt => bt == t.FullName || t.GetNonGenericName().EndsWith(bt, StringComparison.Ordinal)) ||
+                  namespaces.Any(ns => t?.Namespace?.StartsWith(ns, StringComparison.Ordinal) is true)
+              );
+    }
+
+}
+#endif


### PR DESCRIPTION
This change marks a large portion of the library’s public and internal surface with the runtime’s `StackTraceHidden` attribute (only when running on .NET 6+), so failures and exceptions show cleaner stack traces that focus on user code instead of framework plumbing.

As a result, assertion failures should be easier to read and debug because internal helper frames are suppressed by the debugger/stack trace renderer.

Alongside that, there are a few formatting-only tweaks (indentation/line breaks) that don’t affect behavior.
The public API baseline for .NET 6 reflects these added attributes so the API “shape” stays in sync.

**Note** The changes were a mix of AI and manual work, hence there's differences how the attribute was applied

Fixes #512