### PR TITLE
Include original index in extraneous item failure messages

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -152,7 +152,7 @@ internal class EnumerableEquivalencyValidator(
 
             object subjectsArg = remainingSubjects.Count == 1
                 ? remainingSubjects.Single().Item
-                : remainingSubjects.Select(s => s.Item).ToList<object>();
+                : remainingSubjects.Select(s => s.Item).ToList();
 
             assertionChain.FailWith(message.ToString(), remainingExpectations, subjectsArg, allSubjects);
         }

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -151,7 +151,7 @@ internal class EnumerableEquivalencyValidator(
             }
 
             object subjectsArg = remainingSubjects.Count == 1
-                ? remainingSubjects.Single().Item
+                ? remainingSubjects[0].Item
                 : remainingSubjects.Select(s => s.Item).ToList();
 
             assertionChain.FailWith(message.ToString(), remainingExpectations, subjectsArg, allSubjects);

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -4,6 +4,7 @@ using System.Text;
 using FluentAssertions.Equivalency.Execution;
 using FluentAssertions.Equivalency.Tracing;
 using FluentAssertions.Execution;
+using FluentAssertions.Formatting;
 using static FluentAssertions.Common.StringExtensions;
 
 namespace FluentAssertions.Equivalency.Steps;
@@ -56,10 +57,13 @@ internal class EnumerableEquivalencyValidator(
 
     private void ExecuteRecursiveAssertion<T>(object[] subjects, T[] expectation)
     {
-        List<object> remainingSubjects = new(subjects);
+        List<IndexedItem<object>> remainingSubjects = subjects
+            .Select((item, index) => new IndexedItem<object>(item, index))
+            .ToList();
+
         List<T> remainingExpectations = new(expectation);
 
-        bool isOrderingStrict = IsOrderingStrictFor(remainingSubjects, remainingExpectations, context.CurrentNode);
+        bool isOrderingStrict = IsOrderingStrictFor(subjects, remainingExpectations, context.CurrentNode);
         if (isOrderingStrict)
         {
             new StrictlyOrderedEquivalencyStrategy<T>(parent, context)
@@ -75,7 +79,7 @@ internal class EnumerableEquivalencyValidator(
             isOrderingStrict ? "in order" : "in any order");
     }
 
-    private bool IsOrderingStrictFor<T>(List<object> subjects, List<T> expectations, INode currentNode)
+    private bool IsOrderingStrictFor<T>(object[] subjects, List<T> expectations, INode currentNode)
     {
         return OrderingRules.IsOrderingStrictFor(new ObjectInfo(new Comparands(subjects, expectations, typeof(T[])),
             currentNode));
@@ -83,7 +87,7 @@ internal class EnumerableEquivalencyValidator(
 
 #pragma warning disable CA1305
 
-    private void ReportRemainingOrMissingItems<T>(List<object> remainingSubjects, List<T> remainingExpectations,
+    private void ReportRemainingOrMissingItems<T>(List<IndexedItem<object>> remainingSubjects, List<T> remainingExpectations,
         object[] allSubjects,
         int expectationLength, string orderingDescription)
     {
@@ -111,8 +115,32 @@ internal class EnumerableEquivalencyValidator(
 
             if (remainingSubjects.Count > 0)
             {
-                phrase = remainingSubjects.Count > 1 ? "extraneous items" : "one extraneous item";
-                message.Append($"found {phrase} {{1}}");
+                if (remainingExpectations.Count == 0)
+                {
+                    // Subjects are truly extra (the subject collection has more items than expected).
+                    // Show each extraneous item with its original index to help pinpoint the divergence.
+                    if (remainingSubjects.Count == 1)
+                    {
+                        message.Append($"found one extraneous item at index {remainingSubjects[0].Index} {{1}}");
+                    }
+                    else
+                    {
+                        string formattedItems = string.Join(", ",
+                            remainingSubjects.Select(s => $"{Formatter.ToString(s.Item)} (at index {s.Index})"));
+
+                        // Use {{ and }} so that string.Format treats them as literal braces, not placeholders.
+                        message.Append("found extraneous items {{");
+                        message.Append(formattedItems);
+                        message.Append("}}");
+                    }
+                }
+                else
+                {
+                    // Both missing and extra subjects exist (same-size collections with pairwise mismatches).
+                    // Fall back to the compact list format without per-item indices.
+                    phrase = remainingSubjects.Count > 1 ? "extraneous items" : "one extraneous item";
+                    message.Append($"found {phrase} {{1}}");
+                }
             }
 
             if (context.Options.EnableFullDump)
@@ -122,8 +150,11 @@ internal class EnumerableEquivalencyValidator(
                 message.AppendLine("Full dump of {context:subject}: {2}");
             }
 
-            assertionChain.FailWith(message.ToString(), remainingExpectations,
-                remainingSubjects.Count == 1 ? remainingSubjects.Single() : remainingSubjects, allSubjects);
+            object subjectsArg = remainingExpectations.Count == 0 && remainingSubjects.Count == 1
+                ? remainingSubjects.Single().Item
+                : remainingSubjects.Select(s => s.Item).ToList<object>();
+
+            assertionChain.FailWith(message.ToString(), remainingExpectations, subjectsArg, allSubjects);
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -128,7 +128,7 @@ internal class EnumerableEquivalencyValidator(
                     {
                         string formattedItems = string.Join(", ",
                             remainingSubjects.Select(s =>
-                                $"{Formatter.ToString(s.Item).Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal)} (at index {s.Index})"));
+                                $"{Formatter.ToString(s.Item).EscapePlaceholders()} (at index {s.Index})"));
 
                         message.Append("found extraneous items ");
                         message.Append(formattedItems);

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -126,7 +127,8 @@ internal class EnumerableEquivalencyValidator(
                     else
                     {
                         string formattedItems = string.Join(", ",
-                            remainingSubjects.Select(s => $"{Formatter.ToString(s.Item)} (at index {s.Index})"));
+                            remainingSubjects.Select(s =>
+                                $"{Formatter.ToString(s.Item).Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal)} (at index {s.Index})"));
 
                         // Use {{ and }} so that string.Format treats them as literal braces, not placeholders.
                         message.Append("found extraneous items {{");
@@ -150,7 +152,7 @@ internal class EnumerableEquivalencyValidator(
                 message.AppendLine("Full dump of {context:subject}: {2}");
             }
 
-            object subjectsArg = remainingExpectations.Count == 0 && remainingSubjects.Count == 1
+            object subjectsArg = remainingSubjects.Count == 1
                 ? remainingSubjects.Single().Item
                 : remainingSubjects.Select(s => s.Item).ToList<object>();
 

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -122,7 +122,7 @@ internal class EnumerableEquivalencyValidator(
                     // Show each extraneous item with its original index to help pinpoint the divergence.
                     if (remainingSubjects.Count == 1)
                     {
-                        message.Append($"found one extraneous item at index {remainingSubjects[0].Index} {{1}}");
+                        message.Append($"found one extraneous item at index {remainingSubjects[0].Index}: {{1}}");
                     }
                     else
                     {
@@ -130,10 +130,8 @@ internal class EnumerableEquivalencyValidator(
                             remainingSubjects.Select(s =>
                                 $"{Formatter.ToString(s.Item).Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal)} (at index {s.Index})"));
 
-                        // Use {{ and }} so that string.Format treats them as literal braces, not placeholders.
-                        message.Append("found extraneous items {{");
+                        message.Append("found extraneous items ");
                         message.Append(formattedItems);
-                        message.Append("}}");
                     }
                 }
                 else

--- a/Src/FluentAssertions/Equivalency/Steps/LooselyOrderedEquivalencyStrategy.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/LooselyOrderedEquivalencyStrategy.cs
@@ -25,7 +25,7 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
     // Populated lazily during Phase 3 for the ~n selected pairs with full formatting.
     private Dictionary<(object Subject, object Expectation, int ExpectationIndex), string[]> fullFailuresCache = new();
 
-    public void FindAndRemoveMatches(List<object> subjects, List<TExpectation> expectations)
+    public void FindAndRemoveMatches(List<IndexedItem<object>> subjects, List<TExpectation> expectations)
     {
         countCache = new(new ReferentialComparer());
         fullFailuresCache = new(new ReferentialComparer());
@@ -45,7 +45,7 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
         expectationsWithIndexes.RemoveMatchedItemFrom(expectations);
     }
 
-    private void FindAndRemoveExactMatches(List<object> subjects, IndexedItemCollection<TExpectation> expectationsWithIndexes)
+    private void FindAndRemoveExactMatches(List<IndexedItem<object>> subjects, IndexedItemCollection<TExpectation> expectationsWithIndexes)
     {
         int expectationIndex = 0;
         while (expectationsWithIndexes.Count > expectationIndex)
@@ -65,14 +65,14 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
     }
 
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
-    private bool StrictlyMatchAgainst(List<object> remainingSubjects, TExpectation expectation, int expectationIndex)
+    private bool StrictlyMatchAgainst(List<IndexedItem<object>> remainingSubjects, TExpectation expectation, int expectationIndex)
     {
-        foreach ((int index, object subject) in remainingSubjects.Index())
+        foreach ((int index, IndexedItem<object> subject) in remainingSubjects.Index())
         {
             using var _ = tracer.WriteBlock(member =>
                 $"Comparing subject at {member.Subject}[{index}] with the expectation at {member.Expectation}[{expectationIndex}]");
 
-            int failures = TryToMatchCount(expectation, subject, expectationIndex);
+            int failures = TryToMatchCount(expectation, subject.Item, expectationIndex);
             if (failures == 0)
             {
                 tracer.WriteLine(_ => "It's a match");
@@ -91,7 +91,7 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
     /// that are most similar to remaining subjects first, the algorithm is more likely
     /// to find the correct pairings earlier, leading to better error messages when mismatches occur.
     /// </summary>
-    private IndexedItemCollection<TExpectation> SortExpectationsByMinDistance(List<object> remainingSubjects,
+    private IndexedItemCollection<TExpectation> SortExpectationsByMinDistance(List<IndexedItem<object>> remainingSubjects,
         IndexedItemCollection<TExpectation> expectationsWithIndexes)
     {
         if (remainingSubjects.Count > 0)
@@ -100,7 +100,7 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
                 .Select(e => new
                 {
                     Expectation = e,
-                    MinDistance = remainingSubjects.Min(a => TryToMatchCount(e.Item, a, e.Index))
+                    MinDistance = remainingSubjects.Min(a => TryToMatchCount(e.Item, a.Item, e.Index))
                 })
                 .OrderBy(x => x.MinDistance)
                 .Select(x => x.Expectation)
@@ -112,13 +112,13 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
         }
     }
 
-    private void FindAndRemoveClosestMatches(List<object> remainingSubjects,
+    private void FindAndRemoveClosestMatches(List<IndexedItem<object>> remainingSubjects,
         IndexedItemCollection<TExpectation> expectationsWithIndexes)
     {
         int nrFailures = 0;
         if (expectationsWithIndexes.Count > 0 && remainingSubjects.Count > 0)
         {
-            IReadOnlyList<(IndexedItem<TExpectation>, object, string[])> bestMatches =
+            IReadOnlyList<(IndexedItem<TExpectation>, IndexedItem<object>, string[])> bestMatches =
                 FindClosestMismatches(remainingSubjects, expectationsWithIndexes);
 
             foreach (var (expectation, subject, failures) in bestMatches)
@@ -138,8 +138,8 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
         }
     }
 
-    private IReadOnlyList<(IndexedItem<TExpectation> Expectation, object Actual, string[] Failures)> FindClosestMismatches(
-        List<object> remainingSubjects, IndexedItemCollection<TExpectation> expectationsWithIndexes)
+    private IReadOnlyList<(IndexedItem<TExpectation> Expectation, IndexedItem<object> Actual, string[] Failures)> FindClosestMismatches(
+        List<IndexedItem<object>> remainingSubjects, IndexedItemCollection<TExpectation> expectationsWithIndexes)
     {
         // For small collections, use exact permutation search to find the globally optimal assignment.
         // factorial(8) = 40,320 which is well within reason.
@@ -155,13 +155,13 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
     /// Uses failure counts for scoring (no string formatting) and only fetches full failure strings for the
     /// winning assignment.
     /// </summary>
-    private IReadOnlyList<(IndexedItem<TExpectation> Expectation, object Actual, string[] Failures)> FindClosestMismatchesByPermutation(
-        List<object> remainingSubjects, IndexedItemCollection<TExpectation> expectationsWithIndexes)
+    private IReadOnlyList<(IndexedItem<TExpectation> Expectation, IndexedItem<object> Actual, string[] Failures)> FindClosestMismatchesByPermutation(
+        List<IndexedItem<object>> remainingSubjects, IndexedItemCollection<TExpectation> expectationsWithIndexes)
     {
         var bestScore = int.MaxValue;
-        IReadOnlyList<object> bestAssignment = null;
+        IReadOnlyList<IndexedItem<object>> bestAssignment = null;
 
-        foreach (IReadOnlyList<object> assignment in remainingSubjects.Permute())
+        foreach (IReadOnlyList<IndexedItem<object>> assignment in remainingSubjects.Permute())
         {
             int score = 0;
             bool tooHigh = false;
@@ -169,7 +169,7 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
             for (int index = 0; index < expectationsWithIndexes.Count && index < assignment.Count; index++)
             {
                 IndexedItem<TExpectation> expectationWithIndex = expectationsWithIndexes[index];
-                score += TryToMatchCount(expectationWithIndex.Item, assignment[index], expectationWithIndex.Index);
+                score += TryToMatchCount(expectationWithIndex.Item, assignment[index].Item, expectationWithIndex.Index);
 
                 if (score >= bestScore)
                 {
@@ -187,17 +187,17 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
 
         if (bestAssignment is null)
         {
-            return Array.Empty<(IndexedItem<TExpectation>, object, string[])>();
+            return Array.Empty<(IndexedItem<TExpectation>, IndexedItem<object>, string[])>();
         }
 
         // Fetch full failure strings only for the winning assignment.
         int pairCount = Math.Min(expectationsWithIndexes.Count, bestAssignment.Count);
-        var result = new List<(IndexedItem<TExpectation>, object, string[])>(pairCount);
+        var result = new List<(IndexedItem<TExpectation>, IndexedItem<object>, string[])>(pairCount);
 
         for (int index = 0; index < pairCount; index++)
         {
             IndexedItem<TExpectation> expectationWithIndex = expectationsWithIndexes[index];
-            string[] failures = TryToMatch(expectationWithIndex.Item, bestAssignment[index], expectationWithIndex.Index);
+            string[] failures = TryToMatch(expectationWithIndex.Item, bestAssignment[index].Item, expectationWithIndex.Index);
             result.Add((expectationWithIndex, bestAssignment[index], failures));
         }
 
@@ -209,8 +209,8 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
     /// permutation search would be prohibitively expensive. All distances are already cached from Phase 1, so
     /// this is O(n² log n) rather than O(n! × n).
     /// </summary>
-    private IReadOnlyList<(IndexedItem<TExpectation> Expectation, object Actual, string[] Failures)> FindClosestMismatchesByGreedyAssignment(
-        List<object> remainingSubjects, IndexedItemCollection<TExpectation> expectationsWithIndexes)
+    private IReadOnlyList<(IndexedItem<TExpectation> Expectation, IndexedItem<object> Actual, string[] Failures)> FindClosestMismatchesByGreedyAssignment(
+        List<IndexedItem<object>> remainingSubjects, IndexedItemCollection<TExpectation> expectationsWithIndexes)
     {
         int subjectCount = remainingSubjects.Count;
         int expectationCount = expectationsWithIndexes.Count;
@@ -225,7 +225,7 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
 
             for (int subjectIndex = 0; subjectIndex < subjectCount; subjectIndex++)
             {
-                int count = TryToMatchCount(exp.Item, remainingSubjects[subjectIndex], exp.Index);
+                int count = TryToMatchCount(exp.Item, remainingSubjects[subjectIndex].Item, exp.Index);
                 allPairs.Add((expectationIndex, subjectIndex, count));
             }
         }
@@ -248,7 +248,7 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
         var assignedSubjectIndexes = new bool[subjectCount];
         int totalToAssign = Math.Min(expectationCount, subjectCount);
 
-        var result = new List<(IndexedItem<TExpectation>, object, string[])>(totalToAssign);
+        var result = new List<(IndexedItem<TExpectation>, IndexedItem<object>, string[])>(totalToAssign);
 
         // First checks candidate matches from best to worst, then picks the first unused expectation/subject pair it finds,
         // computes detailed failures only for that chosen pair, and then repeats until all possible matches are assigned.
@@ -258,7 +258,7 @@ internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
             {
                 // Fetch full failure strings only for the selected pairs (~n total).
                 string[] failures = TryToMatch(expectationsWithIndexes[expectationIndex].Item,
-                    remainingSubjects[subjectIndex], expectationsWithIndexes[expectationIndex].Index);
+                    remainingSubjects[subjectIndex].Item, expectationsWithIndexes[expectationIndex].Index);
 
                 result.Add((expectationsWithIndexes[expectationIndex], remainingSubjects[subjectIndex], failures));
                 assignedExpectationIndexes[expectationIndex] = true;

--- a/Src/FluentAssertions/Equivalency/Steps/StrictlyOrderedEquivalencyStrategy.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StrictlyOrderedEquivalencyStrategy.cs
@@ -13,7 +13,7 @@ internal class StrictlyOrderedEquivalencyStrategy<TExpectation>(
     private const int FailedItemsFastFailThreshold = 10;
     private readonly Tracer tracer = context.Tracer;
 
-    public void FindAndRemoveMatches(List<object> subjects, List<TExpectation> expectations)
+    public void FindAndRemoveMatches(List<IndexedItem<object>> subjects, List<TExpectation> expectations)
     {
         int failedCount = 0;
 
@@ -44,11 +44,11 @@ internal class StrictlyOrderedEquivalencyStrategy<TExpectation>(
         expectations.RemoveRange(0, index);
     }
 
-    private bool StrictlyMatchAgainst<T>(List<object> subjects, T expectation, int expectationIndex)
+    private bool StrictlyMatchAgainst<T>(List<IndexedItem<object>> subjects, T expectation, int expectationIndex)
     {
         using var scope = new AssertionScope();
 
-        object subject = subjects[expectationIndex];
+        object subject = subjects[expectationIndex].Item;
         IEquivalencyValidationContext equivalencyValidationContext = context.AsCollectionItem<T>(expectationIndex);
 
         parent.AssertEquivalencyOf(new Comparands(subject, expectation, typeof(T)), equivalencyValidationContext);

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -950,7 +950,7 @@ public class BasicSpecs
                 """
                 Expected property actual[0].Name to be "Dennis" with a length of 6, but "Jits" has a length of 4, differs near "Jit" (index 0).
                 Expected property actual[0].Age to be 52, but found 13.
-                Expected actual to contain exactly one item, but found one extraneous item FluentAssertions.Equivalency.Specs.Customer
+                Expected actual to contain exactly one item, but found one extraneous item at index 1 FluentAssertions.Equivalency.Specs.Customer
                 {
                     Age = 16,
                     Birthdate = <0001-01-01 00:00:00.000>,
@@ -1006,7 +1006,7 @@ public class BasicSpecs
                 """
                 Expected property actual[0].Name to be "Dennis" with a length of 6, but "Jits" has a length of 4, differs near "Jit" (index 0).
                 Expected property actual[0].Age to be 52, but found 13.
-                Expected actual to contain exactly one item, but found one extraneous item FluentAssertions.Equivalency.Specs.Customer
+                Expected actual to contain exactly one item, but found one extraneous item at index 1 FluentAssertions.Equivalency.Specs.Customer
                 {
                     Age = 16,
                     Birthdate = <0001-01-01 00:00:00.000>,

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Net;
 using FluentAssertions.Extensions;
 using Xunit;
@@ -950,7 +951,7 @@ public class BasicSpecs
                 """
                 Expected property actual[0].Name to be "Dennis" with a length of 6, but "Jits" has a length of 4, differs near "Jit" (index 0).
                 Expected property actual[0].Age to be 52, but found 13.
-                Expected actual to contain exactly one item, but found one extraneous item at index 1 FluentAssertions.Equivalency.Specs.Customer
+                Expected actual to contain exactly one item, but found one extraneous item at index 1: FluentAssertions.Equivalency.Specs.Customer
                 {
                     Age = 16,
                     Birthdate = <0001-01-01 00:00:00.000>,
@@ -1006,7 +1007,7 @@ public class BasicSpecs
                 """
                 Expected property actual[0].Name to be "Dennis" with a length of 6, but "Jits" has a length of 4, differs near "Jit" (index 0).
                 Expected property actual[0].Age to be 52, but found 13.
-                Expected actual to contain exactly one item, but found one extraneous item at index 1 FluentAssertions.Equivalency.Specs.Customer
+                Expected actual to contain exactly one item, but found one extraneous item at index 1: FluentAssertions.Equivalency.Specs.Customer
                 {
                     Age = 16,
                     Birthdate = <0001-01-01 00:00:00.000>,

--- a/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Net;
 using FluentAssertions.Extensions;
 using Xunit;

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -2222,7 +2222,7 @@ public class CollectionSpecs
         // Assert
         action.Should().Throw<XunitException>()
             .WithMessage(
-                "*Expected subject to contain exactly one item, but found one extraneous item at index 1*Age = 24*");
+                "*Expected subject to contain exactly one item, but found one extraneous item at index 1:*Age = 24*");
     }
 
     [Fact]
@@ -2247,7 +2247,7 @@ public class CollectionSpecs
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("*extraneous items*at index 1*at index 2*");
+            .WithMessage("*extraneous items *at index 1*at index 2*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -2251,6 +2251,34 @@ public class CollectionSpecs
     }
 
     [Fact]
+    public void When_the_subject_contains_multiple_extra_items_the_failure_message_should_include_their_formatted_properties()
+    {
+        // Arrange - Customer objects produce formatted output containing curly braces (e.g. "Customer\r\n{\r\n    Age = 24\r\n}")
+        // which must be escaped before embedding into the FailWith format string to prevent string.Format from
+        // interpreting them as placeholders and producing a **WARNING** instead of the actual failure message.
+        var subject = new List<Customer>
+        {
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 },
+            new() { Name = "Bob", Age = 32, Id = 3 }
+        };
+
+        var expectation = new List<Customer>
+        {
+            new() { Name = "John", Age = 27, Id = 1 }
+        };
+
+        // Act
+        Action action =
+            () => subject.Should().BeEquivalentTo(expectation);
+
+        // Assert
+        action.Should().Throw<XunitException>()
+            .WithMessage("*extraneous items*Age = 24*at index 1*Age = 32*at index 2*")
+            .And.Message.Should().NotContain("**WARNING**");
+    }
+
+    [Fact]
     public void When_the_subject_contains_same_number_of_items_and_both_contain_duplicates_it_should_succeed()
     {
         // Arrange

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -2275,7 +2275,7 @@ public class CollectionSpecs
         // Assert
         action.Should().Throw<XunitException>()
             .WithMessage("*extraneous items*Age = 24*at index 1*Age = 32*at index 2*")
-            .And.Message.Should().NotContain("**WARNING**");
+            .WithoutMessage("**WARNING**");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -2222,7 +2222,32 @@ public class CollectionSpecs
         // Assert
         action.Should().Throw<XunitException>()
             .WithMessage(
-                "*Expected subject to contain exactly one item, but found one extraneous item*Age = 24*");
+                "*Expected subject to contain exactly one item, but found one extraneous item at index 1*Age = 24*");
+    }
+
+    [Fact]
+    public void When_the_subject_contains_multiple_extra_items_it_should_include_the_index_of_each()
+    {
+        // Arrange
+        var subject = new List<Customer>
+        {
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 },
+            new() { Name = "Bob", Age = 32, Id = 3 }
+        };
+
+        var expectation = new List<Customer>
+        {
+            new() { Name = "John", Age = 27, Id = 1 }
+        };
+
+        // Act
+        Action action =
+            () => subject.Should().BeEquivalentTo(expectation);
+
+        // Assert
+        action.Should().Throw<XunitException>()
+            .WithMessage("*extraneous items*at index 1*at index 2*");
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
@@ -58,7 +58,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1*2 items*we treat all alike, but*extraneous item 3*");
+                "Expected collection1*2 items*we treat all alike, but*extraneous item*3*");
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -19,6 +19,7 @@ sidebar:
 
 ### Enhancements
 * Added `ComparingNullCollectionsAsEmpty()` and `ComparingNullStringsAsEmpty()` options to `BeEquivalentTo` to treat `null` collections and strings as equivalent to empty ones - [#3202](https://github.com/fluentassertions/fluentassertions/pull/3202)
+* `BeEquivalentTo` now includes the original index of each extraneous item in the failure message - [#985](https://github.com/fluentassertions/fluentassertions/issues/985)
 * Added option `WithFullDump` to `BeEquivalentTo` to include the entire contents of the subject-under-test in the failure message - [#3133](https://github.com/fluentassertions/fluentassertions/pull/3133)
 * Remove FluentAssertions code from the stack trace when an assertion fails - [#3152](https://github.com/fluentassertions/fluentassertions/pull/3152)
 * Improve reporting the subject when chaining `Throw` with `Which` - [#3160](https://github.com/fluentassertions/fluentassertions/pull/3160)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -19,7 +19,7 @@ sidebar:
 
 ### Enhancements
 * Added `ComparingNullCollectionsAsEmpty()` and `ComparingNullStringsAsEmpty()` options to `BeEquivalentTo` to treat `null` collections and strings as equivalent to empty ones - [#3202](https://github.com/fluentassertions/fluentassertions/pull/3202)
-* `BeEquivalentTo` now includes the original index of each extraneous item in the failure message - [#985](https://github.com/fluentassertions/fluentassertions/issues/985)
+* `BeEquivalentTo` now includes the original index of each extraneous item in the failure message - [#3203](https://github.com/fluentassertions/fluentassertions/pull/3203)
 * Added option `WithFullDump` to `BeEquivalentTo` to include the entire contents of the subject-under-test in the failure message - [#3133](https://github.com/fluentassertions/fluentassertions/pull/3133)
 * Remove FluentAssertions code from the stack trace when an assertion fails - [#3152](https://github.com/fluentassertions/fluentassertions/pull/3152)
 * Improve reporting the subject when chaining `Throw` with `Which` - [#3160](https://github.com/fluentassertions/fluentassertions/pull/3160)


### PR DESCRIPTION
## Summary

Fixes #985.

When `BeEquivalentTo` fails because the subject collection has more items than expected, the error message now includes the **original index** of each extraneous item, making it easier to diagnose where collections diverge.

### Before

```
Expected actual to contain exactly one item, but found one extraneous item Customer { Age = 16, ... }
```

### After

**Single extra item:**
```
Expected actual to contain exactly one item, but found one extraneous item at index 1: Customer { Age = 16, ... }
```

**Multiple extra items:**
```
Expected actual to contain exactly 2 items, but found extraneous items: Customer { Age = 16, ... } (at index 2), Customer { Age = 21, ... } (at index 4)
```

## Implementation

- `EnumerableEquivalencyValidator`: subjects are now wrapped in `List<IndexedItem<object>>` so original indices survive through the matching pipeline to the reporting stage.
- `StrictlyOrderedEquivalencyStrategy` / `LooselyOrderedEquivalencyStrategy`: updated to pass `List<IndexedItem<object>>` instead of `List<object>` for subjects; raw objects are accessed via `.Item`.
- When only extra items exist, each item is reported with `at index N:`. When both missing and extra items exist, the compact fallback format is used to avoid expensive per-item formatting.
- Braces in formatted item strings (e.g. `Customer { Age = 16 }`) are escaped before embedding into the `FailWith` format string to prevent `string.Format` treating them as placeholders.