### PR TITLE
Add support for Span<T>, ReadOnlySpan<T>, Memory<T> and ReadOnlyMemory<T>

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions.Collections;
@@ -229,6 +230,75 @@ public static class AssertionExtensions
         return new BufferedStreamAssertions(actualValue, AssertionChain.GetOrCreate());
     }
 
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+    /// <summary>
+    /// Returns a <see cref="SpanAssertions{T}"/> object that can be used to assert the
+    /// current <see cref="Span{T}"/>.
+    /// </summary>
+    [Pure]
+    [OverloadResolutionPriority(-1)]
+    public static SpanAssertions<T> Should<T>(this Span<T> actualValue)
+    {
+        return new SpanAssertions<T>(actualValue.ToArray(), AssertionChain.GetOrCreate());
+    }
+
+    /// <summary>
+    /// Returns a <see cref="SpanAssertions{T}"/> object that can be used to assert the
+    /// current <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    [Pure]
+    [OverloadResolutionPriority(-1)]
+    public static SpanAssertions<T> Should<T>(this ReadOnlySpan<T> actualValue)
+    {
+        return new SpanAssertions<T>(actualValue.ToArray(), AssertionChain.GetOrCreate());
+    }
+
+    /// <summary>
+    /// Returns a <see cref="StringCollectionAssertions"/> object that can be used to assert the
+    /// current <see cref="Span{T}"/> of strings.
+    /// </summary>
+    [Pure]
+    [OverloadResolutionPriority(-1)]
+    public static StringCollectionAssertions Should(this Span<string> actualValue)
+    {
+        return new StringCollectionAssertions(actualValue.ToArray(), AssertionChain.GetOrCreate());
+    }
+
+    /// <summary>
+    /// Returns a <see cref="StringCollectionAssertions"/> object that can be used to assert the
+    /// current <see cref="ReadOnlySpan{T}"/> of strings.
+    /// </summary>
+    [Pure]
+    [OverloadResolutionPriority(-1)]
+    public static StringCollectionAssertions Should(this ReadOnlySpan<string> actualValue)
+    {
+        return new StringCollectionAssertions(actualValue.ToArray(), AssertionChain.GetOrCreate());
+    }
+
+    /// <summary>
+    /// Returns a <see cref="GenericCollectionAssertions{T}"/> object that can be used to assert the
+    /// current <see cref="Memory{T}"/>.
+    /// </summary>
+    [Pure]
+    [OverloadResolutionPriority(-1)]
+    public static GenericCollectionAssertions<T> Should<T>(this Memory<T> actualValue)
+    {
+        return new GenericCollectionAssertions<T>(actualValue.ToArray(), AssertionChain.GetOrCreate());
+    }
+
+    /// <summary>
+    /// Returns a <see cref="GenericCollectionAssertions{T}"/> object that can be used to assert the
+    /// current <see cref="ReadOnlyMemory{T}"/>.
+    /// </summary>
+    [Pure]
+    [OverloadResolutionPriority(-1)]
+    public static GenericCollectionAssertions<T> Should<T>(this ReadOnlyMemory<T> actualValue)
+    {
+        return new GenericCollectionAssertions<T>(actualValue.ToArray(), AssertionChain.GetOrCreate());
+    }
+
+#endif
+
     /// <summary>
     /// Forces enumerating a collection. Should be used to assert that a method that uses the
     /// <see langword="yield"/> keyword throws a particular exception.
@@ -281,6 +351,7 @@ public static class AssertionExtensions
     /// current <see cref="object"/>.
     /// </summary>
     [Pure]
+    [OverloadResolutionPriority(-2)]
     public static ObjectAssertions Should([NotNull] this object actualValue)
     {
         return new ObjectAssertions(actualValue, AssertionChain.GetOrCreate());

--- a/Src/FluentAssertions/Collections/SpanAssertions.cs
+++ b/Src/FluentAssertions/Collections/SpanAssertions.cs
@@ -1,0 +1,69 @@
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Collections;
+
+/// <summary>
+/// Contains a number of methods to assert that a <see cref="Span{T}"/> or <see cref="ReadOnlySpan{T}"/> matches an expected set of values.
+/// </summary>
+/// <remarks>
+/// Note: Assertion methods convert spans to arrays for comparison, which involves heap allocation.
+/// This is necessary to integrate with the existing assertion infrastructure.
+/// </remarks>
+[DebuggerNonUserCode]
+public class SpanAssertions<T> : GenericCollectionAssertions<T[], T, SpanAssertions<T>>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpanAssertions{T}"/> class.
+    /// </summary>
+    /// <param name="actualValue">The values of the span under test.</param>
+    /// <param name="assertionChain">The assertion chain that is used to build fluent continuations.</param>
+    public SpanAssertions(T[] actualValue, AssertionChain assertionChain)
+        : base(actualValue, assertionChain)
+    {
+    }
+
+    /// <summary>
+    /// Asserts that the current span is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected values to compare against.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+    /// </param>
+    /// <returns>
+    /// An <see cref="AndConstraint{TParent}"/> which can be used to chain assertions.
+    /// </returns>
+    public AndConstraint<SpanAssertions<T>> BeEqualTo(Span<T> expected,
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        return Equal(expected.ToArray(), because, becauseArgs);
+    }
+
+    /// <summary>
+    /// Asserts that the current span is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected values to compare against.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+    /// </param>
+    /// <returns>
+    /// An <see cref="AndConstraint{TParent}"/> which can be used to chain assertions.
+    /// </returns>
+    public AndConstraint<SpanAssertions<T>> BeEqualTo(ReadOnlySpan<T> expected,
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        return Equal(expected.ToArray(), because, becauseArgs);
+    }
+}
+#endif

--- a/Src/FluentAssertions/Collections/SpanAssertionsExtensions.cs
+++ b/Src/FluentAssertions/Collections/SpanAssertionsExtensions.cs
@@ -1,0 +1,54 @@
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions.Collections;
+using FluentAssertions.Common;
+using FluentAssertions.Primitives;
+
+// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace FluentAssertions;
+
+/// <summary>
+/// Provides string-specific assertion extensions for <see cref="SpanAssertions{Char}"/>.
+/// </summary>
+[DebuggerNonUserCode]
+public static class SpanAssertionsExtensions
+{
+    /// <summary>
+    /// Asserts that a <see cref="Span{Char}"/> or <see cref="ReadOnlySpan{Char}"/> is exactly the same as <paramref name="expected"/>,
+    /// including the casing and any leading or trailing whitespace.
+    /// </summary>
+    /// <param name="assertions">The <see cref="SpanAssertions{Char}"/> on which the assertion is executed.</param>
+    /// <param name="expected">The expected string.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <returns>
+    /// An <see cref="AndConstraint{TParent}"/> which can be used to chain assertions.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <see langword="null"/>.</exception>
+    public static AndConstraint<SpanAssertions<char>> Be([NotNull] this SpanAssertions<char> assertions, string expected,
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        Guard.ThrowIfArgumentIsNull(expected);
+
+        var subject = new string(assertions.Subject!);
+
+        var stringEqualityValidator = new StringValidator(assertions.CurrentAssertionChain,
+            new StringEqualityStrategy(StringComparer.Ordinal, "be"),
+            because, becauseArgs);
+
+        stringEqualityValidator.Validate(subject, expected);
+
+        return new AndConstraint<SpanAssertions<char>>(assertions);
+    }
+}
+
+#endif

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reflectify" Version="1.7.0">
+    <PackageReference Include="Reflectify" Version="1.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -89,10 +89,12 @@ namespace FluentAssertions
         public static FluentAssertions.Primitives.NullableGuidAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Guid? actualValue) { }
         public static FluentAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
         public static FluentAssertions.Streams.StreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.Stream actualValue) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.ReadOnlySpan<string> actualValue) { }
         public static FluentAssertions.Types.AssemblyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.Assembly assembly) { }
         public static FluentAssertions.Types.ConstructorInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
         public static FluentAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Span<string> actualValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions Should(this System.Threading.Tasks.TaskCompletionSource tcs) { }
         public static FluentAssertions.Primitives.TimeOnlyAssertions Should(this System.TimeOnly actualValue) { }
         public static FluentAssertions.Primitives.NullableTimeOnlyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.TimeOnly? actualValue) { }
@@ -168,6 +170,10 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Memory<T> actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.ReadOnlyMemory<T> actualValue) { }
+        public static FluentAssertions.Collections.SpanAssertions<T> Should<T>(this System.ReadOnlySpan<T> actualValue) { }
+        public static FluentAssertions.Collections.SpanAssertions<T> Should<T>(this System.Span<T> actualValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
@@ -367,6 +373,10 @@ namespace FluentAssertions
     {
         protected OccurrenceConstraint(int expectedCount) { }
     }
+    public static class SpanAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Collections.SpanAssertions<char>> Be([System.Diagnostics.CodeAnalysis.NotNull] this FluentAssertions.Collections.SpanAssertions<char> assertions, string expected, string because = "", params object[] becauseArgs) { }
+    }
     public static class TypeEnumerableExtensions
     {
         public static System.Collections.Generic.IEnumerable<System.Type> ThatAreClasses(this System.Collections.Generic.IEnumerable<System.Type> types) { }
@@ -565,6 +575,12 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEqual<T>(T unexpected, string because = "", params object[] becauseArgs)
             where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
+    }
+    public class SpanAssertions<T> : FluentAssertions.Collections.GenericCollectionAssertions<T[], T, FluentAssertions.Collections.SpanAssertions<T>>
+    {
+        public SpanAssertions(T[] actualValue, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SpanAssertions<T>> BeEqualTo(System.ReadOnlySpan<T> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SpanAssertions<T>> BeEqualTo(System.Span<T> expected, string because = "", params object[] becauseArgs) { }
     }
     public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -82,10 +82,12 @@ namespace FluentAssertions
         public static FluentAssertions.Primitives.NullableGuidAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Guid? actualValue) { }
         public static FluentAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
         public static FluentAssertions.Streams.StreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.Stream actualValue) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.ReadOnlySpan<string> actualValue) { }
         public static FluentAssertions.Types.AssemblyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.Assembly assembly) { }
         public static FluentAssertions.Types.ConstructorInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
         public static FluentAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Span<string> actualValue) { }
         public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
         public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.TimeSpan? actualValue) { }
         public static FluentAssertions.Types.TypeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Type subject) { }
@@ -150,6 +152,10 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Memory<T> actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.ReadOnlyMemory<T> actualValue) { }
+        public static FluentAssertions.Collections.SpanAssertions<T> Should<T>(this System.ReadOnlySpan<T> actualValue) { }
+        public static FluentAssertions.Collections.SpanAssertions<T> Should<T>(this System.Span<T> actualValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
@@ -331,6 +337,10 @@ namespace FluentAssertions
     public abstract class OccurrenceConstraint
     {
         protected OccurrenceConstraint(int expectedCount) { }
+    }
+    public static class SpanAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Collections.SpanAssertions<char>> Be([System.Diagnostics.CodeAnalysis.NotNull] this FluentAssertions.Collections.SpanAssertions<char> assertions, string expected, string because = "", params object[] becauseArgs) { }
     }
     public static class TypeEnumerableExtensions
     {
@@ -529,6 +539,12 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEqual<T>(T unexpected, string because = "", params object[] becauseArgs)
             where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
+    }
+    public class SpanAssertions<T> : FluentAssertions.Collections.GenericCollectionAssertions<T[], T, FluentAssertions.Collections.SpanAssertions<T>>
+    {
+        public SpanAssertions(T[] actualValue, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SpanAssertions<T>> BeEqualTo(System.ReadOnlySpan<T> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.SpanAssertions<T>> BeEqualTo(System.Span<T> expected, string because = "", params object[] becauseArgs) { }
     }
     public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {

--- a/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionExtensionsSpecs.cs
@@ -9,6 +9,7 @@ using FluentAssertions.Numeric;
 using FluentAssertions.Primitives;
 using FluentAssertions.Specialized;
 using FluentAssertions.Types;
+using Reflectify;
 using Xunit;
 
 namespace FluentAssertions.Specs;
@@ -162,8 +163,13 @@ public class AssertionExtensionsSpecs
     [MemberData(nameof(GetShouldMethods), true)]
     public void Should_methods_returning_reference_or_nullable_type_assertions_are_annotated_with_not_null_attribute(MethodInfo method)
     {
-        var notNullAttribute = method.GetParameters().Single().GetCustomAttribute<NotNullAttribute>();
-        notNullAttribute.Should().NotBeNull();
+        ParameterInfo parameter = method.GetParameters().Single();
+
+        Type type = parameter.ParameterType;
+
+        AssertionChain.GetOrCreate()
+            .ForCondition(type.IsRefStruct() || type.IsStruct() || parameter.HasAttribute<NotNullAttribute>())
+            .FailWith($"Should method '{method}' should have [NotNull] attribute for parameter '{parameter.Name}'");
     }
 
     [Theory]

--- a/Tests/FluentAssertions.Specs/Collections/SpanAndMemorySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/SpanAndMemorySpecs.cs
@@ -1,0 +1,350 @@
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Collections;
+
+public class SpanAndMemorySpecs
+{
+    public class GeneralPurposeCollections
+    {
+        [Fact]
+        public void A_span_supports_all_collection_assertions()
+        {
+            // Arrange
+            Span<int> span = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            span.Should().HaveCount(3)
+                .And.Contain(2)
+                .And.NotContain(4)
+                .And.StartWith(1)
+                .And.EndWith(3)
+                .And.BeInAscendingOrder();
+        }
+
+        [Fact]
+        public void A_readonly_span_supports_all_collection_assertions()
+        {
+            // Arrange
+            ReadOnlySpan<int> span = [1, 2, 3];
+
+            // Act / Assert
+            span.Should().HaveCount(3)
+                .And.Contain(2)
+                .And.NotContain(4)
+                .And.StartWith(1)
+                .And.EndWith(3)
+                .And.BeInAscendingOrder();
+        }
+
+        [Fact]
+        public void A_memory_object_supports_all_collection_assertions()
+        {
+            // Arrange
+            Memory<int> memory = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            memory.Should().HaveCount(3)
+                .And.Contain(2)
+                .And.NotContain(4)
+                .And.StartWith(1)
+                .And.EndWith(3)
+                .And.BeInAscendingOrder();
+        }
+
+        [Fact]
+        public void A_readonly_memory_object_supports_all_collection_assertions()
+        {
+            // Arrange
+            ReadOnlyMemory<int> memory = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            memory.Should().HaveCount(3)
+                .And.Contain(2)
+                .And.NotContain(4)
+                .And.StartWith(1)
+                .And.EndWith(3)
+                .And.BeInAscendingOrder();
+        }
+
+        [Fact]
+        public void A_readonly_span_of_strings_supports_string_collection_assertions()
+        {
+            // Arrange
+            string[] array = ["one", "two", "three"];
+            ReadOnlySpan<string> span = new(array);
+
+            // Act / Assert
+            span.Should().HaveCount(3)
+                .And.Contain("two")
+                .And.NotContain("four")
+                .And.StartWith("one")
+                .And.EndWith("three")
+                .And.ContainMatch("o*");
+        }
+
+        [Fact]
+        public void An_empty_span_supports_assertions()
+        {
+            // Arrange
+            Span<int> span = [];
+
+            // Act / Assert
+            span.Should().BeEmpty()
+                .And.HaveCount(0)
+                .And.NotContain(1);
+        }
+
+        [Fact]
+        public void An_empty_readonly_span_supports_assertions()
+        {
+            // Arrange
+            ReadOnlySpan<int> span = [];
+
+            // Act / Assert
+            span.Should().BeEmpty()
+                .And.HaveCount(0)
+                .And.NotContain(1);
+        }
+
+        [Fact]
+        public void An_empty_memory_supports_assertions()
+        {
+            // Arrange
+            Memory<int> memory = Array.Empty<int>();
+
+            // Act / Assert
+            memory.Should().BeEmpty()
+                .And.HaveCount(0)
+                .And.NotContain(1);
+        }
+
+        [Fact]
+        public void An_empty_readonly_memory_supports_assertions()
+        {
+            // Arrange
+            ReadOnlyMemory<int> memory = Array.Empty<int>();
+
+            // Act / Assert
+            memory.Should().BeEmpty()
+                .And.HaveCount(0)
+                .And.NotContain(1);
+        }
+
+        [Fact]
+        public void A_span_of_strings_supports_string_collection_assertions()
+        {
+            // Arrange
+            Span<string> span = ["one", "two", "three"];
+
+            // Act / Assert
+            span.Should().HaveCount(3)
+                .And.Contain("two")
+                .And.NotContain("four")
+                .And.ContainMatch("t*")
+                .And.OnlyContain(s => s.Length >= 3);
+        }
+
+        [Fact]
+        public void Chaining_on_a_span_is_supported()
+        {
+            // Arrange
+            Span<int> span = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            span.Should().HaveCount(3).And.Contain(2);
+        }
+    }
+
+    public class Equality
+    {
+        [Fact]
+        public void A_span_of_integers_can_be_asserted_for_equality()
+        {
+            // Arrange
+            Span<int> span = [1, 2, 3];
+
+            // Act / Assert
+            span.Should().Equal(1, 2, 3);
+            span.Should().BeEqualTo([1, 2, 3]);
+        }
+
+        [Fact]
+        public void A_readonly_span_of_integers_can_be_asserted_for_equality()
+        {
+            // Arrange
+            ReadOnlySpan<int> span = [1, 2, 3];
+
+            // Act / Assert
+            span.Should().Equal(1, 2, 3);
+            span.Should().BeEqualTo([1, 2, 3]);
+        }
+
+        [Fact]
+        public void A_span_be_equal_to_accepts_span()
+        {
+            // Arrange
+            Span<int> span = [1, 2, 3];
+            Span<int> expected = [1, 2, 3];
+
+            // Act / Assert
+            span.Should().BeEqualTo(expected);
+        }
+
+        [Fact]
+        public void A_span_be_equal_to_accepts_readonly_span()
+        {
+            // Arrange
+            Span<int> span = [1, 2, 3];
+            ReadOnlySpan<int> expected = [1, 2, 3];
+
+            // Act / Assert
+            span.Should().BeEqualTo(expected);
+        }
+
+        [Fact]
+        public void A_readonly_span_be_equal_to_accepts_readonly_span()
+        {
+            // Arrange
+            ReadOnlySpan<int> span = [1, 2, 3];
+            ReadOnlySpan<int> expected = [1, 2, 3];
+
+            // Act / Assert
+            span.Should().BeEqualTo(expected);
+        }
+
+        [Fact]
+        public void A_span_of_integers_be_equal_to_should_throw_when_values_differ()
+        {
+            // Arrange
+            Span<int> span = [1, 2, 3];
+
+            try
+            {
+                // Act
+                span.Should().BeEqualTo([1, 2, 4], "because {0}", "reasons");
+            }
+            catch (XunitException e)
+            {
+                // Assert
+                e.Message.Should().Be(
+                    "Expected span to be equal to {1, 2, 4} because reasons, but {1, 2, 3} differs at index 2.");
+                return;
+            }
+
+            throw new XunitException("This point should not be reached.");
+        }
+
+        [Fact]
+        public void A_readonly_span_of_integers_be_equal_to_should_throw_when_values_differ()
+        {
+            // Arrange
+            ReadOnlySpan<int> span = [1, 2, 3];
+
+            try
+            {
+                // Act
+                span.Should().BeEqualTo([1, 2, 4]);
+            }
+            catch (XunitException e)
+            {
+                // Assert
+                e.Message.Should().Be(
+                    "Expected span to be equal to {1, 2, 4}, but {1, 2, 3} differs at index 2.");
+                return;
+            }
+
+            throw new XunitException("This point should not be reached.");
+        }
+    }
+
+    public class Strings
+    {
+        [Fact]
+        public void A_span_of_chars_can_be_asserted_using_a_string()
+        {
+            // Arrange
+            Span<char> span = ['a', 'b', 'c'];
+
+            // Act / Assert
+            span.Should().Be("abc");
+        }
+
+        [Fact]
+        public void A_readonly_span_of_chars_can_be_asserted_using_a_string()
+        {
+            // Arrange
+            ReadOnlySpan<char> span = ['a', 'b', 'c'];
+
+            // Act / Assert
+            span.Should().Be("abc");
+        }
+
+        [Fact]
+        public void A_span_of_chars_be_should_throw_when_values_differ()
+        {
+            // Arrange
+            Span<char> span = ['a', 'b', 'c'];
+
+            try
+            {
+                // Act
+                span.Should().Be("abd", "because {0}", "reasons");
+            }
+            catch (XunitException e)
+            {
+                // Assert
+                e.Message.Should().Match("Expected span to be \"abd\" because reasons, but*");
+                return;
+            }
+
+            throw new XunitException("This point should not be reached.");
+        }
+
+        [Fact]
+        public void A_readonly_span_of_chars_be_should_throw_when_values_differ()
+        {
+            // Arrange
+            ReadOnlySpan<char> span = ['a', 'b', 'c'];
+
+            try
+            {
+                // Act
+                span.Should().Be("abd");
+            }
+            catch (XunitException e)
+            {
+                // Assert
+                e.Message.Should().Match("Expected span to be \"abd\", but*");
+                return;
+            }
+
+            throw new XunitException("This point should not be reached.");
+        }
+
+        [Fact]
+        public void A_span_of_chars_be_should_throw_when_expected_is_null()
+        {
+            // Arrange
+            Span<char> span = ['a', 'b', 'c'];
+
+            try
+            {
+                // Act
+                span.Should().Be(null!);
+            }
+            catch (ArgumentNullException e)
+            {
+                // Assert
+                e.ParamName.Should().Be("expected");
+                return;
+            }
+
+            throw new XunitException("This point should not be reached.");
+        }
+    }
+}
+
+#endif

--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -90,6 +90,35 @@ singleEquivalent.Should().ContainSingle()
     .Which.Should().BeEquivalentTo(new { Size = 42 });
 ```
 
+You can use the same collection assertions on `Span<T>`, `ReadOnlySpan<T>`, `Memory<T>`, and `ReadOnlyMemory<T>`.
+For spans, `BeEqualTo` is available as a readability alias for `Equal`.
+
+```csharp
+Span<int> span = [1, 2, 3];
+ReadOnlySpan<int> readOnlySpan = [1, 2, 3];
+Memory<int> memory = new[] { 1, 2, 3 };
+ReadOnlyMemory<int> readOnlyMemory = new[] { 1, 2, 3 };
+
+span.Should().Equal([1, 2, 3]);
+span.Should().BeEqualTo([1, 2, 3]);
+
+readOnlySpan.Should().Equal([1, 2, 3]);
+readOnlySpan.Should().BeEqualTo([1, 2, 3]);
+
+memory.Should().Contain(2).And.HaveCount(3);
+readOnlyMemory.Should().Contain(2).And.HaveCount(3);
+```
+
+For character spans, you can assert exact string equality with `Be`.
+
+```csharp
+Span<char> chars = ['a', 'b', 'c'];
+ReadOnlySpan<char> readOnlyChars = ['a', 'b', 'c'];
+
+chars.Should().Be("abc");
+readOnlyChars.Should().Be("abc");
+```
+
 Asserting that a collection contains items in a certain order is as easy as using one of the several overloads of `BeInAscendingOrder` or `BeInDescendingOrder`. The default overload will use the default `Comparer` for the specified type, but overloads also exist that take an `IComparer<T>`, a property expression to sort by an object's property, or a lambda expression to avoid the need for `IComparer<T>` implementations.
 
 ```csharp
@@ -108,7 +137,7 @@ collection.Should().BeInDescendingOrder(item => item.SomeProp, StringComparer.Cu
 collection.Should().NotBeInAscendingOrder(item => item.SomeProp, StringComparer.CurrentCulture);
 collection.Should().NotBeInDescendingOrder(item => item.SomeProp, StringComparer.CurrentCulture);
 ```
- 
+
 For `String` collections there are specific methods to assert the items. For the `ContainMatch` and `NotContainMatch` methods we support wildcards.
 
 The pattern can be a combination of literal and wildcard characters, but it doesn't support regular expressions.

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,7 @@ sidebar:
 
 ### What's new
 
+* Added extensive support for `Span<T>` / `ReadOnlySpan<T>` and `Be(string)` for `Span<char>` / `ReadOnlySpan<char>` - [#3172](https://github.com/fluentassertions/fluentassertions/pull/3172)
 * Added `Excluding<T>()` and `Excluding(Type)` overloads to exclude all members of a certain type from equivalency comparisons - [#3115](https://github.com/fluentassertions/fluentassertions/pull/3115)
 * `BeEquivalentTo` will now report the missing or extraneous items for differently sized collections - [#3133](https://github.com/fluentassertions/fluentassertions/pull/3133)
 


### PR DESCRIPTION
This pull request adds comprehensive support for assertion extensions for `Span<T>`, `ReadOnlySpan<T>`, `Memory<T>`, and `ReadOnlyMemory<T>` types in FluentAssertions for .NET 6.0 and .NET Standard 2.1 or greater. It introduces new assertion classes and methods, updates the public API, and ensures proper annotation and validation in tests. These changes enhance the ability to write fluent assertions for modern .NET types, improving test readability and coverage.

### Assertion Extensions for Span and Memory Types

* Added new `Should` extension methods for `Span<T>`, `ReadOnlySpan<T>`, `Memory<T>`, and `ReadOnlyMemory<T>`, returning appropriate assertion types (`SpanAssertions<T>`, `GenericCollectionAssertions<T>`, `StringCollectionAssertions`). These methods are conditionally compiled for .NET 6.0 and .NET Standard 2.1 or greater. (`Src/FluentAssertions/AssertionExtensions.cs`)
* Introduced the `SpanAssertions<T>` class, enabling assertions on `Span<T>` and `ReadOnlySpan<T>`, including a `BeEqualTo` method for equality checks. (`Src/FluentAssertions/Collections/SpanAssertions.cs`)
* Added string-specific assertion extension for `SpanAssertions<char>`, allowing direct string equality assertions. (`Src/FluentAssertions/Collections/SpanAssertionsExtensions.cs`)

Closes #902 