### PR TITLE
Cancel duplicate CI runs when a push triggers both push and pull_request events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "Build, Test, Analyze and Publish"


### PR DESCRIPTION
Cancel older Build runs when both push and pull_request fire for the same PR branch update. A force-push to a PR branch can start two identical workflow runs, so this adds a concurrency group that keys on the pull request number or branch ref and cancels the older run.