### PR TITLE
Add HaveLineCount()/NotHaveLineCount() and ContainLine()/NotContainLine() to StringAssertions

### DIFF
--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -1580,6 +1580,73 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     }
 
     /// <summary>
+    /// Asserts that a string contains the specified <paramref name="expectedLine"/> as one of its lines.
+    /// </summary>
+    /// <remarks>
+    /// A line is considered to be terminated by <c>\r\n</c>, <c>\n</c>, or <c>\r</c>, matching the same line-ending
+    /// rules used elsewhere by <see cref="StringAssertions{TAssertions}"/>.
+    /// </remarks>
+    /// <param name="expectedLine">The line that the subject is expected to contain.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <returns>
+    /// An <see cref="AndWhichConstraint{TParent,TSubject}"/> which can be used to chain assertions on the line
+    /// that was found through <see cref="AndWhichConstraint{TParent,TSubject}.Which"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="expectedLine"/> is <see langword="null"/>.</exception>
+    public AndWhichConstraint<TAssertions, string> ContainLine(string expectedLine,
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        Guard.ThrowIfArgumentIsNull(expectedLine, nameof(expectedLine), "Cannot assert string line containment against <null>.");
+
+        string[] lines = Subject is not null ? SplitLines(Subject) : [];
+        string matchedLine = Array.Find(lines, line => line == expectedLine);
+
+        assertionChain
+            .ForCondition(matchedLine is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:string} {0} to contain line {1}{reason}.", Subject, expectedLine);
+
+        return new AndWhichConstraint<TAssertions, string>((TAssertions)this, matchedLine, assertionChain);
+    }
+
+    /// <summary>
+    /// Asserts that a string does not contain the specified <paramref name="unexpectedLine"/> as one of its lines.
+    /// </summary>
+    /// <remarks>
+    /// A line is considered to be terminated by <c>\r\n</c>, <c>\n</c>, or <c>\r</c>, matching the same line-ending
+    /// rules used elsewhere by <see cref="StringAssertions{TAssertions}"/>.
+    /// </remarks>
+    /// <param name="unexpectedLine">The line that the subject is not expected to contain.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="unexpectedLine"/> is <see langword="null"/>.</exception>
+    public AndConstraint<TAssertions> NotContainLine(string unexpectedLine,
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        Guard.ThrowIfArgumentIsNull(unexpectedLine, nameof(unexpectedLine), "Cannot assert string line containment against <null>.");
+
+        bool containsLine = Subject is not null && SplitLines(Subject).Contains(unexpectedLine, StringComparer.Ordinal);
+
+        assertionChain
+            .ForCondition(!containsLine)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {context:string} {0} to contain line {1}{reason}.", Subject, unexpectedLine);
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
     /// Asserts that a string does not contain all of the strings provided in <paramref name="values"/>. The string
     /// may contain some subset of the provided values.
     /// </summary>
@@ -1803,6 +1870,79 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
                 .ForCondition(Subject!.Length == expected)
                 .FailWith("Expected {context:string} with length {0}{reason}, but found string {1} with length {2}.",
                     expected, Subject, Subject.Length);
+        }
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
+    /// Asserts that a string has the specified <paramref name="expected"/> number of lines.
+    /// </summary>
+    /// <remarks>
+    /// A line is considered to be terminated by <c>\r\n</c>, <c>\n</c>, or <c>\r</c>, matching the same line-ending
+    /// rules used elsewhere by <see cref="StringAssertions{TAssertions}"/>. A trailing line terminator introduces an
+    /// additional, empty final line, e.g. <c>"one\ntwo\n"</c> has 3 lines.
+    /// </remarks>
+    /// <param name="expected">The expected number of lines in the string.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public AndConstraint<TAssertions> HaveLineCount(int expected,
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        assertionChain
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject is not null)
+            .FailWith("Expected {context:string} to have {0} line(s){reason}, but found <null>.", expected);
+
+        if (assertionChain.Succeeded)
+        {
+            int actual = SplitLines(Subject!).Length;
+
+            assertionChain
+                .ForCondition(actual == expected)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:string} to have {0} line(s){reason}, but found {1}.", expected, actual);
+        }
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    /// <summary>
+    /// Asserts that a string does not have the specified <paramref name="unexpected"/> number of lines.
+    /// </summary>
+    /// <remarks>
+    /// A line is considered to be terminated by <c>\r\n</c>, <c>\n</c>, or <c>\r</c>, matching the same line-ending
+    /// rules used elsewhere by <see cref="StringAssertions{TAssertions}"/>.
+    /// </remarks>
+    /// <param name="unexpected">The number of lines that the string is not expected to have.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public AndConstraint<TAssertions> NotHaveLineCount(int unexpected,
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+    {
+        assertionChain
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject is not null)
+            .FailWith("Expected {context:string} to not have {0} line(s){reason}, but found <null>.", unexpected);
+
+        if (assertionChain.Succeeded)
+        {
+            int actual = SplitLines(Subject!).Length;
+
+            assertionChain
+                .ForCondition(actual != unexpected)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:string} to not have {0} line(s){reason}, but found {1}.", unexpected, actual);
         }
 
         return new AndConstraint<TAssertions>((TAssertions)this);
@@ -2041,6 +2181,12 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     {
         return (actual ?? string.Empty).Contains(expected ?? string.Empty, comparison);
     }
+
+    /// <summary>
+    /// Splits a string into its lines, treating <c>\r\n</c>, <c>\n</c>, and <c>\r</c> as line separators.
+    /// </summary>
+    [StackTraceHidden]
+    private static string[] SplitLines(string value) => value.Split(["\r\n", "\n", "\r"], StringSplitOptions.None);
 
     [StackTraceHidden]
     private static void ThrowIfValuesNullOrEmpty(IEnumerable<string> values)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2082,10 +2082,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainLine(string expectedLine, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLineCount(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
@@ -2108,9 +2110,11 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainLine(string unexpectedLine, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLineCount(int unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2272,10 +2272,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainLine(string expectedLine, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLineCount(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
@@ -2298,9 +2300,11 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainLine(string unexpectedLine, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLineCount(int unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2026,10 +2026,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainLine(string expectedLine, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLineCount(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
@@ -2052,9 +2054,11 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainLine(string unexpectedLine, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLineCount(int unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2098,10 +2098,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainLine(string expectedLine, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLineCount(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
@@ -2124,9 +2126,11 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainLine(string unexpectedLine, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLineCount(int unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, System.Func<FluentAssertions.Equivalency.EquivalencyOptions<string>, FluentAssertions.Equivalency.EquivalencyOptions<string>> config, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainLine.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.ContainLine.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Primitives;
+
+public partial class StringAssertionSpecs
+{
+    public class ContainLine
+    {
+        [Fact]
+        public void Succeeds_when_the_string_contains_the_expected_line()
+        {
+            // Arrange
+            string log = "Starting up\nConnected to database\nReady";
+
+            // Act / Assert
+            log.Should().ContainLine("Connected to database");
+        }
+
+        [Fact]
+        public void Exposes_the_matched_line_through_which()
+        {
+            // Arrange
+            string log = "Starting up\nConnected to database\nReady";
+
+            // Act / Assert
+            log.Should().ContainLine("Connected to database").Which.Should().Be("Connected to database");
+        }
+
+        [Fact]
+        public void Can_chain_another_assertion_on_the_matched_line()
+        {
+            // Arrange
+            string log = "Starting up\nConnected to database\nReady";
+
+            // Act
+            Action act = () => log.Should().ContainLine("Connected to database").Which.Should().HaveLength(4);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected*length*4*21*");
+        }
+
+        [Fact]
+        public void Treats_different_line_endings_as_equivalent()
+        {
+            // Arrange
+            string log = "one\r\ntwo\nthree\rfour";
+
+            // Act / Assert
+            log.Should().ContainLine("three");
+        }
+
+        [Fact]
+        public void Does_not_match_a_partial_line()
+        {
+            // Arrange
+            string log = "Connected to database";
+
+            // Act
+            Action act = () => log.Should().ContainLine("Connected");
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Fails_when_the_string_does_not_contain_the_expected_line()
+        {
+            // Arrange
+            string log = "Ready";
+
+            // Act
+            Action act = () => log.Should().ContainLine("Error", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected log \"Ready\" to contain line \"Error\" *failure message*.");
+        }
+
+        [Fact]
+        public void Fails_for_null_string()
+        {
+            // Arrange
+            string log = null;
+
+            // Act
+            Action act = () => log.Should().ContainLine("Ready");
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void An_expected_line_is_required()
+        {
+            // Act
+            Action act = () => "a".Should().ContainLine(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .WithMessage("Cannot assert string line containment against <null>.*")
+                .WithParameterName("expectedLine");
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.HaveLineCount.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.HaveLineCount.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Primitives;
+
+public partial class StringAssertionSpecs
+{
+    public class HaveLineCount
+    {
+        [Fact]
+        public void Succeeds_for_a_string_with_the_expected_number_of_lines()
+        {
+            // Arrange
+            string actual = "Starting up\nConnected to database\nReady";
+
+            // Act / Assert
+            actual.Should().HaveLineCount(3);
+        }
+
+        [Fact]
+        public void Succeeds_for_a_single_line_string()
+        {
+            // Arrange
+            string actual = "just one line";
+
+            // Act / Assert
+            actual.Should().HaveLineCount(1);
+        }
+
+        [Fact]
+        public void Treats_different_line_endings_as_equivalent()
+        {
+            // Arrange
+            string actual = "one\r\ntwo\nthree\rfour";
+
+            // Act / Assert
+            actual.Should().HaveLineCount(4);
+        }
+
+        [Fact]
+        public void A_trailing_line_terminator_introduces_an_additional_empty_line()
+        {
+            // Arrange
+            string actual = "one\ntwo\n";
+
+            // Act / Assert
+            actual.Should().HaveLineCount(3);
+        }
+
+        [Fact]
+        public void Fails_for_a_string_with_a_different_number_of_lines()
+        {
+            // Arrange
+            string actual = "one\ntwo\nthree";
+
+            // Act
+            Action act = () => actual.Should().HaveLineCount(2, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected actual to have 2 line(s) *failure message*, but found 3.");
+        }
+
+        [Fact]
+        public void Fails_for_null_string()
+        {
+            // Arrange
+            string actual = null;
+
+            // Act
+            Action act = () => actual.Should().HaveLineCount(1, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected actual to have 1 line(s) *failure message*, but found <null>.");
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.HaveLineCount.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.HaveLineCount.cs
@@ -8,44 +8,17 @@ public partial class StringAssertionSpecs
 {
     public class HaveLineCount
     {
-        [Fact]
-        public void Succeeds_for_a_string_with_the_expected_number_of_lines()
+        [Theory]
+        [InlineData("Starting up\nConnected to database\nReady", 3)]
+        [InlineData("just one line", 1)]
+        [InlineData("one\r\ntwo\nthree\rfour", 4)]
+        [InlineData("one\ntwo\n", 3)]
+        [InlineData("", 1)]
+        [InlineData("\n", 2)]
+        public void Succeeds_for_a_string_with_the_expected_number_of_lines(string actual, int expectedLineCount)
         {
-            // Arrange
-            string actual = "Starting up\nConnected to database\nReady";
-
             // Act / Assert
-            actual.Should().HaveLineCount(3);
-        }
-
-        [Fact]
-        public void Succeeds_for_a_single_line_string()
-        {
-            // Arrange
-            string actual = "just one line";
-
-            // Act / Assert
-            actual.Should().HaveLineCount(1);
-        }
-
-        [Fact]
-        public void Treats_different_line_endings_as_equivalent()
-        {
-            // Arrange
-            string actual = "one\r\ntwo\nthree\rfour";
-
-            // Act / Assert
-            actual.Should().HaveLineCount(4);
-        }
-
-        [Fact]
-        public void A_trailing_line_terminator_introduces_an_additional_empty_line()
-        {
-            // Arrange
-            string actual = "one\ntwo\n";
-
-            // Act / Assert
-            actual.Should().HaveLineCount(3);
+            actual.Should().HaveLineCount(expectedLineCount);
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.NotContainLine.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.NotContainLine.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Primitives;
+
+public partial class StringAssertionSpecs
+{
+    public class NotContainLine
+    {
+        [Fact]
+        public void Succeeds_when_the_string_does_not_contain_the_unexpected_line()
+        {
+            // Arrange
+            string log = "Starting up\nReady";
+
+            // Act / Assert
+            log.Should().NotContainLine("Error");
+        }
+
+        [Fact]
+        public void Succeeds_for_a_partial_match_that_is_not_a_full_line()
+        {
+            // Arrange
+            string log = "Connected to database";
+
+            // Act / Assert
+            log.Should().NotContainLine("Connected");
+        }
+
+        [Fact]
+        public void Succeeds_for_null_string()
+        {
+            // Arrange
+            string log = null;
+
+            // Act / Assert
+            log.Should().NotContainLine("Ready");
+        }
+
+        [Fact]
+        public void Fails_when_the_string_contains_the_unexpected_line()
+        {
+            // Arrange
+            string log = "Error";
+
+            // Act
+            Action act = () => log.Should().NotContainLine("Error", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect log \"Error\" to contain line \"Error\" *failure message*.");
+        }
+
+        [Fact]
+        public void An_unexpected_line_is_required()
+        {
+            // Act
+            Action act = () => "a".Should().NotContainLine(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .WithMessage("Cannot assert string line containment against <null>.*")
+                .WithParameterName("unexpectedLine");
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.NotHaveLineCount.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.NotHaveLineCount.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Primitives;
+
+public partial class StringAssertionSpecs
+{
+    public class NotHaveLineCount
+    {
+        [Fact]
+        public void Succeeds_for_a_string_with_a_different_number_of_lines()
+        {
+            // Arrange
+            string actual = "one\ntwo\nthree";
+
+            // Act / Assert
+            actual.Should().NotHaveLineCount(2);
+        }
+
+        [Fact]
+        public void Fails_for_a_string_with_the_unexpected_number_of_lines()
+        {
+            // Arrange
+            string actual = "one\ntwo\nthree";
+
+            // Act
+            Action act = () => actual.Should().NotHaveLineCount(3, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected actual to not have 3 line(s) *failure message*, but found 3.");
+        }
+
+        [Fact]
+        public void Fails_for_null_string()
+        {
+            // Arrange
+            string actual = null;
+
+            // Act
+            Action act = () => actual.Should().NotHaveLineCount(1, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected actual to not have 1 line(s) *failure message*, but found <null>.");
+        }
+    }
+}

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,7 @@ sidebar:
 * Added `ThatSatisfy` to `MethodInfoSelector` and `PropertyInfoSelector` - [#3257](https://github.com/fluentassertions/fluentassertions/pull/3257)
 * Introduced new collection assertion methods `BeSupersetOf`, `BeProperSubsetOf` and `BeProperSupersetOf`, where an empty expected subset is treated as a valid (trivially satisfied) case for `BeSupersetOf` and `BeProperSupersetOf` instead of throwing - [#3271](https://github.com/fluentassertions/fluentassertions/pull/3271)
 * Added `BeJsonSerializable<T>()` for .NET 6+ to assert `System.Text.Json` round-tripping, with overloads for equivalency options and `JsonSerializerOptions` - [#3293](https://github.com/fluentassertions/fluentassertions/pull/3293)
+* Added `HaveLineCount`/`NotHaveLineCount` and `ContainLine`/`NotContainLine` to `StringAssertions` for asserting on the number of lines in a string and whether it contains a specific line, normalizing `\r\n`, `\n` and `\r` line endings. `ContainLine` returns an `AndWhichConstraint` exposing the matched line for further chaining - [#3297](https://github.com/fluentassertions/fluentassertions/pull/3297)
 
 ### Enhancements
 * `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one - [#3198](https://github.com/fluentassertions/fluentassertions/pull/3198)

--- a/docs/_pages/strings.md
+++ b/docs/_pages/strings.md
@@ -67,6 +67,11 @@ theString.Should().ContainAny("any", "of", "these", "will", "do");
 theString.Should().NotContain("is a");
 theString.Should().NotContainAll("can", "contain", "some", "but", "not", "all");
 theString.Should().NotContainAny("can't", "contain", "any", "of", "these");
+theString.Should().ContainLine("this is one of the lines")
+    .Which.Should().Be("this is one of the lines");
+theString.Should().NotContainLine("this line does not exist");
+theString.Should().HaveLineCount(3);
+theString.Should().NotHaveLineCount(5);
 theString.Should().ContainEquivalentOf("WE DONT CARE ABOUT THE CASING");
 theString.Should().ContainEquivalentOf("WE DONT CARE ABOUT THE CASING", Exactly.Once());
 theString.Should().ContainEquivalentOf("WE DONT CARE ABOUT THE CASING", AtLeast.Twice());


### PR DESCRIPTION
Implements the API proposed in #3291.

### What's new

Adds four methods to `StringAssertions<TAssertions>`, matching the proposal in the issue:

```csharp
public AndConstraint<TAssertions> HaveLineCount(int expected, string because = "", params object[] becauseArgs);
public AndConstraint<TAssertions> NotHaveLineCount(int unexpected, string because = "", params object[] becauseArgs);
public AndConstraint<TAssertions> ContainLine(string expectedLine, string because = "", params object[] becauseArgs);
public AndConstraint<TAssertions> NotContainLine(string unexpectedLine, string because = "", params object[] becauseArgs);
```

```csharp
string log = "Starting up\nConnected to database\nReady";

log.Should().HaveLineCount(3);
log.Should().ContainLine("Connected to database");
log.Should().NotContainLine("Error");
```

- Lines are split using `\r\n`, `\n`, and `\r` as line separators (all three treated as equivalent), consistent with line-ending handling already used internally elsewhere in the library.
- `ContainLine`/`NotContainLine` match whole lines only (not substrings), and guard against a `null` expected/unexpected line via `Guard.ThrowIfArgumentIsNull` (empty string is a valid line to search for).
- `HaveLineCount`/`NotHaveLineCount` fail explicitly with a `<null>`-aware message when the subject string is null, following the same pattern as `HaveLength`.

### Tests

Added spec files under `Tests/FluentAssertions.Specs/Primitives/`:
- `StringAssertionSpecs.HaveLineCount.cs`
- `StringAssertionSpecs.NotHaveLineCount.cs`
- `StringAssertionSpecs.ContainLine.cs`
- `StringAssertionSpecs.NotContainLine.cs`

Covering success/failure paths, null subjects, mixed line endings, and argument validation.

### Housekeeping

- Updated `Tests/Approval.Tests/ApprovedApi/FluentAssertions/*.verified.txt` via `AcceptApiChanges.ps1` for the new public API surface.
- Updated `docs/_pages/releases.md` and `docs/_pages/strings.md`.
- Full `FluentAssertions.Specs` suite (6003 tests) and approval tests pass locally.

Closes #3291 (pending maintainer API approval).
