### PR TITLE
Use long for hashCode in ReferentialComparer to avoid overflow

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/ReferentialComparer.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ReferentialComparer.cs
@@ -20,9 +20,9 @@ internal sealed class ReferentialComparer : IEqualityComparer<(object Subject, o
 
     public int GetHashCode((object Subject, object Expectation, int ExpectationIndex) obj)
     {
-        int hashCode = RuntimeHelpers.GetHashCode(obj.Subject);
+        long hashCode = RuntimeHelpers.GetHashCode(obj.Subject);
         hashCode = (hashCode * 397) + RuntimeHelpers.GetHashCode(obj.Expectation);
         hashCode = (hashCode * 397) + obj.ExpectationIndex;
-        return hashCode;
+        return (int)hashCode;
     }
 }


### PR DESCRIPTION
## Problem

The Qodana workflow on `main` has been failing since bumping `JetBrains/qodana-action` from 2025.3 to 2026.1 ([run #25039911647](https://github.com/fluentassertions/fluentassertions/actions/runs/25039911647)). The new Qodana version introduced an improved **Possible overflow in 'unchecked' context** (High severity) inspection.

## Root Cause

`ReferentialComparer.GetHashCode` used an `int hashCode` accumulator with `hashCode * 397` multiplications that can silently overflow. The equivalent pattern in `Node.cs` already wraps the computation in `unchecked {}`, but `ReferentialComparer.cs` did not.

## Fix

Changed the `hashCode` local variable from `int` to `long` so the multiplications cannot overflow, then narrowed back to `int` on return via an explicit truncating cast (the correct and expected behavior for hash codes).

`HashCode.Combine` is not an option since the project targets `net47` and `netstandard2.0`.