### PR TITLE
docs: disclose Xceed stewardship + list Xceed.Zip.FluentAssertions

### DIFF
--- a/docs/_pages/about.md
+++ b/docs/_pages/about.md
@@ -120,6 +120,8 @@ So although you are free to go through the many examples here, please consider t
 
 My name is [Dennis Doomen](https://twitter.com/ddoomen) and I work for [Aviva Solutions](https://www.avivasolutions.nl/) in The Netherlands. I maintain a [blog](https://www.continuousimprover.com/) on my everlasting quest for knowledge that significantly improves the way you build your key systems in an agile world. Fluent Assertions is one of those aspects of that. Since 2018, [Jonas Nyrup](https://github.com/jnyrup) has joined to project and help bring it forward.
 
+Fluent Assertions is now an official partner of [Xceed Software](https://xceed.com/), a long-standing vendor of .NET components. Xceed supports the project's ongoing development and offers [commercial licensing](https://xceed.com/products/unit-testing/fluent-assertions/) for teams that use Fluent Assertions in closed-source products, while the project remains free for open-source and non-commercial use.
+
 ## Versioning
 
 The version numbers of Fluent Assertions releases comply to the [Semantic Versioning](http://semver.org/) scheme. In other words, release 1.4.0 only adds backwards-compatible functionality and bug fixes compared to 1.3.0. Release 1.4.1 should only include bug fixes. And if we ever introduce breaking changes, the number increased to 2.0.0.

--- a/docs/index.html
+++ b/docs/index.html
@@ -86,9 +86,10 @@ feature_row3:
     [Web](https://github.com/adrianiftode/FluentAssertions.Web),
     [Ninject](https://github.com/kevinkuszyk/FluentAssertions.Ioc.Ninject),
     [Autofac](https://github.com/awesome-inc/FluentAssertions.Autofac),
-    [ASP.NET Core MVC](https://github.com/fluentassertions/fluentassertions.aspnetcore.mvc) and even Roslyn analyzers through
+    [ASP.NET Core MVC](https://github.com/fluentassertions/fluentassertions.aspnetcore.mvc),
+    [Zip archives via Xceed](https://www.nuget.org/packages/Xceed.Zip.FluentAssertions) and even Roslyn analyzers through
     [FluentAssertions.Analyzers](https://github.com/fluentassertions/fluentassertions.analyzers)
-    '  
+    '
 ---
 
 {% include feature_row id="intro" type="center" %}


### PR DESCRIPTION
## Summary

Two small, additive doc edits that bring the About page and Community Extensions list in line with the existing Xceed partnership already disclosed on the homepage banner and footer.

### 1. `docs/_pages/about.md` — stewardship disclosure

The About page currently reads as if Fluent Assertions is still solely an Aviva Solutions / Dennis Doomen project, even though the homepage says *\"Xceed is now the official partner of Fluent Assertions\"* and the footer links to xceed.com. This adds one paragraph after the existing \"Who is behind this project\" text noting the Xceed partnership — nothing is removed, Dennis's and Jonas's voice stays intact.

### 2. `docs/index.html` — Community Extensions entry

The Community Extensions section lists Json, DataSets, Web, Ninject, Autofac, ASP.NET Core MVC, and Analyzers — but not [Xceed.Zip.FluentAssertions](https://www.nuget.org/packages/Xceed.Zip.FluentAssertions), which is published on NuGet and depends on the main `FluentAssertions` package. Adds it to the list in alphabetical-ish order (grouped near the end with Analyzers).

## Noted but not fixed in this PR

The `@xceed` Twitter button on the homepage (`docs/index.html:20`) currently links to `https://twitter.com/datagrid`, which appears to be a mismatch between label and handle. Leaving this for a maintainer to confirm the correct account before I touch it.

## Test plan

- [ ] GitHub Pages builds green from `main` merge
- [ ] About page renders the new paragraph correctly
- [ ] Homepage Community Extensions list shows 8 items including Xceed