### PR TITLE
Add `ThatSatisfy` for methods and properties

### DIFF
--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -208,6 +208,15 @@ public class MethodInfoSelector : IEnumerable<MethodInfo>
     }
 
     /// <summary>
+    /// Allows to filter the methods with the <paramref name="predicate"/> passed
+    /// </summary>
+    public MethodInfoSelector ThatSatisfy(Func<MethodInfo, bool> predicate)
+    {
+        selectedMethods = selectedMethods.Where(predicate);
+        return this;
+    }
+
+    /// <summary>
     /// Select return types of the methods
     /// </summary>
     public TypeSelector ReturnTypes()

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -170,6 +170,15 @@ public class PropertyInfoSelector : IEnumerable<PropertyInfo>
     }
 
     /// <summary>
+    /// Allows to filter the properties with the <paramref name="predicate"/> passed
+    /// </summary>
+    public PropertyInfoSelector ThatSatisfy(Func<PropertyInfo, bool> predicate)
+    {
+        selectedProperties = selectedProperties.Where(predicate);
+        return this;
+    }
+
+    /// <summary>
     /// Only select the properties that return the specified type
     /// </summary>
     public PropertyInfoSelector OfType<TReturn>()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2387,6 +2387,7 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
         public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatSatisfy(System.Func<System.Reflection.MethodInfo, bool> predicate) { }
         public System.Reflection.MethodInfo[] ToArray() { }
     }
     public class MethodInfoSelectorAssertions
@@ -2450,6 +2451,7 @@ namespace FluentAssertions.Types
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatSatisfy(System.Func<System.Reflection.PropertyInfo, bool> predicate) { }
         public System.Reflection.PropertyInfo[] ToArray() { }
     }
     public class PropertyInfoSelectorAssertions

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2646,6 +2646,7 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
         public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatSatisfy(System.Func<System.Reflection.MethodInfo, bool> predicate) { }
         public System.Reflection.MethodInfo[] ToArray() { }
     }
     public class MethodInfoSelectorAssertions
@@ -2710,6 +2711,7 @@ namespace FluentAssertions.Types
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatSatisfy(System.Func<System.Reflection.PropertyInfo, bool> predicate) { }
         public System.Reflection.PropertyInfo[] ToArray() { }
     }
     public class PropertyInfoSelectorAssertions

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2331,6 +2331,7 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
         public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatSatisfy(System.Func<System.Reflection.MethodInfo, bool> predicate) { }
         public System.Reflection.MethodInfo[] ToArray() { }
     }
     public class MethodInfoSelectorAssertions
@@ -2394,6 +2395,7 @@ namespace FluentAssertions.Types
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatSatisfy(System.Func<System.Reflection.PropertyInfo, bool> predicate) { }
         public System.Reflection.PropertyInfo[] ToArray() { }
     }
     public class PropertyInfoSelectorAssertions

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2405,6 +2405,7 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatAreVirtual() { }
         public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
         public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatSatisfy(System.Func<System.Reflection.MethodInfo, bool> predicate) { }
         public System.Reflection.MethodInfo[] ToArray() { }
     }
     public class MethodInfoSelectorAssertions
@@ -2468,6 +2469,7 @@ namespace FluentAssertions.Types
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatSatisfy(System.Func<System.Reflection.PropertyInfo, bool> predicate) { }
         public System.Reflection.PropertyInfo[] ToArray() { }
     }
     public class PropertyInfoSelectorAssertions

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -439,6 +439,26 @@ public class MethodInfoSelectorSpecs
         action.Should().Throw<NotSupportedException>()
             .WithMessage("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
     }
+
+    [Fact]
+    public void When_selecting_types_with_predicate_it_should_return_the_correct_type()
+    {
+        // Arrange
+        Type type = typeof(TestClassForThatSatisfy);
+
+        // Act
+        var methods = type.Methods().ThatSatisfy(e => e.Name == nameof(TestClassForThatSatisfy.SomeMethod)).ToArray();
+
+        // Assert
+        methods.Should().ContainSingle();
+    }
+
+    private class TestClassForThatSatisfy
+    {
+        public void SomeMethod() { }
+
+        public void SomeOtherMethod() { }
+    }
 }
 
 #region Internal classes used in unit tests

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -418,6 +418,26 @@ public class PropertyInfoSelectorSpecs
             internal bool InternalBoolPrivateSet { get; private set; }
         }
     }
+
+    [Fact]
+    public void When_selecting_types_with_predicate_it_should_return_the_correct_type()
+    {
+        // Arrange
+        Type type = typeof(TestClassForThatSatisfy);
+
+        // Act
+        var properties = type.Properties().ThatSatisfy(e => e.Name == nameof(TestClassForThatSatisfy.SomeValue)).ToArray();
+
+        // Assert
+        properties.Should().ContainSingle();
+    }
+
+    private class TestClassForThatSatisfy
+    {
+        public int SomeValue { get; set; }
+
+        public int SomeOtherValue { get; set; }
+    }
 }
 
 #region Internal classes used in unit tests

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -9,6 +9,9 @@ sidebar:
 
 ## Unreleased
 
+### What's new
+* Added `ThatSatisfy` to `MethodInfoSelector` and `PropertyInfoSelector` - [#3257](https://github.com/fluentassertions/fluentassertions/pull/3257)
+
 ### Enhancements
 * `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one - [#3198](https://github.com/fluentassertions/fluentassertions/pull/3198)
 


### PR DESCRIPTION
Adds `ThatSatisfy` to `MethodInfoSelector` and `PropertyInfoSelector`

This complements the `TypeSelector.ThatSatisfy` added in #1306

Contributes to #645

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## CONTRIBUTOR LICENSE GRANT

By submitting this contribution, the contributor hereby irrevocably grants to the project owners and maintainers a perpetual, worldwide, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and create derivative works of the contribution for any purpose and under any terms, including proprietary licensing.

The contributor waives any moral rights in the contribution to the extent permitted by law and agrees not to assert any claim of authorship or control over the contribution. The contributor represents that they are the sole author of the contribution and that it is provided free of any third-party claims.

The contributor understands and agrees that the maintainers may, at their sole discretion, use, license, or redistribute the contribution as part of any work and under any terms they choose, without further permission or attribution.

* [ ] I have read the Contributor License Grant and accept the conditions
* [ ] I'm interested in a free license for Fluent Assertions and will share my email address through sales@xceed.com