### PR TITLE
Fix potential NREs when using AssertionScope (#3178)

### DIFF
--- a/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
@@ -40,7 +40,7 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
             .ForCondition(Subject is not null)
             .FailWith("Expected property to be virtual{reason}, but {context:property} is <null>.")
             .Then
-            .ForCondition(Subject.IsVirtual())
+            .ForCondition(Subject?.IsVirtual() == true)
             .BecauseOf(because, becauseArgs)
             .FailWith(() =>
             {
@@ -72,7 +72,7 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
             .ForCondition(Subject is not null)
             .FailWith("Expected property not to be virtual{reason}, but {context:property} is <null>.")
             .Then
-            .ForCondition(!Subject.IsVirtual())
+            .ForCondition(Subject?.IsVirtual() == false)
             .BecauseOf(because, becauseArgs)
             .FailWith(() =>
             {
@@ -104,7 +104,7 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
             .ForCondition(Subject is not null)
             .FailWith("Expected property to have a setter{reason}, but {context:property} is <null>.")
             .Then
-            .ForCondition(Subject!.CanWrite)
+            .ForCondition(Subject?.CanWrite == true)
             .BecauseOf(because, becauseArgs)
             .FailWith(() =>
             {
@@ -145,7 +145,7 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
             .ForCondition(Subject is not null)
             .FailWith($"Expected {{context:project}} to be {accessModifier}{{reason}}, but it is <null>.")
             .Then
-            .ForCondition(Subject!.CanWrite)
+            .ForCondition(Subject?.CanWrite == true)
             .BecauseOf(because, becauseArgs)
             .FailWith($"Expected {subjectDescription} to have a setter{{reason}}.");
 
@@ -178,7 +178,7 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
             .ForCondition(Subject is not null)
             .FailWith("Expected {context:property} not to have a setter{reason}, but it is <null>.")
             .Then
-            .ForCondition(!Subject!.CanWrite)
+            .ForCondition(Subject?.CanWrite == false)
             .BecauseOf(because, becauseArgs)
             .FailWith(() =>
             {
@@ -210,7 +210,7 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
             .ForCondition(Subject is not null)
             .FailWith("Expected property to have a getter{reason}, but {context:property} is <null>.")
             .Then
-            .ForCondition(Subject!.CanRead)
+            .ForCondition(Subject?.CanRead == true)
             .BecauseOf(because, becauseArgs)
             .FailWith(() =>
             {
@@ -251,7 +251,7 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
             .ForCondition(Subject is not null)
             .FailWith($"Expected {{context:property}} to be {accessModifier}{{reason}}, but it is <null>.")
             .Then
-            .ForCondition(Subject!.CanRead)
+            .ForCondition(Subject?.CanRead == true)
             .BecauseOf(because, becauseArgs)
             .FailWith($"Expected {subjectDescription} to have a getter{{reason}}, but it does not.");
 
@@ -284,7 +284,7 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
             .ForCondition(Subject is not null)
             .FailWith("Expected property not to have a getter{reason}, but {context:property} is <null>.")
             .Then
-            .ForCondition(!Subject!.CanRead)
+            .ForCondition(Subject?.CanRead == false)
             .BecauseOf(because, becauseArgs)
             .FailWith(() =>
             {
@@ -319,10 +319,10 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject is not null)
             .FailWith("Expected type of property to be {0}{reason}, but {context:property} is <null>.", propertyType)
-            .Then.ForCondition(Subject!.PropertyType == propertyType)
+            .Then.ForCondition(Subject?.PropertyType == propertyType)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected type of property {2} to be {0}{reason}, but it is {1}.",
-                propertyType, Subject.PropertyType, Subject);
+                propertyType, Subject?.PropertyType, Subject);
 
         return new AndConstraint<PropertyInfoAssertions>(this);
     }
@@ -366,7 +366,7 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
             .ForCondition(Subject is not null)
             .FailWith("Expected type of property not to be {0}{reason}, but {context:property} is <null>.", propertyType)
             .Then
-            .ForCondition(Subject!.PropertyType != propertyType)
+            .ForCondition(Subject?.PropertyType != propertyType)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected type of property {1} not to be {0}{reason}, but it is.", propertyType, Subject);
 

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -920,9 +920,10 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                         $"Expected {subjectDescription} to have a property {name} of type {propertyType.Name}{{reason}}, but it does not.");
                 })
                 .Then
-                .ForCondition(propertyInfo.PropertyType == propertyType)
-                .FailWith($"Expected property {propertyInfo.Name} to be of type {propertyType}{{reason}}, but it is not.",
-                    propertyInfo);
+                .ForCondition(propertyInfo?.PropertyType == propertyType)
+                .FailWith(() => new FailReason(
+                    $"Expected property {propertyInfo.Name} to be of type {propertyType}{{reason}}, but it is not.",
+                    propertyInfo));
         }
 
         return new AndWhichConstraint<TypeAssertions, PropertyInfo>(this, propertyInfo);
@@ -1317,7 +1318,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                     $"Expected {indexerType.Name} {Subject}[{parameterString}] to exist{{reason}}" +
                     ", but it does not.")
                 .Then
-                .ForCondition(propertyInfo.PropertyType == indexerType)
+                .ForCondition(propertyInfo?.PropertyType == indexerType)
                 .FailWith("Expected {0} to be of type {1}{reason}, but it is not.", propertyInfo, indexerType);
         }
 

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
@@ -57,6 +57,24 @@ public class PropertyInfoAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected property to be virtual *failure message*, but propertyInfo is <null>.");
         }
+
+        [Fact]
+        public void When_subject_is_null_be_virtual_should_fail_and_not_throw_a_NullReferenceException_inside_an_assertion_scope()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().BeVirtual("we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property to be virtual *failure message*, but propertyInfo is <null>.");
+        }
     }
 
     public class NotBeVirtual
@@ -103,6 +121,24 @@ public class PropertyInfoAssertionSpecs
             // Act
             Action act = () =>
                 propertyInfo.Should().NotBeVirtual("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property not to be virtual *failure message*, but propertyInfo is <null>.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_be_virtual_should_fail_and_not_throw_a_NullReferenceException_inside_an_assertion_scope()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().NotBeVirtual("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -336,6 +372,24 @@ public class PropertyInfoAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected property to have a setter *failure message*, but propertyInfo is <null>.");
         }
+
+        [Fact]
+        public void When_subject_is_null_be_writable_should_fail_and_not_throw_a_NullReferenceException_inside_an_assertion_scope()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().BeWritable("we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property to have a setter *failure message*, but propertyInfo is <null>.");
+        }
     }
 
     public class BeReadable
@@ -391,6 +445,24 @@ public class PropertyInfoAssertionSpecs
             // Act
             Action act = () =>
                 propertyInfo.Should().BeReadable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property to have a getter *failure message*, but propertyInfo is <null>.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_be_readable_should_fail_and_not_throw_a_NullReferenceException_inside_an_assertion_scope()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().BeReadable("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -459,6 +531,24 @@ public class PropertyInfoAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected propertyInfo not to have a setter *failure message*, but it is <null>.");
         }
+
+        [Fact]
+        public void When_subject_is_null_not_be_writable_should_fail_and_not_throw_a_NullReferenceException_inside_an_assertion_scope()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().NotBeWritable("we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected propertyInfo not to have a setter *failure message*, but it is <null>.");
+        }
     }
 
     public class NotBeReadable
@@ -517,6 +607,24 @@ public class PropertyInfoAssertionSpecs
             // Act
             Action act = () =>
                 propertyInfo.Should().NotBeReadable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property not to have a getter *failure message*, but propertyInfo is <null>.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_be_readable_should_fail_and_not_throw_a_NullReferenceException_inside_an_assertion_scope()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().NotBeReadable("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -582,6 +690,25 @@ public class PropertyInfoAssertionSpecs
             // Act
             Action act = () =>
                 propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected propertyInfo to be Public *failure message*, but it is <null>.");
+        }
+
+        [Fact]
+        public void
+            When_subject_is_null_be_readable_with_accessmodifier_should_fail_and_not_throw_a_NullReferenceException_inside_an_assertion_scope()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -669,6 +796,25 @@ public class PropertyInfoAssertionSpecs
         }
 
         [Fact]
+        public void
+            When_subject_is_null_be_writable_with_accessmodifier_should_fail_and_not_throw_a_NullReferenceException_inside_an_assertion_scope()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected propertyInfo to be Public *failure message*, but it is <null>.");
+        }
+
+        [Fact]
         public void When_asserting_is_writable_with_an_invalid_enum_value_it_should_throw()
         {
             // Arrange
@@ -723,6 +869,24 @@ public class PropertyInfoAssertionSpecs
             // Act
             Action act = () =>
                 propertyInfo.Should().Return(typeof(int), "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type of property to be *.Int32 *failure message*, but propertyInfo is <null>.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_return_should_fail_and_not_throw_a_NullReferenceException_inside_an_assertion_scope()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().Return(typeof(int), "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -815,6 +979,24 @@ public class PropertyInfoAssertionSpecs
             // Act
             Action act = () =>
                 propertyInfo.Should().NotReturn(typeof(int), "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type of property not to be *.Int32 *failure message*, but propertyInfo is <null>.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_return_should_fail_and_not_throw_a_NullReferenceException_inside_an_assertion_scope()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                propertyInfo.Should().NotReturn(typeof(int), "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveIndexer.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveIndexer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions.Common;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -40,6 +41,29 @@ public partial class TypeAssertionSpecs
             Action act = () =>
                 type.Should().HaveIndexer(
                     typeof(string), [typeof(int), typeof(Type)], "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected String *ClassWithNoMembers[System.Int32, System.Type] to exist *failure message*" +
+                    ", but it does not.");
+        }
+
+        [Fact]
+        public void
+            When_asserting_a_type_has_an_indexer_which_it_does_not_it_fails_and_does_not_throw_a_NullReferenceException_inside_an_assertion_scope()
+        {
+            // Arrange
+            var type = typeof(ClassWithNoMembers);
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+
+                type.Should().HaveIndexer(
+                    typeof(string), [typeof(int), typeof(Type)], "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveProperty.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.HaveProperty.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions.Common;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -54,6 +55,25 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveProperty(typeof(string), "PublicProperty", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected ClassWithNoMembers to have a property PublicProperty of type String because we want to test the failure message, but it does not.");
+        }
+
+        [Fact]
+        public void
+            When_asserting_a_type_has_a_property_which_it_does_not_it_fails_and_does_not_throw_a_NullReferenceException_inside_an_assertion_scope()
+        {
+            // Arrange
+            var type = typeof(ClassWithNoMembers);
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                type.Should().HaveProperty(typeof(string), "PublicProperty", "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -23,6 +23,7 @@ sidebar:
 ### Fixes
 * `JsonNodeAssertions.HaveProperty`/`NotHaveProperty` now correctly distinguish an absent property from one with an explicit `null` value - [#3282](https://github.com/fluentassertions/fluentassertions/pull/3282)
 * `JsonNodeAssertions.HaveProperty` no longer throws an `InvalidOperationException` when wrapped in an `AssertionScope` and invoked on a non-`JsonObject` subject - [#3295](https://github.com/fluentassertions/fluentassertions/pull/3295)
+* Fixed several `PropertyInfoAssertions` methods (`BeVirtual`, `NotBeVirtual`, `BeWritable`, `NotBeWritable`, `BeReadable`, `NotBeReadable`, `Return`, `NotReturn`) and `TypeAssertions.HaveProperty`/`HaveIndexer` throwing a `NullReferenceException` instead of failing with a proper message when used inside an `AssertionScope` - [#3178](https://github.com/fluentassertions/fluentassertions/issues/3178)
 
 ### Breaking Changes (for users)
 * `Func<ValueTask>` and `Func<ValueTask<T>>` used to bind to the synchronous `Should<T>(Func<T>)` overload, which treated the value task as an ordinary return value. They now bind to the new asynchronous overloads instead. Replace `Throw`, `ThrowExactly`, `NotThrow` and `NotThrowAfter` with their `ThrowAsync`, `ThrowExactlyAsync`, `NotThrowAsync` and `NotThrowAfterAsync` counterparts, and note that `Subject` now exposes a task-based adapter rather than the original delegate - [#3301](https://github.com/fluentassertions/fluentassertions/pull/3301)


### PR DESCRIPTION
Fixes #3178

## Problem

Several assertion methods followed this pattern:

```csharp
assertionChain
    .ForCondition(subject is not null)
    .FailWith("... is <null>.")
    .Then
    .ForCondition(subject.Member)   // eagerly evaluated!
    .FailWith(...);
```

C# evaluates method arguments before invoking the method, so `subject.Member` is evaluated even when `subject` is `null` and the first condition already failed. Outside of an `AssertionScope`, the first failure throws immediately, so the chain never reaches the second line. Inside an `AssertionScope`, failures are only recorded (not thrown), so execution continues to the second `.ForCondition(...)`, and evaluating `subject.Member` throws a `NullReferenceException` instead of producing a proper assertion failure message.

## Fix

Replaced the eager dereferences with null-conditional comparisons (e.g. `subject?.Member == true`), following the pattern already used in `TimeOnlyAssertions.cs`. Also made a failure message in `TypeAssertions.HaveProperty` lazy, since it referenced `propertyInfo.Name` even when `propertyInfo` could be `null`.

### Affected members
- `PropertyInfoAssertions`: `BeVirtual`, `NotBeVirtual`, `BeWritable` (both overloads), `NotBeWritable`, `BeReadable` (both overloads), `NotBeReadable`, `Return`, `NotReturn`
- `TypeAssertions`: `HaveProperty`, `HaveIndexer`

## Testing

- Added regression tests that wrap each affected assertion in an `AssertionScope`, reproducing the exact scenario from the issue.
- Full `FluentAssertions.Specs` suite passes: 5963/5963 (net8.0).
- Targeted `PropertyInfoAssertionSpecs`/`TypeAssertionSpecs` pass on net47, net6.0, and net8.0 (402/402 each).

No public API changes, so no API-approval step is required.