### PR TITLE
Clean-up the stack trace further

### DIFF
--- a/Src/FluentAssertions/AggregateExceptionExtractor.cs
+++ b/Src/FluentAssertions/AggregateExceptionExtractor.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Common;
 using FluentAssertions.Specialized;
 
 namespace FluentAssertions;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class AggregateExceptionExtractor : IExtractExceptions
 {
     public IEnumerable<T> OfType<T>(Exception actualException)

--- a/Src/FluentAssertions/AssertionConfiguration.cs
+++ b/Src/FluentAssertions/AssertionConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using FluentAssertions.Configuration;
 
 namespace FluentAssertions;
@@ -5,7 +6,7 @@ namespace FluentAssertions;
 /// <summary>
 /// Provides access to the global configuration and options to customize the behavior of FluentAssertions.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public static class AssertionConfiguration
 {
     public static GlobalConfiguration Current => AssertionEngine.Configuration;

--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -330,6 +330,7 @@ public static class AssertionExtensions
         return () => ForceEnumeration(subject, enumerable);
     }
 
+    [StackTraceHidden]
     private static void ForceEnumeration(Func<IEnumerable> enumerable)
     {
         foreach (object _ in enumerable())
@@ -338,6 +339,7 @@ public static class AssertionExtensions
         }
     }
 
+    [StackTraceHidden]
     private static void ForceEnumeration<T>(T subject, Func<T, IEnumerable> enumerable)
     {
         foreach (object _ in enumerable(subject))
@@ -1131,6 +1133,7 @@ public static class AssertionExtensions
     }
 
     [DoesNotReturn]
+    [StackTraceHidden]
     private static void InvalidShouldCall()
     {
         throw new InvalidOperationException(

--- a/Src/FluentAssertions/AtLeast.cs
+++ b/Src/FluentAssertions/AtLeast.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public static class AtLeast
 {
     public static OccurrenceConstraint Once() => new AtLeastTimesConstraint(1);

--- a/Src/FluentAssertions/AtMost.cs
+++ b/Src/FluentAssertions/AtMost.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public static class AtMost
 {
     public static OccurrenceConstraint Once() => new AtMostTimesConstraint(1);

--- a/Src/FluentAssertions/CallerIdentification/AwaitParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/AwaitParsingStrategy.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Diagnostics;
+using System.Text;
 
 namespace FluentAssertions.CallerIdentification;
 
@@ -16,6 +17,7 @@ internal class AwaitParsingStrategy : IParsingStrategy
         return ParsingState.InProgress;
     }
 
+    [StackTraceHidden]
     private static bool EndsWithOurKeyword(StringBuilder statement)
     {
         var leftIndex = statement.Length - 1;
@@ -32,6 +34,7 @@ internal class AwaitParsingStrategy : IParsingStrategy
         return true;
     }
 
+    [StackTraceHidden]
     private static bool IsLongEnoughToContainOurKeyword(StringBuilder statement) => statement.Length >= KeywordToSkip.Length;
 
     public bool IsWaitingForContextEnd()

--- a/Src/FluentAssertions/CallerIdentification/QuotesParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/QuotesParsingStrategy.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 
 namespace FluentAssertions.CallerIdentification;
@@ -52,6 +53,7 @@ internal class QuotesParsingStrategy : IParsingStrategy
     {
     }
 
+    [StackTraceHidden]
     private bool IsVerbatim(StringBuilder statement)
     {
         return (previousChar is '@' && statement is [.., '$', '@'])

--- a/Src/FluentAssertions/CallerIdentification/ShouldCallParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/ShouldCallParsingStrategy.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 
 namespace FluentAssertions.CallerIdentification;
@@ -22,8 +23,10 @@ internal class ShouldCallParsingStrategy : IParsingStrategy
         return ParsingState.InProgress;
     }
 
+    [StackTraceHidden]
     private static bool IsLongEnough(StringBuilder statement) => statement.Length >= ExpectedPhrase.Length + 1;
 
+    [StackTraceHidden]
     private static bool EndsWithExpectedPhrase(StringBuilder statement)
     {
         // Start from the index on the character just before the last ( or .
@@ -43,6 +46,7 @@ internal class ShouldCallParsingStrategy : IParsingStrategy
         return true;
     }
 
+    [StackTraceHidden]
     private static bool EndsWithInvocation(StringBuilder statement) => statement[^1] is '(' or '.';
 
     public bool IsWaitingForContextEnd()

--- a/Src/FluentAssertions/CallerIdentification/WhichParsingStrategy.cs
+++ b/Src/FluentAssertions/CallerIdentification/WhichParsingStrategy.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 
 namespace FluentAssertions.CallerIdentification;
@@ -22,8 +23,10 @@ internal class WhichParsingStrategy : IParsingStrategy
         return ParsingState.InProgress;
     }
 
+    [StackTraceHidden]
     private static bool IsLongEnough(StringBuilder statement) => statement.Length >= ExpectedPhrase.Length;
 
+    [StackTraceHidden]
     private static bool EndsWithExpectedPhrase(StringBuilder statement)
     {
         // Start from the index of the last character

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -3398,6 +3398,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         return StartWith([element], ObjectExtensions.GetComparer<T>(), because, becauseArgs);
     }
 
+    [StackTraceHidden]
     internal AndConstraint<SubsequentOrderingAssertions<T>> BeOrderedBy<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression,
         IComparer<TSelector> comparer,
@@ -3429,6 +3430,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             new SubsequentOrderingAssertions<T>(Subject, Enumerable.Empty<T>().OrderBy(x => x), assertionChain));
     }
 
+    [StackTraceHidden]
     internal virtual IOrderedEnumerable<T> GetOrderedEnumerable<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression,
         IComparer<TSelector> comparer,
@@ -3526,6 +3528,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
                 .AssertCollectionsHaveSameItems(expectedItems, (a, e) => a.IndexOfFirstDifferenceWith(e, equalityComparison)));
     }
 
+    [StackTraceHidden]
     private static string GetExpressionOrderString<TSelector>(Expression<Func<T, TSelector>> propertyExpression)
     {
         string orderString = propertyExpression.GetMemberPath().ToString();
@@ -3533,21 +3536,25 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         return orderString is "\"\"" ? string.Empty : "by " + orderString;
     }
 
+    [StackTraceHidden]
     private static Type GetType<TType>(TType o)
     {
         return o is Type t ? t : o.GetType();
     }
 
+    [StackTraceHidden]
     private static bool HasPredecessor(T successor, TCollection subject)
     {
         return !ReferenceEquals(subject.First(), successor);
     }
 
+    [StackTraceHidden]
     private static bool HasSuccessor(T predecessor, TCollection subject)
     {
         return !ReferenceEquals(subject.Last(), predecessor);
     }
-
+    
+    [StackTraceHidden]
     private static T PredecessorOf(T successor, TCollection subject)
     {
         IList<T> collection = subject.ConvertOrCastToList();
@@ -3555,6 +3562,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         return index > 0 ? collection[index - 1] : default;
     }
 
+    [StackTraceHidden]
     private static IEnumerable<TExpectation> RepeatAsManyAsIterator<TExpectation>(TExpectation value, IEnumerable<T> enumerable)
     {
         using IEnumerator<T> enumerator = enumerable.GetEnumerator();
@@ -3565,6 +3573,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         }
     }
 
+    [StackTraceHidden]
     private static T SuccessorOf(T predecessor, TCollection subject)
     {
         IList<T> collection = subject.ConvertOrCastToList();
@@ -3572,6 +3581,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         return index < collection.Count - 1 ? collection[index + 1] : default;
     }
 
+    [StackTraceHidden]
     private string[] CollectFailuresFromInspectors(IEnumerable<Action<T>> elementInspectors)
     {
         string[] collectionFailures;
@@ -3609,6 +3619,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         return collectionFailures;
     }
 
+    [StackTraceHidden]
     private bool IsValidProperty<TSelector>(Expression<Func<T, TSelector>> propertyExpression,
         [StringSyntax("CompositeFormat")] string because,
         object[] becauseArgs)
@@ -3627,6 +3638,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         return assertionChain.Succeeded;
     }
 
+    [StackTraceHidden]
     private AndConstraint<TAssertions> NotBeOrderedBy<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression,
         IComparer<TSelector> comparer,
@@ -3658,6 +3670,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// Expects the current collection to have all elements in the specified <paramref name="expectedOrder"/>.
     /// Elements are compared using their <see cref="object.Equals(object)" /> implementation.
     /// </summary>
+    [StackTraceHidden]
     private AndConstraint<SubsequentOrderingAssertions<T>> BeInOrder(
         IComparer<T> comparer, SortOrder expectedOrder, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
@@ -3706,6 +3719,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// Asserts the current collection does not have all elements in ascending order. Elements are compared
     /// using their <see cref="object.Equals(object)" /> implementation.
     /// </summary>
+    [StackTraceHidden]
     private AndConstraint<TAssertions> NotBeInOrder(IComparer<T> comparer, SortOrder order,
         [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
@@ -3747,6 +3761,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         throw new NotSupportedException(
             "Equals is not part of Fluent Assertions. Did you mean BeSameAs(), Equal(), or BeEquivalentTo() instead?");
 
+    [StackTraceHidden]
     private static int IndexOf(IList<T> items, T item, int startIndex)
     {
         Func<T, T, bool> comparer = ObjectExtensions.GetComparer<T>();
@@ -3763,6 +3778,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         return -1;
     }
 
+    [StackTraceHidden]
     private static int ConsecutiveItemCount(IList<T> actualItems, IList<T> expectedItems, int startIndex)
     {
         for (var index = 1; index < expectedItems.Count; index++)
@@ -3781,6 +3797,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         return expectedItems.Count;
     }
 
+    [StackTraceHidden]
     private protected static IComparer<TItem> GetComparer<TItem>() =>
         typeof(TItem) == typeof(string) ? (IComparer<TItem>)StringComparer.Ordinal : Comparer<TItem>.Default;
 }

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -955,25 +955,32 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     /// </summary>
     protected override string Identifier => "dictionary";
 
+    [StackTraceHidden]
     private static IEnumerable<TKey> GetKeys(TCollection collection) =>
         collection.GetKeys<TCollection, TKey, TValue>();
 
+    [StackTraceHidden]
     private static IEnumerable<TKey> GetKeys<T>(T collection)
         where T : IEnumerable<KeyValuePair<TKey, TValue>> =>
         collection.GetKeys<T, TKey, TValue>();
 
+    [StackTraceHidden]
     private static IEnumerable<TValue> GetValues(TCollection collection) =>
         collection.GetValues<TCollection, TKey, TValue>();
 
+    [StackTraceHidden]
     private static bool ContainsKey(TCollection collection, TKey key) =>
         collection.ContainsKey<TCollection, TKey, TValue>(key);
 
+    [StackTraceHidden]
     private static bool TryGetValue(TCollection collection, TKey key, out TValue value) =>
         collection.TryGetValue(key, out value);
 
+    [StackTraceHidden]
     private static TValue GetValue(TCollection collection, TKey key) =>
         collection.GetValue<TCollection, TKey, TValue>(key);
 
+    [StackTraceHidden]
     private static TValue GetValue<T>(T collection, TKey key)
         where T : IEnumerable<KeyValuePair<TKey, TValue>> =>
         collection.GetValue<T, TKey, TValue>(key);

--- a/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolver.cs
+++ b/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolver.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace FluentAssertions.Collections.MaximumMatching;
@@ -50,6 +51,7 @@ internal class MaximumMatchingSolver<TValue>
     /// and end at an unmatched element.<br />
     /// - Breadth first search used to traverse the graph.<br />
     /// </summary>
+    [StackTraceHidden]
     private IEnumerable<Match> FindMatchForPredicate(Predicate<TValue> predicate, MatchCollection currentMatches)
     {
         var visitedElements = new HashSet<Element<TValue>>();
@@ -79,6 +81,7 @@ internal class MaximumMatchingSolver<TValue>
         return [];
     }
 
+    [StackTraceHidden]
     private List<Element<TValue>> GetMatchingElements(Predicate<TValue> predicate)
     {
         if (!matchingElementsByPredicate.TryGetValue(predicate, out var matchingElements))

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using FluentAssertions.Common;
@@ -278,6 +279,7 @@ public class StringCollectionAssertions<TCollection, TAssertions> : GenericColle
         return new AndWhichConstraint<TAssertions, string>((TAssertions)this, matches, assertionChain, "[" + firstMatch + "]");
     }
 
+    [StackTraceHidden]
     private (string[] MatchingItems, int? FirstMatchingIndex) AllThatMatch(string wildcardPattern)
     {
         int? firstMatchingIndex = null;
@@ -361,6 +363,7 @@ public class StringCollectionAssertions<TCollection, TAssertions> : GenericColle
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
+    [StackTraceHidden]
     private bool NotContainsMatch(string wildcardPattern)
     {
         using var scope = new AssertionScope();

--- a/Src/FluentAssertions/Collections/SubsequentOrderingAssertions.cs
+++ b/Src/FluentAssertions/Collections/SubsequentOrderingAssertions.cs
@@ -132,6 +132,7 @@ public class SubsequentOrderingAssertions<T>
         return ThenBeOrderedBy(propertyExpression, comparer, SortOrder.Descending, because, becauseArgs);
     }
 
+    [StackTraceHidden]
     private AndConstraint<SubsequentOrderingAssertions<T>> ThenBeOrderedBy<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression,
         IComparer<TSelector> comparer,
@@ -143,6 +144,7 @@ public class SubsequentOrderingAssertions<T>
         return BeOrderedBy(propertyExpression, comparer, direction, because, becauseArgs);
     }
 
+    [StackTraceHidden]
     internal sealed override IOrderedEnumerable<T> GetOrderedEnumerable<TSelector>(
         Expression<Func<T, TSelector>> propertyExpression,
         IComparer<TSelector> comparer,

--- a/Src/FluentAssertions/Collections/WhoseValueConstraint.cs
+++ b/Src/FluentAssertions/Collections/WhoseValueConstraint.cs
@@ -1,8 +1,9 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace FluentAssertions.Collections;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> : AndConstraint<TAssertions>
     where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
     where TAssertions : GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>

--- a/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
+++ b/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
@@ -1,9 +1,10 @@
 using System;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class CSharpAccessModifierExtensions
 {
     internal static CSharpAccessModifier GetCSharpAccessModifier(this MethodBase methodBase)

--- a/Src/FluentAssertions/Common/Clock.cs
+++ b/Src/FluentAssertions/Common/Clock.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,7 +8,7 @@ namespace FluentAssertions.Common;
 /// <summary>
 /// Default implementation for <see cref="IClock"/> for production use.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class Clock : IClock
 {
     public void Delay(TimeSpan timeToDelay) => Task.Delay(timeToDelay).GetAwaiter().GetResult();

--- a/Src/FluentAssertions/Common/EnumerableExtensions.cs
+++ b/Src/FluentAssertions/Common/EnumerableExtensions.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class EnumerableExtensions
 {
     public static ICollection<T> ConvertOrCastToCollection<T>(this IEnumerable<T> source)

--- a/Src/FluentAssertions/Common/ExceptionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExceptionExtensions.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class ExceptionExtensions
 {
     public static ExceptionDispatchInfo Unwrap(this TargetInvocationException exception)

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
@@ -7,7 +8,7 @@ using System.Reflection;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class ExpressionExtensions
 {
     /// <summary>

--- a/Src/FluentAssertions/Common/Guard.cs
+++ b/Src/FluentAssertions/Common/Guard.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class Guard
 {
     public static void ThrowIfArgumentIsNull<T>([ValidatedNotNull][NoEnumeration] T obj,

--- a/Src/FluentAssertions/Common/IntegerExtensions.cs
+++ b/Src/FluentAssertions/Common/IntegerExtensions.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class IntegerExtensions
 {
     public static string Times(this int count) => count == 1 ? "1 time" : $"{count} times";

--- a/Src/FluentAssertions/Common/Iterator.cs
+++ b/Src/FluentAssertions/Common/Iterator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace FluentAssertions.Common;
 
@@ -8,7 +9,7 @@ namespace FluentAssertions.Common;
 /// A smarter enumerator that can provide information about the relative location (current, first, last)
 /// of the current item within the collection without unnecessarily iterating the collection.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal sealed class Iterator<T> : IEnumerator<T>
 {
     private const int InitialIndex = -1;

--- a/Src/FluentAssertions/Common/KeyValuePairCollectionExtensions.cs
+++ b/Src/FluentAssertions/Common/KeyValuePairCollectionExtensions.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class KeyValuePairCollectionExtensions
 {
     public static IEnumerable<TKey> GetKeys<TCollection, TKey, TValue>(this TCollection collection)

--- a/Src/FluentAssertions/Common/MemberPath.cs
+++ b/Src/FluentAssertions/Common/MemberPath.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Equivalency;
 
@@ -9,7 +10,7 @@ namespace FluentAssertions.Common;
 /// Encapsulates a dotted candidate to a (nested) member of a type as well as the
 /// declaring type of the deepest member.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class MemberPath
 {
     private readonly string dottedPath;

--- a/Src/FluentAssertions/Common/MemberPathSegmentEqualityComparer.cs
+++ b/Src/FluentAssertions/Common/MemberPathSegmentEqualityComparer.cs
@@ -2,6 +2,7 @@
 using System;
 #endif
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 namespace FluentAssertions.Common;
@@ -11,7 +12,7 @@ namespace FluentAssertions.Common;
 /// Sets the <see cref="AnyIndexQualifier"/> equal with any numeric index qualifier.
 /// All other comparisons are default string equality.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class MemberPathSegmentEqualityComparer : IEqualityComparer<string>
 {
     private const string AnyIndexQualifier = "*";

--- a/Src/FluentAssertions/Common/MethodInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/MethodInfoExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -7,7 +8,7 @@ using System.Runtime.CompilerServices;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class MethodInfoExtensions
 {
     /// <summary>

--- a/Src/FluentAssertions/Common/ObjectExtensions.cs
+++ b/Src/FluentAssertions/Common/ObjectExtensions.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class ObjectExtensions
 {
     public static Func<T, T, bool> GetComparer<T>()

--- a/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
@@ -1,8 +1,9 @@
+using System.Diagnostics;
 using System.Reflection;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class PropertyInfoExtensions
 {
     internal static bool IsVirtual(this PropertyInfo property)

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -11,7 +12,7 @@ using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class StringExtensions
 {
     /// <summary>

--- a/Src/FluentAssertions/Common/TimeOnlyExtensions.cs
+++ b/Src/FluentAssertions/Common/TimeOnlyExtensions.cs
@@ -1,9 +1,10 @@
 #if NET6_0_OR_GREATER
 using System;
+using System.Diagnostics;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class TimeOnlyExtensions
 {
     /// <summary>

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -11,7 +12,7 @@ using Reflectify;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class TypeExtensions
 {
     private const BindingFlags PublicInstanceMembersFlag =

--- a/Src/FluentAssertions/Common/TypeReflector.cs
+++ b/Src/FluentAssertions/Common/TypeReflector.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 
 namespace FluentAssertions.Common;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class TypeReflector
 {
     public static IEnumerable<Type> GetAllTypesFromAppDomain(Func<Assembly, bool> predicate)

--- a/Src/FluentAssertions/Configuration/GlobalConfiguration.cs
+++ b/Src/FluentAssertions/Configuration/GlobalConfiguration.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Configuration;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class GlobalConfiguration
 {
     /// <summary>

--- a/Src/FluentAssertions/Configuration/GlobalEquivalencyOptions.cs
+++ b/Src/FluentAssertions/Configuration/GlobalEquivalencyOptions.cs
@@ -1,12 +1,12 @@
 using System;
-
+using System.Diagnostics;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 using JetBrains.Annotations;
 
 namespace FluentAssertions.Configuration;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class GlobalEquivalencyOptions
 {
     private EquivalencyOptions defaults = new();

--- a/Src/FluentAssertions/Configuration/GlobalFormattingOptions.cs
+++ b/Src/FluentAssertions/Configuration/GlobalFormattingOptions.cs
@@ -1,10 +1,11 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Common;
 using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Configuration;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class GlobalFormattingOptions : FormattingOptions
 {
     public string ValueFormatterAssembly

--- a/Src/FluentAssertions/CustomAssertionAttribute.cs
+++ b/Src/FluentAssertions/CustomAssertionAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace FluentAssertions;
 
@@ -8,6 +9,6 @@ namespace FluentAssertions;
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
 #pragma warning disable CA1813 // Avoid unsealed attributes. This type has shipped.
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class CustomAssertionAttribute : Attribute;
 

--- a/Src/FluentAssertions/CustomAssertionsAssemblyAttribute.cs
+++ b/Src/FluentAssertions/CustomAssertionsAssemblyAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace FluentAssertions;
 
@@ -7,6 +8,6 @@ namespace FluentAssertions;
 /// internally, or directly uses <c>AssertionChain</c>.
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly)]
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public sealed class CustomAssertionsAssemblyAttribute : Attribute;
 

--- a/Src/FluentAssertions/Disposable.cs
+++ b/Src/FluentAssertions/Disposable.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Diagnostics;
 
 namespace FluentAssertions;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal sealed class Disposable : IDisposable
 {
     private readonly Action action;

--- a/Src/FluentAssertions/Equivalency/AssertionChainExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionChainExtensions.cs
@@ -1,8 +1,9 @@
+using System.Diagnostics;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class AssertionChainExtensions
 {
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/Comparands.cs
+++ b/Src/FluentAssertions/Equivalency/Comparands.cs
@@ -1,11 +1,11 @@
 using System;
-
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class Comparands
 {
     public Comparands()

--- a/Src/FluentAssertions/Equivalency/ConversionSelector.cs
+++ b/Src/FluentAssertions/Equivalency/ConversionSelector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Text;
 using FluentAssertions.Common;
@@ -11,7 +12,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Collects the members that need to be converted by the <see cref="AutoConversionStep"/>.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class ConversionSelector
 {
     private sealed class ConversionSelectorRule

--- a/Src/FluentAssertions/Equivalency/Digit.cs
+++ b/Src/FluentAssertions/Equivalency/Digit.cs
@@ -1,8 +1,9 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace FluentAssertions.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class Digit
 {
     private readonly int length;

--- a/Src/FluentAssertions/Equivalency/EqualityStrategyProvider.cs
+++ b/Src/FluentAssertions/Equivalency/EqualityStrategyProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using FluentAssertions.Common;
@@ -8,7 +9,7 @@ using JetBrains.Annotations;
 
 namespace FluentAssertions.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal sealed class EqualityStrategyProvider
 {
     private readonly List<Type> referenceTypes = [];

--- a/Src/FluentAssertions/Equivalency/EquivalencyOptions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency.Execution;
@@ -12,7 +13,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Represents the run-time type-specific behavior of a structural equivalency assertion.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class EquivalencyOptions<TExpectation>
     : SelfReferenceEquivalencyOptions<EquivalencyOptions<TExpectation>>
 {

--- a/Src/FluentAssertions/Equivalency/EquivalencyPlan.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyPlan.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Equivalency.Inlining;
 using FluentAssertions.Equivalency.Steps;
@@ -11,7 +12,7 @@ namespace FluentAssertions.Equivalency;
 /// Represents a mutable collection of equivalency steps that can be reordered and/or amended with additional
 /// custom equivalency steps.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class EquivalencyPlan : IEnumerable<IEquivalencyStep>
 {
     private List<IEquivalencyStep> steps = GetDefaultSteps();

--- a/Src/FluentAssertions/Equivalency/EquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyStep.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Equivalency;
 
 /// <summary>
 ///  Convenient implementation of <see cref="IEquivalencyStep"/> that will only invoke
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public abstract class EquivalencyStep<T> : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -2,6 +2,7 @@
 using System;
 #endif
 
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Equivalency.Execution;
 using FluentAssertions.Equivalency.Tracing;
@@ -12,7 +13,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Provides information on a particular property during an assertion for structural equality of two object graphs.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class EquivalencyValidationContext : IEquivalencyValidationContext
 {
     private Tracer tracer;

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using FluentAssertions.Equivalency.Tracing;
 using FluentAssertions.Execution;
 
@@ -7,7 +8,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Is responsible for validating the equivalency of a subject with another object.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class EquivalencyValidator : IValidateChildNodeEquivalency
 {
     public void AssertEquality(Comparands comparands, EquivalencyValidationContext context)

--- a/Src/FluentAssertions/Equivalency/Execution/CollectionMemberOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CollectionMemberOptionsDecorator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Equivalency.Ordering;
 using FluentAssertions.Equivalency.Selection;
@@ -11,7 +12,7 @@ namespace FluentAssertions.Equivalency.Execution;
 /// <summary>
 /// Ensures that all the rules remove the collection index from the path before processing it further.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class CollectionMemberOptionsDecorator : IEquivalencyOptions, IContainTypingRules
 {
     private readonly IEquivalencyOptions inner;

--- a/Src/FluentAssertions/Equivalency/Execution/CyclicReferenceDetector.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/CyclicReferenceDetector.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Execution;
@@ -7,7 +8,7 @@ namespace FluentAssertions.Equivalency.Execution;
 /// Keeps track of objects and their location within an object graph so that cyclic references can be detected
 /// and handled upon.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class CyclicReferenceDetector : ICloneable2
 {
     #region Private Definitions

--- a/Src/FluentAssertions/Equivalency/Execution/ObjectInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/ObjectInfo.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Diagnostics;
 
 namespace FluentAssertions.Equivalency.Execution;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class ObjectInfo : IObjectInfo
 {
     public ObjectInfo(Comparands comparands, INode currentNode)

--- a/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/Execution/ObjectReference.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -9,7 +10,7 @@ namespace FluentAssertions.Equivalency.Execution;
 /// <summary>
 /// Represents  an object tracked by the <see cref="CyclicReferenceDetector"/> including it's location within an object graph.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class ObjectReference
 {
     private readonly object @object;

--- a/Src/FluentAssertions/Equivalency/Field.cs
+++ b/Src/FluentAssertions/Equivalency/Field.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Reflection;
 using FluentAssertions.Common;
 
@@ -8,7 +9,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// A specialized type of <see cref="INode"/> that represents a field of an object in a structural equivalency assertion.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class Field : Node, IMember
 {
     private readonly FieldInfo fieldInfo;

--- a/Src/FluentAssertions/Equivalency/Inlining/ActionBasedInlineAssertion.cs
+++ b/Src/FluentAssertions/Equivalency/Inlining/ActionBasedInlineAssertion.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Inlining;
@@ -9,7 +10,7 @@ namespace FluentAssertions.Equivalency.Inlining;
 /// of the assertion APIs provided by Fluent Assertions.
 /// </summary>
 /// <typeparam name="T">The expected type of the subject to which the assertion is applied.</typeparam>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class ActionBasedInlineAssertion<T>(Action<T> assertion) : IInlineEquivalencyAssertion
 {
     /// <inheritdoc />

--- a/Src/FluentAssertions/Equivalency/Inlining/ConditionBasedInlineAssertion.cs
+++ b/Src/FluentAssertions/Equivalency/Inlining/ConditionBasedInlineAssertion.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using FluentAssertions.Execution;
 
@@ -8,7 +9,7 @@ namespace FluentAssertions.Equivalency.Inlining;
 /// Represents a condition-based inline equivalency assertion that evaluates a specified condition against a subject during object equivalency checks.
 /// </summary>
 /// <typeparam name="T">The expected type of the subject being asserted.</typeparam>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class ConditionBasedInlineAssertion<T>(Expression<Func<T, bool>> condition) : IInlineEquivalencyAssertion
 {
     /// <inheritdoc />

--- a/Src/FluentAssertions/Equivalency/Inlining/InlineEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Inlining/InlineEquivalencyStep.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Inlining;
@@ -13,7 +14,7 @@ namespace FluentAssertions.Equivalency.Inlining;
 /// This step allows users to define custom equivalency behaviors inline during assertion
 /// execution.
 /// </remarks>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class InlineEquivalencyStep : IEquivalencyStep
 {
     /// <inheritdoc />

--- a/Src/FluentAssertions/Equivalency/JsonProperty.cs
+++ b/Src/FluentAssertions/Equivalency/JsonProperty.cs
@@ -1,6 +1,7 @@
 #if NET6_0_OR_GREATER
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.Json.Nodes;
 using FluentAssertions.Common;
@@ -12,7 +13,7 @@ namespace FluentAssertions.Equivalency;
 /// information about a specific JSON property, its parent object, and its counterpart in an expectation object
 /// when performing comparisons.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class JsonProperty(JsonNode property, JsonObject parent, INode expectationParent) : IMember
 {
     // SMELL: A lot of properties are required by the IMember interface, but they are not used. In the future

--- a/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MappedMemberMatchingRule.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
@@ -29,6 +30,7 @@ internal class MappedMemberMatchingRule<TExpectation, TSubject> : IMemberMatchin
         this.subjectMemberName = subjectMemberName;
     }
 
+    [StackTraceHidden]
     private static bool IsNestedPath(string path) =>
         path.Contains('.', StringComparison.Ordinal) || path.Contains('[', StringComparison.Ordinal) || path.Contains(']', StringComparison.Ordinal);
 

--- a/Src/FluentAssertions/Equivalency/MemberFactory.cs
+++ b/Src/FluentAssertions/Equivalency/MemberFactory.cs
@@ -1,11 +1,11 @@
 using System;
-
+using System.Diagnostics;
 using System.Reflection;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public static class MemberFactory
 {
     public static IMember Create(MemberInfo memberInfo, INode parent)

--- a/Src/FluentAssertions/Equivalency/MemberSelectionContext.cs
+++ b/Src/FluentAssertions/Equivalency/MemberSelectionContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency;
@@ -6,7 +7,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Provides contextual information to an <see cref="IMemberSelectionRule"/>.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class MemberSelectionContext
 {
     private readonly Type compileTimeType;

--- a/Src/FluentAssertions/Equivalency/MemberVisibilityExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/MemberVisibilityExtensions.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Reflectify;
 
 namespace FluentAssertions.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class MemberVisibilityExtensions
 {
     private static readonly ConcurrentDictionary<MemberVisibility, MemberKind> Cache = new();

--- a/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Execution;
 
@@ -8,7 +9,7 @@ namespace FluentAssertions.Equivalency;
 /// Supports recursively comparing two multi-dimensional arrays for equivalency using strict order for the array items
 /// themselves.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class MultiDimensionalArrayEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/NestedExclusionOptionBuilder.cs
+++ b/Src/FluentAssertions/Equivalency/NestedExclusionOptionBuilder.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency.Selection;
 
 namespace FluentAssertions.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
 {
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Equivalency/Node.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -7,7 +8,7 @@ using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class Node : INode
 {
     private static readonly Regex MatchFirstIndex = new(@"^\[[0-9]+\]$");

--- a/Src/FluentAssertions/Equivalency/Ordering/CollectionMemberObjectInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/CollectionMemberObjectInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace FluentAssertions.Equivalency.Ordering;
 
@@ -17,6 +18,7 @@ internal class CollectionMemberObjectInfo : IObjectInfo
         CompileTimeType = context.CompileTimeType;
     }
 
+    [StackTraceHidden]
     private static string GetAdjustedPropertyPath(string propertyPath)
     {
         return propertyPath.Substring(propertyPath.IndexOf('.', StringComparison.Ordinal) + 1);

--- a/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 namespace FluentAssertions.Equivalency.Ordering;
@@ -38,11 +39,13 @@ internal class PathBasedOrderingRule : IOrderingRule
         return OrderStrictness.Irrelevant;
     }
 
+    [StackTraceHidden]
     private static bool ContainsIndexingQualifiers(string path)
     {
         return path.Contains('[', StringComparison.Ordinal) && path.Contains(']', StringComparison.Ordinal);
     }
 
+    [StackTraceHidden]
     private string RemoveInitialIndexQualifier(string sourcePath)
     {
         var indexQualifierRegex = new Regex(@"^\[[0-9]+]\.");

--- a/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
+++ b/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using FluentAssertions.Equivalency.Ordering;
 
 namespace FluentAssertions.Equivalency;
@@ -7,7 +8,7 @@ namespace FluentAssertions.Equivalency;
 /// <summary>
 /// Collection of <see cref="PathBasedOrderingRule"/>s.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class OrderingRuleCollection : IEnumerable<IOrderingRule>
 {
     private readonly List<IOrderingRule> rules = [];

--- a/Src/FluentAssertions/Equivalency/Property.cs
+++ b/Src/FluentAssertions/Equivalency/Property.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Reflection;
 using FluentAssertions.Common;
 
@@ -9,7 +10,7 @@ namespace FluentAssertions.Equivalency;
 /// A specialized type of <see cref="INode  "/> that represents a property of an object in a structural equivalency assertion.
 /// </summary>
 #pragma warning disable CA1716
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class Property : Node, IMember
 {
     private readonly PropertyInfo propertyInfo;

--- a/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByTypeSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByTypeSelectionRule.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Common;
 
@@ -26,6 +27,7 @@ internal class ExcludeMemberByTypeSelectionRule : IMemberSelectionRule
         return selectedMembers.Where(p => !ShouldExclude(p.Type)).ToArray();
     }
 
+    [StackTraceHidden]
     private bool ShouldExclude(Type memberType)
     {
         if (targetType.IsGenericTypeDefinition)

--- a/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 using FluentAssertions.Common;
@@ -56,6 +57,7 @@ internal abstract class SelectMemberByPathSelectionRule : IPathBasedSelectionRul
     /// selection rules are expressed relative to the collection item type (for example <c>Name</c>).
     /// This method removes that root-item index so both sides use the same coordinate system.
     /// </summary>
+    [StackTraceHidden]
     private static string GetPathRelativeToSelectionRoot(INode currentNode)
     {
         if (currentNode.IsRoot)
@@ -73,6 +75,7 @@ internal abstract class SelectMemberByPathSelectionRule : IPathBasedSelectionRul
     /// Nested collection indices are intentionally left in place; they are handled later by
     /// <see cref="MemberPath"/> comparison, which treats <c>[]</c> and concrete indices as equivalent.
     /// </summary>
+    [StackTraceHidden]
     private static string RemoveLeadingCollectionIndex(string path)
     {
         Match match = LeadingCollectionIndexRegex.Match(path);

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionContext.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionContext.cs
@@ -1,8 +1,9 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal sealed class AssertionContext<TSubject> : IAssertionContext<TSubject>
 {
     private AssertionContext(INode currentNode, TSubject subject, TSubject expectation,

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionResultSet.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionResultSet.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Execution;
 
@@ -8,7 +9,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// <summary>
 /// Represents a collection of assertion results obtained through an <see cref="AssertionScope"/>.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class AssertionResultSet
 {
     private readonly Dictionary<object, string[]> set = [];

--- a/Src/FluentAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
@@ -1,5 +1,5 @@
 using System;
-
+using System.Diagnostics;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency.Execution;
@@ -7,7 +7,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
 {
     private readonly Func<IObjectInfo, bool> predicate;

--- a/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/AutoConversionStep.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Common;
 
@@ -10,7 +11,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// <remarks>
 /// Whether or not the conversion is attempted depends on the <see cref="ConversionSelector"/>.
 /// </remarks>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class AutoConversionStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/DateAndTimeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DateAndTimeEquivalencyStep.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
@@ -10,7 +11,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// Specific equivalency step for handling date and time types where the types are different and the failure message
 /// should make that clear.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class DateAndTimeEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
@@ -2,6 +2,7 @@
 using System;
 #endif
 using System.Collections;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using FluentAssertions.Common;
@@ -9,7 +10,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
 {
     [SuppressMessage("ReSharper", "PossibleNullReferenceException")]

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Common;
@@ -10,7 +11,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// <summary>
 /// Provides Reflection-backed meta-data information about a type implementing the <see cref="IDictionary{TKey,TValue}"/> interface.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal sealed class DictionaryInterfaceInfo
 {
     // ReSharper disable once PossibleNullReferenceException

--- a/Src/FluentAssertions/Equivalency/Steps/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumEqualityStep.cs
@@ -1,6 +1,7 @@
 #region
 
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions.Execution;
 
@@ -8,7 +9,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class EnumEqualityStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -1,12 +1,13 @@
 using System;
 
 using System.Collections;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class EnumerableEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using FluentAssertions.Equivalency.Execution;
@@ -12,7 +13,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// <summary>
 /// Executes a single equivalency assertion on two collections, optionally recursive and with or without strict ordering.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class EnumerableEquivalencyValidator(
     AssertionChain assertionChain,
     IValidateChildNodeEquivalency parent,

--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableExtensions.cs
@@ -1,8 +1,9 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class EnumerableExtensions
 {
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
-
+using System.Diagnostics;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class EqualityComparerEquivalencyStep<T> : IEquivalencyStep
 {
     private readonly IEqualityComparer<T> comparer;

--- a/Src/FluentAssertions/Equivalency/Steps/EquivalencyValidationContextExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EquivalencyValidationContextExtensions.cs
@@ -1,8 +1,9 @@
+using System.Diagnostics;
 using System.Globalization;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class EquivalencyValidationContextExtensions
 {
     // Pre-cached string representations of common collection indices to avoid repeated allocations.

--- a/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
@@ -9,7 +9,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class GenericDictionaryEquivalencyStep : IEquivalencyStep
 {
 #pragma warning disable SA1110 // Allow opening parenthesis on new line to reduce line length

--- a/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Common;
@@ -9,7 +10,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class GenericEnumerableEquivalencyStep : IEquivalencyStep
 {
 #pragma warning disable SA1110 // Allow opening parenthesis on new line to reduce line length

--- a/Src/FluentAssertions/Equivalency/Steps/IndexedItemCollection{T}.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/IndexedItemCollection{T}.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace FluentAssertions.Equivalency.Steps;
@@ -8,7 +9,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// Represents a collection of indexed items of type <typeparamref name="T"/> that implements <see cref="IReadOnlyList{T}"/>.
 /// </summary>
 /// <typeparam name="T">The type of elements in the collection.</typeparam>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class IndexedItemCollection<T> : IReadOnlyList<IndexedItem<T>>
 {
     private readonly List<IndexedItem<T>> items = new();

--- a/Src/FluentAssertions/Equivalency/Steps/IndexedItem{T}.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/IndexedItem{T}.cs
@@ -1,10 +1,12 @@
-﻿namespace FluentAssertions.Equivalency.Steps;
+﻿using System.Diagnostics;
+
+namespace FluentAssertions.Equivalency.Steps;
 
 /// <summary>
 /// Encapsulates an item of type <typeparamref name="T"/> associated with an index.
 /// </summary>
 /// <typeparam name="T">The type of the item being indexed.</typeparam>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class IndexedItem<T>(T item, int index)
 {
     public T Item { get; } = item;

--- a/Src/FluentAssertions/Equivalency/Steps/JsonConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/JsonConversionStep.cs
@@ -1,12 +1,13 @@
 #if NET6_0_OR_GREATER
 
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json.Nodes;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class JsonConversionStep : IEquivalencyStep
 {
     /// <inheritdoc />

--- a/Src/FluentAssertions/Equivalency/Steps/LooselyOrderedEquivalencyStrategy.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/LooselyOrderedEquivalencyStrategy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using FluentAssertions.Common;
@@ -9,7 +10,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class LooselyOrderedEquivalencyStrategy<TExpectation>(
     AssertionChain assertionChain,
     IValidateChildNodeEquivalency parent,

--- a/Src/FluentAssertions/Equivalency/Steps/ReadOnlyCollectionExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ReadOnlyCollectionExtensions.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class ReadOnlyCollectionExtensions
 {
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/Steps/ReferenceEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ReferenceEqualityEquivalencyStep.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class ReferenceEqualityEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/ReferentialComparer.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ReferentialComparer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace FluentAssertions.Equivalency.Steps;
@@ -7,7 +8,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// Provides a mechanism for comparing tuples that consist of a subject, an expectation,
 /// and an expectation index. The comparison is based on object references and the expectation index.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal sealed class ReferentialComparer : IEqualityComparer<(object Subject, object Expectation, int ExpectationIndex)>
 {
     public bool Equals((object Subject, object Expectation, int ExpectationIndex) x,

--- a/Src/FluentAssertions/Equivalency/Steps/RunAllUserStepsEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/RunAllUserStepsEquivalencyStep.cs
@@ -1,10 +1,12 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Equivalency.Steps;
 
 /// <summary>
 /// Represents a composite equivalency step that passes the execution to all user-supplied steps that can handle the
 /// current context.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class RunAllUserStepsEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/SimpleEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/SimpleEqualityEquivalencyStep.cs
@@ -1,8 +1,9 @@
+using System.Diagnostics;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class SimpleEqualityEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/StrictlyOrderedEquivalencyStrategy.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StrictlyOrderedEquivalencyStrategy.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using FluentAssertions.Equivalency.Tracing;
 using FluentAssertions.Execution;
 using static FluentAssertions.Common.StringExtensions;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class StrictlyOrderedEquivalencyStrategy<TExpectation>(
     IValidateChildNodeEquivalency parent,
     IEquivalencyValidationContext context)

--- a/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -1,9 +1,10 @@
 using System;
+using System.Diagnostics;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class StringEqualityEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class StructuralEqualityEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/TypeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/TypeEquivalencyStep.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Equivalency.Typing;
 using FluentAssertions.Execution;
@@ -13,7 +14,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// This differs from the default equivalency assertion which states that two objects are equivalent if they have the
 /// same properties and values, regardless of their type.
 /// </remarks>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class TypeEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Equivalency.Selection;
 using FluentAssertions.Execution;
@@ -9,7 +10,7 @@ namespace FluentAssertions.Equivalency.Steps;
 /// <summary>
 /// Ensures that types that are marked as value types are treated as such.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class ValueTypeEquivalencyStep : IEquivalencyStep
 {
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/Steps/XAttributeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/XAttributeEquivalencyStep.cs
@@ -1,9 +1,10 @@
+using System.Diagnostics;
 using System.Xml.Linq;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class XAttributeEquivalencyStep : EquivalencyStep<XAttribute>
 {
     protected override EquivalencyResult OnHandle(Comparands comparands,

--- a/Src/FluentAssertions/Equivalency/Steps/XDocumentEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/XDocumentEquivalencyStep.cs
@@ -1,9 +1,10 @@
+using System.Diagnostics;
 using System.Xml.Linq;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class XDocumentEquivalencyStep : EquivalencyStep<XDocument>
 {
     protected override EquivalencyResult OnHandle(Comparands comparands,

--- a/Src/FluentAssertions/Equivalency/Steps/XElementEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/XElementEquivalencyStep.cs
@@ -1,9 +1,10 @@
+using System.Diagnostics;
 using System.Xml.Linq;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class XElementEquivalencyStep : EquivalencyStep<XElement>
 {
     protected override EquivalencyResult OnHandle(Comparands comparands,

--- a/Src/FluentAssertions/Equivalency/SubjectInfoExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/SubjectInfoExtensions.cs
@@ -1,8 +1,9 @@
+using System.Diagnostics;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public static class SubjectInfoExtensions
 {
     /// <summary>

--- a/Src/FluentAssertions/Equivalency/Tracing/StringBuilderTraceWriter.cs
+++ b/Src/FluentAssertions/Equivalency/Tracing/StringBuilderTraceWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Text;
 
 namespace FluentAssertions.Equivalency.Tracing;
@@ -26,6 +27,7 @@ public class StringBuilderTraceWriter : ITraceWriter
         });
     }
 
+    [StackTraceHidden]
     private void WriteLine(string trace)
     {
         foreach (string traceLine in trace.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))

--- a/Src/FluentAssertions/Equivalency/Typing/AlwaysBeStrictTypingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Typing/AlwaysBeStrictTypingRule.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Equivalency.Typing;
 
 /// <summary>
 /// An implementation of <see cref="ITypingRule"/> that applies strict typing to all objects.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class AlwaysBeStrictTypingRule : ITypingRule
 {
     /// <inheritdoc />

--- a/Src/FluentAssertions/Equivalency/Typing/PredicateBasedTypingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Typing/PredicateBasedTypingRule.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using FluentAssertions.Equivalency.Execution;
 
@@ -8,7 +9,7 @@ namespace FluentAssertions.Equivalency.Typing;
 /// An implementation of <see cref="ITypingRule"/> that uses a predicate to determine
 /// whether strict typing should be applied during equivalency comparison.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class PredicateBasedTypingRule : ITypingRule
 {
     private readonly Func<IObjectInfo, bool> predicate;

--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
@@ -163,6 +164,7 @@ public static class EventRaisingExtensions
     /// <remarks>
     /// If a <see langword="null"/> or string.Empty is provided as property name, the events are return as-is.
     /// </remarks>
+    [StackTraceHidden]
     internal static IEventRecording WithPropertyChangeFor(this IEventRecording eventRecording, string propertyName)
     {
         if (string.IsNullOrEmpty(propertyName))

--- a/Src/FluentAssertions/Events/EventHandlerFactory.cs
+++ b/Src/FluentAssertions/Events/EventHandlerFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -7,7 +8,7 @@ namespace FluentAssertions.Events;
 /// <summary>
 /// Static methods that aid in generic event subscription
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class EventHandlerFactory
 {
     /// <summary>

--- a/Src/FluentAssertions/Events/EventMetadata.cs
+++ b/Src/FluentAssertions/Events/EventMetadata.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Diagnostics;
 
 namespace FluentAssertions.Events;
 
 /// <summary>
 /// Provides the metadata of a monitored event.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class EventMetadata
 {
     /// <summary>

--- a/Src/FluentAssertions/Events/EventMonitor.cs
+++ b/Src/FluentAssertions/Events/EventMonitor.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Common;
@@ -13,7 +14,7 @@ namespace FluentAssertions.Events;
 /// <summary>
 /// Tracks the events an object raises.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal sealed class EventMonitor<T> : IMonitor<T>
 {
     private readonly WeakReference subject;

--- a/Src/FluentAssertions/Events/EventMonitorOptions.cs
+++ b/Src/FluentAssertions/Events/EventMonitorOptions.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Diagnostics;
 
 namespace FluentAssertions.Events;
 
 /// <summary>
 /// Settings for the EventMonitor.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class EventMonitorOptions
 {
     /// <summary>

--- a/Src/FluentAssertions/Events/FilteredEventRecording.cs
+++ b/Src/FluentAssertions/Events/FilteredEventRecording.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace FluentAssertions.Events;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class FilteredEventRecording : IEventRecording
 {
     private readonly OccurredEvent[] occurredEvents;

--- a/Src/FluentAssertions/Events/OccurredEvent.cs
+++ b/Src/FluentAssertions/Events/OccurredEvent.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 
 namespace FluentAssertions.Events;
@@ -7,7 +8,7 @@ namespace FluentAssertions.Events;
 /// <summary>
 /// Represents an occurrence of a particular event.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class OccurredEvent
 {
     /// <summary>

--- a/Src/FluentAssertions/Events/ThreadSafeSequenceGenerator.cs
+++ b/Src/FluentAssertions/Events/ThreadSafeSequenceGenerator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Threading;
 
 namespace FluentAssertions.Events;
@@ -5,7 +6,7 @@ namespace FluentAssertions.Events;
 /// <summary>
 /// Generates a sequence in a thread-safe manner.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal sealed class ThreadSafeSequenceGenerator
 {
     private int sequence = -1;

--- a/Src/FluentAssertions/Exactly.cs
+++ b/Src/FluentAssertions/Exactly.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public static class Exactly
 {
     public static OccurrenceConstraint Once() => new ExactlyTimesConstraint(1);

--- a/Src/FluentAssertions/Execution/AssertionChain.cs
+++ b/Src/FluentAssertions/Execution/AssertionChain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -14,7 +15,7 @@ namespace FluentAssertions.Execution;
 /// This is the core engine of many of the assertion APIs in this library. When combined with <see cref="AssertionScope"/>,
 /// you can run multiple assertions which failure messages will be collected until the scope is disposed.
 /// </remarks>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public sealed class AssertionChain
 {
     private readonly Func<AssertionScope> getCurrentScope;

--- a/Src/FluentAssertions/Execution/AssertionFailedException.cs
+++ b/Src/FluentAssertions/Execution/AssertionFailedException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace FluentAssertions.Execution;
 
@@ -7,7 +8,7 @@ namespace FluentAssertions.Execution;
 /// </summary>
 /// <param name="message">The <em>mandatory</em> exception message</param>
 #pragma warning disable CA1032, RCS1194 // AssertionFailedException should never be constructed with an empty message
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class AssertionFailedException(string message) : Exception(message), IAssertionException
 #pragma warning restore CA1032, RCS1194
 {

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -15,7 +16,7 @@ namespace FluentAssertions.Execution;
 /// such as when using <see langword="async"/> or <see langword="await"/>.
 /// </remarks>
 // Remove all assertion logic from this class since it is superseded by the Assertion class
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public sealed class AssertionScope : IDisposable
 {
     private readonly IAssertionStrategy assertionStrategy;

--- a/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
 
 namespace FluentAssertions.Execution;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class CollectingAssertionStrategy : IAssertionStrategy
 {
     private readonly List<string> failureMessages = [];

--- a/Src/FluentAssertions/Execution/ContextDataDictionary.cs
+++ b/Src/FluentAssertions/Execution/ContextDataDictionary.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Formatting;
 
@@ -8,7 +9,7 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Represents a collection of data items that are associated with an <see cref="AssertionScope"/>.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class ContextDataDictionary
 {
     private readonly List<DataItem> items = [];

--- a/Src/FluentAssertions/Execution/Continuation.cs
+++ b/Src/FluentAssertions/Execution/Continuation.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Execution;
 
 /// <summary>
 /// Enables chaining multiple assertions on an <see cref="AssertionScope"/>.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class Continuation
 {
     internal Continuation(AssertionChain parent)

--- a/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
+++ b/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Execution;
 
 /// <summary>
 /// Enables chaining multiple assertions from an <see cref="AssertionChain.Given{T}"/> call.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class ContinuationOfGiven<TSubject>
 {
     internal ContinuationOfGiven(GivenSelector<TSubject> parent)

--- a/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace FluentAssertions.Execution;
 
 [ExcludeFromCodeCoverage]
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class DefaultAssertionStrategy : IAssertionStrategy
 {
     /// <summary>

--- a/Src/FluentAssertions/Execution/FailReason.cs
+++ b/Src/FluentAssertions/Execution/FailReason.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Execution;
 
 /// <summary>
@@ -19,7 +21,7 @@ namespace FluentAssertions.Execution;
 /// Note that only 10 <c>args</c> are supported in combination with a <em>{reason}</em>.
 /// </para>
 /// </remarks>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class FailReason
 {
     /// <summary>

--- a/Src/FluentAssertions/Execution/FailureMessageFormatter.cs
+++ b/Src/FluentAssertions/Execution/FailureMessageFormatter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -10,7 +11,7 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Encapsulates expanding the various placeholders supported in a failure message.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class FailureMessageFormatter(FormattingOptions formattingOptions)
 {
     private static readonly char[] Blanks = ['\r', '\n', ' ', '\t'];

--- a/Src/FluentAssertions/Execution/FallbackTestFramework.cs
+++ b/Src/FluentAssertions/Execution/FallbackTestFramework.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace FluentAssertions.Execution;
@@ -5,7 +6,7 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Throws a generic exception in case no other test harness is detected.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class FallbackTestFramework : ITestFramework
 {
     /// <summary>

--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Common;
 
@@ -8,7 +9,7 @@ namespace FluentAssertions.Execution;
 /// Represents a chaining object returned from <see cref="AssertionChain"/> to continue the assertion using
 /// an object returned by a selector.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class GivenSelector<T>
 {
     private readonly AssertionChain assertionChain;

--- a/Src/FluentAssertions/Execution/GivenSelectorExtensions.cs
+++ b/Src/FluentAssertions/Execution/GivenSelectorExtensions.cs
@@ -2,11 +2,12 @@ using System;
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Execution;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class GivenSelectorExtensions
 {
     public static ContinuationOfGiven<IEnumerable<T>> AssertCollectionIsNotNull<T>(

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 
 namespace FluentAssertions.Execution;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal abstract class LateBoundTestFramework : ITestFramework
 {
     private Func<string, Exception> exceptionFactory =

--- a/Src/FluentAssertions/Execution/MSTestFrameworkV2.cs
+++ b/Src/FluentAssertions/Execution/MSTestFrameworkV2.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Execution;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class MSTestFrameworkV2 : LateBoundTestFramework
 {
     protected override string ExceptionFullName => "Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException";

--- a/Src/FluentAssertions/Execution/MSTestFrameworkV4.cs
+++ b/Src/FluentAssertions/Execution/MSTestFrameworkV4.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Execution;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal sealed class MSTestFrameworkV4 : LateBoundTestFramework
 {
     protected override string ExceptionFullName => "Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException";

--- a/Src/FluentAssertions/Execution/MSpecFramework.cs
+++ b/Src/FluentAssertions/Execution/MSpecFramework.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Execution;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class MSpecFramework : LateBoundTestFramework
 {
     protected internal override string AssemblyName => "Machine.Specifications";

--- a/Src/FluentAssertions/Execution/NUnitTestFramework.cs
+++ b/Src/FluentAssertions/Execution/NUnitTestFramework.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Execution;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class NUnitTestFramework : LateBoundTestFramework
 {
     protected internal override string AssemblyName => "nunit.framework";

--- a/Src/FluentAssertions/Execution/Reason.cs
+++ b/Src/FluentAssertions/Execution/Reason.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace FluentAssertions.Execution;
@@ -5,7 +6,7 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Represents the reason for a structural equivalency assertion.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class Reason
 {
     public Reason([StringSyntax("CompositeFormat")] string formattedMessage, object[] arguments)

--- a/Src/FluentAssertions/Execution/StringExtensions.cs
+++ b/Src/FluentAssertions/Execution/StringExtensions.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Execution;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class StringExtensions
 {
     /// <summary>

--- a/Src/FluentAssertions/Execution/SubjectIdentificationBuilder.cs
+++ b/Src/FluentAssertions/Execution/SubjectIdentificationBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Execution;
@@ -12,7 +13,7 @@ namespace FluentAssertions.Execution;
 /// (nested) instances of <see cref="AssertionScope"/> and modifications made by the
 /// <see cref="AndWhichConstraint{TParent,TSubject}"/>.
 /// </remarks>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class SubjectIdentificationBuilder
 {
     private readonly Func<string> getScopeName;

--- a/Src/FluentAssertions/Execution/TUnitFramework.cs
+++ b/Src/FluentAssertions/Execution/TUnitFramework.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Execution;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class TUnitFramework : LateBoundTestFramework
 {
     public TUnitFramework()

--- a/Src/FluentAssertions/Execution/TestFrameworkFactory.cs
+++ b/Src/FluentAssertions/Execution/TestFrameworkFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using FluentAssertions.Configuration;
 
@@ -9,7 +10,7 @@ namespace FluentAssertions.Execution;
 /// Determines the test framework, either by scanning the current app domain for known test framework assemblies or by
 /// passing the framework name directly.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class TestFrameworkFactory
 {
     private static readonly Dictionary<TestFramework, ITestFramework> Frameworks = new()

--- a/Src/FluentAssertions/Execution/WithoutFormattingWrapper.cs
+++ b/Src/FluentAssertions/Execution/WithoutFormattingWrapper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Execution;
@@ -5,7 +6,7 @@ namespace FluentAssertions.Execution;
 /// <summary>
 /// Wrapper to tell the <see cref="Formatter"/> not to apply any value formatters on this string.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class WithoutFormattingWrapper(string value)
 {
     public override string ToString() => value;

--- a/Src/FluentAssertions/Execution/XUnitTestFramework.cs
+++ b/Src/FluentAssertions/Execution/XUnitTestFramework.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Execution;
 
 /// <summary>
 /// Implements the xUnit (version 2 and 3) test framework adapter.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class XUnitTestFramework : LateBoundTestFramework
 {
     private readonly string assemblyName;

--- a/Src/FluentAssertions/Extensibility/AssertionEngineInitializerAttribute.cs
+++ b/Src/FluentAssertions/Extensibility/AssertionEngineInitializerAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace FluentAssertions.Extensibility;
@@ -7,7 +8,7 @@ namespace FluentAssertions.Extensibility;
 /// Can be added to an assembly so it gets a change to initialize Fluent Assertions before the first assertion happens.
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public sealed class AssertionEngineInitializerAttribute : Attribute
 {
     private readonly string methodName;

--- a/Src/FluentAssertions/Formatting/Anchor.cs
+++ b/Src/FluentAssertions/Formatting/Anchor.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Formatting;
 
 /// <summary>
@@ -73,6 +75,7 @@ internal class Anchor
         }
     }
 
+    [StackTraceHidden]
     internal void AddLineOrFragment(string fragment)
     {
         if (line is null)

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Common;
@@ -39,6 +40,7 @@ public class AttributeBasedFormatter : IValueFormatter
         method.Invoke(null, parameters);
     }
 
+    [StackTraceHidden]
     private MethodInfo GetFormatter(object value)
     {
         Type valueType = value.GetType();
@@ -67,6 +69,7 @@ public class AttributeBasedFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private void HandleValueFormatterDetectionModeChanges()
     {
         ValueFormatterDetectionMode configuredDetectionMode =
@@ -79,6 +82,7 @@ public class AttributeBasedFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private static Dictionary<Type, MethodInfo> FindCustomFormatters()
     {
         var query =
@@ -99,6 +103,7 @@ public class AttributeBasedFormatter : IValueFormatter
         return query.ToDictionary(f => f.Type, f => f.Method);
     }
 
+    [StackTraceHidden]
     private static bool Applicable(Assembly assembly)
     {
         GlobalFormattingOptions options = AssertionEngine.Configuration.Formatting;

--- a/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using FluentAssertions.Common;
@@ -98,6 +99,7 @@ public class DateTimeOffsetValueFormatter : IValueFormatter
         formattedGraph.AddFragment(">");
     }
 
+    [StackTraceHidden]
     private static bool HasTime(DateTimeOffset dateTime)
     {
         return dateTime.Hour != 0
@@ -108,21 +110,25 @@ public class DateTimeOffsetValueFormatter : IValueFormatter
             || HasNanoSeconds(dateTime);
     }
 
+    [StackTraceHidden]
     private static bool HasDate(DateTimeOffset dateTime)
     {
         return dateTime.Day != 1 || dateTime.Month != 1 || dateTime.Year != 1;
     }
 
+    [StackTraceHidden]
     private static bool HasMilliSeconds(DateTimeOffset dateTime)
     {
         return dateTime.Millisecond > 0;
     }
 
+    [StackTraceHidden]
     private static bool HasMicroSeconds(DateTimeOffset dateTime)
     {
         return (dateTime.Ticks % TimeSpan.FromMilliseconds(1).Ticks) > 0;
     }
 
+    [StackTraceHidden]
     private static bool HasNanoSeconds(DateTimeOffset dateTime)
     {
         return (dateTime.Ticks % (TimeSpan.FromMilliseconds(1).Ticks / 1000)) > 0;

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Common;
@@ -53,6 +54,7 @@ public class DefaultValueFormatter : IValueFormatter
         return type.GetMembers(MemberKind.Public);
     }
 
+    [StackTraceHidden]
     private static bool HasCompilerGeneratedToStringImplementation(object value)
     {
         Type type = value.GetType();
@@ -60,6 +62,7 @@ public class DefaultValueFormatter : IValueFormatter
         return HasDefaultToStringImplementation(value) || type.IsCompilerGenerated();
     }
 
+    [StackTraceHidden]
     private static bool HasDefaultToStringImplementation(object value)
     {
         string str = value.ToString();
@@ -67,6 +70,7 @@ public class DefaultValueFormatter : IValueFormatter
         return str is null || str == value.GetType().ToString();
     }
 
+    [StackTraceHidden]
     private void WriteTypeAndMemberValues(object obj, FormattedObjectGraph formattedGraph, FormatChild formatChild)
     {
         Type type = obj.GetType();
@@ -74,6 +78,7 @@ public class DefaultValueFormatter : IValueFormatter
         WriteTypeValue(obj, formattedGraph, formatChild, type);
     }
 
+    [StackTraceHidden]
     private void WriteTypeName(FormattedObjectGraph formattedGraph, Type type)
     {
         if (type.HasFriendlyName())
@@ -82,6 +87,7 @@ public class DefaultValueFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private void WriteTypeValue(object obj, FormattedObjectGraph formattedGraph, FormatChild formatChild, Type type)
     {
         MemberInfo[] members = GetMembers(type);
@@ -97,6 +103,7 @@ public class DefaultValueFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private static void WriteMemberValues(object obj, MemberInfo[] members, FormattedObjectGraph formattedGraph, FormatChild formatChild)
     {
         using var iterator = new Iterator<MemberInfo>(members.OrderBy(mi => mi.Name, StringComparer.Ordinal));
@@ -120,6 +127,7 @@ public class DefaultValueFormatter : IValueFormatter
     /// <remarks>The default is <see cref="Type.FullName"/>.</remarks>
     protected virtual string TypeDisplayName(Type type) => type.FullName;
 
+    [StackTraceHidden]
     private static void WriteMemberValueTextFor(object value, MemberInfo member, FormattedObjectGraph formattedGraph,
         FormatChild formatChild)
     {

--- a/Src/FluentAssertions/Formatting/DictionaryValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DictionaryValueFormatter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using FluentAssertions.Common;
@@ -72,6 +73,7 @@ public class DictionaryValueFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private static void AddLineOrFragment(FormattedObjectGraph formattedGraph, int startCount, string fragment)
     {
         if (formattedGraph.LineCount > (startCount + 1))
@@ -84,6 +86,7 @@ public class DictionaryValueFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private static IEnumerable<KeyValuePair<object, object>> AsEnumerable(IDictionary dictionary)
     {
         IDictionaryEnumerator iterator = dictionary.GetEnumerator();

--- a/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Globalization;
 
 namespace FluentAssertions.Formatting;
@@ -22,6 +23,7 @@ public class DoubleValueFormatter : IValueFormatter
         formattedGraph.AddFragment(Format(value));
     }
 
+    [StackTraceHidden]
     private static string Format(object value)
     {
         double doubleValue = (double)value;

--- a/Src/FluentAssertions/Formatting/EnumerableExtensions.cs
+++ b/Src/FluentAssertions/Formatting/EnumerableExtensions.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 
 namespace FluentAssertions.Formatting;
 
 internal static class EnumerableExtensions
 {
+    [StackTraceHidden]
     internal static string JoinUsingWritingStyle<T>(this IEnumerable<T> items)
     {
         var buffer = new StringBuilder();

--- a/Src/FluentAssertions/Formatting/FormattedObjectGraph.cs
+++ b/Src/FluentAssertions/Formatting/FormattedObjectGraph.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 
 namespace FluentAssertions.Formatting;
@@ -102,6 +103,7 @@ public class FormattedObjectGraph
         GetCurrentLine().Append(fragment);
     }
 
+    [StackTraceHidden]
     private void FlushCurrentLine()
     {
         // We only need to flush the line if there's something to flush.
@@ -112,6 +114,7 @@ public class FormattedObjectGraph
         }
     }
 
+    [StackTraceHidden]
     private Line GetCurrentLine()
     {
         // We prefer to lazily initialize the current line so we don't waste memory.
@@ -154,6 +157,7 @@ public class FormattedObjectGraph
     /// Get a reference to the current line (or the last line if there is no active line), so that we can
     /// insert fragments and lines at that specific point.
     /// </summary>
+    [StackTraceHidden]
     internal Anchor GetAnchor()
     {
         if (lines.Count == 0)
@@ -164,25 +168,31 @@ public class FormattedObjectGraph
         return new Anchor(this, currentLine ?? lines.Last());
     }
 
+    [StackTraceHidden]
     internal static string MakeWhitespace(int indent) => new(' ', indent * SpacesPerIndentation);
-
+    
+    [StackTraceHidden]
     internal bool HasLinesBeyond(Line line) => lines.HasLinesBeyond(line);
 
+    [StackTraceHidden]
     internal void AddLineAfter(Line line, string content)
     {
         lines.AddLineAfter(line, new Line(content));
     }
 
+    [StackTraceHidden]
     internal void InsertAtTop(string content)
     {
         lines.InsertAtTop(new Line(content));
     }
 
+    [StackTraceHidden]
     internal void InsertAtLineStartOrTop(string fragment)
     {
         lines.InsertAtLineStartOrTop(fragment);
     }
 
+    [StackTraceHidden]
     internal void SplitLine(Line line, int characterIndex)
     {
         lines.SplitLine(line, characterIndex);

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using FluentAssertions.Common;
@@ -130,6 +131,7 @@ public static class Formatter
     }
 
     [SuppressMessage("Maintainability", "AV1561:Signature contains too many parameters")]
+    [StackTraceHidden]
     private static void FormatChild(string path, object value, FormattedObjectGraph output, FormattingContext context,
         FormattingOptions options, ObjectGraph graph)
     {
@@ -161,6 +163,7 @@ public static class Formatter
         }
     }
 
+    [StackTraceHidden]
     private static void Format(object value, FormattedObjectGraph output, FormattingContext context, FormatChild formatChild)
     {
         IValueFormatter firstFormatterThatCanHandleValue = Formatters.First(f => f.CanHandle(value));

--- a/Src/FluentAssertions/Formatting/FormattingOptions.cs
+++ b/Src/FluentAssertions/Formatting/FormattingOptions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Formatting;
@@ -64,6 +65,7 @@ public class FormattingOptions
         }
     }
 
+    [StackTraceHidden]
     internal FormattingOptions Clone()
     {
         return new FormattingOptions

--- a/Src/FluentAssertions/Formatting/LineCollection.cs
+++ b/Src/FluentAssertions/Formatting/LineCollection.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Formatting;
@@ -63,6 +64,7 @@ internal class LineCollection(int maxLines) : IEnumerable<Line>
         }
     }
 
+    [StackTraceHidden]
     private void Insert(int index, Line item)
     {
         lines.Insert(index, item);
@@ -74,6 +76,7 @@ internal class LineCollection(int maxLines) : IEnumerable<Line>
         }
     }
 
+    [StackTraceHidden]
     private void OnCollectionIsModified()
     {
         if (lines.Count > maxLines)
@@ -90,5 +93,6 @@ internal class LineCollection(int maxLines) : IEnumerable<Line>
 
     public IEnumerator<Line> GetEnumerator() => lines.GetEnumerator();
 
+    [StackTraceHidden]
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
+++ b/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -91,16 +92,19 @@ public class MultidimensionalArrayFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private static bool IsFirstIteration(Array arr, int index, int dimension)
     {
         return index == arr.GetLowerBound(dimension);
     }
-
+    
+    [StackTraceHidden]
     private static bool IsInnerMostLoop(Array arr, int index)
     {
         return index == (arr.Rank - 1);
     }
 
+    [StackTraceHidden]
     private static bool IsLastIteration(Array arr, int index, int dimension)
     {
         return index >= arr.GetUpperBound(dimension);

--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -36,6 +37,7 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
     /// E.g. "(_.Text == "two") AndAlso (_.Number == 3)"
     /// Instead of "(_.Text == value(FluentAssertions.Specs.Collections.GenericCollectionAssertionsSpecs+c__DisplayClass122_0).twoText) AndAlso (_.Number == 3)".
     /// </summary>
+    [StackTraceHidden]
     private static Expression ReduceConstantSubExpressions(Expression expression)
     {
         try
@@ -56,6 +58,7 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
     /// This simplification is only implemented for the chain of AND operators because this is the most common predicate scenario.
     /// Similar logic can be implemented in the future for other operators.
     /// </summary>
+    [StackTraceHidden]
     private static List<Expression> ExtractChainOfExpressionsJoinedWithAndOperator(BinaryExpression binaryExpression)
     {
         var visitor = new AndOperatorChainExtractor();

--- a/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 
@@ -54,6 +55,7 @@ public class TimeSpanValueFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private static List<string> GetNonZeroFragments(TimeSpan timeSpan)
     {
         TimeSpan absoluteTimespan = timeSpan.Duration();
@@ -70,6 +72,7 @@ public class TimeSpanValueFormatter : IValueFormatter
         return fragments;
     }
 
+    [StackTraceHidden]
     private static void AddMicrosecondsIfNotZero(TimeSpan timeSpan, List<string> fragments)
     {
         var ticks = timeSpan.Ticks % TimeSpan.TicksPerMillisecond;
@@ -81,6 +84,7 @@ public class TimeSpanValueFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private static void AddSecondsIfNotZero(TimeSpan timeSpan, List<string> fragments)
     {
         if (timeSpan.Seconds > 0)
@@ -91,6 +95,7 @@ public class TimeSpanValueFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private static void AddMilliSecondsIfNotZero(TimeSpan timeSpan, List<string> fragments)
     {
         if (timeSpan.Milliseconds > 0)
@@ -101,6 +106,7 @@ public class TimeSpanValueFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private static void AddMinutesIfNotZero(TimeSpan timeSpan, List<string> fragments)
     {
         if (timeSpan.Minutes > 0)
@@ -109,6 +115,7 @@ public class TimeSpanValueFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private static void AddHoursIfNotZero(TimeSpan timeSpan, List<string> fragments)
     {
         if (timeSpan.Hours > 0)
@@ -117,6 +124,7 @@ public class TimeSpanValueFormatter : IValueFormatter
         }
     }
 
+    [StackTraceHidden]
     private static void AddDaysIfNotZero(TimeSpan timeSpan, List<string> fragments)
     {
         if (timeSpan.Days > 0)

--- a/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Xml.Linq;
 using FluentAssertions.Common;
 
@@ -27,11 +28,13 @@ public class XElementValueFormatter : IValueFormatter
             : FormatElementWithoutChildren(element));
     }
 
+    [StackTraceHidden]
     private static string FormatElementWithoutChildren(XElement element)
     {
         return element.ToString().EscapePlaceholders();
     }
-
+    
+    [StackTraceHidden]
     private static string FormatElementWithChildren(XElement element)
     {
         string[] lines = SplitIntoSeparateLines(element);
@@ -45,6 +48,7 @@ public class XElementValueFormatter : IValueFormatter
         return formattedElement.EscapePlaceholders();
     }
 
+    [StackTraceHidden]
     private static string[] SplitIntoSeparateLines(XElement element)
     {
         string formattedXml = element.ToString();

--- a/Src/FluentAssertions/LessThan.cs
+++ b/Src/FluentAssertions/LessThan.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public static class LessThan
 {
     public static OccurrenceConstraint Twice() => new LessThanTimesConstraint(2);

--- a/Src/FluentAssertions/License.cs
+++ b/Src/FluentAssertions/License.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics;
+
 namespace FluentAssertions;
 
 /// <summary>
 /// Provides access to the licensing state of Fluent Assertions
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public static class License
 {
     /// <summary>

--- a/Src/FluentAssertions/MoreThan.cs
+++ b/Src/FluentAssertions/MoreThan.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public static class MoreThan
 {
     public static OccurrenceConstraint Once() => new MoreThanTimesConstraint(1);

--- a/Src/FluentAssertions/Numeric/ByteAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ByteAssertions.cs
@@ -15,6 +15,7 @@ internal class ByteAssertions : NumericAssertions<byte>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(byte subject, byte expected)
     {
         int difference = subject - expected;

--- a/Src/FluentAssertions/Numeric/DecimalAssertions.cs
+++ b/Src/FluentAssertions/Numeric/DecimalAssertions.cs
@@ -16,6 +16,7 @@ internal class DecimalAssertions : NumericAssertions<decimal>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(decimal subject, decimal expected)
     {
         try

--- a/Src/FluentAssertions/Numeric/DoubleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/DoubleAssertions.cs
@@ -15,8 +15,10 @@ internal class DoubleAssertions : NumericAssertions<double>
     {
     }
 
+    [StackTraceHidden]
     private protected override bool IsNaN(double value) => double.IsNaN(value);
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(double subject, double expected)
     {
         var difference = subject - expected;

--- a/Src/FluentAssertions/Numeric/Int16Assertions.cs
+++ b/Src/FluentAssertions/Numeric/Int16Assertions.cs
@@ -15,6 +15,7 @@ internal class Int16Assertions : NumericAssertions<short>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(short subject, short expected)
     {
         if (subject < 10 && expected < 10)

--- a/Src/FluentAssertions/Numeric/Int32Assertions.cs
+++ b/Src/FluentAssertions/Numeric/Int32Assertions.cs
@@ -15,6 +15,7 @@ internal class Int32Assertions : NumericAssertions<int>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(int subject, int expected)
     {
         if (subject is > 0 and < 10 && expected is > 0 and < 10)

--- a/Src/FluentAssertions/Numeric/Int64Assertions.cs
+++ b/Src/FluentAssertions/Numeric/Int64Assertions.cs
@@ -15,6 +15,7 @@ internal class Int64Assertions : NumericAssertions<long>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(long subject, long expected)
     {
         if (subject is > 0 and < 10 && expected is > 0 and < 10)

--- a/Src/FluentAssertions/Numeric/NullableByteAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableByteAssertions.cs
@@ -15,6 +15,7 @@ internal class NullableByteAssertions : NullableNumericAssertions<byte>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(byte subject, byte expected)
     {
         int difference = subject - expected;

--- a/Src/FluentAssertions/Numeric/NullableDecimalAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableDecimalAssertions.cs
@@ -16,6 +16,7 @@ internal class NullableDecimalAssertions : NullableNumericAssertions<decimal>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(decimal subject, decimal expected)
     {
         try

--- a/Src/FluentAssertions/Numeric/NullableDoubleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableDoubleAssertions.cs
@@ -15,8 +15,10 @@ internal class NullableDoubleAssertions : NullableNumericAssertions<double>
     {
     }
 
+    [StackTraceHidden]
     private protected override bool IsNaN(double value) => double.IsNaN(value);
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(double subject, double expected)
     {
         double difference = subject - expected;

--- a/Src/FluentAssertions/Numeric/NullableInt16Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableInt16Assertions.cs
@@ -15,6 +15,7 @@ internal class NullableInt16Assertions : NullableNumericAssertions<short>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(short subject, short expected)
     {
         if (subject < 10 && expected < 10)

--- a/Src/FluentAssertions/Numeric/NullableInt32Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableInt32Assertions.cs
@@ -15,6 +15,7 @@ internal class NullableInt32Assertions : NullableNumericAssertions<int>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(int subject, int expected)
     {
         if (subject is > 0 and < 10 && expected is > 0 and < 10)

--- a/Src/FluentAssertions/Numeric/NullableInt64Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableInt64Assertions.cs
@@ -15,6 +15,7 @@ internal class NullableInt64Assertions : NullableNumericAssertions<long>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(long subject, long expected)
     {
         if (subject is > 0 and < 10 && expected is > 0 and < 10)

--- a/Src/FluentAssertions/Numeric/NullableSByteAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableSByteAssertions.cs
@@ -15,6 +15,7 @@ internal class NullableSByteAssertions : NullableNumericAssertions<sbyte>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(sbyte subject, sbyte expected)
     {
         int difference = subject - expected;

--- a/Src/FluentAssertions/Numeric/NullableSingleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableSingleAssertions.cs
@@ -15,8 +15,10 @@ internal class NullableSingleAssertions : NullableNumericAssertions<float>
     {
     }
 
+    [StackTraceHidden]
     private protected override bool IsNaN(float value) => float.IsNaN(value);
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(float subject, float expected)
     {
         float difference = subject - expected;

--- a/Src/FluentAssertions/Numeric/NullableUInt16Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableUInt16Assertions.cs
@@ -15,6 +15,7 @@ internal class NullableUInt16Assertions : NullableNumericAssertions<ushort>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(ushort subject, ushort expected)
     {
         if (subject < 10 && expected < 10)

--- a/Src/FluentAssertions/Numeric/NullableUInt32Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableUInt32Assertions.cs
@@ -15,6 +15,7 @@ internal class NullableUInt32Assertions : NullableNumericAssertions<uint>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(uint subject, uint expected)
     {
         if (subject < 10 && expected < 10)

--- a/Src/FluentAssertions/Numeric/NullableUInt64Assertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableUInt64Assertions.cs
@@ -15,6 +15,7 @@ internal class NullableUInt64Assertions : NullableNumericAssertions<ulong>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(ulong subject, ulong expected)
     {
         if (subject < 10 && expected < 10)

--- a/Src/FluentAssertions/Numeric/NumericAssertionsBase.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertionsBase.cs
@@ -464,6 +464,7 @@ public abstract class NumericAssertionsBase<T, TSubject, TAssertions>
     public override bool Equals(object obj) =>
         throw new NotSupportedException("Equals is not part of Fluent Assertions. Did you mean Be() instead?");
 
+    [StackTraceHidden]
     private protected virtual bool IsNaN(T value) => false;
 
     /// <summary>
@@ -475,8 +476,10 @@ public abstract class NumericAssertionsBase<T, TSubject, TAssertions>
     /// Returns the difference between a number value and the <paramref name="expected" /> value.
     /// Returns `null` if the compared numbers are small enough that a difference message is irrelevant.
     /// </returns>
+    [StackTraceHidden]
     private protected virtual string CalculateDifferenceForFailureMessage(T subject, T expected) => null;
 
+    [StackTraceHidden]
     private string GenerateDifferenceMessage(T? expected)
     {
         const string noDifferenceMessage = ".";

--- a/Src/FluentAssertions/Numeric/SByteAssertions.cs
+++ b/Src/FluentAssertions/Numeric/SByteAssertions.cs
@@ -15,6 +15,7 @@ internal class SByteAssertions : NumericAssertions<sbyte>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(sbyte subject, sbyte expected)
     {
         int difference = subject - expected;

--- a/Src/FluentAssertions/Numeric/SingleAssertions.cs
+++ b/Src/FluentAssertions/Numeric/SingleAssertions.cs
@@ -15,8 +15,10 @@ internal class SingleAssertions : NumericAssertions<float>
     {
     }
 
+    [StackTraceHidden]
     private protected override bool IsNaN(float value) => float.IsNaN(value);
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(float subject, float expected)
     {
         float difference = subject - expected;

--- a/Src/FluentAssertions/Numeric/UInt16Assertions.cs
+++ b/Src/FluentAssertions/Numeric/UInt16Assertions.cs
@@ -15,6 +15,7 @@ internal class UInt16Assertions : NumericAssertions<ushort>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(ushort subject, ushort expected)
     {
         if (subject < 10 && expected < 10)

--- a/Src/FluentAssertions/Numeric/UInt32Assertions.cs
+++ b/Src/FluentAssertions/Numeric/UInt32Assertions.cs
@@ -15,6 +15,7 @@ internal class UInt32Assertions : NumericAssertions<uint>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(uint subject, uint expected)
     {
         if (subject < 10 && expected < 10)

--- a/Src/FluentAssertions/Numeric/UInt64Assertions.cs
+++ b/Src/FluentAssertions/Numeric/UInt64Assertions.cs
@@ -15,6 +15,7 @@ internal class UInt64Assertions : NumericAssertions<ulong>
     {
     }
 
+    [StackTraceHidden]
     private protected override string CalculateDifferenceForFailureMessage(ulong subject, ulong expected)
     {
         if (subject < 10 && expected < 10)

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
@@ -355,6 +356,7 @@ public static class NumericAssertionsExtensions
     }
 
     [SuppressMessage("Maintainability", "AV1561:Signature contains too many parameters")]
+    [StackTraceHidden]
     private static void FailIfValueOutsideBounds<TValue, TDelta>(AssertionChain assertionChain, bool valueWithinBounds,
         TValue nearbyValue, TDelta delta, TValue actualValue,
         [StringSyntax("CompositeFormat")] string because, object[] becauseArgs)
@@ -717,6 +719,7 @@ public static class NumericAssertionsExtensions
     }
 
     [SuppressMessage("Maintainability", "AV1561:Signature contains too many parameters")]
+    [StackTraceHidden]
     private static void FailIfValueInsideBounds<TValue, TDelta>(
         AssertionChain assertionChain,
         bool valueOutsideBounds,
@@ -1133,6 +1136,7 @@ public static class NumericAssertionsExtensions
     }
 
     [SuppressMessage("Maintainability", "AV1561:Signature contains too many parameters")]
+    [StackTraceHidden]
     private static void FailIfDifferenceOutsidePrecision<T>(
         bool differenceWithinPrecision,
         NumericAssertions<T> parent, T expectedValue, T precision, T actualDifference,
@@ -1529,6 +1533,7 @@ public static class NumericAssertionsExtensions
     }
 
     [SuppressMessage("Maintainability", "AV1561:Signature contains too many parameters")]
+    [StackTraceHidden]
     private static void FailIfDifferenceWithinPrecision<T>(
         NumericAssertions<T> parent, bool differenceOutsidePrecision,
         T unexpectedValue, T precision, T actualDifference,
@@ -1746,6 +1751,7 @@ public static class NumericAssertionsExtensions
 
     #endregion
 
+    [StackTraceHidden]
     private static long GetMinValue(long value, ulong delta)
     {
         decimal minValue = ((decimal)value) - delta;
@@ -1758,6 +1764,7 @@ public static class NumericAssertionsExtensions
         return (long)minValue;
     }
 
+    [StackTraceHidden]
     private static long GetMaxValue(long value, ulong delta)
     {
         decimal maxValue = ((decimal)value) + delta;

--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 using System.IO;
@@ -100,6 +101,7 @@ public static class ObjectAssertionsExtensions
         return new AndConstraint<ObjectAssertions>(assertions);
     }
 
+    [StackTraceHidden]
     private static object CreateCloneUsingDataContractSerializer(object subject)
     {
         using var stream = new MemoryStream();
@@ -190,6 +192,7 @@ public static class ObjectAssertionsExtensions
     }
 
     [SuppressMessage("Security", "CA5369:Use XmlReader for \'XmlSerializer.Deserialize()\'")]
+    [StackTraceHidden]
     private static object CreateCloneUsingXmlSerializer(object subject)
     {
         using var stream = new MemoryStream();

--- a/Src/FluentAssertions/OccurrenceConstraint.cs
+++ b/Src/FluentAssertions/OccurrenceConstraint.cs
@@ -1,9 +1,10 @@
 using System;
+using System.Diagnostics;
 using FluentAssertions.Common;
 
 namespace FluentAssertions;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public abstract class OccurrenceConstraint
 {
     protected OccurrenceConstraint(int expectedCount)

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
@@ -129,6 +129,7 @@ public class DateTimeOffsetRangeAssertions<TAssertions>
         return new AndConstraint<TAssertions>(parentAssertions);
     }
 
+    [StackTraceHidden]
     private static string PositionRelativeToTarget(DateTimeOffset actual, DateTimeOffset target)
     {
         return (actual - target) >= TimeSpan.Zero ? "ahead" : "behind";

--- a/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
@@ -131,6 +131,7 @@ public class DateTimeRangeAssertions<TAssertions>
         return new AndConstraint<TAssertions>(parentAssertions);
     }
 
+    [StackTraceHidden]
     private static string PositionRelativeToTarget(DateTime actual, DateTime target)
     {
         return (actual - target) >= TimeSpan.Zero ? "ahead" : "behind";

--- a/Src/FluentAssertions/Primitives/EnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/EnumAssertions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -444,12 +445,14 @@ public class EnumAssertions<TEnum, TAssertions>
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
+    [StackTraceHidden]
     private static decimal GetValue<T>(T @enum)
         where T : struct, Enum
     {
         return Convert.ToDecimal(@enum, CultureInfo.InvariantCulture);
     }
 
+    [StackTraceHidden]
     private static string GetName<T>(T @enum)
         where T : struct, Enum
     {

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -1988,6 +1988,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
+    [StackTraceHidden]
     private static bool HasMixedOrNoCase(string value)
     {
         var hasUpperCase = false;
@@ -2014,6 +2015,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// <remarks>
     /// Is used by <see cref="StringAssertions{TAssertions}"/>.
     /// </remarks>
+    [StackTraceHidden]
     internal void Be(string expected, Func<EquivalencyOptions<string>, EquivalencyOptions<string>> config,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
@@ -2034,11 +2036,13 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         expectation.Validate(subject, expected);
     }
 
+    [StackTraceHidden]
     private static bool Contains(string actual, string expected, StringComparison comparison)
     {
         return (actual ?? string.Empty).Contains(expected ?? string.Empty, comparison);
     }
 
+    [StackTraceHidden]
     private static void ThrowIfValuesNullOrEmpty(IEnumerable<string> values)
     {
         Guard.ThrowIfArgumentIsNull(values, nameof(values), "Cannot assert string containment of values in null collection");
@@ -2057,6 +2061,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     /// When <see cref="IEquivalencyOptions.IgnoreTrailingWhitespace"/> is set, whitespace is removed from the end of the <paramref name="value"/>.<br />
     /// When <see cref="IEquivalencyOptions.IgnoreNewlineStyle"/> is set, all newlines (<c>\r\n</c> and <c>\r</c>) are replaced with <c>\n</c> in the <paramref name="value"/>.<br />
     /// </remarks>
+    [StackTraceHidden]
     private static string ApplyStringSettings(string value, IEquivalencyOptions options)
     {
         if (options.IgnoreLeadingWhitespace)

--- a/Src/FluentAssertions/Primitives/StringContainsStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringContainsStrategy.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
-
+using System.Diagnostics;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class StringContainsStrategy : IStringComparisonStrategy
 {
     private readonly IEqualityComparer<string> comparer;

--- a/Src/FluentAssertions/Primitives/StringEndStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEndStrategy.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
-
+using System.Diagnostics;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class StringEndStrategy : IStringComparisonStrategy
 {
     private readonly IEqualityComparer<string> comparer;

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -8,7 +9,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class StringEqualityStrategy : IStringComparisonStrategy
 {
     private readonly IEqualityComparer<string> comparer;

--- a/Src/FluentAssertions/Primitives/StringStartStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringStartStrategy.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
-
+using System.Diagnostics;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class StringStartStrategy : IStringComparisonStrategy
 {
     private readonly IEqualityComparer<string> comparer;

--- a/Src/FluentAssertions/Primitives/StringValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringValidator.cs
@@ -1,9 +1,10 @@
+using System.Diagnostics;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class StringValidator
 {
     private readonly IStringComparisonStrategy comparisonStrategy;

--- a/Src/FluentAssertions/Primitives/StringValidatorSupportingNull.cs
+++ b/Src/FluentAssertions/Primitives/StringValidatorSupportingNull.cs
@@ -1,10 +1,11 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class StringValidatorSupportingNull
 {
     private readonly IStringComparisonStrategy comparisonStrategy;

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingStrategy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 using FluentAssertions.Common;
@@ -6,7 +7,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class StringWildcardMatchingStrategy : IStringComparisonStrategy
 {
     public void AssertForEquality(AssertionChain assertionChain, string subject, string expected)

--- a/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
@@ -174,6 +174,7 @@ public class TimeOnlyAssertions<TAssertions>
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
+    [StackTraceHidden]
     private static TimeSpan? MinimumDifference(TimeOnly a, TimeOnly b)
     {
         var diff1 = a - b;

--- a/Src/FluentAssertions/Primitives/TimeSpanPredicate.cs
+++ b/Src/FluentAssertions/Primitives/TimeSpanPredicate.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Diagnostics;
 
 namespace FluentAssertions.Primitives;
 
 /// <summary>
 /// Provides the logic and the display text for a <see cref="TimeSpanCondition"/>.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class TimeSpanPredicate
 {
     private readonly Func<TimeSpan, TimeSpan, bool> lambda;

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -209,6 +209,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         return new ExceptionAssertions<TException>([], assertionChain);
     }
 
+    [StackTraceHidden]
     private ExceptionAssertions<TException> AssertThrows<TException>(
         Exception exception, TimeSpan timeSpan,
         [StringSyntax("CompositeFormat")] string because, object[] becauseArgs)
@@ -229,7 +230,8 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
 
         return new ExceptionAssertions<TException>(expectedExceptions, assertionChain);
     }
-
+    
+    [StackTraceHidden]
     private async Task<Exception> InvokeWithInterceptionAsync(TimeSpan timeout)
     {
         try
@@ -313,6 +315,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     /// <summary>
     ///     Invokes the subject and measures the sync execution time.
     /// </summary>
+    [StackTraceHidden]
     private protected (TTask Result, TimeSpan RemainingTime) InvokeWithTimer(TimeSpan timeSpan)
     {
         ITimer timer = Clock.StartTimer();
@@ -325,6 +328,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     /// <summary>
     ///     Monitors the specified task whether it completes withing the remaining time span.
     /// </summary>
+    [StackTraceHidden]
     private protected async Task<bool> CompletesWithinTimeoutAsync(Task target, TimeSpan remainingTime, Func<Task, Task> onTaskCanceled)
     {
         using var delayCancellationTokenSource = new CancellationTokenSource();
@@ -354,6 +358,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         return true;
     }
 
+    [StackTraceHidden]
     private protected static async Task<Exception> InvokeWithInterceptionAsync(Func<Task> action)
     {
         try

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -152,6 +152,7 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
 
     protected abstract void InvokeSubject();
 
+    [StackTraceHidden]
     private protected Exception InvokeSubjectWithInterception()
     {
         Exception actualException = null;
@@ -181,6 +182,7 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
         return actualException;
     }
 
+    [StackTraceHidden]
     private protected void FailIfSubjectIsAsyncVoid()
     {
         if (Subject.GetMethodInfo().IsDecoratedWithOrInherit<AsyncStateMachineAttribute>())

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -138,6 +138,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
         return this;
     }
 
+    [StackTraceHidden]
     private void AssertExceptionMessage(Action<string> messageAssertion)
     {
         var results = new AssertionResultSet();
@@ -280,6 +281,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
         return this;
     }
 
+    [StackTraceHidden]
     private IEnumerable<Exception> AssertInnerExceptionExactly(Type innerException,
         [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
@@ -301,6 +303,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
         return expectedExceptions;
     }
 
+    [StackTraceHidden]
     private IEnumerable<Exception> AssertInnerExceptions(Type innerException,
         [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
@@ -339,6 +342,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
         }
     }
 
+    [StackTraceHidden]
     private static string BuildExceptionsString(IEnumerable<TException> exceptions)
     {
         return string.Join(Environment.NewLine, exceptions.Select(exception => "\t" + Formatter.ToString(exception)));

--- a/Src/FluentAssertions/Specialized/ExecutionTime.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTime.cs
@@ -1,11 +1,11 @@
 using System;
-
+using System.Diagnostics;
 using System.Threading.Tasks;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Specialized;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class ExecutionTime
 {
     private ITimer timer;

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -36,6 +36,7 @@ public class ExecutionTimeAssertions
     /// <param name="expectedResult">Polling stops when condition returns the expected result.</param>
     /// <param name="rate">The rate at which the condition is re-checked.</param>
     /// <return>The elapsed time. (use this, don't measure twice)</return>
+    [StackTraceHidden]
     private (bool IsRunning, TimeSpan Elapsed) PollUntil(Func<TimeSpan, bool> condition, bool expectedResult, TimeSpan rate)
     {
         TimeSpan elapsed = execution.ElapsedTime;

--- a/Src/FluentAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertions.cs
@@ -113,6 +113,7 @@ public class FunctionAssertions<T> : DelegateAssertions<Func<T>, FunctionAsserti
     }
 
     [SuppressMessage("Maintainability", "AV1561:Signature contains too many parameters")]
+    [StackTraceHidden]
     internal TResult NotThrowAfter<TResult>(Func<TResult> subject, IClock clock, TimeSpan waitTime, TimeSpan pollInterval,
         [StringSyntax("CompositeFormat")] string because, object[] becauseArgs)
     {

--- a/Src/FluentAssertions/Specialized/JsonValueExtensions.cs
+++ b/Src/FluentAssertions/Specialized/JsonValueExtensions.cs
@@ -1,11 +1,12 @@
 #if NET6_0_OR_GREATER
 
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace FluentAssertions.Specialized;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal static class JsonValueExtensions
 {
     public static bool IsNumeric(this JsonValue value)

--- a/Src/FluentAssertions/Specialized/MemberExecutionTime.cs
+++ b/Src/FluentAssertions/Specialized/MemberExecutionTime.cs
@@ -1,11 +1,11 @@
 using System;
-
+using System.Diagnostics;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Specialized;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class MemberExecutionTime<T> : ExecutionTime
 {
     /// <summary>

--- a/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertionsBase.cs
+++ b/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertionsBase.cs
@@ -30,6 +30,7 @@ public class TaskCompletionSourceAssertionsBase
     /// <summary>
     ///     Monitors the specified task whether it completes withing the remaining time span.
     /// </summary>
+    [StackTraceHidden]
     private protected async Task<bool> CompletesWithinTimeoutAsync(Task target, TimeSpan remainingTime)
     {
         using var timeoutCancellationTokenSource = new CancellationTokenSource();

--- a/Src/FluentAssertions/Types/AllTypes.cs
+++ b/Src/FluentAssertions/Types/AllTypes.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 
 namespace FluentAssertions.Types;
@@ -11,7 +12,7 @@ namespace FluentAssertions.Types;
 /// .Should()<br />
 /// .BeDecoratedWith&lt;SomeAttribute&gt;()
 /// </example>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public static class AllTypes
 {
     /// <summary>

--- a/Src/FluentAssertions/Types/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Types/AssemblyAssertions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
@@ -212,6 +213,7 @@ public class AssemblyAssertions : ReferenceTypeAssertions<Assembly, AssemblyAsse
         return new AndConstraint<AssemblyAssertions>(this);
     }
 
+    [StackTraceHidden]
     private static string ToHexString(byte[] bytes) =>
 #if NET6_0_OR_GREATER
         Convert.ToHexString(bytes);

--- a/Src/FluentAssertions/Types/ConstructorInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/ConstructorInfoAssertions.cs
@@ -23,6 +23,7 @@ public class ConstructorInfoAssertions : MethodBaseAssertions<ConstructorInfo, C
 
     protected override string Identifier => "constructor";
 
+    [StackTraceHidden]
     private static string GetDescriptionFor(ConstructorInfo constructorInfo)
     {
         return $"{constructorInfo.DeclaringType}({GetParameterString(constructorInfo)})";

--- a/Src/FluentAssertions/Types/MethodBaseAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodBaseAssertions.cs
@@ -113,6 +113,7 @@ public abstract class MethodBaseAssertions<TSubject, TAssertions> : MemberInfoAs
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
+    [StackTraceHidden]
     internal static string GetParameterString(MethodBase methodBase)
     {
         IEnumerable<Type> parameterTypes = methodBase.GetParameters().Select(p => p.ParameterType);

--- a/Src/FluentAssertions/Types/MethodInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoAssertions.cs
@@ -295,6 +295,7 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
         return NotReturn(typeof(TReturn), because, becauseArgs);
     }
 
+    [StackTraceHidden]
     internal static string GetDescriptionFor(MethodInfo method)
     {
         if (method is null)

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Common;
@@ -11,7 +12,7 @@ namespace FluentAssertions.Types;
 /// <summary>
 /// Allows for fluent selection of methods of a type through reflection.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class MethodInfoSelector : IEnumerable<MethodInfo>
 {
     private IEnumerable<MethodInfo> selectedMethods;

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -92,11 +92,13 @@ public class MethodInfoSelectorAssertions
         return new AndConstraint<MethodInfoSelectorAssertions>(this);
     }
 
+    [StackTraceHidden]
     private MethodInfo[] GetAllNonVirtualMethodsFromSelection()
     {
         return SubjectMethods.Where(method => method.IsNonVirtual()).ToArray();
     }
 
+    [StackTraceHidden]
     private MethodInfo[] GetAllVirtualMethodsFromSelection()
     {
         return SubjectMethods.Where(method => !method.IsNonVirtual()).ToArray();
@@ -318,18 +320,21 @@ public class MethodInfoSelectorAssertions
         return new AndConstraint<MethodInfoSelectorAssertions>(this);
     }
 
+    [StackTraceHidden]
     private MethodInfo[] GetMethodsWithout<TAttribute>(Expression<Func<TAttribute, bool>> isMatchingPredicate)
         where TAttribute : Attribute
     {
         return SubjectMethods.Where(method => !method.IsDecoratedWith(isMatchingPredicate)).ToArray();
     }
 
+    [StackTraceHidden]
     private MethodInfo[] GetMethodsWith<TAttribute>(Expression<Func<TAttribute, bool>> isMatchingPredicate)
         where TAttribute : Attribute
     {
         return SubjectMethods.Where(method => method.IsDecoratedWith(isMatchingPredicate)).ToArray();
     }
 
+    [StackTraceHidden]
     private static string GetDescriptionsFor(IEnumerable<MethodInfo> methods)
     {
         IEnumerable<string> descriptions = methods.Select(method => MethodInfoAssertions.GetDescriptionFor(method));

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Common;
@@ -10,7 +11,7 @@ namespace FluentAssertions.Types;
 /// <summary>
 /// Allows for fluent selection of properties of a type through reflection.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class PropertyInfoSelector : IEnumerable<PropertyInfo>
 {
     private IEnumerable<PropertyInfo> selectedProperties;

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -134,21 +134,25 @@ public class PropertyInfoSelectorAssertions
         return new AndConstraint<PropertyInfoSelectorAssertions>(this);
     }
 
+    [StackTraceHidden]
     private PropertyInfo[] GetAllReadOnlyPropertiesFromSelection()
     {
         return SubjectProperties.Where(property => !property.CanWrite).ToArray();
     }
 
+    [StackTraceHidden]
     private PropertyInfo[] GetAllWritablePropertiesFromSelection()
     {
         return SubjectProperties.Where(property => property.CanWrite).ToArray();
     }
 
+    [StackTraceHidden]
     private PropertyInfo[] GetAllNonVirtualPropertiesFromSelection()
     {
         return SubjectProperties.Where(property => !property.IsVirtual()).ToArray();
     }
 
+    [StackTraceHidden]
     private PropertyInfo[] GetAllVirtualPropertiesFromSelection()
     {
         return SubjectProperties.Where(property => property.IsVirtual()).ToArray();
@@ -208,18 +212,21 @@ public class PropertyInfoSelectorAssertions
         return new AndConstraint<PropertyInfoSelectorAssertions>(this);
     }
 
+    [StackTraceHidden]
     private PropertyInfo[] GetPropertiesWithout<TAttribute>()
         where TAttribute : Attribute
     {
         return SubjectProperties.Where(property => !property.IsDecoratedWith<TAttribute>()).ToArray();
     }
 
+    [StackTraceHidden]
     private PropertyInfo[] GetPropertiesWith<TAttribute>()
         where TAttribute : Attribute
     {
         return SubjectProperties.Where(property => property.IsDecoratedWith<TAttribute>()).ToArray();
     }
 
+    [StackTraceHidden]
     private static string GetDescriptionsFor(IEnumerable<PropertyInfo> properties)
     {
         IEnumerable<string> descriptions = properties.Select(property => Formatter.ToString(property));

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -171,6 +171,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// An empty <see cref="string"/> if the two specified types are the same, or an error message that describes that
     /// the two specified types are not the same.
     /// </returns>
+    [StackTraceHidden]
     private static string GetFailureMessageIfTypesAreDifferent(Type actual, Type expected)
     {
         if (actual == expected)
@@ -486,6 +487,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
         return new AndConstraint<TypeAssertions>(this);
     }
 
+    [StackTraceHidden]
     private bool AssertSubjectImplements(Type interfaceType,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
@@ -1573,6 +1575,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
         return NotHaveConstructor([], because, becauseArgs);
     }
 
+    [StackTraceHidden]
     private static string GetParameterString(IEnumerable<Type> parameterTypes)
     {
         return string.Join(", ", parameterTypes.Select(p => p.FullName));
@@ -1908,6 +1911,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     /// </summary>
     protected override string Identifier => "type";
 
+    [StackTraceHidden]
     private void AssertThatSubjectIsClass()
     {
         if (Subject.IsInterface || Subject.IsValueType || typeof(Delegate).IsAssignableFrom(Subject.BaseType))

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions.Common;
@@ -10,7 +11,7 @@ namespace FluentAssertions.Types;
 /// <summary>
 /// Allows for fluent filtering a list of types.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class TypeSelector : IEnumerable<Type>
 {
     private List<Type> types;

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -473,12 +473,14 @@ public class TypeSelectorAssertions
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
 
+    [StackTraceHidden]
     private static string GetDescriptionsFor(IEnumerable<Type> types)
     {
         IEnumerable<string> descriptions = types.Select(type => GetDescriptionFor(type));
         return string.Join(Environment.NewLine, descriptions);
     }
 
+    [StackTraceHidden]
     private static string GetDescriptionFor(Type type)
     {
         return type.ToString();

--- a/Src/FluentAssertions/Value.cs
+++ b/Src/FluentAssertions/Value.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency.Inlining;
@@ -8,7 +9,7 @@ namespace FluentAssertions;
 /// <summary>
 /// Provides a fluent API for defining inline assertions.
 /// </summary>
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public static class Value
 {
     /// <summary>

--- a/Src/FluentAssertions/Xml/Equivalency/AttributeData.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/AttributeData.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Xml.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class AttributeData
 {
     public AttributeData(string namespaceUri, string localName, string value, string prefix)

--- a/Src/FluentAssertions/Xml/Equivalency/Failure.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/Failure.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
+
 namespace FluentAssertions.Xml.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class Failure
 {
     public Failure(string formatString, params object[] formatParams)

--- a/Src/FluentAssertions/Xml/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/Node.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
 
 namespace FluentAssertions.Xml.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal sealed class Node
 {
     private readonly List<Node> children = [];

--- a/Src/FluentAssertions/Xml/Equivalency/XmlIterator.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/XmlIterator.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Xml;
 
 namespace FluentAssertions.Xml.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class XmlIterator
 {
     private readonly XmlReader reader;

--- a/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Xml;
@@ -7,7 +8,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Xml.Equivalency;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 internal class XmlReaderValidator
 {
     private readonly AssertionChain assertionChain;

--- a/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
@@ -1,10 +1,11 @@
+using System.Diagnostics;
 using System.Xml;
 using FluentAssertions.Common;
 using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Xml;
 
-[System.Diagnostics.StackTraceHidden]
+[StackTraceHidden]
 public class XmlNodeFormatter : IValueFormatter
 {
     public bool CanHandle(object value)

--- a/Tests/FluentAssertions.Specs/StackTraceHiddenSpecs.cs
+++ b/Tests/FluentAssertions.Specs/StackTraceHiddenSpecs.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Types;
@@ -84,5 +85,33 @@ public class StackTraceHiddenSpecs
               );
     }
 
+    [Fact]
+    public void Non_public_methods_in_annotable_classes_are_hidden()
+    {
+        // Arrange / Act
+        var methods = ShouldNotBeAnnotated()
+            .Methods()
+            .ThatSatisfy(m => ShouldBeHidden(m));
+
+        // Assert
+        methods.Should().BeDecoratedWith<StackTraceHiddenAttribute>(
+            "because all \"internal\" code should be hidden from the stacktrace to improve the debugging experience");
+    }
+
+    [Fact]
+    public void Public_methods_in_annotable_classes_are_not_hidden()
+    {
+        // Arrange / Act
+        var methods = ShouldNotBeAnnotated()
+            .Methods()
+            .ThatSatisfy(m => !ShouldBeHidden(m));
+
+        // Assert
+        methods.Should().NotBeDecoratedWith<StackTraceHiddenAttribute>(
+            "because all \"non-internal\" code should be hidden from the stacktrace to improve the debugging experience");
+    }
+
+    private static bool ShouldBeHidden(MethodInfo m) =>
+        !(m.IsPublic || m.IsFamily || m.IsFamilyOrAssembly) && !m.HasAttribute<CompilerGeneratedAttribute>();
 }
 #endif


### PR DESCRIPTION
Hide methods that are not { `public`, `protected`, `protected internal` }.

Follow-up to #3152

As an example, here are the before and after stack traces of `When_an_ulong_value_is_not_close_to_expected_value_it_should_fail` if we let it fail.

before:
```
NumericAssertionsExtensions.FailIfValueOutsideBounds[TValue,TDelta](AssertionChain assertionChain, Boolean valueWithinBounds, TValue nearbyValue, TDelta delta, TValue actualValue, String because, Object[] becauseArgs) line 363
NumericAssertionsExtensions.BeCloseTo(NumericAssertions`1 parent, UInt64 nearbyValue, UInt64 delta, String because, Object[] becauseArgs) line 350
BeCloseTo.When_an_ulong_value_is_not_close_to_expected_value_it_should_fail(UInt64 actual, UInt64 nearbyValue, UInt64 delta) line 707
RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
```

after:
```
NumericAssertionsExtensions.BeCloseTo(NumericAssertions`1 parent, UInt64 nearbyValue, UInt64 delta, String because, Object[] becauseArgs) line 350
BeCloseTo.When_an_ulong_value_is_not_close_to_expected_value_it_should_fail(UInt64 actual, UInt64 nearbyValue, UInt64 delta) line 707
InvokeStub_BeCloseTo.When_an_ulong_value_is_not_close_to_expected_value_it_should_fail(Object, Span`1)
MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
```

Ignore the first commit, that's #3257

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## CONTRIBUTOR LICENSE GRANT

By submitting this contribution, the contributor hereby irrevocably grants to the project owners and maintainers a perpetual, worldwide, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and create derivative works of the contribution for any purpose and under any terms, including proprietary licensing.

The contributor waives any moral rights in the contribution to the extent permitted by law and agrees not to assert any claim of authorship or control over the contribution. The contributor represents that they are the sole author of the contribution and that it is provided free of any third-party claims.

The contributor understands and agrees that the maintainers may, at their sole discretion, use, license, or redistribute the contribution as part of any work and under any terms they choose, without further permission or attribution.

* [ ] I have read the Contributor License Grant and accept the conditions
* [ ] I'm interested in a free license for Fluent Assertions and will share my email address through sales@xceed.com