### PR TITLE
Fix exception on `HaveProperty` on `JsonArray`

### DIFF
--- a/Src/FluentAssertions/Specialized/JsonNodeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/JsonNodeAssertions.cs
@@ -42,7 +42,8 @@ public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertio
     public AndWhichConstraint<JsonNodeAssertions<T>, JsonNode> HaveProperty(string code,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        bool hasProperty = Subject is JsonObject obj && obj.TryGetPropertyValue(code, out _);
+        JsonNode property = null;
+        bool hasProperty = Subject is JsonObject obj && obj.TryGetPropertyValue(code, out property);
 
         CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
@@ -52,7 +53,7 @@ public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertio
             .ForCondition(hasProperty)
             .FailWith("Expected {context:JSON node} to have property {0}{reason}.", code);
 
-        return new AndWhichConstraint<JsonNodeAssertions<T>, JsonNode>(this, Subject?[code]);
+        return new AndWhichConstraint<JsonNodeAssertions<T>, JsonNode>(this, property);
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Specialized/JsonNodeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/JsonNodeAssertions.cs
@@ -205,12 +205,13 @@ public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertio
     public AndWhichConstraint<JsonNodeAssertions<T>, DateTime> BeLocalDate(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
+        DateTime actualValue = default;
+
         CurrentAssertionChain
-            .ForCondition(Subject is JsonValue value && value.TryGetValue<DateTime>(out _) && !Subject.ToString().EndsWith('Z'))
+            .ForCondition(Subject is JsonValue value && value.TryGetValue(out actualValue) && !Subject.ToString().EndsWith('Z'))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:JSON node} to be a local date{reason}, but {0} is not.", Subject);
 
-        var actualValue = Subject is JsonValue jsonValue && jsonValue.TryGetValue<DateTime>(out var result) ? result : default;
         return new AndWhichConstraint<JsonNodeAssertions<T>, DateTime>(this, actualValue);
     }
 
@@ -249,12 +250,13 @@ public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertio
     public AndWhichConstraint<JsonNodeAssertions<T>, DateTime> BeUtcDate(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
+        DateTime actualValue = default;
+
         CurrentAssertionChain
-            .ForCondition(Subject is JsonValue value && value.TryGetValue<DateTime>(out _) && Subject.ToString().EndsWith('Z'))
+            .ForCondition(Subject is JsonValue value && value.TryGetValue(out actualValue) && Subject.ToString().EndsWith('Z'))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} to be a UTC date{reason}, but {0} is not.", Subject);
 
-        var actualValue = Subject is JsonValue jsonValue && jsonValue.TryGetValue<DateTime>(out var result) ? result : default;
         return new AndWhichConstraint<JsonNodeAssertions<T>, DateTime>(this, actualValue);
     }
 
@@ -293,12 +295,13 @@ public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertio
     public AndWhichConstraint<JsonNodeAssertions<T>, bool> BeBool(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
+        bool actualValue = default;
+
         CurrentAssertionChain
-            .ForCondition(Subject is JsonValue value && value.TryGetValue(out bool _))
+            .ForCondition(Subject is JsonValue value && value.TryGetValue(out actualValue))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context} to be a boolean{reason}, but {0} is not.", Subject);
 
-        var actualValue = Subject is JsonValue jsonValue && jsonValue.TryGetValue<bool>(out var result) && result;
         return new AndWhichConstraint<JsonNodeAssertions<T>, bool>(this, actualValue);
     }
 
@@ -336,12 +339,13 @@ public class JsonNodeAssertions<T> : ReferenceTypeAssertions<T, JsonNodeAssertio
     public AndWhichConstraint<JsonNodeAssertions<T>, string> BeString(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
+        string actualValue = null;
+
         CurrentAssertionChain
-            .ForCondition(Subject is JsonValue value && value.TryGetValue(out string _))
+            .ForCondition(Subject is JsonValue value && value.TryGetValue(out actualValue))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:JSON node} to be a string{reason}, but {0} is not.", Subject);
 
-        var actualValue = Subject is JsonValue jsonValue && jsonValue.TryGetValue<string>(out var result) ? result : null;
         return new AndWhichConstraint<JsonNodeAssertions<T>, string>(this, actualValue);
     }
 

--- a/Tests/FluentAssertions.Specs/Specialized/JsonNodeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/JsonNodeSpecs.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.Json.Nodes;
+using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
@@ -37,6 +38,23 @@ public class JsonNodeSpecs
 
             // Assert
             subject.ToString().Should().Be("John");
+        }
+
+        [Fact]
+        public void Arrays_do_not_have_properties()
+        {
+            // Arrange
+            var jsonNode = JsonNode.Parse("[1, 2, 3]");
+
+            // Act
+            var act = () =>
+            {
+                using var _ = new AssertionScope();
+                return jsonNode.Should().HaveProperty("code", "that is what we expect");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>();
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,6 +18,7 @@ sidebar:
 
 ### Fixes
 * `JsonNodeAssertions.HaveProperty`/`NotHaveProperty` now correctly distinguish an absent property from one with an explicit `null` value - [#3282](https://github.com/fluentassertions/fluentassertions/pull/3282)
+* `JsonNodeAssertions.HaveProperty` no longer throws an `InvalidOperationException` when wrapped in an `AssertionScope` and invoked on a non-`JsonObject` subject - [#3295](https://github.com/fluentassertions/fluentassertions/pull/3295)
 
 ## 8.9.0
 


### PR DESCRIPTION
When `HaveProperty` is called on a non-`JsonObject`, e.g. `JsonArray`, and the assertion is wrapped in an `AssertionScope`, we would try to lookup the property on the `JsonArray`, which throws and `InvalidOperationException`.

The second commit is purely cleaup


## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## CONTRIBUTOR LICENSE GRANT

By submitting this contribution, the contributor hereby irrevocably grants to the project owners and maintainers a perpetual, worldwide, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and create derivative works of the contribution for any purpose and under any terms, including proprietary licensing.

The contributor waives any moral rights in the contribution to the extent permitted by law and agrees not to assert any claim of authorship or control over the contribution. The contributor represents that they are the sole author of the contribution and that it is provided free of any third-party claims.

The contributor understands and agrees that the maintainers may, at their sole discretion, use, license, or redistribute the contribution as part of any work and under any terms they choose, without further permission or attribution.

* [ ] I have read the Contributor License Grant and accept the conditions
* [ ] I'm interested in a free license for Fluent Assertions and will share my email address through sales@xceed.com