### PR TITLE
Add BeSupersetOf, BeProperSubsetOf and BeProperSupersetOf collection assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ node_modules/
 
 # JetBrains Junie AI agent memory
 .junie/memory/
+
+# Nuke/Fallout
+.nuke/temp

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -786,6 +786,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
+    [StackTraceHidden]
     private void AssertSubsetOf(IEnumerable<T> expectedSuperset, string subsetType,
         string because, object[] becauseArgs)
     {
@@ -913,6 +914,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
+    [StackTraceHidden]
     private void AssertContainment(IEnumerable<T> expected, string containmentType, string because, object[] becauseArgs,
         bool allowEmptyExpectation)
     {

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -661,7 +661,10 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that the collection is a subset of the <paramref name="expectedSuperset" />.
+    /// Asserts that every item in the collection is also present in <paramref name="expectedSuperset" />.
+    /// In other words, <paramref name="expectedSuperset" /> must contain all the items of the collection, but is
+    /// allowed to have additional items of its own. If <paramref name="expectedSuperset" /> is empty, this only
+    /// passes when the collection itself is also empty (an empty collection has nothing else to find items for).
     /// </summary>
     /// <param name="expectedSuperset">An <see cref="IEnumerable{T}"/> with the expected superset.</param>
     /// <param name="because">
@@ -682,9 +685,11 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that the collection is a superset of the <paramref name="expectedSubset" />.
-    /// If <paramref name="expectedSubset" /> is equivalent to the subject then it's still a valid superset since all of
-    /// its items are contained in the subject.
+    /// Asserts that every item in <paramref name="expectedSubset" /> is also present in the collection.
+    /// In other words, the collection must contain all the items of <paramref name="expectedSubset" />, but is
+    /// allowed to have additional items of its own (if the collection contains exactly the same items as
+    /// <paramref name="expectedSubset" />, it still counts as a valid superset). If <paramref name="expectedSubset" />
+    /// is empty, this always passes: there are no items left to find, no matter what the collection looks like.
     /// </summary>
     /// <param name="expectedSubset">An <see cref="IEnumerable{T}"/> with the expected subset.</param>
     /// <param name="because">
@@ -695,22 +700,22 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="expectedSubset"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentException"><paramref name="expectedSubset"/> is empty.</exception>
     /// <remarks>This method is an alias for <see cref="Contain(IEnumerable{T}, string, object[])"/></remarks>
     public AndConstraint<TAssertions> BeSupersetOf(IEnumerable<T> expectedSubset,
         [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        AssertContainment(expectedSubset, "be a superset of", because, becauseArgs);
+        AssertContainment(expectedSubset, "be a superset of", because, becauseArgs, allowEmptyExpectation: true);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
     /// <summary>
-    /// Asserts that the collection is a proper subset of the <paramref name="expectedProperSuperset" />.
-    /// If <paramref name="expectedProperSuperset" /> is equivalent to the subject then the subject is not a proper
-    /// subset. <paramref name="expectedProperSuperset" /> must contain at least one element that is not present in the
-    /// subject.
+    /// Asserts that every item in the collection is also present in <paramref name="expectedProperSuperset" />, and
+    /// that <paramref name="expectedProperSuperset" /> also contains at least one item that is not present in the
+    /// collection. In other words, the two collections may not contain exactly the same items: if they do, the
+    /// collection is not a proper subset and this assertion fails (even when both are empty, because two empty
+    /// collections are considered identical).
     /// </summary>
     /// <param name="expectedProperSuperset">An <see cref="IEnumerable{T}"/> with the expected superset.</param>
     /// <param name="because">
@@ -743,10 +748,13 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     }
 
     /// <summary>
-    /// Asserts that the collection is a proper superset of the <paramref name="expectedProperSubset" />.
-    /// If <paramref name="expectedProperSubset" /> is equivalent to the subject then the subject is not a proper
-    /// superset. The subject must contain at least one element that is not present in
-    /// <paramref name="expectedProperSubset" />.
+    /// Asserts that every item in <paramref name="expectedProperSubset" /> is also present in the collection, and
+    /// that the collection also contains at least one item that is not present in
+    /// <paramref name="expectedProperSubset" />. In other words, the two collections may not contain exactly the
+    /// same items: if they do, the collection is not a proper superset and this assertion fails (even when both are
+    /// empty, because two empty collections are considered identical). If <paramref name="expectedProperSubset" />
+    /// is empty and the collection has at least one item, this always passes: any non-empty collection is a proper
+    /// superset of an empty one.
     /// </summary>
     /// <param name="expectedProperSubset">An <see cref="IEnumerable{T}"/> with the expected subset.</param>
     /// <param name="because">
@@ -757,12 +765,11 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="expectedProperSubset"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentException"><paramref name="expectedProperSubset"/> is empty.</exception>
     public AndConstraint<TAssertions> BeProperSupersetOf(IEnumerable<T> expectedProperSubset,
         [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        AssertContainment(expectedProperSubset, "be a proper superset of", because, becauseArgs);
+        AssertContainment(expectedProperSubset, "be a proper superset of", because, becauseArgs, allowEmptyExpectation: true);
 
         if (assertionChain.Succeeded)
         {
@@ -901,17 +908,22 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     public AndConstraint<TAssertions> Contain(IEnumerable<T> expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        AssertContainment(expected, "contain", because, becauseArgs);
+        AssertContainment(expected, "contain", because, becauseArgs, allowEmptyExpectation: false);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
-    private void AssertContainment(IEnumerable<T> expected, string containmentType, string because, object[] becauseArgs)
+    private void AssertContainment(IEnumerable<T> expected, string containmentType, string because, object[] becauseArgs,
+        bool allowEmptyExpectation)
     {
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify containment against a <null> collection");
 
         ICollection<T> expectedObjects = expected.ConvertOrCastToCollection();
-        Guard.ThrowIfArgumentIsEmpty(expectedObjects, nameof(expected), "Cannot verify containment against an empty collection");
+
+        if (!allowEmptyExpectation)
+        {
+            Guard.ThrowIfArgumentIsEmpty(expectedObjects, nameof(expected), "Cannot verify containment against an empty collection");
+        }
 
         assertionChain
             .BecauseOf(because, becauseArgs)
@@ -924,7 +936,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
 
             if (missingItems.Any())
             {
-                if (expectedObjects.Count > 1)
+                if (expectedObjects.Count > 1 || allowEmptyExpectation)
                 {
                     assertionChain
                         .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -676,21 +676,126 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
+        AssertSubsetOf(expectedSuperset, "subset", because, becauseArgs);
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
+    /// Asserts that the collection is a superset of the <paramref name="expectedSubset" />.
+    /// If <paramref name="expectedSubset" /> is equivalent to the subject then it's still a valid superset since all of
+    /// its items are contained in the subject.
+    /// </summary>
+    /// <param name="expectedSubset">An <see cref="IEnumerable{T}"/> with the expected subset.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="expectedSubset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="expectedSubset"/> is empty.</exception>
+    /// <remarks>This method is an alias for <see cref="Contain(IEnumerable{T}, string, object[])"/></remarks>
+    public AndConstraint<TAssertions> BeSupersetOf(IEnumerable<T> expectedSubset,
+        [StringSyntax("CompositeFormat")] string because = "",
+        params object[] becauseArgs)
+    {
+        AssertContainment(expectedSubset, "be a superset of", because, becauseArgs);
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
+    /// Asserts that the collection is a proper subset of the <paramref name="expectedProperSuperset" />.
+    /// If <paramref name="expectedProperSuperset" /> is equivalent to the subject then the subject is not a proper
+    /// subset. <paramref name="expectedProperSuperset" /> must contain at least one element that is not present in the
+    /// subject.
+    /// </summary>
+    /// <param name="expectedProperSuperset">An <see cref="IEnumerable{T}"/> with the expected superset.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="expectedProperSuperset"/> is <see langword="null"/>.</exception>
+    public AndConstraint<TAssertions> BeProperSubsetOf(IEnumerable<T> expectedProperSuperset,
+        [StringSyntax("CompositeFormat")] string because = "",
+        params object[] becauseArgs)
+    {
+        AssertSubsetOf(expectedProperSuperset, "proper subset", because, becauseArgs);
+
+        if (assertionChain.Succeeded)
+        {
+            ISet<T> expectedItems = expectedProperSuperset.ConvertOrCastToSet();
+
+            assertionChain
+                .ForCondition(expectedItems.Intersect(Subject!).Count() != expectedItems.Count)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected {context:collection} to be a proper subset of {0}{reason}, but items {1} are equivalent to the superset {2}",
+                    expectedProperSuperset, Subject, expectedProperSuperset);
+        }
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
+    /// Asserts that the collection is a proper superset of the <paramref name="expectedProperSubset" />.
+    /// If <paramref name="expectedProperSubset" /> is equivalent to the subject then the subject is not a proper
+    /// superset. The subject must contain at least one element that is not present in
+    /// <paramref name="expectedProperSubset" />.
+    /// </summary>
+    /// <param name="expectedProperSubset">An <see cref="IEnumerable{T}"/> with the expected subset.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="expectedProperSubset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="expectedProperSubset"/> is empty.</exception>
+    public AndConstraint<TAssertions> BeProperSupersetOf(IEnumerable<T> expectedProperSubset,
+        [StringSyntax("CompositeFormat")] string because = "",
+        params object[] becauseArgs)
+    {
+        AssertContainment(expectedProperSubset, "be a proper superset of", because, becauseArgs);
+
+        if (assertionChain.Succeeded)
+        {
+            ISet<T> actualItems = Subject!.ConvertOrCastToSet();
+
+            assertionChain
+                .ForCondition(actualItems.Intersect(expectedProperSubset).Count() != actualItems.Count)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected {context:collection} to be a proper superset of {0}{reason}, but items {1} are equivalent to the subset {2}",
+                    expectedProperSubset, Subject, expectedProperSubset);
+        }
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    private void AssertSubsetOf(IEnumerable<T> expectedSuperset, string subsetType,
+        string because, object[] becauseArgs)
+    {
         Guard.ThrowIfArgumentIsNull(expectedSuperset, nameof(expectedSuperset),
-            "Cannot verify a subset against a <null> collection.");
+            "Cannot verify a " + subsetType + " against a <null> collection.");
 
         assertionChain
             .BecauseOf(because, becauseArgs)
-            .WithExpectation("Expected {context:collection} to be a subset of {0}{reason}, ", expectedSuperset, chain => chain
-                .Given(() => Subject)
-                .ForCondition(subject => subject is not null)
-                .FailWith("but found <null>.")
-                .Then
-                .Given(subject => subject.Except(expectedSuperset))
-                .ForCondition(excessItems => !excessItems.Any())
-                .FailWith("but items {0} are not part of the superset.", excessItems => excessItems));
-
-        return new AndConstraint<TAssertions>((TAssertions)this);
+            .WithExpectation("Expected {context:collection} to be a " + subsetType + " of {0}{reason}, ", expectedSuperset,
+                chain => chain
+                    .Given(() => Subject)
+                    .ForCondition(subject => subject is not null)
+                    .FailWith("but found <null>.")
+                    .Then
+                    .Given(subject => subject.Except(expectedSuperset))
+                    .ForCondition(excessItems => !excessItems.Any())
+                    .FailWith("but items {0} are not part of the superset.", excessItems => excessItems));
     }
 
     /// <summary>
@@ -796,6 +901,13 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     public AndConstraint<TAssertions> Contain(IEnumerable<T> expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
+        AssertContainment(expected, "contain", because, becauseArgs);
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    private void AssertContainment(IEnumerable<T> expected, string containmentType, string because, object[] becauseArgs)
+    {
         Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify containment against a <null> collection");
 
         ICollection<T> expectedObjects = expected.ConvertOrCastToCollection();
@@ -804,7 +916,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         assertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject is not null)
-            .FailWith("Expected {context:collection} to contain {0}{reason}, but found <null>.", expectedObjects);
+            .FailWith("Expected {context:collection} to " + containmentType + " {0}{reason}, but found <null>.", expectedObjects);
 
         if (assertionChain.Succeeded)
         {
@@ -816,20 +928,19 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
                 {
                     assertionChain
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} {0} to contain {1}{reason}, but could not find {2}.",
+                        .FailWith(
+                            "Expected {context:collection} {0} to " + containmentType + " {1}{reason}, but could not find {2}.",
                             Subject, expectedObjects, missingItems);
                 }
                 else
                 {
                     assertionChain
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} {0} to contain {1}{reason}.",
+                        .FailWith("Expected {context:collection} {0} to " + containmentType + " {1}{reason}.",
                             Subject, expectedObjects.Single());
                 }
             }
         }
-
-        return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Common/EnumerableExtensions.cs
+++ b/Src/FluentAssertions/Common/EnumerableExtensions.cs
@@ -17,6 +17,11 @@ internal static class EnumerableExtensions
         return source as IList<T> ?? source.ToList();
     }
 
+    public static ISet<T> ConvertOrCastToSet<T>(this IEnumerable<T> source)
+    {
+        return source as ISet<T> ?? new HashSet<T>(source);
+    }
+
     /// <summary>
     /// Searches for the first different element in two sequences using specified <paramref name="equalityComparison" />
     /// </summary>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -419,7 +419,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSubsetOf(System.Collections.Generic.IEnumerable<T> expectedProperSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSupersetOf(System.Collections.Generic.IEnumerable<T> expectedProperSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.Generic.IEnumerable<T> expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSupersetOf(System.Collections.Generic.IEnumerable<T> expectedSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -465,7 +465,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSubsetOf(System.Collections.Generic.IEnumerable<T> expectedProperSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSupersetOf(System.Collections.Generic.IEnumerable<T> expectedProperSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.Generic.IEnumerable<T> expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSupersetOf(System.Collections.Generic.IEnumerable<T> expectedSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -411,7 +411,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSubsetOf(System.Collections.Generic.IEnumerable<T> expectedProperSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSupersetOf(System.Collections.Generic.IEnumerable<T> expectedProperSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.Generic.IEnumerable<T> expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSupersetOf(System.Collections.Generic.IEnumerable<T> expectedSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -429,7 +429,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSubsetOf(System.Collections.Generic.IEnumerable<T> expectedProperSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeProperSupersetOf(System.Collections.Generic.IEnumerable<T> expectedProperSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.Generic.IEnumerable<T> expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSupersetOf(System.Collections.Generic.IEnumerable<T> expectedSubset, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeProperSubsetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeProperSubsetOf.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using FluentAssertions.Execution;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Collections;
+
+/// <content>
+/// The BeProperSubsetOf specs.
+/// </content>
+public partial class CollectionAssertionSpecs
+{
+    public class BeProperSubsetOf
+    {
+        [Fact]
+        public void A_collection_with_only_items_of_a_superset_but_misses_some_is_a_proper_subset()
+        {
+            // Arrange
+            var subset = new[] { 1, 2 };
+            var superset = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            subset.Should().BeProperSubsetOf(superset);
+        }
+
+        [Fact]
+        public void A_collection_with_duplicates_and_only_items_of_a_superset_with_duplicates_but_misses_some_is_a_proper_subset()
+        {
+            // Arrange
+            var subset = new[] { 1, 1, 1, 2, 2, 3, 3 };
+            var superset = new[] { 1, 2, 3, 3, 3, 4 };
+
+            // Act / Assert
+            subset.Should().BeProperSubsetOf(superset);
+        }
+
+        [Fact]
+        public void A_collection_with_all_items_of_a_superset_but_has_extra_items_is_not_a_proper_subset()
+        {
+            // Arrange
+            var subset = new[] { 1, 2, 3, 4 };
+            var superset = new[] { 4, 3, 2, 1 };
+
+            // Act
+            Action act = () => subset.Should().BeProperSubsetOf(superset, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected subset to be a proper subset of {4, 3, 2, 1} because we want to test the failure message, " +
+                "but items {1, 2, 3, 4} are equivalent to the superset {4, 3, 2, 1}");
+        }
+
+        [Fact]
+        public void A_collection_with_all_items_and_duplicates_of_a_superset_but_has_extra_items_is_not_a_proper_subset()
+        {
+            // Arrange
+            var subset = new[] { 1, 1, 1, 2, 2, 3, 3, 4 };
+            var superset = new[] { 4, 3, 2, 1 };
+
+            // Act
+            Action act = () => subset.Should().BeProperSubsetOf(superset, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected subset to be a proper subset of {4, 3, 2, 1} because we want to test the failure message, " +
+                "but items {1, 1, 1, 2, 2, 3, 3, 4} are equivalent to the superset {4, 3, 2, 1}");
+        }
+
+        [Fact]
+        public void A_collection_with_duplicates_is_not_a_proper_subset_of_a_superset_with_duplicates()
+        {
+            // Arrange
+            var subset = new[] { 1, 1, 1, 2, 2, 3, 3, 4 };
+            var superset = new[] { 4, 4, 4, 3, 3, 2, 1, 1 };
+
+            // Act
+            Action act = () => subset.Should().BeProperSubsetOf(superset, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected subset to be a proper subset of {4, 4, 4, 3, 3, 2, 1, 1} because we want to test the failure message, " +
+                "but items {1, 1, 1, 2, 2, 3, 3, 4} are equivalent to the superset {4, 4, 4, 3, 3, 2, 1, 1}");
+        }
+
+        [Fact]
+        public void A_collection_that_is_not_a_proper_subset_of_other_collection_with_assertion_scope()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().BeProperSubsetOf(new[] { 4 });
+                collection.Should().BeProperSubsetOf(new[] { 5, 6 });
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*to be a proper subset of {4}*to be a proper subset of {5, 6}*");
+        }
+
+        [Fact]
+        public void An_empty_collection_tested_against_a_proper_superset()
+        {
+            // Arrange
+            var subset = new int[0];
+            var superset = new[] { 1, 2, 4, 5 };
+
+            // Act
+            Action act = () => subset.Should().BeProperSubsetOf(superset);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void A_non_empty_subset_tested_against_a_null_superset()
+        {
+            // Arrange
+            var subset = new[] { 1, 2, 3 };
+            int[] superset = null;
+
+            // Act
+            Action act = () => subset.Should().BeProperSubsetOf(superset);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithMessage(
+                "Cannot verify a proper subset against a <null> collection.*");
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeProperSubsetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeProperSubsetOf.cs
@@ -116,6 +116,21 @@ public partial class CollectionAssertionSpecs
         }
 
         [Fact]
+        public void An_empty_collection_is_not_a_proper_subset_of_an_empty_collection()
+        {
+            // Arrange
+            var subset = new int[0];
+            var superset = new int[0];
+
+            // Act
+            Action act = () => subset.Should().BeProperSubsetOf(superset);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected subset to be a proper subset of {empty}, but items {empty} are equivalent to the superset {empty}*");
+        }
+
+        [Fact]
         public void A_non_empty_subset_tested_against_a_null_superset()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeProperSupersetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeProperSupersetOf.cs
@@ -105,7 +105,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to be a proper superset of 4 because we do.");
+                "Expected collection {1, 2, 3} to be a proper superset of {4} because we do, but could not find {4}.");
         }
 
         [Fact]
@@ -124,21 +124,45 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*to be a proper superset of 4*to be a proper superset of {5, 6}*");
+                "*to be a proper superset of {4}*to be a proper superset of {5, 6}*");
         }
 
         [Fact]
-        public void A_collection_is_not_a_proper_superset_of_an_empty_collection()
+        public void A_non_empty_collection_is_a_proper_superset_of_an_empty_collection()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().BeProperSupersetOf(new int[0]);
+        }
+
+        [Fact]
+        public void An_empty_collection_is_not_a_proper_superset_of_an_empty_collection()
+        {
+            // Arrange
+            var collection = new int[0];
 
             // Act
             Action act = () => collection.Should().BeProperSupersetOf(new int[0]);
 
             // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify containment against an empty collection*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection to be a proper superset of {empty}, but items {empty} are equivalent to the subset {empty}*");
+        }
+
+        [Fact]
+        public void A_collection_is_not_a_proper_superset_of_an_equal_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeProperSupersetOf(new[] { 1, 2, 3 });
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection to be a proper superset of {1, 2, 3}, but items {1, 2, 3} are equivalent to the subset {1, 2, 3}*");
         }
 
         [Fact]
@@ -157,6 +181,20 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected collection to be a proper superset of {1, 2} *failure message*, but found <null>.");
+        }
+
+        [Fact]
+        public void A_collection_cannot_be_a_proper_superset_of_a_null_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeProperSupersetOf(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithMessage(
+                "Cannot verify containment against a <null> collection*");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeProperSupersetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeProperSupersetOf.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using FluentAssertions.Execution;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Collections;
+
+/// <content>
+/// The BeProperSupersetOf specs.
+/// </content>
+public partial class CollectionAssertionSpecs
+{
+    public class BeProperSupersetOf
+    {
+        [Fact]
+        public void A_collection_contains_multiple_items_from_the_collection_in_any_order()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().BeProperSupersetOf(new[] { 2, 1 });
+        }
+
+        [Fact]
+        public void A_collection_contains_multiple_items_with_duplicates_from_the_collection_in_any_order()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().BeProperSupersetOf(new[] { 2, 1, 1, 1, 2 });
+        }
+
+        [Fact]
+        public void A_collection_is_not_a_proper_superset_of_a_subset()
+        {
+            // Arrange
+            var superset = new[] { 1, 2, 3, 4 };
+            var subset = new[] { 4, 3, 2, 1 };
+
+            // Act
+            Action act = () => superset.Should().BeProperSupersetOf(subset, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected superset to be a proper superset of {4, 3, 2, 1} because we want to test the failure message, " +
+                "but items {1, 2, 3, 4} are equivalent to the subset {4, 3, 2, 1}");
+        }
+
+        [Fact]
+        public void A_collection_is_not_a_proper_superset_of_another_with_duplicates()
+        {
+            // Arrange
+            var subset = new[] { 1, 1, 1, 2, 2, 3, 3, 4 };
+            var superset = new[] { 4, 3, 2, 1 };
+
+            // Act
+            Action act = () => superset.Should().BeProperSupersetOf(subset, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected superset to be a proper superset of {1, 1, 1, 2, 2, 3, 3, 4} because we want to test the failure message, " +
+                "but items {4, 3, 2, 1} are equivalent to the subset {1, 1, 1, 2, 2, 3, 3, 4}");
+        }
+
+        [Fact]
+        public void A_collection_with_duplicates_is_not_a_proper_superset_of_another_with_duplicates()
+        {
+            // Arrange
+            var subset = new[] { 1, 1, 1, 2, 2, 3, 3, 4 };
+            var superset = new[] { 4, 4, 4, 3, 3, 2, 1, 1 };
+
+            // Act
+            Action act = () => superset.Should().BeProperSupersetOf(subset, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected superset to be a proper superset of {1, 1, 1, 2, 2, 3, 3, 4} because we want to test the failure message, " +
+                "but items {4, 4, 4, 3, 3, 2, 1, 1} are equivalent to the subset {1, 1, 1, 2, 2, 3, 3, 4}");
+        }
+
+        [Fact]
+        public void A_collection_does_not_contain_another_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeProperSupersetOf(new[] { 3, 4, 5 }, "because {0}", "we do");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3} to be a proper superset of {3, 4, 5} because we do, but could not find {4, 5}.");
+        }
+
+        [Fact]
+        public void A_collection_does_not_contain_a_single_element_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeProperSupersetOf(new[] { 4 }, "because {0}", "we do");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3} to be a proper superset of 4 because we do.");
+        }
+
+        [Fact]
+        public void A_collection_does_not_contain_other_collection_with_assertion_scope()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().BeProperSupersetOf(new[] { 4 });
+                collection.Should().BeProperSupersetOf(new[] { 5, 6 });
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*to be a proper superset of 4*to be a proper superset of {5, 6}*");
+        }
+
+        [Fact]
+        public void A_collection_is_not_a_proper_superset_of_an_empty_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeProperSupersetOf(new int[0]);
+
+            // Assert
+            act.Should().Throw<ArgumentException>().WithMessage(
+                "Cannot verify containment against an empty collection*");
+        }
+
+        [Fact]
+        public void A_null_collection_is_not_a_proper_superset_of_a_collection()
+        {
+            // Arrange
+            int[] collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().BeProperSupersetOf(new[] { 1, 2 }, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection to be a proper superset of {1, 2} *failure message*, but found <null>.");
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeSupersetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeSupersetOf.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using FluentAssertions.Execution;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Collections;
+
+/// <content>
+/// The BeSupersetOf specs.
+/// </content>
+public partial class CollectionAssertionSpecs
+{
+    public class BeSupersetOf
+    {
+        [Fact]
+        public void A_collection_contains_multiple_items_from_the_collection_in_any_order()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().BeSupersetOf(new[] { 2, 1 });
+        }
+
+        [Fact]
+        public void A_collection_does_not_contain_another_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeSupersetOf(new[] { 3, 4, 5 }, "because {0}", "we do");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3} to be a superset of {3, 4, 5} because we do, but could not find {4, 5}.");
+        }
+
+        [Fact]
+        public void A_collection_does_not_contain_a_single_element_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeSupersetOf(new[] { 4 }, "because {0}", "we do");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3} to be a superset of 4 because we do.");
+        }
+
+        [Fact]
+        public void A_collection_does_not_contain_other_collection_with_assertion_scope()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().BeSupersetOf(new[] { 4 });
+                collection.Should().BeSupersetOf(new[] { 5, 6 });
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*to be a superset of 4*to be a superset of {5, 6}*");
+        }
+
+        [Fact]
+        public void A_collection_is_not_a_superset_of_an_empty_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeSupersetOf(new int[0]);
+
+            // Assert
+            act.Should().Throw<ArgumentException>().WithMessage(
+                "Cannot verify containment against an empty collection*");
+        }
+
+        [Fact]
+        public void A_null_collection_is_not_a_superset_of_a_collection()
+        {
+            // Arrange
+            int[] collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().BeSupersetOf(new[] { 1, 2 }, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection to be a superset of {1, 2} *failure message*, but found <null>.");
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeSupersetOf.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeSupersetOf.cs
@@ -47,7 +47,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to be a superset of 4 because we do.");
+                "Expected collection {1, 2, 3} to be a superset of {4} because we do, but could not find {4}.");
         }
 
         [Fact]
@@ -66,21 +66,37 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*to be a superset of 4*to be a superset of {5, 6}*");
+                "*to be a superset of {4}*to be a superset of {5, 6}*");
         }
 
         [Fact]
-        public void A_collection_is_not_a_superset_of_an_empty_collection()
+        public void A_collection_is_a_superset_of_an_empty_collection()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
 
-            // Act
-            Action act = () => collection.Should().BeSupersetOf(new int[0]);
+            // Act / Assert
+            collection.Should().BeSupersetOf(new int[0]);
+        }
 
-            // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot verify containment against an empty collection*");
+        [Fact]
+        public void An_empty_collection_is_a_superset_of_an_empty_collection()
+        {
+            // Arrange
+            var collection = new int[0];
+
+            // Act / Assert
+            collection.Should().BeSupersetOf(new int[0]);
+        }
+
+        [Fact]
+        public void A_collection_is_a_superset_of_an_equal_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().BeSupersetOf(new[] { 1, 2, 3 });
         }
 
         [Fact]
@@ -99,6 +115,20 @@ public partial class CollectionAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected collection to be a superset of {1, 2} *failure message*, but found <null>.");
+        }
+
+        [Fact]
+        public void A_collection_cannot_be_a_superset_of_a_null_collection()
+        {
+            // Arrange
+            var collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().BeSupersetOf(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithMessage(
+                "Cannot verify containment against a <null> collection*");
         }
     }
 }

--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -40,7 +40,17 @@ collection.Should().StartWith(new[] { 1, 2 });
 collection.Should().EndWith(8);
 collection.Should().EndWith(new[] { 5, 8 });
 
+// Every item in the collection must be part of the given superset. The two collections may be equivalent.
 collection.Should().BeSubsetOf(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, });
+
+// Every item in the collection must be part of the given superset, which must contain at least one item that is not in the collection.
+collection.Should().BeProperSubsetOf(new[] { 1, 2, 5, 6, 7, 8 });
+
+// The collection must contain every item of the given subset. The two collections may be equivalent.
+collection.Should().BeSupersetOf(new[] { 1, 2, 5, 8 });
+
+// The collection must contain every item of the given subset, and must itself contain at least one item that is not in the subset.
+collection.Should().BeProperSupersetOf(new[] { 1, 5, 2 });
 
 collection.Should().ContainSingle();
 collection.Should().ContainSingle(x => x > 3);

--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -47,9 +47,11 @@ collection.Should().BeSubsetOf(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, });
 collection.Should().BeProperSubsetOf(new[] { 1, 2, 5, 6, 7, 8 });
 
 // The collection must contain every item of the given subset. The two collections may be equivalent.
+// An empty subset always satisfies this assertion.
 collection.Should().BeSupersetOf(new[] { 1, 2, 5, 8 });
 
 // The collection must contain every item of the given subset, and must itself contain at least one item that is not in the subset.
+// If the subset is empty, this passes as long as the collection has any items at all.
 collection.Should().BeProperSupersetOf(new[] { 1, 5, 2 });
 
 collection.Should().ContainSingle();

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,8 +11,7 @@ sidebar:
 
 ### What's new
 * Added `ThatSatisfy` to `MethodInfoSelector` and `PropertyInfoSelector` - [#3257](https://github.com/fluentassertions/fluentassertions/pull/3257)
-* Introduced new collection assertion methods `BeSupersetOf`, `BeProperSubsetOf` and `BeProperSupersetOf` - [#3271](https://github.com/fluentassertions/fluentassertions/pull/3271)
-* `BeSupersetOf` and `BeProperSupersetOf` no longer throw when the expected subset is empty; an empty expectation is now treated as a valid (trivially satisfied) subset - [#3271](https://github.com/fluentassertions/fluentassertions/pull/3271)
+* Introduced new collection assertion methods `BeSupersetOf`, `BeProperSubsetOf` and `BeProperSupersetOf`, where an empty expected subset is treated as a valid (trivially satisfied) case for `BeSupersetOf` and `BeProperSupersetOf` instead of throwing - [#3271](https://github.com/fluentassertions/fluentassertions/pull/3271)
 
 ### Enhancements
 * `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one - [#3198](https://github.com/fluentassertions/fluentassertions/pull/3198)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's new
 * Added `ThatSatisfy` to `MethodInfoSelector` and `PropertyInfoSelector` - [#3257](https://github.com/fluentassertions/fluentassertions/pull/3257)
 * Introduced new collection assertion methods `BeSupersetOf`, `BeProperSubsetOf` and `BeProperSupersetOf` - [#3271](https://github.com/fluentassertions/fluentassertions/pull/3271)
+* `BeSupersetOf` and `BeProperSupersetOf` no longer throw when the expected subset is empty; an empty expectation is now treated as a valid (trivially satisfied) subset - [#3271](https://github.com/fluentassertions/fluentassertions/pull/3271)
 
 ### Enhancements
 * `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one - [#3198](https://github.com/fluentassertions/fluentassertions/pull/3198)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,7 @@ sidebar:
 
 ### What's new
 * Added `ThatSatisfy` to `MethodInfoSelector` and `PropertyInfoSelector` - [#3257](https://github.com/fluentassertions/fluentassertions/pull/3257)
+* Introduced new collection assertion methods `BeSupersetOf`, `BeProperSubsetOf` and `BeProperSupersetOf` - [#3271](https://github.com/fluentassertions/fluentassertions/pull/3271)
 
 ### Enhancements
 * `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one - [#3198](https://github.com/fluentassertions/fluentassertions/pull/3198)


### PR DESCRIPTION
Ports the work originally submitted in #2432 by @Meir017 (` Meir017:feature/api-subset-and-superset`), which added BeSupersetOf, BeProperSubsetOf and BeProperSupersetOf collection assertions.

That PR could not be reopened because its base branch (develop) has since been deleted/renamed to main, so this PR recreates the same feature against current main.

## What's included
- BeSupersetOf / BeProperSubsetOf / BeProperSupersetOf assertions on GenericCollectionAssertions
- ConvertOrCastToSet extension in EnumerableExtensions
- Extracted AssertSubsetOf / AssertContainment helpers so BeSubsetOf / Contain share logic with the new assertions
- Ported and adjusted spec tests from the original PR (adapted to the current AssertionChain API; fixed a couple of tests that relied on .And.-chaining the same assertions instance, which no longer replays a second failing assertion once the chain has already failed)
- Updated docs/_pages/collections.md and docs/_pages/releases.md
- Regenerated API approval baselines (AcceptApiChanges.ps1)

Closes #2432
Resolves #2363

All credit for the original design and implementation goes to @Meir017.

## Empty-collection behavior

Following up on review feedback, here's how each assertion behaves when the expected collection is empty:

| Assertion | Expectation | Subject | Result |
|---|---|---|---|
| `BeSubsetOf` | empty | empty | Passes |
| `BeSubsetOf` | empty | non-empty | Fails (subject has extra items) |
| `BeProperSubsetOf` | empty | empty | Fails (two empty collections are identical, so it's not a *proper* subset) |
| `BeSupersetOf` | empty | empty or non-empty | Passes (there's nothing left to find in an empty expectation, so it's always satisfied) |
| `BeProperSupersetOf` | empty | empty | Fails (identical collections aren't a *proper* superset) |
| `BeProperSupersetOf` | empty | non-empty | Passes (any non-empty collection is a proper superset of an empty one) |
| any of the four | `null` | any | Throws `ArgumentNullException` |

`BeSupersetOf` and `BeProperSupersetOf` previously threw `ArgumentException` for an empty expectation instead of evaluating normally - that's now fixed so they behave consistently with `BeSubsetOf`/`BeProperSubsetOf`.
