### PR TITLE
Improve reporting the subject when chaining Throw and Which

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -92,6 +92,14 @@ public static class CallerIdentifier
         return callers;
     }
 
+    /// <summary>
+    /// Represents a specific point in the call stack to facilitate skipping over internal FluentAssertions
+    /// frames when analyzing stack traces for caller identification.
+    /// </summary>
+    /// <remarks>
+    /// Instances of this class are used to track and adjust starting points for stack trace searches,
+    /// ensuring that FluentAssertions internal frames are excluded from caller identification processes.
+    /// </remarks>
     private sealed class StackFrameReference : IDisposable
     {
         public int SkipStackFrameCount { get; }
@@ -126,11 +134,23 @@ public static class CallerIdentifier
 
     private static readonly AsyncLocal<StackFrameReference> StartStackSearchAfterStackFrame = new();
 
+    /// <summary>
+    /// Temporarily adjusts the stack trace search behavior to focus on the current scope during Fluent Assertions evaluations.
+    /// </summary>
+    /// <returns>An <see cref="IDisposable"/> object that reverts the stack trace search behavior upon disposal.</returns>
     internal static IDisposable OverrideStackSearchUsingCurrentScope()
     {
         return new StackFrameReference();
     }
 
+    /// <summary>
+    /// Determines whether there is only one Fluent Assertions scope present in the current call stack.
+    /// This is used to identify if a nested Fluent Assertions scope exists within the stack trace.
+    /// </summary>
+    /// <returns>
+    /// A boolean value indicating true if only one Fluent Assertions scope exists on the call stack;
+    /// otherwise, false.
+    /// </returns>
     internal static bool OnlyOneFluentAssertionScopeOnCallStack()
     {
         var allStackFrames = GetFrames(new StackTrace());

--- a/Src/FluentAssertions/Execution/AssertionChain.cs
+++ b/Src/FluentAssertions/Execution/AssertionChain.cs
@@ -32,9 +32,10 @@ public sealed class AssertionChain
     /// <summary>
     /// Ensures that the next call to <see cref="GetOrCreate"/> will reuse the current instance.
     /// </summary>
-    public void ReuseOnce()
+    public AssertionChain ReuseOnce()
     {
         Instance.Value = this;
+        return this;
     }
 
     /// <summary>
@@ -288,7 +289,17 @@ public sealed class AssertionChain
     public AssertionChain WithCallerPostfix(string postfix)
     {
         identifierBuilder.UsePostfix(postfix);
+        return this;
+    }
 
+    /// <summary>
+    /// Adds a specified prefix to the caller identifier used in the current assertion chain.
+    /// </summary>
+    /// <param name="prefix">The prefix to prepend to the caller identifier.</param>
+    /// <returns>An updated instance of <see cref="AssertionChain"/> with the specified prefix applied.</returns>
+    public AssertionChain WithCallerPrefix(string prefix)
+    {
+        identifierBuilder.UsePrefix(prefix);
         return this;
     }
 
@@ -296,9 +307,10 @@ public sealed class AssertionChain
     /// Marks the next assertion as being part of a chained call to Should where it needs to find the next
     /// caller identifier.
     /// </summary>
-    internal void AdvanceToNextIdentifier()
+    internal AssertionChain AdvanceToNextIdentifier()
     {
         identifierBuilder.AdvanceToNextSubject();
+        return this;
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Execution/SubjectIdentificationBuilder.cs
+++ b/Src/FluentAssertions/Execution/SubjectIdentificationBuilder.cs
@@ -60,6 +60,18 @@ internal class SubjectIdentificationBuilder
     }
 
     /// <summary>
+    /// Prepends the given prefix to the current subject and combines that with next subject.
+    /// </summary>
+    /// <param name="prefix">The prefix to prepend to the current subject.</param>
+    public void UsePrefix(string prefix)
+    {
+        var localIndex = identifierIndex;
+        getSubject = () => (prefix + GetIdentifier(localIndex)).Combine(GetIdentifier(localIndex + 1));
+
+        HasOverriddenIdentifier = true;
+    }
+
+    /// <summary>
     /// Appends the given postfix to the current subject and combines that with next subject.
     /// </summary>
     /// <remarks>

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -368,7 +368,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
             // not "await action".
             using (CallerIdentifier.OnlyOneFluentAssertionScopeOnCallStack()
                        ? CallerIdentifier.OverrideStackSearchUsingCurrentScope()
-                       : default)
+                       : null)
             {
                 await action();
             }

--- a/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -52,6 +52,11 @@ public abstract class DelegateAssertionsBase<TDelegate, TAssertions>
                 .FailWith("but found <{0}>:" + Environment.NewLine + "{1}.",
                     exception?.GetType(),
                     exception));
+
+        AssertionChain.GetOrCreate()
+            .ReuseOnce()
+            .AdvanceToNextIdentifier()
+            .WithCallerPrefix($"{typeof(TException).Name}.");
 
         return new ExceptionAssertions<TException>(expectedExceptions, assertionChain);
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1197,8 +1197,9 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionChain ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public void OverrideCallerIdentifier(System.Func<string> getCallerIdentifier) { }
-        public void ReuseOnce() { }
+        public FluentAssertions.Execution.AssertionChain ReuseOnce() { }
         public FluentAssertions.Execution.AssertionChain WithCallerPostfix(string postfix) { }
+        public FluentAssertions.Execution.AssertionChain WithCallerPrefix(string prefix) { }
         public FluentAssertions.Execution.AssertionChain WithDefaultIdentifier(string identifier) { }
         public FluentAssertions.Execution.Continuation WithExpectation(string message, System.Action<FluentAssertions.Execution.AssertionChain> chain) { }
         public FluentAssertions.Execution.Continuation WithExpectation(string message, object arg1, System.Action<FluentAssertions.Execution.AssertionChain> chain) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1280,8 +1280,9 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionChain ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public void OverrideCallerIdentifier(System.Func<string> getCallerIdentifier) { }
-        public void ReuseOnce() { }
+        public FluentAssertions.Execution.AssertionChain ReuseOnce() { }
         public FluentAssertions.Execution.AssertionChain WithCallerPostfix(string postfix) { }
+        public FluentAssertions.Execution.AssertionChain WithCallerPrefix(string prefix) { }
         public FluentAssertions.Execution.AssertionChain WithDefaultIdentifier(string identifier) { }
         public FluentAssertions.Execution.Continuation WithExpectation(string message, System.Action<FluentAssertions.Execution.AssertionChain> chain) { }
         public FluentAssertions.Execution.Continuation WithExpectation(string message, object arg1, System.Action<FluentAssertions.Execution.AssertionChain> chain) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1141,8 +1141,9 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionChain ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public void OverrideCallerIdentifier(System.Func<string> getCallerIdentifier) { }
-        public void ReuseOnce() { }
+        public FluentAssertions.Execution.AssertionChain ReuseOnce() { }
         public FluentAssertions.Execution.AssertionChain WithCallerPostfix(string postfix) { }
+        public FluentAssertions.Execution.AssertionChain WithCallerPrefix(string prefix) { }
         public FluentAssertions.Execution.AssertionChain WithDefaultIdentifier(string identifier) { }
         public FluentAssertions.Execution.Continuation WithExpectation(string message, System.Action<FluentAssertions.Execution.AssertionChain> chain) { }
         public FluentAssertions.Execution.Continuation WithExpectation(string message, object arg1, System.Action<FluentAssertions.Execution.AssertionChain> chain) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1197,8 +1197,9 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.AssertionChain ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public void OverrideCallerIdentifier(System.Func<string> getCallerIdentifier) { }
-        public void ReuseOnce() { }
+        public FluentAssertions.Execution.AssertionChain ReuseOnce() { }
         public FluentAssertions.Execution.AssertionChain WithCallerPostfix(string postfix) { }
+        public FluentAssertions.Execution.AssertionChain WithCallerPrefix(string prefix) { }
         public FluentAssertions.Execution.AssertionChain WithDefaultIdentifier(string identifier) { }
         public FluentAssertions.Execution.Continuation WithExpectation(string message, System.Action<FluentAssertions.Execution.AssertionChain> chain) { }
         public FluentAssertions.Execution.Continuation WithExpectation(string message, object arg1, System.Action<FluentAssertions.Execution.AssertionChain> chain) { }

--- a/Tests/FluentAssertions.Specs/Exceptions/MiscellaneousExceptionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/MiscellaneousExceptionSpecs.cs
@@ -47,7 +47,6 @@ public class MiscellaneousExceptionSpecs
 
         // Act / Assert
         testSubject
-            
             .Should().Throw<InvalidOperationException>()
             .WithInnerException<ArgumentException>()
             .WithMessage("inner message");
@@ -198,5 +197,23 @@ public class MiscellaneousExceptionSpecs
         // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("*with parameter name \"someParameter\"*we want to test the failure message*\"someOtherParameter\"*");
+    }
+
+    [Fact]
+    public void Reports_the_exception_type_for_chained_assertions()
+    {
+        // Arrange
+        Action throwingAction = () => throw new SomeException();
+
+        // Act
+        var act = () => throwingAction.Should().Throw<SomeException>().Which.Property.Should().Be("Value");
+
+        // Assert
+        act.Should().Throw<XunitException>().WithMessage("*SomeException*Value*");
+    }
+
+    private class SomeException : Exception
+    {
+        public string Property { get; } = "OtherValue";
     }
 }


### PR DESCRIPTION
This commit improves caller/subject identification for chained assertions, especially in exception assertions, by allowing the chain to prepend a custom prefix to the generated caller identifier.

`throwingAction.Should().Throw<SomeException>().Which.Property.Should().Be("Value");`

will now report

`Expected SomeException.Property to be a match with the expectation, but it differs at index 0:`

Notice the name of the exception type.

Closes #871
