### PR TITLE
Add ComparingNullCollectionsAsEmpty and ComparingNullStringsAsEmpty options to BeEquivalentTo

### DIFF
--- a/Src/FluentAssertions/Equivalency/Execution/CollectionMemberOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CollectionMemberOptionsDecorator.cs
@@ -94,6 +94,12 @@ internal class CollectionMemberOptionsDecorator : IEquivalencyOptions, IContainT
 
     public bool EnableFullDump => inner.EnableFullDump;
 
+    /// <inheritdoc />
+    public bool TreatNullCollectionsAsEmpty => inner.TreatNullCollectionsAsEmpty;
+
+    /// <inheritdoc />
+    public bool TreatNullStringsAsEmpty => inner.TreatNullStringsAsEmpty;
+
     public ITraceWriter TraceWriter => inner.TraceWriter;
 }
 

--- a/Src/FluentAssertions/Equivalency/IEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyOptions.cs
@@ -137,4 +137,14 @@ public interface IEquivalencyOptions
     /// Gets a value indicating whether the full dump of the subject should be included in the failure message.
     /// </summary>
     bool EnableFullDump { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether <c>null</c> collections should be treated as equivalent to empty collections.
+    /// </summary>
+    bool TreatNullCollectionsAsEmpty { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether <c>null</c> strings should be treated as equivalent to empty strings.
+    /// </summary>
+    bool TreatNullStringsAsEmpty { get; }
 }

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -100,6 +100,8 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
         IgnoreNewlineStyle = defaults.IgnoreNewlineStyle;
         IncludeFullStringsInDifference = defaults.IncludeFullStringsInDifference;
         IgnoreJsonPropertyCasing = defaults.IgnoreJsonPropertyCasing;
+        TreatNullCollectionsAsEmpty = defaults.TreatNullCollectionsAsEmpty;
+        TreatNullStringsAsEmpty = defaults.TreatNullStringsAsEmpty;
 
         ConversionSelector = defaults.ConversionSelector.Clone();
 
@@ -215,6 +217,10 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
 
     /// <inheritdoc />
     public bool EnableFullDump { get; private set; }
+
+    public bool TreatNullCollectionsAsEmpty { get; private set; }
+
+    public bool TreatNullStringsAsEmpty { get; private set; }
 
     public ITraceWriter TraceWriter { get; private set; }
 
@@ -901,6 +907,26 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     public TSelf IncludingFullStringsInDifference()
     {
         IncludeFullStringsInDifference = true;
+        return (TSelf)this;
+    }
+
+    /// <summary>
+    /// Instructs the comparison to treat <c>null</c> collections as equivalent to empty collections,
+    /// regardless of whether the subject or the expectation is <c>null</c>.
+    /// </summary>
+    public TSelf ComparingNullCollectionsAsEmpty()
+    {
+        TreatNullCollectionsAsEmpty = true;
+        return (TSelf)this;
+    }
+
+    /// <summary>
+    /// Instructs the comparison to treat <c>null</c> strings as equivalent to empty strings,
+    /// regardless of whether the subject or the expectation is <c>null</c>.
+    /// </summary>
+    public TSelf ComparingNullStringsAsEmpty()
+    {
+        TreatNullStringsAsEmpty = true;
         return (TSelf)this;
     }
 

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -19,7 +19,13 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
 
         var assertionChain = AssertionChain.GetOrCreate().For(context);
 
-        if (AssertSubjectIsCollection(assertionChain, comparands.Subject))
+        bool treatNullAsEmpty = context.Options.TreatNullCollectionsAsEmpty;
+
+        bool subjectIsUsable = treatNullAsEmpty
+            ? comparands.Subject is null || AssertSubjectIsCollection(assertionChain, comparands.Subject)
+            : AssertSubjectIsCollection(assertionChain, comparands.Subject);
+
+        if (subjectIsUsable)
         {
             var validator = new EnumerableEquivalencyValidator(assertionChain, valueChildNodes, context)
             {
@@ -27,7 +33,9 @@ public class EnumerableEquivalencyStep : IEquivalencyStep
                 OrderingRules = context.Options.OrderingRules
             };
 
-            validator.Execute(ToArray(comparands.Subject), ToArray(comparands.Expectation));
+            validator.Execute(
+                treatNullAsEmpty && comparands.Subject is null ? [] : ToArray(comparands.Subject),
+                treatNullAsEmpty && comparands.Expectation is null ? [] : ToArray(comparands.Expectation));
         }
 
         return EquivalencyResult.EquivalencyProven;

--- a/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
@@ -22,7 +22,12 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
     {
         Type expectedType = comparands.GetExpectedType(context.Options);
 
-        if (comparands.Expectation is null || !IsGenericCollection(expectedType))
+        if (!IsGenericCollection(expectedType))
+        {
+            return EquivalencyResult.ContinueWithNext;
+        }
+
+        if (comparands.Expectation is null && !context.Options.TreatNullCollectionsAsEmpty)
         {
             return EquivalencyResult.ContinueWithNext;
         }
@@ -37,7 +42,7 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
                 "to use for asserting the equivalency of the collection. ",
                 interfaceTypes.Select(type => "IEnumerable<" + type.GetGenericArguments().Single() + ">")));
 
-        if (AssertSubjectIsCollection(assertionChain, comparands.Subject))
+        if (AssertSubjectIsCollection(assertionChain, comparands.Subject, context.Options.TreatNullCollectionsAsEmpty))
         {
             var validator = new EnumerableEquivalencyValidator(assertionChain, valueChildNodes, context)
             {
@@ -47,12 +52,13 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
 
             Type typeOfEnumeration = GetTypeOfEnumeration(expectedType);
 
-            var subjectAsArray = EnumerableEquivalencyStep.ToArray(comparands.Subject);
+            var subjectAsArray = comparands.Subject is null ? [] : EnumerableEquivalencyStep.ToArray(comparands.Subject);
+            object expectation = comparands.Expectation ?? Array.CreateInstance(typeOfEnumeration, 0);
 
             try
             {
                 HandleMethod.MakeGenericMethod(typeOfEnumeration)
-                    .Invoke(null, [validator, subjectAsArray, comparands.Expectation]);
+                    .Invoke(null, [validator, subjectAsArray, expectation]);
             }
             catch (TargetInvocationException e)
             {
@@ -66,8 +72,13 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
     private static void HandleImpl<T>(EnumerableEquivalencyValidator validator, object[] subject, IEnumerable<T> expectation) =>
         validator.Execute(subject, ToArray(expectation));
 
-    private static bool AssertSubjectIsCollection(AssertionChain assertionChain, object subject)
+    private static bool AssertSubjectIsCollection(AssertionChain assertionChain, object subject, bool treatNullAsEmpty)
     {
+        if (treatNullAsEmpty && subject is null)
+        {
+            return true;
+        }
+
         assertionChain
             .ForCondition(subject is not null)
             .FailWith("Expected {context:subject} not to be {0}.", new object[] { null });

--- a/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -18,7 +18,7 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
 
         var assertionChain = AssertionChain.GetOrCreate().For(context);
 
-        if (!ValidateAgainstNulls(assertionChain, comparands, context.CurrentNode))
+        if (!ValidateAgainstNulls(assertionChain, comparands, context.CurrentNode, context.Options.TreatNullStringsAsEmpty))
         {
             return EquivalencyResult.EquivalencyProven;
         }
@@ -74,7 +74,8 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         return o;
     };
 
-    private static bool ValidateAgainstNulls(AssertionChain assertionChain, Comparands comparands, INode currentNode)
+    private static bool ValidateAgainstNulls(AssertionChain assertionChain, Comparands comparands, INode currentNode,
+        bool treatNullAsEmpty)
     {
         object expected = comparands.Expectation;
         object subject = comparands.Subject;
@@ -83,6 +84,16 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
 
         if (onlyOneNull)
         {
+            if (treatNullAsEmpty)
+            {
+                string nonNullValue = (string)(expected ?? subject);
+
+                if (nonNullValue.Length == 0)
+                {
+                    return false;
+                }
+            }
+
             assertionChain.FailWith(
                 "Expected {0} to be {1}{reason}, but found {2}.", currentNode.Subject.Description.AsNonFormattable(), expected,
                 subject);

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -156,7 +156,10 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
             new StringEqualityStrategy(options.GetStringComparerOrDefault(), "be equivalent to"),
             because, becauseArgs);
 
-        var subject = ApplyStringSettings(Subject, options);
+        string subject = options.TreatNullStringsAsEmpty ? Subject ?? "" : Subject;
+        expected = options.TreatNullStringsAsEmpty ? expected ?? "" : expected;
+
+        subject = ApplyStringSettings(subject, options);
         expected = ApplyStringSettings(expected, options);
 
         expectation.Validate(subject, expected);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -776,6 +776,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
         FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        bool TreatNullCollectionsAsEmpty { get; }
+        bool TreatNullStringsAsEmpty { get; }
         bool UseRuntimeTyping { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> UserEquivalencySteps { get; }
         FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
@@ -918,6 +920,8 @@ namespace FluentAssertions.Equivalency
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        public bool TreatNullCollectionsAsEmpty { get; }
+        public bool TreatNullStringsAsEmpty { get; }
         protected TSelf AddMatchingRule(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
@@ -927,6 +931,8 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }
+        public TSelf ComparingNullCollectionsAsEmpty() { }
+        public TSelf ComparingNullStringsAsEmpty() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -838,6 +838,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
         FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        bool TreatNullCollectionsAsEmpty { get; }
+        bool TreatNullStringsAsEmpty { get; }
         bool UseRuntimeTyping { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> UserEquivalencySteps { get; }
         FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
@@ -985,6 +987,8 @@ namespace FluentAssertions.Equivalency
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        public bool TreatNullCollectionsAsEmpty { get; }
+        public bool TreatNullStringsAsEmpty { get; }
         protected TSelf AddMatchingRule(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
@@ -994,6 +998,8 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }
+        public TSelf ComparingNullCollectionsAsEmpty() { }
+        public TSelf ComparingNullStringsAsEmpty() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -768,6 +768,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
         FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        bool TreatNullCollectionsAsEmpty { get; }
+        bool TreatNullStringsAsEmpty { get; }
         bool UseRuntimeTyping { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> UserEquivalencySteps { get; }
         FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
@@ -910,6 +912,8 @@ namespace FluentAssertions.Equivalency
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        public bool TreatNullCollectionsAsEmpty { get; }
+        public bool TreatNullStringsAsEmpty { get; }
         protected TSelf AddMatchingRule(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
@@ -919,6 +923,8 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }
+        public TSelf ComparingNullCollectionsAsEmpty() { }
+        public TSelf ComparingNullStringsAsEmpty() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -792,6 +792,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
         FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        bool TreatNullCollectionsAsEmpty { get; }
+        bool TreatNullStringsAsEmpty { get; }
         bool UseRuntimeTyping { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> UserEquivalencySteps { get; }
         FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
@@ -934,6 +936,8 @@ namespace FluentAssertions.Equivalency
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
+        public bool TreatNullCollectionsAsEmpty { get; }
+        public bool TreatNullStringsAsEmpty { get; }
         protected TSelf AddMatchingRule(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
@@ -943,6 +947,8 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }
+        public TSelf ComparingNullCollectionsAsEmpty() { }
+        public TSelf ComparingNullStringsAsEmpty() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -2824,6 +2824,142 @@ public class CollectionSpecs
         act.ExecutionTime().Should().BeLessThan(20.Seconds());
     }
 
+    public class ComparingNullCollectionsAsEmpty
+    {
+        [Fact]
+        public void A_null_subject_collection_is_equivalent_to_an_empty_expectation()
+        {
+            // Arrange
+            int[] subject = null;
+            int[] expectation = [];
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullCollectionsAsEmpty());
+        }
+
+        [Fact]
+        public void An_empty_subject_collection_is_equivalent_to_a_null_expectation()
+        {
+            // Arrange
+            int[] subject = [];
+            int[] expectation = null;
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullCollectionsAsEmpty());
+        }
+
+        [Fact]
+        public void A_null_subject_collection_fails_when_the_expectation_is_non_empty()
+        {
+            // Arrange
+            int[] subject = null;
+            int[] expectation = [1, 2, 3];
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullCollectionsAsEmpty());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void A_non_empty_subject_collection_fails_when_the_expectation_is_null()
+        {
+            // Arrange
+            int[] subject = [1, 2, 3];
+            int[] expectation = null;
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullCollectionsAsEmpty());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Without_the_option_a_null_subject_collection_is_not_equivalent_to_an_empty_expectation()
+        {
+            // Arrange
+            int[] subject = null;
+            int[] expectation = [];
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Without_the_option_an_empty_subject_collection_is_not_equivalent_to_a_null_expectation()
+        {
+            // Arrange
+            int[] subject = [];
+            int[] expectation = null;
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void A_null_generic_list_subject_is_equivalent_to_an_empty_generic_list_expectation()
+        {
+            // Arrange
+            List<int> subject = null;
+            var expectation = new List<int>();
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullCollectionsAsEmpty());
+        }
+
+        [Fact]
+        public void An_empty_generic_list_subject_is_equivalent_to_a_null_generic_list_expectation()
+        {
+            // Arrange
+            var subject = new List<int>();
+            List<int> expectation = null;
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullCollectionsAsEmpty());
+        }
+
+        [Fact]
+        public void A_null_nested_collection_is_equivalent_to_an_empty_nested_collection()
+        {
+            // Arrange
+            var subject = new { Items = (int[])null };
+            var expectation = new { Items = Array.Empty<int>() };
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullCollectionsAsEmpty());
+        }
+
+        [Fact]
+        public void An_empty_nested_collection_is_equivalent_to_a_null_nested_collection()
+        {
+            // Arrange
+            var subject = new { Items = Array.Empty<int>() };
+            var expectation = new { Items = (int[])null };
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullCollectionsAsEmpty());
+        }
+
+        [Fact]
+        public void Two_null_collections_are_equivalent()
+        {
+            // Arrange
+            int[] subject = null;
+            int[] expectation = null;
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullCollectionsAsEmpty());
+        }
+    }
+
     private class ClassWithLotsOfProperties
     {
         public string Id { get; set; }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.BeEquivalentTo.cs
@@ -375,4 +375,118 @@ public partial class StringAssertionSpecs
             act.Should().NotThrow();
         }
     }
+
+    public class ComparingNullStringsAsEmpty
+    {
+        [Fact]
+        public void A_null_subject_string_is_equivalent_to_an_empty_expectation_string()
+        {
+            // Arrange
+            string subject = null;
+            string expectation = "";
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullStringsAsEmpty());
+        }
+
+        [Fact]
+        public void An_empty_subject_string_is_equivalent_to_a_null_expectation_string()
+        {
+            // Arrange
+            string subject = "";
+            string expectation = null;
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullStringsAsEmpty());
+        }
+
+        [Fact]
+        public void Two_null_strings_are_equivalent()
+        {
+            // Arrange
+            string subject = null;
+            string expectation = null;
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullStringsAsEmpty());
+        }
+
+        [Fact]
+        public void A_null_subject_string_fails_when_the_expectation_is_non_empty()
+        {
+            // Arrange
+            string subject = null;
+            string expectation = "hello";
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullStringsAsEmpty());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void A_non_empty_subject_string_fails_when_the_expectation_is_null()
+        {
+            // Arrange
+            string subject = "hello";
+            string expectation = null;
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullStringsAsEmpty());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Without_the_option_a_null_subject_string_is_not_equivalent_to_an_empty_expectation_string()
+        {
+            // Arrange
+            string subject = null;
+            string expectation = "";
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Without_the_option_an_empty_subject_string_is_not_equivalent_to_a_null_expectation_string()
+        {
+            // Arrange
+            string subject = "";
+            string expectation = null;
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void A_null_nested_string_is_equivalent_to_an_empty_nested_string()
+        {
+            // Arrange
+            var subject = new { Name = (string)null };
+            var expectation = new { Name = "" };
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullStringsAsEmpty());
+        }
+
+        [Fact]
+        public void An_empty_nested_string_is_equivalent_to_a_null_nested_string()
+        {
+            // Arrange
+            var subject = new { Name = "" };
+            var expectation = new { Name = (string)null };
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expectation, opt => opt.ComparingNullStringsAsEmpty());
+        }
+    }
 }

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -396,7 +396,13 @@ string expect = "A\r\nB\nC";
 actual.Should().BeEquivalentTo(expect, o => o.IgnoringNewlineStyle());
 ```
 
-Next to that, when two long strings differ, by default the reporting will only include the relevant fragments needed to highlight the differences. If you want to see the full text of both strings, use the `IncludingFullStringsInDifference()` option. 
+Next to that, when two long strings differ, by default the reporting will only include the relevant fragments needed to highlight the differences. If you want to see the full text of both strings, use the `IncludingFullStringsInDifference()` option.
+
+You can also treat `null` strings as equivalent to empty strings using `ComparingNullStringsAsEmpty()`:
+
+```csharp
+((string)null).Should().BeEquivalentTo("", o => o.ComparingNullStringsAsEmpty());
+```
 
 ### Enums
 
@@ -422,6 +428,12 @@ You can also assert that all instances of `OrderDto` are structurally equal to a
 
 ```csharp
 orderDtos.Should().AllBeEquivalentTo(singleOrder);
+```
+
+If you want to treat `null` collections as equivalent to empty collections, use `ComparingNullCollectionsAsEmpty()`:
+
+```csharp
+((int[])null).Should().BeEquivalentTo([], o => o.ComparingNullCollectionsAsEmpty());
 ```
 
 ### JSON

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,6 +18,7 @@ sidebar:
 * Added `HaveMillisecond` and `NotHaveMillisecond` assertion methods for `DateTime` and `DateTimeOffset` - [#3164](https://github.com/fluentassertions/fluentassertions/pull/3164)
 
 ### Enhancements
+* Added `ComparingNullCollectionsAsEmpty()` and `ComparingNullStringsAsEmpty()` options to `BeEquivalentTo` to treat `null` collections and strings as equivalent to empty ones - [#3202](https://github.com/fluentassertions/fluentassertions/pull/3202)
 * Added option `WithFullDump` to `BeEquivalentTo` to include the entire contents of the subject-under-test in the failure message - [#3133](https://github.com/fluentassertions/fluentassertions/pull/3133)
 * Remove FluentAssertions code from the stack trace when an assertion fails - [#3152](https://github.com/fluentassertions/fluentassertions/pull/3152)
 * Improve reporting the subject when chaining `Throw` with `Which` - [#3160](https://github.com/fluentassertions/fluentassertions/pull/3160)


### PR DESCRIPTION
Closes #1938

## Summary

Adds two new equivalency options to treat `null` as equivalent to empty in `BeEquivalentTo` comparisons:

- **`ComparingNullCollectionsAsEmpty()`** — treats a `null` collection (subject or expectation) as equivalent to an empty collection
- **`ComparingNullStringsAsEmpty()`** — treats a `null` string (subject or expectation) as equivalent to an empty string `""`

Both options follow the existing gerund naming pattern (`ComparingEnumsByName`, `ComparingRecordsByValue`, etc.) and work symmetrically (either side may be `null`).

## Usage

```csharp
// Collections
((int[])null).Should().BeEquivalentTo([], opt => opt.ComparingNullCollectionsAsEmpty());
Array.Empty<int>().Should().BeEquivalentTo(null, opt => opt.ComparingNullCollectionsAsEmpty());

// Strings
((string)null).Should().BeEquivalentTo("", opt => opt.ComparingNullStringsAsEmpty());
"".Should().BeEquivalentTo(null, opt => opt.ComparingNullStringsAsEmpty());

// Nested in an object graph
var subject = new { Items = (int[])null, Name = (string)null };
var expected = new { Items = Array.Empty<int>(), Name = "" };
subject.Should().BeEquivalentTo(expected, opt => opt
    .ComparingNullCollectionsAsEmpty()
    .ComparingNullStringsAsEmpty());
```
