### PR TITLE
Reduce allocations in BeEquivalentTo hot path

### DIFF
--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -21,7 +21,6 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
     {
         Options = options;
         CurrentNode = root;
-        CyclicReferenceDetector = new CyclicReferenceDetector();
     }
 
     public INode CurrentNode { get; }
@@ -32,7 +31,11 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
 
     public IEquivalencyOptions Options { get; }
 
-    internal CyclicReferenceDetector CyclicReferenceDetector { get; set; }
+    internal CyclicReferenceDetector CyclicReferenceDetector
+    {
+        get => field ??= new CyclicReferenceDetector();
+        set;
+    }
 
     public IEquivalencyValidationContext AsNestedMember(IMember expectationMember)
     {
@@ -76,9 +79,17 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
 
     public bool IsCyclicReference(object expectation)
     {
-        EqualityStrategy strategy = expectation is not null
-            ? Options.GetEqualityStrategy(expectation.GetType())
-            : EqualityStrategy.Equals;
+        if (expectation is null)
+        {
+            return false;
+        }
+
+        EqualityStrategy strategy = Options.GetEqualityStrategy(expectation.GetType());
+
+        if (strategy is not (EqualityStrategy.Members or EqualityStrategy.ForceMembers))
+        {
+            return false;
+        }
 
         var reference = new ObjectReference(expectation, CurrentNode.Subject.PathAndName, strategy);
 

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -84,7 +84,15 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
             return false;
         }
 
-        EqualityStrategy strategy = Options.GetEqualityStrategy(expectation.GetType());
+        var type = expectation.GetType();
+
+        // Value types cannot form reference cycles, so skip the strategy lookup entirely.
+        if (type.IsValueType)
+        {
+            return false;
+        }
+
+        EqualityStrategy strategy = Options.GetEqualityStrategy(type);
 
         if (strategy is not (EqualityStrategy.Members or EqualityStrategy.ForceMembers))
         {

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -34,8 +34,7 @@ internal class EquivalencyValidator : IValidateChildNodeEquivalency
     public void AssertEquivalencyOf(Comparands comparands, IEquivalencyValidationContext context)
     {
         var assertionChain = AssertionChain.GetOrCreate()
-            .For(context)
-            .BecauseOf(context.Reason);
+            .For(context);
 
         if (ShouldContinueThisDeep(context.CurrentNode, context.Options, assertionChain))
         {

--- a/Src/FluentAssertions/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Equivalency/Node.cs
@@ -13,6 +13,7 @@ internal class Node : INode
     private static readonly Regex MatchFirstIndex = new(@"^\[[0-9]+\]$");
 
     private string cachedSubjectId;
+    private int cachedDepth = -1;
 
     public GetSubjectId GetSubjectId
     {
@@ -53,14 +54,20 @@ internal class Node : INode
     public void AdjustForRemappedSubject(IMember subjectMember)
     {
         Subject = subjectMember.Subject;
+        cachedDepth = -1;
     }
 
     public int Depth
     {
         get
         {
-            const char memberSeparator = '.';
-            return Subject.PathAndName.Count(chr => chr == memberSeparator);
+            if (cachedDepth == -1)
+            {
+                const char memberSeparator = '.';
+                cachedDepth = Subject.PathAndName.Count(chr => chr == memberSeparator);
+            }
+
+            return cachedDepth;
         }
     }
 

--- a/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
@@ -101,16 +101,13 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
 
     private static Type[] GetIEnumerableInterfaces(Type type)
     {
-        return IEnumerableInterfacesCache.GetOrAdd(type, static t =>
+        // Avoid expensive calculation when the type in question can't possibly implement IEnumerable<>.
+        if (Type.GetTypeCode(type) != TypeCode.Object)
         {
-            // Avoid expensive calculation when the type in question can't possibly implement IEnumerable<>.
-            if (Type.GetTypeCode(t) != TypeCode.Object)
-            {
-                return [];
-            }
+            return [];
+        }
 
-            return t.GetClosedGenericInterfaces(typeof(IEnumerable<>));
-        });
+        return IEnumerableInterfacesCache.GetOrAdd(type, static t => t.GetClosedGenericInterfaces(typeof(IEnumerable<>)));
     }
 
     private static Type GetTypeOfEnumeration(Type enumerableType)

--- a/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -16,6 +17,10 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
     private static readonly MethodInfo HandleMethod = new Action<EnumerableEquivalencyValidator, object[], IEnumerable<object>>
         (HandleImpl).GetMethodInfo().GetGenericMethodDefinition();
 #pragma warning restore SA1110
+
+    private static readonly ConcurrentDictionary<Type, MethodInfo> HandleMethodCache = new();
+
+    private static readonly ConcurrentDictionary<Type, Type[]> IEnumerableInterfacesCache = new();
 
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
@@ -51,7 +56,7 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
 
             try
             {
-                HandleMethod.MakeGenericMethod(typeOfEnumeration)
+                HandleMethodCache.GetOrAdd(typeOfEnumeration, t => HandleMethod.MakeGenericMethod(t))
                     .Invoke(null, [validator, subjectAsArray, comparands.Expectation]);
             }
             catch (TargetInvocationException e)
@@ -96,15 +101,16 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
 
     private static Type[] GetIEnumerableInterfaces(Type type)
     {
-        // Avoid expensive calculation when the type in question can't possibly implement IEnumerable<>.
-        if (Type.GetTypeCode(type) != TypeCode.Object)
+        return IEnumerableInterfacesCache.GetOrAdd(type, static t =>
         {
-            return [];
-        }
+            // Avoid expensive calculation when the type in question can't possibly implement IEnumerable<>.
+            if (Type.GetTypeCode(t) != TypeCode.Object)
+            {
+                return [];
+            }
 
-        Type soughtType = typeof(IEnumerable<>);
-
-        return type.GetClosedGenericInterfaces(soughtType);
+            return t.GetClosedGenericInterfaces(typeof(IEnumerable<>));
+        });
     }
 
     private static Type GetTypeOfEnumeration(Type enumerableType)


### PR DESCRIPTION
## Summary

Reduces memory allocations and improves throughput in the \BeEquivalentTo\ equivalency pipeline, focusing on the hot paths exercised during recursive structural comparison of large collections.

### Benchmark Results (net8.0)

| N   | Depth | Before       | After        | Δ Time  | Before Alloc | After Alloc  | Δ Alloc |
|-----|-------|-------------|-------------|---------|-------------|-------------|---------|
| 1   | 1     | 14.49 µs    | 13.75 µs    | -5.1%   | 43.56 KB    | 41.89 KB    | -3.8%   |
| 1   | 6     | 35.54 µs    | 33.97 µs    | -4.4%   | 111.83 KB   | 107.70 KB   | -3.7%   |
| 10  | 6     | 311.17 µs   | 305.63 µs   | -1.8%   | 1,001.44 KB | 964.25 KB   | -3.7%   |
| 100 | 6     | 3,099.97 µs | 3,048.33 µs | -1.6%   | 9,906.72 KB | 9,538.95 KB | -3.7%   |
| 500 | 6     | 15,766.61 µs| 15,207.30 µs| -3.5%   | 49,477.70 KB| 47,640.67 KB| -3.7%   |

Benchmark: \BeEquivalentToWithDeeplyNestedStructures\ — a \List<ComplexType>\ where \ComplexType\ has an \int\ property and a recursive self-referencing \ComplexType\ property, chained to depth \D\. All subjects equal their expectations (pure success path).

### Changes

**1. Remove redundant \BecauseOf\ call**  
\AssertEquivalencyOf\ was calling \.For(context).BecauseOf(context.Reason)\, but \For(context)\ already calls \BecauseOf\ internally. The duplicate call allocates a lambda closure that is immediately overwritten.

**2. Lazy \CyclicReferenceDetector\ init + short-circuit for non-reference types**  
\EquivalencyValidationContext\'s constructor always created a \CyclicReferenceDetector\ (backed by a \HashSet\), but all child-context creation paths (\AsNestedMember\, \AsCollectionItem\, \AsDictionaryItem\) immediately overwrite it with the parent's detector. Changed to lazy-init so the \HashSet\ is only created once for the root context.

Additionally, \IsCyclicReference\ now returns \alse\ early for \
ull\ and for types with an \Equals\/\ForceEquals\ strategy (value types and types overriding \Equals\), skipping the \ObjectReference\ allocation and \HashSet\ lookup entirely for those types.

**3. Cache \MakeGenericMethod\ and \GetIEnumerableInterfaces\ per type**  
\GenericEnumerableEquivalencyStep\ now caches the reflected \MethodInfo\ from \MakeGenericMethod\ in a \ConcurrentDictionary<Type, MethodInfo>\. The \GetIEnumerableInterfaces\ helper result is also cached per type — for non-collection types visited during recursive descent, this avoids repeating an interface scan for every node at every depth on every item.

**4. Cache \Node.Depth\**  
\Node.Depth\ previously counted \.\ separators in \Subject.PathAndName\ via a LINQ \Count\ on every call. Since \ShouldContinueThisDeep\ calls \Depth\ for every \AssertEquivalencyOf\ invocation, this ran thousands of times. The result is now memoised and invalidated only when \AdjustForRemappedSubject\ changes the path.