### PR TITLE
Pin System.Security.Cryptography.Xml to patched version to fix build restore failures

### DIFF
--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -18,5 +18,8 @@
     <PackageReference Include="Fallout.Common" Version="$(FalloutVersion)" />
     <PackageReference Include="Fallout.Components" Version="$(FalloutVersion)" />
     <PackageReference Include="SharpCompress" Version="0.49.1" />
+    <!-- Pin transitive dependency to a patched version to avoid the NU1903 audit error for
+         System.Security.Cryptography.Xml 10.0.6 (GHSA-23rf-6693-g89p and related advisories). -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why

PR #3282's CI checks (and any other PR/branch right now) fail during `dotnet restore` of `Build/_build.csproj`, unrelated to any code changes:

```
error NU1903: Warning As Error: Package 'System.Security.Cryptography.Xml' 10.0.6
has a known high severity vulnerability, https://github.com/advisories/GHSA-23rf-6693-g89p
(+ 4 more advisories for the same package/version)
```

`System.Security.Cryptography.Xml` 10.0.6 is pulled in transitively by build-tooling packages referenced in `Build/_build.csproj`. Because `Directory.Build.props` sets `TreatWarningsAsErrors = true`, NuGet's audit warning (NU1903) is escalated to a hard error, breaking restore for the whole solution.

## Fix

Add a direct `PackageReference` for `System.Security.Cryptography.Xml` pinned to the patched `10.0.10` version in `Build/_build.csproj`, overriding the vulnerable transitive version.

## Verification

- `dotnet restore Build\_build.csproj` — succeeds, no NU1903.
- `dotnet build Build\_build.csproj` — succeeds, 0 warnings/errors.

Only touches build tooling; no public API or library changes, so no `api-approved` issue/docs update needed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>