### PR TITLE
Expose ShouldThrowOnCyclicReference on IEquivalencyValidationContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ Tests/Benchmarks/BenchmarkDotNet.Artifacts/
 
 # Documentation spell check
 node_modules/
+
+# JetBrains Junie AI agent memory
+.junie/memory/

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -74,6 +74,9 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
         };
     }
 
+    public bool ShouldThrowOnCyclicReference =>
+        Options.CyclicReferenceHandling == CyclicReferenceHandling.ThrowException;
+
     public bool IsCyclicReference(object expectation)
     {
         EqualityStrategy strategy = expectation is not null

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -10,8 +10,6 @@ namespace FluentAssertions.Equivalency;
 [System.Diagnostics.StackTraceHidden]
 internal class EquivalencyValidator : IValidateChildNodeEquivalency
 {
-    private const int MaxDepth = 10;
-
     public void AssertEquality(Comparands comparands, EquivalencyValidationContext context)
     {
         context.ResetTracing();
@@ -43,7 +41,7 @@ internal class EquivalencyValidator : IValidateChildNodeEquivalency
             {
                 TryToProveNodesAreEquivalent(comparands, context);
             }
-            else if (context.Options.CyclicReferenceHandling == CyclicReferenceHandling.ThrowException)
+            else if (context.ShouldThrowOnCyclicReference)
             {
                 assertionChain.FailWith("Expected {context:subject} to be {0}{reason}, but it contains a cyclic reference.", comparands.Expectation);
             }
@@ -57,12 +55,13 @@ internal class EquivalencyValidator : IValidateChildNodeEquivalency
     private static bool ShouldContinueThisDeep(INode currentNode, IEquivalencyOptions options,
         AssertionChain assertionChain)
     {
-        bool shouldRecurse = options.AllowInfiniteRecursion || currentNode.Depth <= MaxDepth;
+        const int maxDepth = 10;
 
+        bool shouldRecurse = options.AllowInfiniteRecursion || currentNode.Depth <= maxDepth;
         if (!shouldRecurse)
         {
             // This will throw, unless we're inside an AssertionScope
-            assertionChain.FailWith($"The maximum recursion depth of {MaxDepth} was reached.  ");
+            assertionChain.FailWith($"The maximum recursion depth of {maxDepth} was reached.  ");
         }
 
         return shouldRecurse;
@@ -97,7 +96,7 @@ internal class EquivalencyValidator : IValidateChildNodeEquivalency
 
         foreach (IEquivalencyStep step in AssertionConfiguration.Current.Equivalency.Plan)
         {
-            var result = step.Handle(comparands, context, this);
+            EquivalencyResult result = step.Handle(comparands, context, this);
 
             if (result == EquivalencyResult.EquivalencyProven)
             {

--- a/Src/FluentAssertions/Equivalency/IEquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyValidationContext.cs
@@ -34,6 +34,11 @@ public interface IEquivalencyValidationContext
     bool IsCyclicReference(object expectation);
 
     /// <summary>
+    /// Determines whether a cyclic reference should cause an exception to be thrown.
+    /// </summary>
+    bool ShouldThrowOnCyclicReference { get; }
+
+    /// <summary>
     /// Creates a context from the current object intended to assert the equivalency of a nested member.
     /// </summary>
     IEquivalencyValidationContext AsNestedMember(IMember expectationMember);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -735,6 +735,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.INode CurrentNode { get; }
         public FluentAssertions.Equivalency.IEquivalencyOptions Options { get; }
         public FluentAssertions.Execution.Reason Reason { get; set; }
+        public bool ShouldThrowOnCyclicReference { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; set; }
         public FluentAssertions.Equivalency.Tracing.Tracer Tracer { get; }
         public FluentAssertions.Equivalency.IEquivalencyValidationContext AsCollectionItem<TItem>(string index) { }
@@ -791,6 +792,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.INode CurrentNode { get; }
         FluentAssertions.Equivalency.IEquivalencyOptions Options { get; }
         FluentAssertions.Execution.Reason Reason { get; }
+        bool ShouldThrowOnCyclicReference { get; }
         FluentAssertions.Equivalency.Tracing.Tracer Tracer { get; }
         FluentAssertions.Equivalency.IEquivalencyValidationContext AsCollectionItem<TItem>(string index);
         FluentAssertions.Equivalency.IEquivalencyValidationContext AsDictionaryItem<TKey, TExpectation>(TKey key);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -797,6 +797,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.INode CurrentNode { get; }
         public FluentAssertions.Equivalency.IEquivalencyOptions Options { get; }
         public FluentAssertions.Execution.Reason Reason { get; set; }
+        public bool ShouldThrowOnCyclicReference { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; set; }
         public FluentAssertions.Equivalency.Tracing.Tracer Tracer { get; }
         public FluentAssertions.Equivalency.IEquivalencyValidationContext AsCollectionItem<TItem>(string index) { }
@@ -853,6 +854,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.INode CurrentNode { get; }
         FluentAssertions.Equivalency.IEquivalencyOptions Options { get; }
         FluentAssertions.Execution.Reason Reason { get; }
+        bool ShouldThrowOnCyclicReference { get; }
         FluentAssertions.Equivalency.Tracing.Tracer Tracer { get; }
         FluentAssertions.Equivalency.IEquivalencyValidationContext AsCollectionItem<TItem>(string index);
         FluentAssertions.Equivalency.IEquivalencyValidationContext AsDictionaryItem<TKey, TExpectation>(TKey key);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -727,6 +727,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.INode CurrentNode { get; }
         public FluentAssertions.Equivalency.IEquivalencyOptions Options { get; }
         public FluentAssertions.Execution.Reason Reason { get; set; }
+        public bool ShouldThrowOnCyclicReference { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; set; }
         public FluentAssertions.Equivalency.Tracing.Tracer Tracer { get; }
         public FluentAssertions.Equivalency.IEquivalencyValidationContext AsCollectionItem<TItem>(string index) { }
@@ -783,6 +784,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.INode CurrentNode { get; }
         FluentAssertions.Equivalency.IEquivalencyOptions Options { get; }
         FluentAssertions.Execution.Reason Reason { get; }
+        bool ShouldThrowOnCyclicReference { get; }
         FluentAssertions.Equivalency.Tracing.Tracer Tracer { get; }
         FluentAssertions.Equivalency.IEquivalencyValidationContext AsCollectionItem<TItem>(string index);
         FluentAssertions.Equivalency.IEquivalencyValidationContext AsDictionaryItem<TKey, TExpectation>(TKey key);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -751,6 +751,7 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.INode CurrentNode { get; }
         public FluentAssertions.Equivalency.IEquivalencyOptions Options { get; }
         public FluentAssertions.Execution.Reason Reason { get; set; }
+        public bool ShouldThrowOnCyclicReference { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; set; }
         public FluentAssertions.Equivalency.Tracing.Tracer Tracer { get; }
         public FluentAssertions.Equivalency.IEquivalencyValidationContext AsCollectionItem<TItem>(string index) { }
@@ -807,6 +808,7 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.INode CurrentNode { get; }
         FluentAssertions.Equivalency.IEquivalencyOptions Options { get; }
         FluentAssertions.Execution.Reason Reason { get; }
+        bool ShouldThrowOnCyclicReference { get; }
         FluentAssertions.Equivalency.Tracing.Tracer Tracer { get; }
         FluentAssertions.Equivalency.IEquivalencyValidationContext AsCollectionItem<TItem>(string index);
         FluentAssertions.Equivalency.IEquivalencyValidationContext AsDictionaryItem<TKey, TExpectation>(TKey key);


### PR DESCRIPTION
## Summary

* Adds `ShouldThrowOnCyclicReference` property to `IEquivalencyValidationContext` and its implementation `EquivalencyValidationContext`, extracting the `Options.CyclicReferenceHandling == CyclicReferenceHandling.ThrowException` check into a single, named place.
* Updates `EquivalencyValidator` to use the new property instead of the inline comparison.
* Moves the `MaxDepth` constant to local scope inside `ShouldContinueThisDeep()` where it is actually used.
* Replaces a `var result` declaration with the explicit `EquivalencyResult` type for clarity.

### Public API change

`IEquivalencyValidationContext` is a public interface, so the new property is a technically breaking addition for custom implementations. The API approval baselines in `Tests/Approval.Tests/ApprovedApi/` have been updated accordingly.

## Test plan

- [x] `dotnet build` passes with no warnings
- [x] Approval tests regenerated and accepted via `AcceptApiChanges.ps1`
- [x] Existing `CyclicReferencesSpecs` tests continue to cover the behaviour end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)