### PR TITLE
BeEmpty for IEnumerable<T> assertions now lists the first 10 items in…

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -285,17 +285,17 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// </param>
     public AndConstraint<TAssertions> BeEmpty([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        var singleItemArray = Subject?.Take(1).ToArray();
+        var tenItemArray = Subject?.Take(10).ToArray();
 
         assertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:collection} to be empty{reason}, ", chain => chain
-                .Given(() => singleItemArray)
+                .Given(() => tenItemArray)
                 .ForCondition(subject => subject is not null)
                 .FailWith("but found <null>.")
                 .Then
                 .ForCondition(subject => subject.Length == 0)
-                .FailWith("but found at least one item {0}.", singleItemArray));
+                .FailWith("but found at least {0}.", tenItemArray));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -42,6 +42,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     where TCollection : IEnumerable<T>
     where TAssertions : GenericCollectionAssertions<TCollection, T, TAssertions>
 {
+    private const int MaxItemsShownOnBeEmptyFailure = 10;
     private readonly AssertionChain assertionChain;
 
     public GenericCollectionAssertions(TCollection actualValue, AssertionChain assertionChain)
@@ -285,17 +286,17 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// </param>
     public AndConstraint<TAssertions> BeEmpty([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        var tenItemArray = Subject?.Take(10).ToArray();
+        var firstItems = Subject?.Take(MaxItemsShownOnBeEmptyFailure).ToArray();
 
         assertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:collection} to be empty{reason}, ", chain => chain
-                .Given(() => tenItemArray)
+                .Given(() => firstItems)
                 .ForCondition(subject => subject is not null)
                 .FailWith("but found <null>.")
                 .Then
                 .ForCondition(subject => subject.Length == 0)
-                .FailWith("but found at least these items {0}.", tenItemArray));
+                .FailWith("but found at least these items {0}.", firstItems));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -295,7 +295,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
                 .FailWith("but found <null>.")
                 .Then
                 .ForCondition(subject => subject.Length == 0)
-                .FailWith("but found at least {0}.", tenItemArray));
+                .FailWith("but found at least these items {0}.", tenItemArray));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -35,7 +35,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty because that's what we expect, but found at least one item*1*");
+                .WithMessage("*to be empty because that's what we expect, but found at least {1, 2, 3}.");
         }
 
         [Fact]
@@ -130,8 +130,22 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty, but found at least one item {1}.");
+                .WithMessage("*to be empty, but found at least {1, 2, 3}.");
             collection.GetEnumeratorCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void When_asserting_non_empty_collection_is_empty_it_should_take_up_to_ten_elements()
+        {
+            // Arrange
+            var collection = new CountingGenericEnumerable<int>([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+
+            // Act
+            Action act = () => collection.Should().BeEmpty();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*to be empty, but found at least {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -35,7 +35,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty because that's what we expect, but found at least {1, 2, 3}.");
+                .WithMessage("*to be empty because that's what we expect, but found at least these items {1, 2, 3}.");
         }
 
         [Fact]
@@ -130,7 +130,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty, but found at least {1, 2, 3}.");
+                .WithMessage("*to be empty, but found at least these items {1, 2, 3}.");
             collection.GetEnumeratorCallCount.Should().Be(1);
         }
 
@@ -145,7 +145,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty, but found at least {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}.");
+                .WithMessage("*to be empty, but found at least these items {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}.");
             collection.GetEnumeratorCallCount.Should().Be(1);
         }
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -146,6 +146,7 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("*to be empty, but found at least {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}.");
+            collection.GetEnumeratorCallCount.Should().Be(1);
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEmpty.cs
@@ -59,7 +59,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to be empty because we want to test the failure message, but found at least one item*one*");
+                    "Expected collection to be empty because we want to test the failure message, but found at least {\"one\", \"two\", \"three\"}.");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEmpty.cs
@@ -59,7 +59,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to be empty because we want to test the failure message, but found at least {\"one\", \"two\", \"three\"}.");
+                    "Expected collection to be empty because we want to test the failure message, but found at least these items {\"one\", \"two\", \"three\"}.");
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.BeEmpty.cs
@@ -50,7 +50,7 @@ public partial class GenericDictionaryAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected dictionary to be empty because we want to test the failure message, but found at least one item {[1, One]}.");
+                    "Expected dictionary to be empty because we want to test the failure message, but found at least {[1, One]}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.BeEmpty.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.BeEmpty.cs
@@ -50,7 +50,7 @@ public partial class GenericDictionaryAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected dictionary to be empty because we want to test the failure message, but found at least {[1, One]}.");
+                    "Expected dictionary to be empty because we want to test the failure message, but found at least these items {[1, One]}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -59,11 +59,11 @@ public partial class ReferenceTypeAssertionsSpecs
         act.Should().Throw<XunitException>()
             .WithMessage(
             """
-            Expected subject to be empty, but found at least one item {
+            Expected subject to be empty, but found at least {
                 FluentAssertions.Specs.Primitives.Complex
                 {
                     Statement = "goodbye"
-                }
+                }, Simple(Hello)
             }.
             """);
     }

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -59,7 +59,7 @@ public partial class ReferenceTypeAssertionsSpecs
         act.Should().Throw<XunitException>()
             .WithMessage(
             """
-            Expected subject to be empty, but found at least {
+            Expected subject to be empty, but found at least these items {
                 FluentAssertions.Specs.Primitives.Complex
                 {
                     Statement = "goodbye"

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -7,6 +7,11 @@ sidebar:
   nav: "sidebar"
 ---
 
+## Unreleased
+
+### Enhancements
+* `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one.
+
 ## 8.9.0
 
 ### What's new

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,7 +10,7 @@ sidebar:
 ## Unreleased
 
 ### Enhancements
-* `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one - [#2782](https://github.com/fluentassertions/fluentassertions/issues/2782)
+* `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one - [#3198](https://github.com/fluentassertions/fluentassertions/pull/3198)
 
 ## 8.9.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,7 +10,7 @@ sidebar:
 ## Unreleased
 
 ### Enhancements
-* `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one - [#2782](https://github.com/fluentassertions/fluentassertions/pull/2782)
+* `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one - [#2782](https://github.com/fluentassertions/fluentassertions/issues/2782)
 
 ## 8.9.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,7 +10,7 @@ sidebar:
 ## Unreleased
 
 ### Enhancements
-* `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one.
+* `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one - [#2782](https://github.com/fluentassertions/fluentassertions/pull/2782)
 
 ## 8.9.0
 


### PR DESCRIPTION
… the collection instead of only the first one.

Resolves #2782.

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
* [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## CONTRIBUTOR LICENSE GRANT

By submitting this contribution, the contributor hereby irrevocably grants to the project owners and maintainers a perpetual, worldwide, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and create derivative works of the contribution for any purpose and under any terms, including proprietary licensing.

The contributor waives any moral rights in the contribution to the extent permitted by law and agrees not to assert any claim of authorship or control over the contribution. The contributor represents that they are the sole author of the contribution and that it is provided free of any third-party claims.

The contributor understands and agrees that the maintainers may, at their sole discretion, use, license, or redistribute the contribution as part of any work and under any terms they choose, without further permission or attribution.

* [x] I have read the Contributor License Grant and accept the conditions
* [ ] I'm interested in a free license for Fluent Assertions and will share my email address through sales@xceed.com