### PR TITLE
Correct the arguments passed to `string.Format` on failure

### DIFF
--- a/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
@@ -340,8 +340,7 @@ public class DateOnlyAssertions<TAssertions>
                 unexpected)
             .Then
             .ForCondition(Subject.Value.Year != unexpected)
-            .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but it was.", unexpected,
-                Subject.Value.Year);
+            .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but it was.", unexpected);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -439,8 +439,7 @@ public class DateTimeAssertions<TAssertions>
                 unexpected)
             .Then
             .ForCondition(Subject.Value.Year != unexpected)
-            .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but it was.", unexpected,
-                Subject.Value.Year);
+            .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but it was.", unexpected);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -593,10 +592,10 @@ public class DateTimeAssertions<TAssertions>
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the hour part of {context:the time} to be {0}{reason}", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
-                .FailWith(", but found a <null> DateTime.", unexpected)
+                .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Hour != unexpected)
-                .FailWith(", but it was.", unexpected, Subject.Value.Hour));
+                .FailWith(", but it was."));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -645,10 +644,10 @@ public class DateTimeAssertions<TAssertions>
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the minute part of {context:the time} to be {0}{reason}", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
-                .FailWith(", but found a <null> DateTime.", unexpected)
+                .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Minute != unexpected)
-                .FailWith(", but it was.", unexpected, Subject.Value.Minute));
+                .FailWith(", but it was."));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -844,10 +843,10 @@ public class DateTimeAssertions<TAssertions>
             .WithExpectation("Expected the date part of {context:the date and time} to be {0}{reason}", expectedDate,
                 chain => chain
                     .ForCondition(Subject.HasValue)
-                    .FailWith(", but found a <null> DateTime.", expectedDate)
+                    .FailWith(", but found a <null> DateTime.")
                     .Then
                     .ForCondition(Subject.Value.Date == expectedDate)
-                    .FailWith(", but found {1}.", expectedDate, Subject.Value));
+                    .FailWith(", but found {0}.", Subject.Value));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -1028,7 +1028,7 @@ public class DateTimeOffsetAssertions<TAssertions>
             .WithExpectation("Expected the date part of {context:the date and time} to be {0}{reason}, ", expectedDate,
                 chain => chain
                     .ForCondition(Subject.HasValue)
-                    .FailWith("but found a <null> DateTimeOffset.", expectedDate)
+                    .FailWith("but found a <null> DateTimeOffset.")
                     .Then
                     .ForCondition(Subject.Value.Date == expectedDate)
                     .FailWith("but it was {0}.", Subject.Value.Date));

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -468,7 +468,6 @@ public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
                 CurrentAssertionChain
                     .WithDefaultIdentifier(Identifier)
                     .WithExpectation("Expected {context:object} to match inspector, but the inspector was not satisfied:",
-                        Subject,
                         chain => chain.FailWithPreFormatted(failureMessage));
             }
         }

--- a/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
@@ -426,8 +426,7 @@ public class TimeOnlyAssertions<TAssertions>
                 unexpected)
             .Then
             .ForCondition(Subject.Value.Hour != unexpected)
-            .FailWith("Did not expect the hours part of {context:the time} to be {0}{reason}, but it was.", unexpected,
-                Subject.Value.Hour);
+            .FailWith("Did not expect the hours part of {context:the time} to be {0}{reason}, but it was.", unexpected);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -549,7 +549,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                 .FailWith(", but {0} is not an interface.", interfaceType)
                 .Then
                 .ForCondition(!containsInterface)
-                .FailWith(", but it does.", interfaceType));
+                .FailWith(", but it does."));
 
         return new AndConstraint<TypeAssertions>(this);
     }
@@ -922,8 +922,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
                 .Then
                 .ForCondition(propertyInfo?.PropertyType == propertyType)
                 .FailWith(() => new FailReason(
-                    $"Expected property {propertyInfo.Name} to be of type {propertyType}{{reason}}, but it is not.",
-                    propertyInfo));
+                    $"Expected property {propertyInfo.Name} to be of type {propertyType}{{reason}}, but it is not."));
         }
 
         return new AndWhichConstraint<TypeAssertions, PropertyInfo>(this, propertyInfo);

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -456,9 +456,7 @@ public class XDocumentAssertions : ReferenceTypeAssertions<XDocument, XDocumentA
                 expectedElement.ToString(), expectedValue, chain => chain
                     .ForCondition(Subject is not null)
                     .BecauseOf(because, becauseArgs)
-                    .FailWith(
-                        "but the element itself is <null>.",
-                        expectedElement.ToString(), expectedValue)
+                    .FailWith("but the element itself is <null>.")
                     .Then
                     .Given(() =>
                     {

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -264,9 +264,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
                 chain => chain
                     .BecauseOf(because, becauseArgs)
                     .ForCondition(Subject is not null)
-                    .FailWith(
-                        "but {context:member} is <null>.",
-                        unexpectedText))
+                    .FailWith("but {context:member} is <null>."))
             .Then
             .WithExpectation("Did not expect {context:subject} to have attribute {0}{reason}, ", unexpectedText,
                 chain => chain


### PR DESCRIPTION
I found we had a number of places where we passed more arguments than we had corresponding placeholders.


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## CONTRIBUTOR LICENSE GRANT

By submitting this contribution, the contributor hereby irrevocably grants to the project owners and maintainers a perpetual, worldwide, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and create derivative works of the contribution for any purpose and under any terms, including proprietary licensing.

The contributor waives any moral rights in the contribution to the extent permitted by law and agrees not to assert any claim of authorship or control over the contribution. The contributor represents that they are the sole author of the contribution and that it is provided free of any third-party claims.

The contributor understands and agrees that the maintainers may, at their sole discretion, use, license, or redistribute the contribution as part of any work and under any terms they choose, without further permission or attribution.

* [ ] I have read the Contributor License Grant and accept the conditions
* [ ] I'm interested in a free license for Fluent Assertions and will share my email address through sales@xceed.com