### PR TITLE
Fix typo in exceptions page

### DIFF
--- a/docs/_pages/exceptions.md
+++ b/docs/_pages/exceptions.md
@@ -47,7 +47,7 @@ The pattern can be a combination of literal and wildcard characters, but it does
 
 The following wildcard specifiers are permitted in the pattern:
 
-| Wilcard specifier | Matches                                   |
+| Wildcard specifier | Matches                                   |
 | ----------------- | ----------------------------------------- |
 | * (asterisk)      | Zero or more characters in that position. |
 | ? (question mark) | Exactly one character in that position.   |


### PR DESCRIPTION
Fixes a typo in the exceptions documentation: \Wilcard\ -> \Wildcard\ in the wildcard specifier table header.