### PR TITLE
Support asserting on delegates that return a value task

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -916,6 +916,40 @@ public static class AssertionExtensions
     }
 
     /// <summary>
+    /// Returns a <see cref="NonGenericAsyncFunctionAssertions"/> object that can be used to assert the
+    /// current <see><cref>System.Func{ValueTask}</cref></see>.
+    /// </summary>
+    /// <remarks>
+    /// Because the assertions operate on tasks, the delegate is wrapped in a <see cref="Func{Task}"/> that converts the
+    /// value task returned by every invocation into a task. The <c>Subject</c> property therefore exposes that wrapper
+    /// instead of the original delegate.
+    /// </remarks>
+    [Pure]
+    public static NonGenericAsyncFunctionAssertions Should([NotNull] this Func<ValueTask> action)
+    {
+        Func<Task> taskFunc = action is null ? null : () => action().AsTask();
+
+        return new NonGenericAsyncFunctionAssertions(taskFunc, Extractor, AssertionChain.GetOrCreate());
+    }
+
+    /// <summary>
+    /// Returns a <see cref="GenericAsyncFunctionAssertions{T}"/> object that can be used to assert the
+    /// current <see><cref>System.Func{ValueTask{T}}</cref></see>.
+    /// </summary>
+    /// <remarks>
+    /// Because the assertions operate on tasks, the delegate is wrapped in a <see cref="Func{Task}"/> that converts the
+    /// value task returned by every invocation into a task. The <c>Subject</c> property therefore exposes that wrapper
+    /// instead of the original delegate.
+    /// </remarks>
+    [Pure]
+    public static GenericAsyncFunctionAssertions<T> Should<T>([NotNull] this Func<ValueTask<T>> action)
+    {
+        Func<Task<T>> taskFunc = action is null ? null : () => action().AsTask();
+
+        return new GenericAsyncFunctionAssertions<T>(taskFunc, Extractor, AssertionChain.GetOrCreate());
+    }
+
+    /// <summary>
     /// Returns a <see cref="FunctionAssertions{T}"/> object that can be used to assert the
     /// current <see cref="Func{T}"/>.
     /// </summary>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -78,6 +78,7 @@ namespace FluentAssertions
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateTimeOffset? actualValue) { }
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.ValueTask> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Guid? actualValue) { }
         public static FluentAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
@@ -148,6 +149,7 @@ namespace FluentAssertions
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
         public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T> actualValue) { }
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.ValueTask<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -85,6 +85,7 @@ namespace FluentAssertions
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateTimeOffset? actualValue) { }
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.ValueTask> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Guid? actualValue) { }
         public static FluentAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
@@ -168,6 +169,7 @@ namespace FluentAssertions
             where TAssertions : FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions> { }
         public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T> actualValue) { }
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.ValueTask<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Memory<T> actualValue) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -76,6 +76,7 @@ namespace FluentAssertions
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateTimeOffset? actualValue) { }
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.ValueTask> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Guid? actualValue) { }
         public static FluentAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
@@ -146,6 +147,7 @@ namespace FluentAssertions
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
         public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T> actualValue) { }
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.ValueTask<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -78,6 +78,7 @@ namespace FluentAssertions
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateTimeOffset? actualValue) { }
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.ValueTask> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Guid? actualValue) { }
         public static FluentAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
@@ -150,6 +151,7 @@ namespace FluentAssertions
             where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
         public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T> actualValue) { }
         public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.ValueTask<T>> action) { }
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Memory<T> actualValue) { }

--- a/Tests/FluentAssertions.Specs/Specialized/ValueTaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ValueTaskAssertionSpecs.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Specialized;
+
+public static class ValueTaskAssertionSpecs
+{
+    public class ThrowAsync
+    {
+        [Fact]
+        public async Task Succeeds_for_a_value_task_that_throws_the_expected_exception()
+        {
+            // Arrange
+            Func<ValueTask> subject = async () =>
+            {
+                await Task.Yield();
+                throw new ArgumentException();
+            };
+
+            // Act / Assert
+            await subject.Should().ThrowAsync<ArgumentException>();
+        }
+
+        [Fact]
+        public async Task The_value_task_must_throw_the_expected_exception()
+        {
+            // Arrange
+            Func<ValueTask> subject = () => default;
+
+            // Act
+            Func<Task> act = () => subject.Should().ThrowAsync<ArgumentException>(
+                "because we want to test the failure {0}", "message");
+
+            // Assert
+            await act.Should().ThrowAsync<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
+        }
+
+        [Fact]
+        public async Task Succeeds_for_a_generic_value_task_that_throws_the_expected_exception()
+        {
+            // Arrange
+            Func<ValueTask<int>> subject = async () =>
+            {
+                await Task.Yield();
+                throw new ArgumentException();
+            };
+
+            // Act / Assert
+            await subject.Should().ThrowAsync<ArgumentException>();
+        }
+
+        [Fact]
+        public async Task Fails_for_a_null_delegate()
+        {
+            // Arrange
+            Func<ValueTask> subject = null;
+
+            // Act
+            Func<Task> act = () => subject.Should().ThrowAsync<ArgumentException>();
+
+            // Assert
+            await act.Should().ThrowAsync<XunitException>()
+                .WithMessage("*found <null>*");
+        }
+    }
+
+    public class NotThrowAsync
+    {
+        [Fact]
+        public async Task Succeeds_for_a_value_task_that_does_not_throw()
+        {
+            // Arrange
+            Func<ValueTask> subject = () => default;
+
+            // Act / Assert
+            await subject.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Succeeds_for_a_generic_value_task_that_does_not_throw()
+        {
+            // Arrange
+            Func<ValueTask<int>> subject = () => new ValueTask<int>(42);
+
+            // Act / Assert
+            (await subject.Should().NotThrowAsync()).Which.Should().Be(42);
+        }
+
+        [Fact]
+        public async Task The_value_task_must_not_throw()
+        {
+            // Arrange
+            Func<ValueTask> subject = async () =>
+            {
+                await Task.Yield();
+                throw new ArgumentException("some message");
+            };
+
+            // Act
+            Func<Task> act = () => subject.Should().NotThrowAsync(
+                "because we want to test the failure {0}", "message");
+
+            // Assert
+            await act.Should().ThrowAsync<XunitException>()
+                .WithMessage("*because we want to test the failure message*some message*");
+        }
+
+        [Fact]
+        public async Task Fails_for_a_null_generic_delegate()
+        {
+            // Arrange
+            Func<ValueTask<int>> subject = null;
+
+            // Act
+            Func<Task> act = () => subject.Should().NotThrowAsync();
+
+            // Assert
+            await act.Should().ThrowAsync<XunitException>()
+                .WithMessage("*found <null>*");
+        }
+
+        [Fact]
+        public async Task The_value_task_is_invoked_only_once()
+        {
+            // Arrange
+            var invocations = 0;
+
+            Func<ValueTask> subject = () =>
+            {
+                invocations++;
+                return default;
+            };
+
+            // Act
+            await subject.Should().NotThrowAsync();
+
+            // Assert
+            invocations.Should().Be(1);
+        }
+    }
+
+    public class CompleteWithinAsync
+    {
+        [Fact]
+        public async Task Succeeds_for_a_value_task_that_completes_in_time()
+        {
+            // Arrange
+            Func<ValueTask> subject = () => default;
+
+            // Act / Assert
+            await subject.Should().CompleteWithinAsync(1.Minutes());
+        }
+
+        [Fact]
+        public async Task Succeeds_for_a_generic_value_task_that_completes_in_time()
+        {
+            // Arrange
+            Func<ValueTask<int>> subject = () => new ValueTask<int>(42);
+
+            // Act / Assert
+            (await subject.Should().CompleteWithinAsync(1.Minutes())).Which.Should().Be(42);
+        }
+
+        [Fact]
+        public async Task The_value_task_must_complete_within_the_time_limit()
+        {
+            // Arrange
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            // ReSharper disable once AccessToDisposedClosure
+            Func<ValueTask> subject = () => new ValueTask(Task.Delay(Timeout.Infinite, cancellationTokenSource.Token));
+
+            // Act
+            Func<Task> act = () => subject.Should().CompleteWithinAsync(
+                10.Milliseconds(), "because we want to test the failure {0}", "message");
+
+            // Assert
+            await act.Should().ThrowAsync<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
+        }
+
+        [Fact]
+        public async Task Fails_for_a_null_delegate()
+        {
+            // Arrange
+            Func<ValueTask> subject = null;
+
+            // Act
+            Func<Task> act = () => subject.Should().CompleteWithinAsync(1.Minutes());
+
+            // Assert
+            await act.Should().ThrowAsync<XunitException>()
+                .WithMessage("*found <null>*");
+        }
+    }
+
+    public class Subject
+    {
+        [Fact]
+        public void Exposes_the_task_based_adapter_rather_than_the_original_delegate()
+        {
+            // Arrange
+            Func<ValueTask> subject = () => default;
+
+            // Act
+            Func<Task> exposedSubject = subject.Should().Subject;
+
+            // Assert
+            exposedSubject.Should().NotBeNull();
+            exposedSubject.As<object>().Should().NotBeSameAs(subject);
+        }
+
+        [Fact]
+        public async Task Invokes_the_original_delegate_when_the_adapter_is_invoked()
+        {
+            // Arrange
+            var invocations = 0;
+
+            Func<ValueTask> subject = () =>
+            {
+                invocations++;
+                return default;
+            };
+
+            // Act
+            await subject.Should().Subject();
+
+            // Assert
+            invocations.Should().Be(1);
+        }
+    }
+}

--- a/docs/_pages/exceptions.md
+++ b/docs/_pages/exceptions.md
@@ -121,6 +121,13 @@ await act.Should().ThrowAsync<ArgumentException>();
 
 Both give you the same results, so it's just a matter of personal preference.
 
+Delegates that return a `ValueTask` or `ValueTask<T>` are supported in the same way:
+
+```csharp
+Func<ValueTask> act = () => asyncObject.ThrowValueTaskAsync<ArgumentException>();
+await act.Should().ThrowAsync<ArgumentException>();
+```
+
 As for synchronous methods, you can also check that an asynchronously executed method executes successfully after a given wait time using `NotThrowAfter`:
 
 ```csharp

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,6 +14,7 @@ sidebar:
 * Introduced new collection assertion methods `BeSupersetOf`, `BeProperSubsetOf` and `BeProperSupersetOf`, where an empty expected subset is treated as a valid (trivially satisfied) case for `BeSupersetOf` and `BeProperSupersetOf` instead of throwing - [#3271](https://github.com/fluentassertions/fluentassertions/pull/3271)
 * Added `BeJsonSerializable<T>()` for .NET 6+ to assert `System.Text.Json` round-tripping, with overloads for equivalency options and `JsonSerializerOptions` - [#3293](https://github.com/fluentassertions/fluentassertions/pull/3293)
 * Added `HaveLineCount`/`NotHaveLineCount` and `ContainLine`/`NotContainLine` to `StringAssertions` for asserting on the number of lines in a string and whether it contains a specific line, normalizing `\r\n`, `\n` and `\r` line endings. `ContainLine` returns an `AndWhichConstraint` exposing the matched line for further chaining - [#3297](https://github.com/fluentassertions/fluentassertions/pull/3297)
+* Added `Should()` overloads for `Func<ValueTask>` and `Func<ValueTask<T>>`, so `ValueTask`-returning delegates support the same assertions as `Task`-returning ones - [#3301](https://github.com/fluentassertions/fluentassertions/pull/3301)
 
 ### Enhancements
 * `BeEmpty` for `IEnumerable<T>` assertions now lists the first 10 items in the collection instead of only the first one - [#3198](https://github.com/fluentassertions/fluentassertions/pull/3198)
@@ -21,6 +22,21 @@ sidebar:
 ### Fixes
 * `JsonNodeAssertions.HaveProperty`/`NotHaveProperty` now correctly distinguish an absent property from one with an explicit `null` value - [#3282](https://github.com/fluentassertions/fluentassertions/pull/3282)
 * `JsonNodeAssertions.HaveProperty` no longer throws an `InvalidOperationException` when wrapped in an `AssertionScope` and invoked on a non-`JsonObject` subject - [#3295](https://github.com/fluentassertions/fluentassertions/pull/3295)
+
+### Breaking Changes (for users)
+* `Func<ValueTask>` and `Func<ValueTask<T>>` used to bind to the synchronous `Should<T>(Func<T>)` overload, which treated the value task as an ordinary return value. They now bind to the new asynchronous overloads instead. Replace `Throw`, `ThrowExactly`, `NotThrow` and `NotThrowAfter` with their `ThrowAsync`, `ThrowExactlyAsync`, `NotThrowAsync` and `NotThrowAfterAsync` counterparts, and note that `Subject` now exposes a task-based adapter rather than the original delegate - [#3301](https://github.com/fluentassertions/fluentassertions/pull/3301)
+
+## 8.10.0
+
+### What's new
+
+* Add `ComparingNullCollectionsAsEmpty` and `ComparingNullStringsAsEmpty` options to `BeEquivalentTo` - [#3202](https://github.com/fluentassertions/fluentassertions/pull/3202)
+
+### Enhancements
+
+* Fail with a descriptive error when path-based rules are used on value-semantic types - [#3187](https://github.com/fluentassertions/fluentassertions/pull/3187)
+* Significantly speed up `BeEquivalentTo` for large unordered collections - [#3189](https://github.com/fluentassertions/fluentassertions/pull/3188)
+* Include original index in extraneous item failure messages - [#3203](https://github.com/fluentassertions/fluentassertions/pull/3203)
 
 ## 8.9.0
 


### PR DESCRIPTION
## Summary

Asserting on a delegate that returns a value task previously meant going through the `Awaiting` adapter or calling `.AsTask()` by hand, purely to reach the assertions that task-returning delegates already get directly. This gives value tasks the same first-class treatment, so `ThrowAsync`, `NotThrowAsync`, `CompleteWithinAsync` and friends work straight off a `Func<ValueTask>` or `Func<ValueTask<T>>`.

Closes #3269.

## Reviewer note: this is a source-breaking change

Issue #3269 states that these delegate shapes "currently do not resolve to any existing `Should()` overload, so this is purely additive". That is not correct, and I want to flag it clearly rather than let it slip through.

`AssertionExtensions` already has a catch-all overload:

```csharp
public static FunctionAssertions<T> Should<T>(this Func<T> func)
```

A `Func<ValueTask>` binds to it with `T = ValueTask`, and a `Func<ValueTask<int>>` binds with `T = ValueTask<int>`. So today this compiles:

```csharp
Func<ValueTask> act = () => DoSomethingAsync();

act.Should().NotThrow();   // binds to FunctionAssertions<ValueTask>
```

It compiles, but it does not do what it looks like it does. `FunctionAssertions<T>` invokes the delegate and treats the returned value task as an ordinary return value. It never awaits it, so any exception thrown after the first suspension point goes unobserved and the assertion passes regardless. In other words, the existing binding is close to useless — but it is there, and people may have written it.

### What changes

C# prefers a non-generic applicable overload over a generic one, so the new `Should(this Func<ValueTask>)` now wins. Two consequences:

**1. Compile errors (`CS1061`).** The synchronous members disappear from the returned type:

| Was available | Replacement |
|---|---|
| `Throw<TException>()` | `ThrowAsync<TException>()` |
| `ThrowExactly<TException>()` | `ThrowExactlyAsync<TException>()` |
| `NotThrow()` | `NotThrowAsync()` |
| `NotThrowAfter(...)` | `NotThrowAfterAsync(...)` |

Anyone hitting this gets a loud compiler error and a one-line fix that also makes their test correct for the first time, so I think the break is worth taking.

**2. A silent behaviour change on `Subject`.** Members shared by both types — `Subject`, `BeSameAs`, `Match`, `Satisfy` — still compile but can now behave differently, because `Subject` no longer returns the delegate you passed in:

```csharp
Func<ValueTask> act = () => DoSomethingAsync();

act.Should().Subject.Should().BeSameAs(act);   // passed before, fails now
```

This one I could not avoid. The asynchronous assertions derive from `AsyncFunctionAssertions<TTask, TAssertions> where TTask : Task`, so `Subject` is a `Func<TTask>` and a `Func<ValueTask>` can never be it. Preserving the original identity would need a whole new assertions type duplicating the existing async logic, which the issue explicitly rules out in favour of reusing the existing classes. Instead the adapter is documented in `<remarks>` on both overloads and pinned down by specs, so the behaviour is intentional rather than incidental.

Note this is **source**-breaking only. No existing type, member or signature is removed, so already-compiled assemblies keep working; only recompilation is affected.

### How I verified it

I built `origin/main` in Release, compiled a scratch console app against the resulting `FluentAssertions.dll`, then swapped the reference to this branch's build and recompiled the same call sites. `act.Should().NotThrow()` compiles against `main` and fails with `CS1061` against this branch. Reflection over `FunctionAssertions<ValueTask>` versus `NonGenericAsyncFunctionAssertions` produced the member table above.

### What I would like you to decide

The `api-approved` label on #3269 was granted on the assumption that the change is additive. Given it is not, please confirm you are happy to take the break in the next release — the signatures themselves are unchanged from what was approved.

## Design notes

Value tasks are common in modern, performance-sensitive code, but there was no direct entry point for them, which made the assertions harder to discover and inconsistent with their task-based counterparts.

Two new entry points accept a value-task-returning delegate and reuse the existing asynchronous assertions, so behaviour, chaining and failure messages stay identical to the task-based ones. The returned value task is converted exactly once per invocation, which respects the rule that a value task must not be awaited more than once. A null delegate is still reported as `<null>` rather than throwing.

## Verification

- 15 new specs cover throwing, not throwing, completing within a time limit, generic results, null delegates, the delegate being invoked exactly once, and the adapted subject.
- `FluentAssertions.Specs` (6036 tests on net8.0/net6.0, 111 on net47), `FluentAssertions.Equivalency.Specs` and the API approval tests all pass.
- The release notes record the break under "Breaking Changes (for users)".
- Rebased onto the latest `upstream/main`; the only conflict was in the release notes, where this PR's "What's new" entry collided with a newly landed entry for `HaveLineCount`/`ContainLine` (#3297) — resolved by keeping both.
