### PR TITLE
Fail with a descriptive error when path-based rules are used on value-semantic types

### DIFF
--- a/Src/FluentAssertions/Common/MemberPath.cs
+++ b/Src/FluentAssertions/Common/MemberPath.cs
@@ -70,7 +70,11 @@ internal class MemberPath
         return false;
     }
 
-    private bool IsParentOf(MemberPath candidate)
+    /// <summary>
+    /// Determines whether the current path is the prefix of <paramref name="candidate"/>
+    /// (i.e., the current path "owns" the candidate), treating numeric indices and wildcards as interchangeable.
+    /// </summary>
+    public bool IsParentOf(MemberPath candidate)
     {
         string[] candidateSegments = candidate.Segments;
 

--- a/Src/FluentAssertions/Equivalency/Selection/CollectionMemberSelectionRuleDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/CollectionMemberSelectionRuleDecorator.cs
@@ -2,21 +2,20 @@ using System.Collections.Generic;
 
 namespace FluentAssertions.Equivalency.Selection;
 
-internal class CollectionMemberSelectionRuleDecorator : IMemberSelectionRule
+internal class CollectionMemberSelectionRuleDecorator(IMemberSelectionRule selectionRule) : IPathBasedSelectionRule
 {
-    private readonly IMemberSelectionRule selectionRule;
-
-    public CollectionMemberSelectionRuleDecorator(IMemberSelectionRule selectionRule)
-    {
-        this.selectionRule = selectionRule;
-    }
-
     public bool IncludesMembers => selectionRule.IncludesMembers;
 
     public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
         MemberSelectionContext context)
     {
         return selectionRule.SelectMembers(currentNode, selectedMembers, context);
+    }
+
+    public bool SelectsMembersOf(INode currentNode)
+    {
+        return selectionRule is IPathBasedSelectionRule pathBasedRule &&
+            pathBasedRule.SelectsMembersOf(currentNode);
     }
 
     public override string ToString()

--- a/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByPathSelectionRule.cs
@@ -6,14 +6,9 @@ namespace FluentAssertions.Equivalency.Selection;
 /// <summary>
 /// Selection rule that removes a particular property from the structural comparison.
 /// </summary>
-internal class ExcludeMemberByPathSelectionRule : SelectMemberByPathSelectionRule
+internal class ExcludeMemberByPathSelectionRule(MemberPath pathToExclude) : SelectMemberByPathSelectionRule
 {
-    private MemberPath memberToExclude;
-
-    public ExcludeMemberByPathSelectionRule(MemberPath pathToExclude)
-    {
-        memberToExclude = pathToExclude;
-    }
+    private MemberPath memberToExclude = pathToExclude;
 
     protected override void AddOrRemoveMembersFrom(List<IMember> selectedMembers, INode parent, string parentPath,
         MemberSelectionContext context)
@@ -26,6 +21,8 @@ internal class ExcludeMemberByPathSelectionRule : SelectMemberByPathSelectionRul
     {
         memberToExclude = memberToExclude.AsParentCollectionOf(nextPath);
     }
+
+    protected override MemberPath MemberPath => memberToExclude;
 
     public MemberPath CurrentPath => memberToExclude;
 

--- a/Src/FluentAssertions/Equivalency/Selection/IPathBasedSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IPathBasedSelectionRule.cs
@@ -1,0 +1,16 @@
+namespace FluentAssertions.Equivalency.Selection;
+
+/// <summary>
+/// Represents a selection rule whose effect is determined by a configured member path.
+/// This allows callers to ask whether the rule targets any members within the subtree rooted at
+/// a given <see cref="INode"/>, even when the rule is wrapped by decorators such as the
+/// collection-member options decorator.
+/// </summary>
+internal interface IPathBasedSelectionRule : IMemberSelectionRule
+{
+    /// <summary>
+    /// Returns <c>true</c> when this rule targets at least one member of <paramref name="currentNode"/>
+    /// or one of its descendants.
+    /// </summary>
+    bool SelectsMembersOf(INode currentNode);
+}

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
@@ -8,16 +8,11 @@ namespace FluentAssertions.Equivalency.Selection;
 /// <summary>
 /// Selection rule that includes a particular property in the structural comparison.
 /// </summary>
-internal class IncludeMemberByPathSelectionRule : SelectMemberByPathSelectionRule
+internal class IncludeMemberByPathSelectionRule(MemberPath pathToInclude) : SelectMemberByPathSelectionRule
 {
-    private readonly MemberPath memberToInclude;
-
-    public IncludeMemberByPathSelectionRule(MemberPath pathToInclude)
-    {
-        memberToInclude = pathToInclude;
-    }
-
     public override bool IncludesMembers => true;
+
+    protected override MemberPath MemberPath => pathToInclude;
 
     protected override void AddOrRemoveMembersFrom(List<IMember> selectedMembers, INode parent, string parentPath,
         MemberSelectionContext context)
@@ -26,7 +21,7 @@ internal class IncludeMemberByPathSelectionRule : SelectMemberByPathSelectionRul
         {
             var memberPath = new MemberPath(context.Type, memberInfo.DeclaringType, parentPath.Combine(memberInfo.Name));
 
-            if (memberToInclude.IsSameAs(memberPath) || memberToInclude.IsParentOrChildOf(memberPath))
+            if (pathToInclude.IsSameAs(memberPath) || pathToInclude.IsParentOrChildOf(memberPath))
             {
                 selectedMembers.Add(MemberFactory.Create(memberInfo, parent));
             }
@@ -35,6 +30,6 @@ internal class IncludeMemberByPathSelectionRule : SelectMemberByPathSelectionRul
 
     public override string ToString()
     {
-        return "Include member root." + memberToInclude;
+        return "Include member root." + pathToInclude;
     }
 }

--- a/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
@@ -1,36 +1,82 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency.Selection;
 
-internal abstract class SelectMemberByPathSelectionRule : IMemberSelectionRule
+internal abstract class SelectMemberByPathSelectionRule : IPathBasedSelectionRule
 {
+    private static readonly Regex LeadingCollectionIndexRegex = new(@"^\[[0-9]+]\.?");
+
     public virtual bool IncludesMembers => false;
+
+    protected abstract MemberPath MemberPath { get; }
 
     public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
         MemberSelectionContext context)
     {
-        var currentPath = RemoveRootIndexQualifier(currentNode.Expectation.PathAndName);
         var members = selectedMembers.ToList();
-        AddOrRemoveMembersFrom(members, currentNode, currentPath, context);
+        AddOrRemoveMembersFrom(members, currentNode, GetPathRelativeToSelectionRoot(currentNode), context);
 
         return members;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if this rule would select members within the subtree rooted at
+    /// <paramref name="currentNode"/>, meaning the rule path targets any member at or below the current node.
+    /// </summary>
+    public bool SelectsMembersOf(INode currentNode)
+    {
+        if (currentNode.IsRoot)
+        {
+            return !MemberPath.ToString().IsNullOrEmpty();
+        }
+
+        string currentPath = GetPathRelativeToSelectionRoot(currentNode);
+
+        if (string.IsNullOrEmpty(currentPath))
+        {
+            return !MemberPath.ToString().IsNullOrEmpty();
+        }
+
+        // Compare normalized path segments rather than raw strings so collection rules like "Items[].Name"
+        // still match the concrete node path "Items[0].Name", and so paths built through
+        // MemberPath.AsParentCollectionOf are interpreted consistently.
+        return new MemberPath(currentPath).IsParentOf(MemberPath);
     }
 
     protected abstract void AddOrRemoveMembersFrom(List<IMember> selectedMembers,
         INode parent, string parentPath,
         MemberSelectionContext context);
 
-    private static string RemoveRootIndexQualifier(string path)
+    /// <summary>
+    /// Returns the path used for member-selection matching at <paramref name="currentNode"/>.
+    /// For items inside a root collection, Fluent Assertions exposes paths such as <c>[0].Name</c>, but
+    /// selection rules are expressed relative to the collection item type (for example <c>Name</c>).
+    /// This method removes that root-item index so both sides use the same coordinate system.
+    /// </summary>
+    private static string GetPathRelativeToSelectionRoot(INode currentNode)
     {
-        Match match = new Regex(@"^\[[0-9]+]").Match(path);
-
-        if (match.Success)
+        if (currentNode.IsRoot)
         {
-            path = path.Substring(match.Length);
+            return string.Empty;
         }
 
-        return path;
+        string expectationPath = currentNode.Expectation.PathAndName;
+        return RemoveLeadingCollectionIndex(expectationPath);
+    }
+
+    /// <summary>
+    /// Removes only the leading root-collection index from <paramref name="path"/>, such as turning
+    /// <c>[0]</c> into an empty path and <c>[0].Name</c> into <c>Name</c>.
+    /// Nested collection indices are intentionally left in place; they are handled later by
+    /// <see cref="MemberPath"/> comparison, which treats <c>[]</c> and concrete indices as equivalent.
+    /// </summary>
+    private static string RemoveLeadingCollectionIndex(string path)
+    {
+        Match match = LeadingCollectionIndexRegex.Match(path);
+        return match.Success ? path.Substring(match.Length) : path;
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions.Equivalency.Selection;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
@@ -12,32 +15,164 @@ public class ValueTypeEquivalencyStep : IEquivalencyStep
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {
-        Type expectationType = comparands.GetExpectedType(context.Options);
-        EqualityStrategy strategy = context.Options.GetEqualityStrategy(expectationType);
+        var options = context.Options;
+        Type expectationType = comparands.GetExpectedType(options);
+        EqualityStrategy strategy = options.GetEqualityStrategy(expectationType);
 
-        bool canHandle = strategy is EqualityStrategy.Equals or EqualityStrategy.ForceEquals;
-
-        if (canHandle)
+        if (strategy is not (EqualityStrategy.Equals or EqualityStrategy.ForceEquals))
         {
-            context.Tracer.WriteLine(member =>
-            {
-                string strategyName = strategy == EqualityStrategy.Equals
-                    ? $"{expectationType} overrides Equals"
-                    : "we are forced to use Equals";
+            return EquivalencyResult.ContinueWithNext;
+        }
 
-                return $"Treating {member.Expectation.Description} as a value type because {strategyName}.";
-            });
-
-            AssertionChain.GetOrCreate()
-                .For(context)
-                .ReuseOnce();
-
-            comparands.Subject.Should().Be(comparands.Expectation, context.Reason.FormattedMessage, context.Reason.Arguments);
-
+        if (ReportConflictIfAny(context, comparands, options, expectationType, strategy))
+        {
             return EquivalencyResult.EquivalencyProven;
         }
 
-        return EquivalencyResult.ContinueWithNext;
+        ApplyValueSemantics(comparands, context, expectationType, strategy);
+        return EquivalencyResult.EquivalencyProven;
+    }
+
+    /// <summary>
+    /// Checks for any selection rule that targets members of the current node, which would be silently
+    /// ignored under value-semantic comparison. Reports the conflict and returns <c>true</c> if one is found.
+    /// </summary>
+    private static bool ReportConflictIfAny(
+        IEquivalencyValidationContext context,
+        Comparands comparands,
+        IEquivalencyOptions options,
+        Type expectationType,
+        EqualityStrategy strategy)
+    {
+        // Path-based rules can be checked cheaply by comparing path strings (also handles deep paths like o.Child.Text).
+        IMemberSelectionRule conflictingRule = options.SelectionRules
+            .OfType<IPathBasedSelectionRule>()
+            .FirstOrDefault(rule => rule.SelectsMembersOf(context.CurrentNode));
+
+        // Non-path rules (based on predicates) require evaluating them against the actual member list
+        conflictingRule ??= FindConflictingNonPathRule(context.CurrentNode, comparands, options);
+
+        if (conflictingRule is not null)
+        {
+            ReportConflict(context, expectationType, conflictingRule, strategy);
+        }
+
+        return conflictingRule is not null;
+    }
+
+    /// <summary>
+    /// Finds the first non-path selection rule that would modify the member list of <paramref name="currentNode"/>,
+    /// indicating it would be silently ignored due to value-semantic comparison.
+    /// </summary>
+    private static IMemberSelectionRule FindConflictingNonPathRule(
+        INode currentNode, Comparands comparands, IEquivalencyOptions options)
+    {
+        var selectionContext = new MemberSelectionContext(comparands.CompileTimeType, comparands.RuntimeType, options);
+        IList<IMember> allMembers = GetAllMembers(currentNode, selectionContext);
+
+        // If the type has no accessible members, no selection rule can meaningfully conflict.
+        if (allMembers.Count == 0)
+        {
+            return null;
+        }
+
+        return options.SelectionRules
+            .Where(rule => !IsInfrastructureRule(rule) && rule is not IPathBasedSelectionRule)
+            .FirstOrDefault(rule => RuleAffectsMembers(rule, allMembers, GetFilteredMembers(rule, currentNode, allMembers, selectionContext)));
+    }
+
+    /// <summary>
+    /// Applies <paramref name="rule"/> in isolation to determine whether it modifies the member list.
+    /// Inclusion rules are run from an empty starting set; exclusion rules are run on the full member list.
+    /// </summary>
+    private static IList<IMember> GetFilteredMembers(
+        IMemberSelectionRule rule, INode currentNode, IList<IMember> allMembers, MemberSelectionContext context)
+    {
+        IEnumerable<IMember> seed = rule.IncludesMembers ? [] : allMembers;
+        return rule.SelectMembers(currentNode, seed, context).ToList();
+    }
+
+    /// <summary>Gets all properties and fields of the current node's type, respecting the configured visibility.</summary>
+    private static IList<IMember> GetAllMembers(INode currentNode, MemberSelectionContext context)
+    {
+        IEnumerable<IMember> members = new AllPropertiesSelectionRule().SelectMembers(currentNode, [], context);
+        return new AllFieldsSelectionRule().SelectMembers(currentNode, members, context).ToList();
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if <paramref name="rule"/> actually affects the member set of the current value type.
+    /// For inclusion rules, a conflict exists only when the rule selects at least one member of this type,
+    /// meaning the user intended to compare this value type member-by-member.
+    /// For exclusion rules, a conflict exists when the rule removes at least one member from the full set.
+    /// </summary>
+    private static bool RuleAffectsMembers(IMemberSelectionRule rule, IList<IMember> allMembers, IList<IMember> filteredMembers) =>
+        rule.IncludesMembers
+            ? filteredMembers.Count > 0
+            : MemberSetChanged(allMembers, filteredMembers);
+
+    /// <summary>Returns <c>true</c> if <paramref name="after"/> represents a different set of members than <paramref name="before"/>.</summary>
+    private static bool MemberSetChanged(IList<IMember> before, IList<IMember> after) =>
+        before.Count != after.Count || before.Except(after).Any();
+
+    /// <summary>Returns <c>true</c> for rules that are part of the default selection pipeline, not user-configured.</summary>
+    private static bool IsInfrastructureRule(IMemberSelectionRule rule) =>
+        rule is AllPropertiesSelectionRule or AllFieldsSelectionRule or ExcludeNonBrowsableMembersRule;
+
+    /// <summary>Reports an assertion failure for a selection rule that conflicts with value semantics.</summary>
+    private static void ReportConflict(
+        IEquivalencyValidationContext context,
+        Type expectationType,
+        IMemberSelectionRule conflictingRule,
+        EqualityStrategy strategy)
+    {
+        Reason reason = context.Reason;
+        bool isGeneric = expectationType.IsGenericType;
+
+        string cause = strategy == EqualityStrategy.ForceEquals
+            ? $"{expectationType} is compared by value (because ComparingByValue was configured), "
+            : $"{expectationType} is compared by value (because it overrides Equals), ";
+
+        string suggestion = strategy == EqualityStrategy.ForceEquals
+            ? "Either remove the ComparingByValue configuration, "
+            : isGeneric
+                ? "Either call the ComparingByMembers(Type) overload to force member-wise comparison, "
+                : $"Either call ComparingByMembers<{expectationType.Name}>() to force member-wise comparison, ";
+
+        string message =
+            cause +
+            $"so the {conflictingRule} selection rule does not apply. " +
+            suggestion +
+            "or remove the selection rule." +
+            reason.FormattedMessage;
+
+        AssertionChain.GetOrCreate().For(context).FailWith(message, reason.Arguments);
+    }
+
+    /// <summary>
+    /// Traces the value-semantic comparison strategy and performs the equality assertion.
+    /// </summary>
+    private static void ApplyValueSemantics(
+        Comparands comparands,
+        IEquivalencyValidationContext context,
+        Type expectationType,
+        EqualityStrategy strategy)
+    {
+        context.Tracer.WriteLine(member =>
+        {
+            string strategyName = strategy == EqualityStrategy.Equals
+                ? $"{expectationType} overrides Equals"
+                : "we are forced to use Equals";
+
+            return $"Treating {member.Expectation.Description} as a value type because {strategyName}.";
+        });
+
+        var reason = context.Reason;
+
+        AssertionChain.GetOrCreate()
+            .For(context)
+            .ReuseOnce();
+
+        comparands.Subject.Should().Be(comparands.Expectation, reason.FormattedMessage, reason.Arguments);
     }
 }
 

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Excluding.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Excluding.cs
@@ -1259,5 +1259,213 @@ public partial class SelectionRulesSpecs
             act.Should().Throw<ArgumentException>()
                 .WithMessage("*Member names cannot be null*");
         }
+
+        [Fact]
+        public void Excluding_a_member_by_path_on_a_type_with_value_semantics_fails_with_a_descriptive_error()
+        {
+            // Arrange
+            var actual = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "x" };
+            var expected = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "y" };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected,
+                opt => opt.Excluding(o => o.NestedProperty));
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "*ClassWithValueSemanticsOnSingleProperty*compared by value*overrides Equals*" +
+                    "*ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>*");
+        }
+
+        [Fact]
+        public void Excluding_a_member_by_path_when_forcing_value_semantics_explicitly_fails_with_a_descriptive_error()
+        {
+            // Arrange
+            var actual = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "x" };
+            var expected = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "y" };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected,
+                opt => opt.Excluding(o => o.NestedProperty).ComparingByValue<ClassWithValueSemanticsOnSingleProperty>());
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "*ClassWithValueSemanticsOnSingleProperty*compared by value*ComparingByValue was configured*" +
+                    "*remove the ComparingByValue configuration*");
+        }
+
+        [Fact]
+        public void Including_a_member_by_path_when_forcing_value_semantics_explicitly_fails_with_a_descriptive_error()
+        {
+            // Arrange
+            var actual = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "x" };
+            var expected = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "y" };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected,
+                opt => opt.Including(o => o.Key).ComparingByValue<ClassWithValueSemanticsOnSingleProperty>());
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "*ClassWithValueSemanticsOnSingleProperty*compared by value*ComparingByValue was configured*" +
+                    "*remove the ComparingByValue configuration*");
+        }
+
+        [Fact]
+        public void Excluding_a_member_by_predicate_when_forcing_value_semantics_explicitly_fails_with_a_descriptive_error()
+        {
+            // Arrange
+            var actual = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "x" };
+            var expected = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "y" };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected,
+                opt => opt
+                    .Excluding(m => m.Name == nameof(ClassWithValueSemanticsOnSingleProperty.NestedProperty))
+                    .ComparingByValue<ClassWithValueSemanticsOnSingleProperty>());
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "*ClassWithValueSemanticsOnSingleProperty*compared by value*ComparingByValue was configured*" +
+                    "*remove the ComparingByValue configuration*");
+        }
+
+        [Fact]
+        public void Excluding_a_member_by_path_and_then_forcing_member_comparison_does_not_fail()
+        {
+            // Arrange
+            var actual = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "x" };
+            var expected = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "y" };
+
+            // Act / Assert
+            actual.Should().BeEquivalentTo(expected, opt => opt
+                .ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>()
+                .Excluding(o => o.NestedProperty));
+        }
+
+        [Fact]
+        public void Excluding_a_nested_member_by_path_on_a_type_with_value_semantics_fails_with_a_descriptive_error()
+        {
+            // Arrange
+            var actual = new ClassWithValueSemanticsAndNestedObject { Key = "same", Child = new NestedObjectWithProperty { Text = "x" } };
+            var expected = new ClassWithValueSemanticsAndNestedObject { Key = "same", Child = new NestedObjectWithProperty { Text = "y" } };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected,
+                opt => opt.Excluding(o => o.Child.Text));
+
+            // Assert - multi-segment path at root should also be detected as conflicting
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "*ClassWithValueSemanticsAndNestedObject*compared by value*overrides Equals*" +
+                    "*ComparingByMembers<ClassWithValueSemanticsAndNestedObject>*");
+        }
+
+        [Fact]
+        public void Excluding_a_member_by_predicate_on_a_type_with_value_semantics_fails_with_a_descriptive_error()
+        {
+            // Arrange
+            var actual = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "x" };
+            var expected = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "y" };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected,
+                opt => opt.Excluding(m => m.Name == nameof(ClassWithValueSemanticsOnSingleProperty.NestedProperty)));
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "*ClassWithValueSemanticsOnSingleProperty*compared by value*overrides Equals*" +
+                    "*ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>*");
+        }
+
+        [Fact]
+        public void Including_members_by_predicate_on_a_type_with_value_semantics_fails_with_a_descriptive_error()
+        {
+            // Arrange
+            var actual = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "x" };
+            var expected = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "y" };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected,
+                opt => opt.Including(m => m.Name == nameof(ClassWithValueSemanticsOnSingleProperty.Key)));
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "*ClassWithValueSemanticsOnSingleProperty*compared by value*overrides Equals*" +
+                    "*ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>*");
+        }
+
+        [Fact]
+        public void Excluding_a_member_of_a_collection_element_with_value_semantics_via_For_and_Exclude_fails_with_a_descriptive_error()
+        {
+            // Arrange
+            var actual = new ClassWithCollectionOfValueSemantics
+            {
+                Items = [new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "x" }]
+            };
+
+            var expected = new ClassWithCollectionOfValueSemantics
+            {
+                Items = [new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "y" }]
+            };
+
+            // Act
+            // .For(o => o.Items).Exclude(c => c.NestedProperty) creates path "Items[].NestedProperty" (wildcard),
+            // which should be detected as conflicting when processing the value-semantic item at Items[0].
+            Action act = () => actual.Should().BeEquivalentTo(expected,
+                opt => opt.For(o => o.Items).Exclude(c => c.NestedProperty));
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "*ClassWithValueSemanticsOnSingleProperty*compared by value*overrides Equals*");
+        }
     }
+}
+
+public class ClassWithCollectionOfValueSemantics
+{
+    public List<ClassWithValueSemanticsOnSingleProperty> Items { get; set; }
+}
+
+public class ClassWithValueSemanticsAndNestedObject
+{
+    public string Key { get; set; }
+
+    public NestedObjectWithProperty Child { get; set; }
+
+    protected bool Equals(ClassWithValueSemanticsAndNestedObject other) => Key == other.Key;
+
+    public override bool Equals(object obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return Equals((ClassWithValueSemanticsAndNestedObject)obj);
+    }
+
+    public override int GetHashCode() => Key?.GetHashCode() ?? 0;
+}
+
+public class NestedObjectWithProperty
+{
+    public string Text { get; set; }
 }

--- a/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Including.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/SelectionRulesSpecs.Including.cs
@@ -506,5 +506,23 @@ public partial class SelectionRulesSpecs
                 .Match("*Expected*subject.NestedField.FieldB*").And
                 .NotMatch("*Expected*FieldC*FieldD*FieldE*");
         }
+
+        [Fact]
+        public void Including_a_member_by_path_on_a_type_with_value_semantics_fails_with_a_descriptive_error()
+        {
+            // Arrange
+            var actual = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "x" };
+            var expected = new ClassWithValueSemanticsOnSingleProperty { Key = "same", NestedProperty = "y" };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected,
+                opt => opt.Including(o => o.Key));
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "*ClassWithValueSemanticsOnSingleProperty*compared by value*overrides Equals*" +
+                    "*ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>*");
+        }
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -22,6 +22,7 @@ sidebar:
 ### Fixes
 
 * Fixed a formatting exception when comparing strings containing braces - [#3151](https://github.com/fluentassertions/fluentassertions/pull/3151)
+* Path-based `Excluding()` and `Including()` rules on types that use value semantics (i.e. override `Equals`) now fail with a descriptive error instead of being silently ignored - [#3187](https://github.com/fluentassertions/fluentassertions/pull/3187)
 
 ## 8.8.0
 


### PR DESCRIPTION
## Summary

Closes #2571

When `Excluding()` or `Including()` targets a member of a type that is compared by value, the rule is silently ignored because `BeEquivalentTo()` never traverses that type’s members. This is surprising and hard to debug.

This PR detects that conflict at comparison time and fails with a descriptive assertion error.

## Changes

This PR now reports a descriptive failure when a selection rule targets a type that is being compared by value, including both:

- **Auto-detected value semantics** (`EqualityStrategy.Equals`) when the type overrides `Equals()`
- **Explicit value semantics** (`EqualityStrategy.ForceEquals`) when the user calls `ComparingByValue()`

Example message for auto-detected value semantics:

> `CustomerDto` is compared by value (because it overrides Equals), so the `Excluding member o.Etag` selection rule does not apply. Either call `ComparingByMembers<CustomerDto>()` to force member-wise comparison, or remove the selection rule.

Example message for explicit `ComparingByValue()`:

> `CustomerDto` is compared by value (because ComparingByValue was configured), so the `Excluding member o.Etag` selection rule does not apply. Either remove the ComparingByValue configuration, or remove the selection rule.

All user-specified selection rule types are detected:

| Rule type | Example | Detection method |
|---|---|---|
| Path-based exclusion | `Excluding(o => o.Prop)` | Path matching against the current node |
| Path-based inclusion | `Including(o => o.Prop)` | Path matching against the current node |
| Predicate exclusion | `Excluding(m => m.Name == "Etag")` | Evaluated against the actual member list |
| Predicate inclusion | `Including(m => m.Name == "Id")` | Evaluated from empty set vs. full member list |
| Type exclusion | `Excluding<TMemberType>()` | Evaluated against the actual member list |

### Design decisions

- **Only selection rules are reported as conflicts**; normal value-based equivalency behavior is unchanged otherwise.
- **Supports both implicit and explicit value semantics** (`Equals` and `ComparingByValue()`).
- **Works at any depth** — if a nested type uses value semantics and a selection rule targets one of its members, the conflict is caught when that node is visited.
- **Collection paths are handled correctly** — rules such as `.For(x => x.Items).Exclude(i => i.Name)` are matched against concrete item paths like `Items[0].Name`.
- **Infrastructure rules** (`AllPropertiesSelectionRule`, `AllFieldsSelectionRule`, `ExcludeNonBrowsableMembersRule`) are skipped since they are not user-specified selections.
- Path-based conflict detection now uses a dedicated **path-aware selection rule abstraction** so wrapped collection rules can participate without special-case unwrapping.

## Tests

Added coverage for:

- Excluding a member by path on a value-semantic type
- Including a member by path on a value-semantic type
- Excluding a nested member by path
- Excluding a member by predicate
- Including members by predicate
- Excluding members of a collection element via `.For(...).Exclude(...)`
- Explicit `ComparingByValue()` with path-based exclusion
- Explicit `ComparingByValue()` with path-based inclusion
- Explicit `ComparingByValue()` with predicate-based exclusion
- Explicit `ComparingByMembers()` continuing to work normally