### PR TITLE
Fix Qodana PR scans failing on pull requests from forks

### DIFF
--- a/.github/workflows/code_quality_pr.yml
+++ b/.github/workflows/code_quality_pr.yml
@@ -1,16 +1,24 @@
 name: Qodana (PR)
 
-# Triggered by pull_request (NOT pull_request_target), so this job runs with
-# the PR contributor's untrusted code. It still needs QODANA_TOKEN to run the
-# cloud linter, so that secret is scoped to the "qodana-pr" GitHub Environment
-# instead of being a repo/org-wide secret. That keeps this job's blast radius
-# limited to QODANA_TOKEN only: no other repository or organization secret is
-# exposed to code checked out from a pull request, no matter how the job
-# steps are edited later. Add required reviewers on the "qodana-pr"
-# environment to also gate first-time/fork contributors behind manual
-# approval before their code runs with the token.
+# Qodana needs QODANA_TOKEN to run the cloud linter, and GitHub withholds every
+# secret from a `pull_request` run that originates from a fork. So this workflow
+# uses `pull_request_target`, which runs in the trusted base-branch context and
+# therefore does receive secrets.
+#
+# The trade-off is that the job checks out and analyses the contributor's
+# untrusted code while a secret is in scope. Two things contain that:
+#
+#  1. QODANA_TOKEN is scoped to the "qodana-pr" GitHub Environment rather than
+#     being a repo/org-wide secret, so no other repository or organization
+#     secret is ever exposed to code checked out from a pull request, no matter
+#     how the job steps are edited later.
+#  2. The "qodana-pr" environment has required reviewers, so a maintainer must
+#     approve each run before the contributor's code executes with the token.
+#
+# Keep both in place. Dropping the environment, or removing its reviewers, would
+# hand QODANA_TOKEN to arbitrary fork code without human review.
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   checks: write
@@ -23,9 +31,12 @@ jobs:
     runs-on: windows-latest
     environment: qodana-pr
     steps:
+      # `pull_request_target` defaults to the base branch, so check out the PR
+      # head explicitly. refs/pull/<n>/head lives in this repository and points
+      # at the contributor's commit, which works for forks too.
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 0
 
       - name: 'Qodana Scan'


### PR DESCRIPTION
## Problem

The `Qodana (PR)` workflow fails on every pull request that comes from a fork, for example [run 31382941522](https://github.com/fluentassertions/fluentassertions/actions/runs/31382941522/job/93436924765?pr=3297) on #3297:

```
env:
  QODANA_TOKEN:            <- empty
...
Starting from version 2023.2 release versions of Qodana Linters require
connection to Qodana Cloud. ... provide the token as the QODANA_TOKEN
environment variable.
##[error]qodana scan failed with exit code 1
```

`QODANA_TOKEN` is empty because GitHub withholds **every** secret from a `pull_request` run that originates from a fork:

> With the exception of `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository.
>
> — [Events that trigger workflows → `pull_request` → Workflows in forked repositories](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request)

That restriction is enforced at the run level and covers environment secrets too, so scoping `QODANA_TOKEN` to the `qodana-pr` environment did not help. The comment in the workflow assumed that adding required reviewers to the environment would gate fork contributors and then hand them the token, but reviewer approval cannot unlock a secret the run was never entitled to receive.

The run history confirms the cause: the same branch passed while it lived in this repository and started failing once it was pushed to a fork.

## Fix

Switch the trigger to `pull_request_target`, which runs in the trusted base-branch context and therefore does receive secrets, and check out `refs/pull/<n>/head` so the contributor's commit is still what gets analysed. That ref lives in this repository and resolves for forks, so no cross-repository clone is needed.

Because the job now runs untrusted code while a secret is in scope, the `qodana-pr` environment has been given required reviewers (@dennisdoomen and @jnyrup, configured in repository settings, not in this diff). A maintainer has to approve each run before a contributor's code executes with the token. `QODANA_TOKEN` remains scoped to that environment, so no other repository or organization secret is ever exposed.

The workflow comment has been rewritten to explain why both parts are needed, so neither gets removed later by accident.

## Notes

- This only takes effect once merged, because `pull_request_target` reads the workflow from the base branch. Re-running an existing fork PR before then will still fail.
- Every push to a fork PR now queues a fresh approval. That is the cost of gating untrusted code against a secret.
- Contributors can no longer change this workflow from inside their own pull request, which is intended hardening.
- The `couldn't find remote ref` warning stays for fork PRs, since the head branch genuinely is not on `origin`. It is not fatal; the action falls back to the webhook payload to work out the merge base, which is what the previously passing runs did as well.